### PR TITLE
Add CI: fmt, clippy, test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Tests
+        run: cargo test


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow triggered on push and PR to master
- Runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` on ubuntu-latest with stable Rust
- Uses `Swatinem/rust-cache@v2` for dependency caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)