### PR TITLE
Fix all formatting and clippy warnings

### DIFF
--- a/src/batch_builder.rs
+++ b/src/batch_builder.rs
@@ -6,9 +6,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use arrow::array::{
-    ArrayRef, Float64Builder, Int64Builder, StringBuilder,
-};
+use arrow::array::{ArrayRef, Float64Builder, Int64Builder, StringBuilder};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 
@@ -69,17 +67,13 @@ pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
     }
     let mut acc: i64 = 0;
     for &b in &bytes[start..] {
-        if b < b'0' || b > b'9' {
+        if !b.is_ascii_digit() {
             return None;
         }
         acc = acc.checked_mul(10)?;
         acc = acc.checked_add((b - b'0') as i64)?;
     }
-    if neg {
-        Some(-acc)
-    } else {
-        Some(acc)
-    }
+    if neg { Some(-acc) } else { Some(acc) }
 }
 
 /// Parse a byte slice as f64 using the standard library (adequate perf for v1).
@@ -189,7 +183,10 @@ impl BatchBuilder {
             fields: Vec::with_capacity(32),
             field_index: HashMap::with_capacity(32),
             raw_builder: if keep_raw {
-                Some(StringBuilder::with_capacity(expected_rows, expected_rows * 256))
+                Some(StringBuilder::with_capacity(
+                    expected_rows,
+                    expected_rows * 256,
+                ))
             } else {
                 None
             },
@@ -366,39 +363,32 @@ impl BatchBuilder {
 
         for fc in &mut self.fields {
             let name = unsafe { std::str::from_utf8_unchecked(&fc.name) };
-            let type_count =
-                fc.has_str as u8 + fc.has_int as u8 + fc.has_float as u8;
-            let multi = type_count > 1;
+            let type_count = fc.has_str as u8 + fc.has_int as u8 + fc.has_float as u8;
+            let _multi = type_count > 1;
 
             // Determine suffix: if single type, use plain name; if multi, use name_suffix.
-            let make_col_name = |suffix: &str| -> String {
-                if multi {
-                    format!("{}_{}", name, suffix)
-                } else {
-                    format!("{}_{}", name, suffix)
-                }
-            };
+            let make_col_name = |suffix: &str| -> String { format!("{}_{}", name, suffix) };
 
-            if fc.has_int {
-                if let Some(ref mut b) = fc.int_builder {
-                    let col_name = make_col_name("int");
-                    schema_fields.push(Field::new(&col_name, DataType::Int64, true));
-                    arrays.push(Arc::new(b.finish()) as ArrayRef);
-                }
+            if fc.has_int
+                && let Some(ref mut b) = fc.int_builder
+            {
+                let col_name = make_col_name("int");
+                schema_fields.push(Field::new(&col_name, DataType::Int64, true));
+                arrays.push(Arc::new(b.finish()) as ArrayRef);
             }
-            if fc.has_float {
-                if let Some(ref mut b) = fc.float_builder {
-                    let col_name = make_col_name("float");
-                    schema_fields.push(Field::new(&col_name, DataType::Float64, true));
-                    arrays.push(Arc::new(b.finish()) as ArrayRef);
-                }
+            if fc.has_float
+                && let Some(ref mut b) = fc.float_builder
+            {
+                let col_name = make_col_name("float");
+                schema_fields.push(Field::new(&col_name, DataType::Float64, true));
+                arrays.push(Arc::new(b.finish()) as ArrayRef);
             }
-            if fc.has_str {
-                if let Some(ref mut b) = fc.str_builder {
-                    let col_name = make_col_name("str");
-                    schema_fields.push(Field::new(&col_name, DataType::Utf8, true));
-                    arrays.push(Arc::new(b.finish()) as ArrayRef);
-                }
+            if fc.has_str
+                && let Some(ref mut b) = fc.str_builder
+            {
+                let col_name = make_col_name("str");
+                schema_fields.push(Field::new(&col_name, DataType::Utf8, true));
+                arrays.push(Arc::new(b.finish()) as ArrayRef);
             }
         }
 
@@ -451,7 +441,7 @@ impl BatchBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::{Array, Int64Array, Float64Array, StringArray};
+    use arrow::array::{Array, Float64Array, Int64Array, StringArray};
 
     #[test]
     fn test_parse_int_fast() {
@@ -499,7 +489,9 @@ mod tests {
         assert_eq!(host_arr.value(1), "web2");
 
         // status should be int-only → column "status_int"
-        let status_col = batch.column_by_name("status_int").expect("status_int column");
+        let status_col = batch
+            .column_by_name("status_int")
+            .expect("status_int column");
         let status_arr = status_col.as_any().downcast_ref::<Int64Array>().unwrap();
         assert_eq!(status_arr.value(0), 200);
         assert_eq!(status_arr.value(1), 404);
@@ -567,11 +559,21 @@ mod tests {
         let batch = bb.finish_batch();
         assert_eq!(batch.num_rows(), 2);
 
-        let a = batch.column_by_name("a_str").unwrap().as_any().downcast_ref::<StringArray>().unwrap();
+        let a = batch
+            .column_by_name("a_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert_eq!(a.value(0), "hello");
         assert!(a.is_null(1));
 
-        let b = batch.column_by_name("b_str").unwrap().as_any().downcast_ref::<StringArray>().unwrap();
+        let b = batch
+            .column_by_name("b_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert!(b.is_null(0));
         assert_eq!(b.value(1), "world");
     }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -67,15 +67,16 @@ impl ChunkCompressor {
         // Compress directly into out_buf after the header.
         // Use bulk compress with our level — zstd internally reuses thread-local contexts.
         let payload_start = self.out_buf.len();
-        let compressed_payload = zstd::bulk::compress(raw, self.level)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        let compressed_payload = zstd::bulk::compress(raw, self.level).map_err(io::Error::other)?;
 
         let compressed_size = compressed_payload.len();
         self.out_buf.extend_from_slice(&compressed_payload);
 
         // Compute checksum over the compressed payload.
-        let checksum =
-            xxhash_rust::xxh32::xxh32(&self.out_buf[payload_start..payload_start + compressed_size], 0);
+        let checksum = xxhash_rust::xxh32::xxh32(
+            &self.out_buf[payload_start..payload_start + compressed_size],
+            0,
+        );
 
         // Fill in the header.
         self.out_buf[0..2].copy_from_slice(&MAGIC.to_le_bytes());
@@ -105,7 +106,10 @@ impl ChunkCompressor {
 /// Decompress and verify a compressed chunk (for testing / receiver side).
 pub fn decompress_chunk(data: &[u8]) -> io::Result<Vec<u8>> {
     if data.len() < HEADER_SIZE {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "chunk too small"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "chunk too small",
+        ));
     }
 
     let magic = u16::from_le_bytes([data[0], data[1]]);
@@ -127,7 +131,10 @@ pub fn decompress_chunk(data: &[u8]) -> io::Result<Vec<u8>> {
     let expected_checksum = u32::from_le_bytes([data[12], data[13], data[14], data[15]]);
 
     if data.len() < HEADER_SIZE + compressed_size {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "truncated payload"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "truncated payload",
+        ));
     }
 
     let payload = &data[HEADER_SIZE..HEADER_SIZE + compressed_size];

--- a/src/config.rs
+++ b/src/config.rs
@@ -288,7 +288,10 @@ impl Config {
                     .map(String::from)
                     .unwrap_or_else(|| format!("#{i}"));
                 match output.output_type {
-                    OutputType::Otlp | OutputType::Http | OutputType::Elasticsearch | OutputType::Loki => {
+                    OutputType::Otlp
+                    | OutputType::Http
+                    | OutputType::Elasticsearch
+                    | OutputType::Loki => {
                         if output.endpoint.is_none() {
                             return Err(ConfigError::Validation(format!(
                                 "pipeline '{name}' output '{label}': {} output requires 'endpoint'",
@@ -416,11 +419,17 @@ storage:
         let pipe = &cfg.pipelines["default"];
         assert_eq!(pipe.inputs.len(), 1);
         assert_eq!(pipe.inputs[0].input_type, InputType::File);
-        assert_eq!(pipe.inputs[0].path.as_deref(), Some("/var/log/pods/**/*.log"));
+        assert_eq!(
+            pipe.inputs[0].path.as_deref(),
+            Some("/var/log/pods/**/*.log")
+        );
         assert_eq!(pipe.inputs[0].format, Some(Format::Cri));
         assert!(pipe.transform.as_ref().unwrap().contains("SELECT"));
         assert_eq!(pipe.outputs[0].output_type, OutputType::Otlp);
-        assert_eq!(pipe.outputs[0].endpoint.as_deref(), Some("otel-collector:4317"));
+        assert_eq!(
+            pipe.outputs[0].endpoint.as_deref(),
+            Some("otel-collector:4317")
+        );
         assert_eq!(cfg.server.diagnostics.as_deref(), Some("0.0.0.0:9090"));
         assert_eq!(cfg.storage.data_dir.as_deref(), Some("/var/lib/logfwd"));
     }
@@ -625,8 +634,7 @@ output:
             ("tcp", "listen: 0.0.0.0:514"),
             ("otlp", ""),
         ] {
-            let yaml =
-                format!("input:\n  type: {itype}\n  {extra}\noutput:\n  type: stdout\n");
+            let yaml = format!("input:\n  type: {itype}\n  {extra}\noutput:\n  type: stdout\n");
             Config::load_str(&yaml).unwrap_or_else(|e| panic!("failed for {itype}: {e}"));
         }
     }

--- a/src/cri.rs
+++ b/src/cri.rs
@@ -52,7 +52,11 @@ pub fn parse_cri_line(line: &[u8]) -> Option<CriLine<'_>> {
         line.len()
     };
 
-    let flags = &line[sp2 + 1..if msg_start > sp2 + 1 { msg_start - 1 } else { line.len() }];
+    let flags = &line[sp2 + 1..if msg_start > sp2 + 1 {
+        msg_start - 1
+    } else {
+        line.len()
+    }];
     let is_full = flags == b"F";
 
     let message = if msg_start < line.len() {
@@ -138,12 +142,12 @@ where
             continue;
         }
 
-        if let Some(cri) = parse_cri_line(line) {
-            if let Some(complete_msg) = reassembler.feed(&cri) {
-                emit(complete_msg);
-                count += 1;
-                reassembler.reset();
-            }
+        if let Some(cri) = parse_cri_line(line)
+            && let Some(complete_msg) = reassembler.feed(&cri)
+        {
+            emit(complete_msg);
+            count += 1;
+            reassembler.reset();
         }
     }
 
@@ -179,12 +183,12 @@ pub fn process_cri_to_buf(
             continue;
         }
 
-        if let Some(cri) = parse_cri_line(line) {
-            if let Some(complete_msg) = reassembler.feed(&cri) {
-                write_json_line(complete_msg, json_prefix, out);
-                count += 1;
-                reassembler.reset();
-            }
+        if let Some(cri) = parse_cri_line(line)
+            && let Some(complete_msg) = reassembler.feed(&cri)
+        {
+            write_json_line(complete_msg, json_prefix, out);
+            count += 1;
+            reassembler.reset();
         }
     }
 
@@ -214,7 +218,8 @@ mod tests {
 
     #[test]
     fn test_parse_full_line() {
-        let line = b"2024-01-15T10:30:00.123456789Z stdout F {\"level\":\"INFO\",\"msg\":\"hello\"}";
+        let line =
+            b"2024-01-15T10:30:00.123456789Z stdout F {\"level\":\"INFO\",\"msg\":\"hello\"}";
         let cri = parse_cri_line(line).unwrap();
         assert_eq!(cri.timestamp, b"2024-01-15T10:30:00.123456789Z");
         assert_eq!(cri.stream, b"stdout");

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
@@ -90,7 +90,8 @@ impl PipelineMetrics {
         typ: impl Into<String>,
     ) -> Arc<ComponentStats> {
         let stats = Arc::new(ComponentStats::new());
-        self.inputs.push((name.into(), typ.into(), Arc::clone(&stats)));
+        self.inputs
+            .push((name.into(), typ.into(), Arc::clone(&stats)));
         stats
     }
 
@@ -100,7 +101,8 @@ impl PipelineMetrics {
         typ: impl Into<String>,
     ) -> Arc<ComponentStats> {
         let stats = Arc::new(ComponentStats::new());
-        self.outputs.push((name.into(), typ.into(), Arc::clone(&stats)));
+        self.outputs
+            .push((name.into(), typ.into(), Arc::clone(&stats)));
         stats
     }
 }
@@ -164,11 +166,8 @@ impl DiagnosticsServer {
                 let resp = tiny_http::Response::from_string("not found")
                     .with_status_code(404)
                     .with_header(
-                        tiny_http::Header::from_bytes(
-                            &b"Content-Type"[..],
-                            &b"text/plain"[..],
-                        )
-                        .unwrap(),
+                        tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/plain"[..])
+                            .unwrap(),
                     );
                 request.respond(resp)?;
                 Ok(())
@@ -190,10 +189,7 @@ impl DiagnosticsServer {
         Ok(())
     }
 
-    fn serve_health(
-        &self,
-        request: tiny_http::Request,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn serve_health(&self, request: tiny_http::Request) -> Result<(), Box<dyn std::error::Error>> {
         let uptime = self.start_time.elapsed().as_secs();
         let body = format!(
             r#"{{"status":"ok","uptime_seconds":{},"version":"{}"}}"#,
@@ -278,10 +274,7 @@ impl DiagnosticsServer {
         Ok(())
     }
 
-    fn serve_metrics(
-        &self,
-        request: tiny_http::Request,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    fn serve_metrics(&self, request: tiny_http::Request) -> Result<(), Box<dyn std::error::Error>> {
         let mut out = String::with_capacity(2048);
 
         // Input lines
@@ -376,7 +369,9 @@ impl DiagnosticsServer {
         }
 
         // Backpressure stalls
-        out.push_str("\n# HELP logfwd_backpressure_stalls_total Times reader blocked on full channel\n");
+        out.push_str(
+            "\n# HELP logfwd_backpressure_stalls_total Times reader blocked on full channel\n",
+        );
         out.push_str("# TYPE logfwd_backpressure_stalls_total counter\n");
         for pm in &self.pipelines {
             out.push_str(&format!(
@@ -457,12 +452,14 @@ mod tests {
         use std::io::Write;
         use std::net::TcpStream;
 
-        let mut stream =
-            TcpStream::connect(format!("127.0.0.1:{}", port)).expect("connect failed");
+        let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port)).expect("connect failed");
         stream
             .set_read_timeout(Some(std::time::Duration::from_secs(5)))
             .ok();
-        let req = format!("GET {} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n", path);
+        let req = format!(
+            "GET {} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            path
+        );
         stream.write_all(req.as_bytes()).unwrap();
 
         let mut buf = Vec::new();
@@ -478,11 +475,7 @@ mod tests {
             .unwrap_or(0);
 
         // Split headers from body.
-        let body = text
-            .split("\r\n\r\n")
-            .nth(1)
-            .unwrap_or("")
-            .to_string();
+        let body = text.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
 
         (status, body)
     }
@@ -542,7 +535,9 @@ mod tests {
             body,
         );
         assert!(
-            body.contains(r#"logfwd_output_lines_total{pipeline="default",output="collector"} 900"#),
+            body.contains(
+                r#"logfwd_output_lines_total{pipeline="default",output="collector"} 900"#
+            ),
             "body: {}",
             body,
         );

--- a/src/otlp.rs
+++ b/src/otlp.rs
@@ -35,6 +35,7 @@ pub fn encode_varint(buf: &mut Vec<u8>, mut value: u64) {
 
 /// Compute encoded varint length without writing.
 #[inline(always)]
+#[allow(clippy::match_overlapping_arm)]
 pub const fn varint_len(value: u64) -> usize {
     match value {
         0..=0x7F => 1,
@@ -145,14 +146,15 @@ struct JsonFields<'a> {
 /// Field names we recognize (checked in order of likelihood).
 /// These cover the most common JSON log field names across ecosystems.
 const TIMESTAMP_KEYS: &[&[u8]] = &[
-    b"timestamp", b"time", b"ts", b"@timestamp", b"datetime", b"t",
+    b"timestamp",
+    b"time",
+    b"ts",
+    b"@timestamp",
+    b"datetime",
+    b"t",
 ];
-const LEVEL_KEYS: &[&[u8]] = &[
-    b"level", b"severity", b"log_level", b"loglevel", b"lvl",
-];
-const MESSAGE_KEYS: &[&[u8]] = &[
-    b"message", b"msg", b"body", b"log", b"text",
-];
+const LEVEL_KEYS: &[&[u8]] = &[b"level", b"severity", b"log_level", b"loglevel", b"lvl"];
+const MESSAGE_KEYS: &[&[u8]] = &[b"message", b"msg", b"body", b"log", b"text"];
 
 /// Extract known fields from a JSON line. Uses memchr to find quotes,
 /// then matches field names. No full JSON parse — just enough to find
@@ -215,23 +217,21 @@ fn extract_json_fields<'a>(line: &'a [u8]) -> JsonFields<'a> {
             }
             let val = &line[val_start..pos];
             // Trim trailing whitespace.
-            let trimmed_end = val.iter().rposition(|&b| b != b' ' && b != b'\t')
+            let trimmed_end = val
+                .iter()
+                .rposition(|&b| b != b' ' && b != b'\t')
                 .map(|i| i + 1)
                 .unwrap_or(0);
             &val[..trimmed_end]
         };
 
         // Match key against known field names.
-        let key_lower_first = if key.is_empty() { 0 } else { key[0] | 0x20 };
+        let _key_lower_first = if key.is_empty() { 0 } else { key[0] | 0x20 };
         // Check all field categories — a key starting with 't' could be
         // "timestamp" OR "text", so we check each category independently.
-        if fields.timestamp.is_none()
-            && TIMESTAMP_KEYS.iter().any(|k| key_eq_ignore_case(key, k))
-        {
+        if fields.timestamp.is_none() && TIMESTAMP_KEYS.iter().any(|k| key_eq_ignore_case(key, k)) {
             fields.timestamp = Some(value);
-        } else if fields.level.is_none()
-            && LEVEL_KEYS.iter().any(|k| key_eq_ignore_case(key, k))
-        {
+        } else if fields.level.is_none() && LEVEL_KEYS.iter().any(|k| key_eq_ignore_case(key, k)) {
             fields.level = Some(value);
         } else if fields.message.is_none()
             && MESSAGE_KEYS.iter().any(|k| key_eq_ignore_case(key, k))
@@ -341,7 +341,11 @@ fn parse_2digits(s: &[u8], off: usize) -> u8 {
 /// Days from 1970-01-01 to the given civil date. Algorithm from Howard Hinnant.
 fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
     let y = if month <= 2 { year - 1 } else { year };
-    let m = if month <= 2 { month as i64 + 9 } else { month as i64 - 3 };
+    let m = if month <= 2 {
+        month as i64 + 9
+    } else {
+        month as i64 - 3
+    };
     let era = y.div_euclid(400);
     let yoe = y.rem_euclid(400);
     let doy = (153 * m + 2) / 5 + day as i64 - 1;
@@ -394,7 +398,7 @@ pub fn encode_log_record(line: &[u8], observed_time_ns: u64, buf: &mut Vec<u8>) 
     // Parse severity.
     let (severity_num, severity_text) = fields
         .level
-        .map(|l| parse_severity(l))
+        .map(parse_severity)
         .unwrap_or((Severity::Unspecified, b"" as &[u8]));
 
     // Body: use message field if found, otherwise the full line.
@@ -486,6 +490,12 @@ pub struct BatchEncoder {
     out: Vec<u8>,
 }
 
+impl Default for BatchEncoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BatchEncoder {
     pub fn new() -> Self {
         BatchEncoder {
@@ -514,9 +524,8 @@ impl BatchEncoder {
         let mut scope_logs_inner_size = 0usize;
         for &(start, end) in &self.record_ranges {
             let record_len = end - start;
-            scope_logs_inner_size += varint_len(((2u64) << 3) | 2)
-                + varint_len(record_len as u64)
-                + record_len;
+            scope_logs_inner_size +=
+                varint_len(((2u64) << 3) | 2) + varint_len(record_len as u64) + record_len;
         }
 
         let resource_logs_inner_size = bytes_field_size(2, scope_logs_inner_size);
@@ -589,9 +598,8 @@ impl BatchEncoder {
         let mut scope_logs_inner_size = 0usize;
         for &(start, end) in &self.record_ranges {
             let record_len = end - start;
-            scope_logs_inner_size += varint_len(((2u64) << 3) | 2)
-                + varint_len(record_len as u64)
-                + record_len;
+            scope_logs_inner_size +=
+                varint_len(((2u64) << 3) | 2) + varint_len(record_len as u64) + record_len;
         }
 
         let resource_logs_inner_size = bytes_field_size(2, scope_logs_inner_size);
@@ -649,7 +657,10 @@ mod tests {
         assert!(matches!(parse_severity(b"DEBUG").0, Severity::Debug));
         assert!(matches!(parse_severity(b"TRACE").0, Severity::Trace));
         assert!(matches!(parse_severity(b"FATAL").0, Severity::Fatal));
-        assert!(matches!(parse_severity(b"unknown").0, Severity::Unspecified));
+        assert!(matches!(
+            parse_severity(b"unknown").0,
+            Severity::Unspecified
+        ));
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -9,8 +9,8 @@ use arrow::record_batch::RecordBatch;
 
 use crate::compress::ChunkCompressor;
 use crate::otlp::{
-    bytes_field_size, encode_bytes_field, encode_fixed64, encode_tag, encode_varint,
-    encode_varint_field, parse_severity, parse_timestamp_nanos, varint_len, Severity,
+    Severity, bytes_field_size, encode_bytes_field, encode_fixed64, encode_tag, encode_varint,
+    encode_varint_field, parse_severity, parse_timestamp_nanos, varint_len,
 };
 
 // ---------------------------------------------------------------------------
@@ -341,7 +341,7 @@ impl OutputSink for JsonLinesSink {
         req = req.header("Content-Type", "application/x-ndjson");
 
         req.send(&self.batch_buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| io::Error::other(e.to_string()))?;
         Ok(())
     }
 
@@ -509,7 +509,7 @@ impl OutputSink for OtlpSink {
         }
 
         req.send(payload)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+            .map_err(|e| io::Error::other(e.to_string()))?;
         Ok(())
     }
 
@@ -617,9 +617,7 @@ fn encode_row_as_log_record(
 
     // field 6: attributes — all remaining columns
     for (idx, field) in schema.fields().iter().enumerate() {
-        if Some(idx) == timestamp_col_idx
-            || Some(idx) == level_col_idx
-            || Some(idx) == body_col_idx
+        if Some(idx) == timestamp_col_idx || Some(idx) == level_col_idx || Some(idx) == body_col_idx
         {
             continue;
         }
@@ -634,12 +632,16 @@ fn encode_row_as_log_record(
 
         match type_suffix {
             "int" => {
-                let arr = batch.column(idx).as_primitive::<arrow::datatypes::Int64Type>();
+                let arr = batch
+                    .column(idx)
+                    .as_primitive::<arrow::datatypes::Int64Type>();
                 let v = arr.value(row);
                 encode_key_value_int(buf, field_name.as_bytes(), v);
             }
             "float" => {
-                let arr = batch.column(idx).as_primitive::<arrow::datatypes::Float64Type>();
+                let arr = batch
+                    .column(idx)
+                    .as_primitive::<arrow::datatypes::Float64Type>();
                 let v = arr.value(row);
                 encode_key_value_double(buf, field_name.as_bytes(), v);
             }
@@ -798,7 +800,10 @@ mod tests {
     fn test_parse_column_name() {
         assert_eq!(parse_column_name("status_int"), ("status", "int"));
         assert_eq!(parse_column_name("level_str"), ("level", "str"));
-        assert_eq!(parse_column_name("duration_ms_float"), ("duration_ms", "float"));
+        assert_eq!(
+            parse_column_name("duration_ms_float"),
+            ("duration_ms", "float")
+        );
         assert_eq!(parse_column_name("_raw"), ("_raw", ""));
         assert_eq!(parse_column_name("plain"), ("plain", ""));
     }
@@ -815,7 +820,11 @@ mod tests {
         let lines: Vec<&str> = output.trim().split('\n').collect();
         assert_eq!(lines.len(), 2);
         // First row: level=ERROR, status=500
-        assert!(lines[0].contains("\"level\":\"ERROR\""), "got: {}", lines[0]);
+        assert!(
+            lines[0].contains("\"level\":\"ERROR\""),
+            "got: {}",
+            lines[0]
+        );
         assert!(lines[0].contains("\"status\":500"), "got: {}", lines[0]);
         // Second row: level=INFO, status=200
         assert!(lines[1].contains("\"level\":\"INFO\""), "got: {}", lines[1]);
@@ -845,10 +854,7 @@ mod tests {
         // Also test FanOut trait dispatch works.
         let fanout_s1 = StdoutSink::new("f1".to_string(), StdoutFormat::Json);
         let fanout_s2 = StdoutSink::new("f2".to_string(), StdoutFormat::Json);
-        let mut fanout = FanOut::new(vec![
-            Box::new(fanout_s1),
-            Box::new(fanout_s2),
-        ]);
+        let mut fanout = FanOut::new(vec![Box::new(fanout_s1), Box::new(fanout_s2)]);
         // send_batch writes to real stdout, but should not error.
         let result = fanout.send_batch(&batch, &meta);
         assert!(result.is_ok());
@@ -868,7 +874,12 @@ mod tests {
         let status = Int64Array::from(vec![Some(500)]);
         let batch = RecordBatch::try_new(
             schema,
-            vec![Arc::new(ts), Arc::new(level), Arc::new(msg), Arc::new(status)],
+            vec![
+                Arc::new(ts),
+                Arc::new(level),
+                Arc::new(msg),
+                Arc::new(status),
+            ],
         )
         .unwrap();
 
@@ -894,9 +905,7 @@ mod tests {
     #[test]
     fn test_raw_passthrough() {
         // Build a batch with only _raw column (simulating no transforms).
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("_raw", DataType::Utf8, true),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new("_raw", DataType::Utf8, true)]));
         let raw = StringArray::from(vec![
             Some(r#"{"ts":"2024-01-15","msg":"hello"}"#),
             Some(r#"{"ts":"2024-01-15","msg":"world"}"#),
@@ -926,8 +935,7 @@ mod tests {
         ]));
         let raw = StringArray::from(vec![Some("original log line")]);
         let level = StringArray::from(vec![Some("INFO")]);
-        let batch =
-            RecordBatch::try_new(schema, vec![Arc::new(raw), Arc::new(level)]).unwrap();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(raw), Arc::new(level)]).unwrap();
         let meta = make_metadata();
 
         let mut sink = StdoutSink::new("test".to_string(), StdoutFormat::Text);
@@ -962,9 +970,11 @@ mod tests {
 
     #[test]
     fn test_float_column_json() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("duration_ms_float", DataType::Float64, true),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "duration_ms_float",
+            DataType::Float64,
+            true,
+        )]));
         let dur = Float64Array::from(vec![Some(3.14)]);
         let batch = RecordBatch::try_new(schema, vec![Arc::new(dur)]).unwrap();
         let meta = make_metadata();

--- a/src/pipeline_v2.rs
+++ b/src/pipeline_v2.rs
@@ -5,8 +5,8 @@
 
 use std::io;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::config::{Format, InputConfig, InputType, OutputConfig, OutputType, PipelineConfig};
@@ -183,9 +183,9 @@ impl Pipeline {
                 .inputs
                 .iter()
                 .any(|i| i.json_buf.len() >= self.batch_target_bytes);
-            let time_ready =
-                had_data && !self.inputs.iter().all(|i| i.json_buf.is_empty())
-                    && last_flush.elapsed() >= self.batch_timeout;
+            let time_ready = had_data
+                && !self.inputs.iter().all(|i| i.json_buf.is_empty())
+                && last_flush.elapsed() >= self.batch_timeout;
 
             if size_ready || time_ready {
                 let mut combined = Vec::new();
@@ -198,13 +198,12 @@ impl Pipeline {
                 if !combined.is_empty() {
                     let batch = self.scanner.scan(&combined);
                     if batch.num_rows() > 0 {
-                        self.metrics
-                            .transform_in
-                            .inc_lines(batch.num_rows() as u64);
+                        self.metrics.transform_in.inc_lines(batch.num_rows() as u64);
 
-                        let result = self.transform.execute(batch).map_err(|e| {
-                            io::Error::new(io::ErrorKind::Other, format!("transform error: {e}"))
-                        })?;
+                        let result = self
+                            .transform
+                            .execute(batch)
+                            .map_err(|e| io::Error::other(format!("transform error: {e}")))?;
 
                         self.metrics
                             .transform_out
@@ -278,10 +277,7 @@ fn build_input_state(
 // Output construction
 // ---------------------------------------------------------------------------
 
-fn build_output_sink(
-    name: &str,
-    cfg: &OutputConfig,
-) -> Result<Box<dyn OutputSink>, String> {
+fn build_output_sink(name: &str, cfg: &OutputConfig) -> Result<Box<dyn OutputSink>, String> {
     match cfg.output_type {
         OutputType::Stdout => {
             let fmt = match cfg.format.as_ref() {
@@ -427,12 +423,7 @@ mod tests {
         let mut partial = Vec::new();
         let mut out = Vec::new();
 
-        accumulate_json_lines(
-            b"{\"a\":1}\n{\"b\":2}\n",
-            &mut partial,
-            &mut out,
-            &stats,
-        );
+        accumulate_json_lines(b"{\"a\":1}\n{\"b\":2}\n", &mut partial, &mut out, &stats);
 
         let result = String::from_utf8(out).unwrap();
         assert_eq!(result, "{\"a\":1}\n{\"b\":2}\n");
@@ -667,9 +658,6 @@ output:
             .transform_in
             .lines_total
             .load(Ordering::Relaxed);
-        assert!(
-            lines_in > 0,
-            "expected transform_in > 0, got {lines_in}"
-        );
+        assert!(lines_in > 0, "expected transform_in > 0, got {lines_in}");
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -179,7 +179,12 @@ impl Scanner {
                 b't' | b'f' => {
                     // Boolean — store as string "true" / "false".
                     let start = pos;
-                    while pos < len && line[pos] != b',' && line[pos] != b'}' && line[pos] != b' ' && line[pos] != b'\t' {
+                    while pos < len
+                        && line[pos] != b','
+                        && line[pos] != b'}'
+                        && line[pos] != b' '
+                        && line[pos] != b'\t'
+                    {
                         pos += 1;
                     }
                     if wanted {
@@ -204,7 +209,13 @@ impl Scanner {
                         let c = line[pos];
                         if c == b'.' || c == b'e' || c == b'E' {
                             is_float = true;
-                        } else if c == b',' || c == b'}' || c == b' ' || c == b'\t' || c == b'\n' || c == b'\r' {
+                        } else if c == b','
+                            || c == b'}'
+                            || c == b' '
+                            || c == b'\t'
+                            || c == b'\n'
+                            || c == b'\r'
+                        {
                             break;
                         }
                         pos += 1;
@@ -339,20 +350,32 @@ mod tests {
         let batch = s.scan(input);
         assert_eq!(batch.num_rows(), 3);
 
-        let host = batch.column_by_name("host_str").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let host = batch
+            .column_by_name("host_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert_eq!(host.value(0), "web1");
         assert_eq!(host.value(1), "web2");
         assert_eq!(host.value(2), "web3");
 
-        let status = batch.column_by_name("status_int").unwrap()
-            .as_any().downcast_ref::<Int64Array>().unwrap();
+        let status = batch
+            .column_by_name("status_int")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
         assert_eq!(status.value(0), 200);
         assert_eq!(status.value(1), 404);
         assert_eq!(status.value(2), 200);
 
-        let lat = batch.column_by_name("latency_float").unwrap()
-            .as_any().downcast_ref::<Float64Array>().unwrap();
+        let lat = batch
+            .column_by_name("latency_float")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
         assert!((lat.value(0) - 1.5).abs() < 1e-10);
     }
 
@@ -368,13 +391,21 @@ mod tests {
         assert!(batch.column_by_name("status_int").is_some());
         assert!(batch.column_by_name("status_str").is_some());
 
-        let int_col = batch.column_by_name("status_int").unwrap()
-            .as_any().downcast_ref::<Int64Array>().unwrap();
+        let int_col = batch
+            .column_by_name("status_int")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
         assert_eq!(int_col.value(0), 200);
         assert!(int_col.is_null(1));
 
-        let str_col = batch.column_by_name("status_str").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let str_col = batch
+            .column_by_name("status_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert!(str_col.is_null(0));
         assert_eq!(str_col.value(1), "OK");
     }
@@ -388,13 +419,21 @@ mod tests {
         let batch = s.scan(input);
         assert_eq!(batch.num_rows(), 2);
 
-        let a = batch.column_by_name("a_str").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let a = batch
+            .column_by_name("a_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert_eq!(a.value(0), "hello");
         assert!(a.is_null(1));
 
-        let b = batch.column_by_name("b_str").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let b = batch
+            .column_by_name("b_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert!(b.is_null(0));
         assert_eq!(b.value(1), "world");
     }
@@ -408,8 +447,12 @@ mod tests {
         assert_eq!(batch.num_rows(), 1);
 
         // Nested object stored as string
-        let user = batch.column_by_name("user_str").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let user = batch
+            .column_by_name("user_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         let val = user.value(0);
         assert!(val.contains("alice"));
         assert!(val.starts_with('{'));
@@ -417,12 +460,19 @@ mod tests {
 
     #[test]
     fn test_scan_config_pushdown() {
-        let input = br#"{"a":"1","b":"2","c":"3","d":"4","e":"5","f":"6","g":"7","h":"8","i":"9","j":"10"}
+        let input =
+            br#"{"a":"1","b":"2","c":"3","d":"4","e":"5","f":"6","g":"7","h":"8","i":"9","j":"10"}
 "#;
         let config = ScanConfig {
             wanted_fields: vec![
-                FieldSpec { name: "a".into(), aliases: vec![] },
-                FieldSpec { name: "c".into(), aliases: vec![] },
+                FieldSpec {
+                    name: "a".into(),
+                    aliases: vec![],
+                },
+                FieldSpec {
+                    name: "c".into(),
+                    aliases: vec![],
+                },
             ],
             extract_all: false,
             keep_raw: false,
@@ -444,8 +494,12 @@ mod tests {
         let input = [line.as_slice(), b"\n"].concat();
         let mut s = default_scanner(4);
         let batch = s.scan(&input);
-        let raw = batch.column_by_name("_raw").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let raw = batch
+            .column_by_name("_raw")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert_eq!(raw.value(0), r#"{"msg":"hello"}"#);
     }
 
@@ -478,8 +532,12 @@ mod tests {
         let b2 = s.scan(input);
         assert_eq!(b2.num_rows(), 2);
 
-        let col = b2.column_by_name("x_int").unwrap()
-            .as_any().downcast_ref::<Int64Array>().unwrap();
+        let col = b2
+            .column_by_name("x_int")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
         assert_eq!(col.value(0), 1);
         assert_eq!(col.value(1), 2);
     }
@@ -492,12 +550,20 @@ mod tests {
         let batch = s.scan(input);
         assert_eq!(batch.num_rows(), 1);
 
-        let active = batch.column_by_name("active_str").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let active = batch
+            .column_by_name("active_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert_eq!(active.value(0), "true");
 
-        let deleted = batch.column_by_name("deleted_str").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let deleted = batch
+            .column_by_name("deleted_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         assert_eq!(deleted.value(0), "false");
 
         // "extra" with null — should exist but be null
@@ -513,8 +579,12 @@ mod tests {
 "#;
         let mut s = default_scanner(4);
         let batch = s.scan(input);
-        let col = batch.column_by_name("offset_int").unwrap()
-            .as_any().downcast_ref::<Int64Array>().unwrap();
+        let col = batch
+            .column_by_name("offset_int")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
         assert_eq!(col.value(0), -42);
     }
 
@@ -525,8 +595,12 @@ mod tests {
 "#;
         let mut s = default_scanner(4);
         let batch = s.scan(input);
-        let col = batch.column_by_name("msg_str").unwrap()
-            .as_any().downcast_ref::<StringArray>().unwrap();
+        let col = batch
+            .column_by_name("msg_str")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
         // Escapes are preserved (not decoded) — this is by design for speed.
         assert!(col.value(0).contains("\\\"world\\\""));
     }

--- a/src/tail.rs
+++ b/src/tail.rs
@@ -28,6 +28,7 @@ pub struct FileIdentity {
 
 /// State tracked per tailed file.
 struct TailedFile {
+    #[allow(dead_code)]
     path: PathBuf,
     identity: FileIdentity,
     file: File,
@@ -40,18 +41,11 @@ struct TailedFile {
 pub enum TailEvent {
     /// New data available. The Vec is raw bytes read from the file.
     /// NOT necessarily aligned on line boundaries — the pipeline handles that.
-    Data {
-        path: PathBuf,
-        bytes: Vec<u8>,
-    },
+    Data { path: PathBuf, bytes: Vec<u8> },
     /// A file was rotated (old file at path replaced by new file).
-    Rotated {
-        path: PathBuf,
-    },
+    Rotated { path: PathBuf },
     /// A file was truncated (copytruncate rotation).
-    Truncated {
-        path: PathBuf,
-    },
+    Truncated { path: PathBuf },
 }
 
 /// Configuration for the file tailer.
@@ -96,12 +90,6 @@ fn compute_fingerprint(file: &mut File, max_bytes: usize) -> io::Result<u64> {
     Ok(xxhash_rust::xxh64::xxh64(&buf[..n], 0))
 }
 
-/// Get the (device, inode) for a path.
-fn get_dev_ino(path: &Path) -> io::Result<(u64, u64)> {
-    let meta = fs::metadata(path)?;
-    Ok((meta.dev(), meta.ino()))
-}
-
 /// Build a FileIdentity for a path.
 fn identify_file(path: &Path, fingerprint_bytes: usize) -> io::Result<FileIdentity> {
     let meta = fs::metadata(path)?;
@@ -139,20 +127,20 @@ impl FileTailer {
         let mut watcher = notify::recommended_watcher(move |res| {
             let _ = tx.send(res);
         })
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        .map_err(io::Error::other)?;
 
         // Watch the parent directories (not the files themselves).
         // This catches file creation, rename, and deletion events
         // that inotify/kqueue on the file itself would miss.
         let mut watched_dirs = std::collections::HashSet::new();
         for path in paths {
-            if let Some(parent) = path.parent() {
-                if watched_dirs.insert(parent.to_path_buf()) {
-                    use notify::Watcher;
-                    watcher
-                        .watch(parent, notify::RecursiveMode::NonRecursive)
-                        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-                }
+            if let Some(parent) = path.parent()
+                && watched_dirs.insert(parent.to_path_buf())
+            {
+                use notify::Watcher;
+                watcher
+                    .watch(parent, notify::RecursiveMode::NonRecursive)
+                    .map_err(io::Error::other)?;
             }
         }
 
@@ -168,10 +156,10 @@ impl FileTailer {
 
         // Open existing files.
         for path in paths {
-            if path.exists() {
-                if let Err(e) = tailer.open_file(path) {
-                    eprintln!("warn: could not open {}: {e}", path.display());
-                }
+            if path.exists()
+                && let Err(e) = tailer.open_file(path)
+            {
+                eprintln!("warn: could not open {}: {e}", path.display());
             }
         }
 
@@ -222,8 +210,7 @@ impl FileTailer {
 
         // Periodic full poll as safety net.
         let poll_interval = Duration::from_millis(self.config.poll_interval_ms);
-        let should_poll = something_changed
-            || self.last_poll.elapsed() >= poll_interval;
+        let should_poll = something_changed || self.last_poll.elapsed() >= poll_interval;
 
         if !should_poll {
             return Ok(events);
@@ -248,9 +235,7 @@ impl FileTailer {
                     // Identity changed — file was rotated or replaced.
                     // Check if it's inode reuse with different content (fingerprint mismatch)
                     // or a genuine rotation.
-                    events.push(TailEvent::Rotated {
-                        path: path.clone(),
-                    });
+                    events.push(TailEvent::Rotated { path: path.clone() });
 
                     // Re-open from the beginning.
                     let _ = self.files.remove(path);
@@ -394,10 +379,7 @@ mod tests {
 
         // Append more data.
         {
-            let mut f = fs::OpenOptions::new()
-                .append(true)
-                .open(&log_path)
-                .unwrap();
+            let mut f = fs::OpenOptions::new().append(true).open(&log_path).unwrap();
             writeln!(f, "line 3").unwrap();
             writeln!(f, "line 4").unwrap();
         }
@@ -566,10 +548,7 @@ mod tests {
 
         // Append new data.
         {
-            let mut f = fs::OpenOptions::new()
-                .append(true)
-                .open(&log_path)
-                .unwrap();
+            let mut f = fs::OpenOptions::new().append(true).open(&log_path).unwrap();
             writeln!(f, "new line 1").unwrap();
         }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -4,8 +4,8 @@
 // execution plan, and executes it against Arrow RecordBatches from the scanner.
 
 use std::any::Any;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -43,8 +43,8 @@ impl QueryAnalyzer {
     /// Parse the SQL and extract metadata about column usage.
     pub fn new(sql: &str) -> Result<Self, String> {
         let dialect = GenericDialect {};
-        let statements = Parser::parse_sql(&dialect, sql)
-            .map_err(|e| format!("SQL parse error: {e}"))?;
+        let statements =
+            Parser::parse_sql(&dialect, sql).map_err(|e| format!("SQL parse error: {e}"))?;
 
         if statements.len() != 1 {
             return Err("Expected exactly one SQL statement".to_string());
@@ -132,10 +132,10 @@ impl QueryAnalyzer {
 /// the raw JSON field name. E.g., `level_str` → `level`, `duration_ms_int` → `duration_ms`.
 fn strip_type_suffix(name: &str) -> String {
     for suffix in &["_str", "_int", "_float"] {
-        if let Some(base) = name.strip_suffix(suffix) {
-            if !base.is_empty() {
-                return base.to_string();
-            }
+        if let Some(base) = name.strip_suffix(suffix)
+            && !base.is_empty()
+        {
+            return base.to_string();
         }
     }
     name.to_string()
@@ -170,25 +170,26 @@ fn collect_column_refs(expr: &SqlExpr, cols: &mut HashSet<String>) {
         SqlExpr::UnaryOp { expr, .. } => {
             collect_column_refs(expr, cols);
         }
-        SqlExpr::Function(func) => {
-            match &func.args {
-                sqlast::FunctionArguments::List(arg_list) => {
-                    for arg in &arg_list.args {
-                        match arg {
-                            sqlast::FunctionArg::Unnamed(
-                                sqlast::FunctionArgExpr::Expr(e),
-                            ) => collect_column_refs(e, cols),
-                            sqlast::FunctionArg::Named { arg: sqlast::FunctionArgExpr::Expr(e), .. } => {
-                                collect_column_refs(e, cols);
-                            }
-                            _ => {}
+        SqlExpr::Function(func) => match &func.args {
+            sqlast::FunctionArguments::List(arg_list) => {
+                for arg in &arg_list.args {
+                    match arg {
+                        sqlast::FunctionArg::Unnamed(sqlast::FunctionArgExpr::Expr(e)) => {
+                            collect_column_refs(e, cols)
                         }
+                        sqlast::FunctionArg::Named {
+                            arg: sqlast::FunctionArgExpr::Expr(e),
+                            ..
+                        } => {
+                            collect_column_refs(e, cols);
+                        }
+                        _ => {}
                     }
                 }
-                sqlast::FunctionArguments::None => {}
-                sqlast::FunctionArguments::Subquery(_) => {}
             }
-        }
+            sqlast::FunctionArguments::None => {}
+            sqlast::FunctionArguments::Subquery(_) => {}
+        },
         SqlExpr::Nested(inner) => {
             collect_column_refs(inner, cols);
         }
@@ -289,7 +290,8 @@ impl ScalarUDFImpl for IntCastUdf {
             }
             ColumnarValue::Scalar(scalar) => {
                 // Convert scalar to single-element array, cast, convert back.
-                let array = scalar.to_array()
+                let array = scalar
+                    .to_array()
                     .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
                 let result = arrow::compute::cast(&array, &DataType::Int64)
                     .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
@@ -343,7 +345,8 @@ impl ScalarUDFImpl for FloatCastUdf {
                 Ok(ColumnarValue::Array(result))
             }
             ColumnarValue::Scalar(scalar) => {
-                let array = scalar.to_array()
+                let array = scalar
+                    .to_array()
                     .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
                 let result = arrow::compute::cast(&array, &DataType::Float64)
                     .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
@@ -564,8 +567,7 @@ mod tests {
     #[test]
     fn test_except() {
         let batch = make_test_batch();
-        let mut transform =
-            SqlTransform::new("SELECT * EXCEPT (status_str) FROM logs").unwrap();
+        let mut transform = SqlTransform::new("SELECT * EXCEPT (status_str) FROM logs").unwrap();
         let result = transform.execute(batch).unwrap();
         assert_eq!(result.num_rows(), 4);
         // status_str should be removed.
@@ -578,8 +580,7 @@ mod tests {
     #[test]
     fn test_computed() {
         let batch = make_test_batch();
-        let mut transform =
-            SqlTransform::new("SELECT *, 'prod' AS env FROM logs").unwrap();
+        let mut transform = SqlTransform::new("SELECT *, 'prod' AS env FROM logs").unwrap();
         let result = transform.execute(batch).unwrap();
         assert_eq!(result.num_rows(), 4);
         let env = result
@@ -658,9 +659,11 @@ mod tests {
 
     #[test]
     fn test_float_udf() {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("val_str", DataType::Utf8, true),
-        ]));
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "val_str",
+            DataType::Utf8,
+            true,
+        )]));
         let vals: ArrayRef = Arc::new(StringArray::from(vec![
             Some("3.14"),
             Some("not_float"),
@@ -668,8 +671,7 @@ mod tests {
         ]));
         let batch = RecordBatch::try_new(schema, vec![vals]).unwrap();
 
-        let mut transform =
-            SqlTransform::new("SELECT float(val_str) AS val_f FROM logs").unwrap();
+        let mut transform = SqlTransform::new("SELECT float(val_str) AS val_f FROM logs").unwrap();
         let result = transform.execute(batch).unwrap();
         let col = result
             .column_by_name("val_f")
@@ -702,8 +704,7 @@ mod tests {
 
     #[test]
     fn test_query_analyzer_except() {
-        let analyzer =
-            QueryAnalyzer::new("SELECT * EXCEPT (stack_trace_str) FROM logs").unwrap();
+        let analyzer = QueryAnalyzer::new("SELECT * EXCEPT (stack_trace_str) FROM logs").unwrap();
         assert!(analyzer.uses_select_star);
         assert_eq!(analyzer.except_fields, vec!["stack_trace_str"]);
     }


### PR DESCRIPTION
## Summary
- Run `cargo fmt` across 11 source files to fix all formatting inconsistencies
- Fix all 22 clippy warnings: collapsible ifs, `io::Error::other()` shorthand, redundant closures, `Default` impl for `BatchEncoder`, dead code removal (`get_dev_ino`), unused variable prefix, `is_ascii_digit()`, identical if/else collapse, and overlapping match arm annotation
- Zero logic changes — pure lint/format cleanup

## Verification
- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — zero warnings
- `cargo test` — all 87 tests pass

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes with no errors
- [x] All 87 unit tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)