### PR TITLE
Fix CI: sccache not found in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- CI has been failing because `.cargo/config.toml` sets `rustc-wrapper = "sccache"` which isn't installed on the GitHub Actions runner
- Sets `RUSTC_WRAPPER=""` as a job-level env var to override the local config
- Swatinem/rust-cache already handles CI-side caching, so sccache isn't needed there

## Test plan
- [ ] CI passes (format, clippy, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)