### PR TITLE
Add OpenTelemetry metrics with OTLP push export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,7 +673,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "regex",
  "sqlparser",
  "tempfile",
@@ -753,7 +759,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "tempfile",
  "url",
 ]
@@ -811,7 +817,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "rand",
+ "rand 0.8.5",
  "regex",
  "unicode-segmentation",
  "uuid",
@@ -1353,6 +1359,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1398,50 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1544,6 +1617,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1692,8 @@ version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1757,8 +1848,12 @@ dependencies = [
  "logfwd-output",
  "logfwd-transform",
  "memchr",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "tempfile",
  "tiny_http",
+ "tokio",
 ]
 
 [[package]]
@@ -1789,6 +1884,7 @@ dependencies = [
  "crossbeam-channel",
  "memchr",
  "notify",
+ "opentelemetry",
  "serde",
  "tempfile",
  "tiny_http",
@@ -2004,6 +2100,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,10 +2237,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -2150,6 +2346,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,8 +2406,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2198,7 +2427,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2208,6 +2447,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2296,6 +2544,40 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "ring"
@@ -2457,6 +2739,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2521,6 +2815,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2578,6 +2882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2912,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2655,8 +2988,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2669,6 +3006,94 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2700,6 +3125,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
@@ -2823,6 +3254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,6 +3297,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
 
 [workspace.dependencies]
 arrow = { version = "54", default-features = false }
+opentelemetry = "0.31"
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.31", features = ["http-proto", "reqwest-client"] }
 serde = { version = "1", features = ["derive"] }
 
 [profile.release]

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -139,6 +139,11 @@ pub struct PipelineConfig {
 pub struct ServerConfig {
     pub diagnostics: Option<String>,
     pub log_level: Option<String>,
+    /// OTLP endpoint for metrics push (e.g. "http://localhost:4318").
+    /// If not set, OTLP push is disabled; /metrics scrape still works.
+    pub metrics_endpoint: Option<String>,
+    /// OTLP push interval in seconds. Default: 60.
+    pub metrics_interval_secs: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/crates/logfwd-core/Cargo.toml
+++ b/crates/logfwd-core/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 arrow = { workspace = true }
 crossbeam-channel = "0.5"
+opentelemetry = { workspace = true }
 memchr = "2"
 notify = "7"
 serde = { workspace = true }

--- a/crates/logfwd-core/src/diagnostics.rs
+++ b/crates/logfwd-core/src/diagnostics.rs
@@ -3,36 +3,59 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::{Counter, Meter};
+
 // ---------------------------------------------------------------------------
 // Atomic stats structures (lock-free, hot-path friendly)
 // ---------------------------------------------------------------------------
 
-/// Stats for one component. Lock-free, readable from any thread.
+/// Stats for one component. Dual-write: atomics for /metrics + /api/pipelines,
+/// OTel counters for OTLP push. Both are lock-free on the hot path.
 pub struct ComponentStats {
     pub lines_total: AtomicU64,
     pub bytes_total: AtomicU64,
     pub errors_total: AtomicU64,
+    // OTel counters (for OTLP push)
+    otel_lines: Counter<u64>,
+    otel_bytes: Counter<u64>,
+    otel_errors: Counter<u64>,
+    otel_attrs: Vec<KeyValue>,
 }
 
 impl ComponentStats {
-    pub fn new() -> Self {
+    /// Create stats with OTel counters. `prefix` is e.g. "logfwd_input" or "logfwd_output".
+    pub fn with_meter(meter: &Meter, prefix: &str, attrs: Vec<KeyValue>) -> Self {
         Self {
             lines_total: AtomicU64::new(0),
             bytes_total: AtomicU64::new(0),
             errors_total: AtomicU64::new(0),
+            otel_lines: meter.u64_counter(format!("{prefix}_lines")).build(),
+            otel_bytes: meter.u64_counter(format!("{prefix}_bytes")).build(),
+            otel_errors: meter.u64_counter(format!("{prefix}_errors")).build(),
+            otel_attrs: attrs,
         }
+    }
+
+    /// Create stats without OTel (for tests and standalone use).
+    pub fn new() -> Self {
+        let noop = opentelemetry::global::meter("noop");
+        Self::with_meter(&noop, "noop", vec![])
     }
 
     pub fn inc_lines(&self, n: u64) {
         self.lines_total.fetch_add(n, Ordering::Relaxed);
+        self.otel_lines.add(n, &self.otel_attrs);
     }
 
     pub fn inc_bytes(&self, n: u64) {
         self.bytes_total.fetch_add(n, Ordering::Relaxed);
+        self.otel_bytes.add(n, &self.otel_attrs);
     }
 
     pub fn inc_errors(&self) {
         self.errors_total.fetch_add(1, Ordering::Relaxed);
+        self.otel_errors.add(1, &self.otel_attrs);
     }
 
     fn lines(&self) -> u64 {
@@ -58,7 +81,8 @@ impl Default for ComponentStats {
 // Pipeline-level metrics (shared between pipeline thread and diagnostics)
 // ---------------------------------------------------------------------------
 
-/// Stats for a full pipeline.
+/// Stats for a full pipeline. Dual-write: atomics for local endpoints,
+/// OTel counters for OTLP push.
 pub struct PipelineMetrics {
     pub name: String,
     /// (name, type, stats)
@@ -70,7 +94,7 @@ pub struct PipelineMetrics {
     /// (name, type, stats)
     pub outputs: Vec<(String, String, Arc<ComponentStats>)>,
     pub backpressure_stalls: AtomicU64,
-    // Batch-level metrics
+    // Batch-level metrics (atomics for local, OTel for push)
     pub batches_total: AtomicU64,
     pub batch_rows_total: AtomicU64,
     pub flush_by_size: AtomicU64,
@@ -79,17 +103,38 @@ pub struct PipelineMetrics {
     pub scan_nanos_total: AtomicU64,
     pub transform_nanos_total: AtomicU64,
     pub output_nanos_total: AtomicU64,
+    // OTel counters (for OTLP push)
+    meter: Meter,
+    otel_attrs: Vec<KeyValue>,
+    otel_transform_errors: Counter<u64>,
+    otel_batches: Counter<u64>,
+    otel_batch_rows: Counter<u64>,
+    otel_flush_by_size: Counter<u64>,
+    otel_flush_by_timeout: Counter<u64>,
+    otel_scan_nanos: Counter<u64>,
+    otel_transform_nanos: Counter<u64>,
+    otel_output_nanos: Counter<u64>,
+    otel_backpressure_stalls: Counter<u64>,
 }
 
 impl PipelineMetrics {
-    pub fn new(name: impl Into<String>, transform_sql: impl Into<String>) -> Self {
+    pub fn new(name: impl Into<String>, transform_sql: impl Into<String>, meter: &Meter) -> Self {
+        let name = name.into();
+        let attrs = vec![KeyValue::new("pipeline", name.clone())];
         Self {
-            name: name.into(),
-            inputs: Vec::new(),
             transform_sql: transform_sql.into(),
-            transform_in: Arc::new(ComponentStats::new()),
-            transform_out: Arc::new(ComponentStats::new()),
+            transform_in: Arc::new(ComponentStats::with_meter(
+                meter,
+                "logfwd_transform_in",
+                attrs.clone(),
+            )),
+            transform_out: Arc::new(ComponentStats::with_meter(
+                meter,
+                "logfwd_transform_out",
+                attrs.clone(),
+            )),
             transform_errors: AtomicU64::new(0),
+            inputs: Vec::new(),
             outputs: Vec::new(),
             backpressure_stalls: AtomicU64::new(0),
             batches_total: AtomicU64::new(0),
@@ -99,6 +144,18 @@ impl PipelineMetrics {
             scan_nanos_total: AtomicU64::new(0),
             transform_nanos_total: AtomicU64::new(0),
             output_nanos_total: AtomicU64::new(0),
+            otel_transform_errors: meter.u64_counter("logfwd_transform_errors").build(),
+            otel_batches: meter.u64_counter("logfwd_batches").build(),
+            otel_batch_rows: meter.u64_counter("logfwd_batch_rows").build(),
+            otel_flush_by_size: meter.u64_counter("logfwd_flush_by_size").build(),
+            otel_flush_by_timeout: meter.u64_counter("logfwd_flush_by_timeout").build(),
+            otel_scan_nanos: meter.u64_counter("logfwd_stage_scan_nanos").build(),
+            otel_transform_nanos: meter.u64_counter("logfwd_stage_transform_nanos").build(),
+            otel_output_nanos: meter.u64_counter("logfwd_stage_output_nanos").build(),
+            otel_backpressure_stalls: meter.u64_counter("logfwd_backpressure_stalls").build(),
+            meter: meter.clone(),
+            otel_attrs: attrs,
+            name,
         }
     }
 
@@ -107,9 +164,18 @@ impl PipelineMetrics {
         name: impl Into<String>,
         typ: impl Into<String>,
     ) -> Arc<ComponentStats> {
-        let stats = Arc::new(ComponentStats::new());
-        self.inputs
-            .push((name.into(), typ.into(), Arc::clone(&stats)));
+        let name = name.into();
+        let typ = typ.into();
+        let attrs = vec![
+            KeyValue::new("pipeline", self.name.clone()),
+            KeyValue::new("input", name.clone()),
+        ];
+        let stats = Arc::new(ComponentStats::with_meter(
+            &self.meter,
+            "logfwd_input",
+            attrs,
+        ));
+        self.inputs.push((name, typ, Arc::clone(&stats)));
         stats
     }
 
@@ -118,18 +184,65 @@ impl PipelineMetrics {
         name: impl Into<String>,
         typ: impl Into<String>,
     ) -> Arc<ComponentStats> {
-        let stats = Arc::new(ComponentStats::new());
-        self.outputs
-            .push((name.into(), typ.into(), Arc::clone(&stats)));
+        let name = name.into();
+        let typ = typ.into();
+        let attrs = vec![
+            KeyValue::new("pipeline", self.name.clone()),
+            KeyValue::new("output", name.clone()),
+        ];
+        let stats = Arc::new(ComponentStats::with_meter(
+            &self.meter,
+            "logfwd_output",
+            attrs,
+        ));
+        self.outputs.push((name, typ, Arc::clone(&stats)));
         stats
     }
 
-    /// Increment error counter on all outputs (used when a FanOut or single
-    /// sink fails — we don't know which one, so count it on all).
+    /// Increment error counter on all outputs.
     pub fn output_error(&self) {
         for (_, _, stats) in &self.outputs {
             stats.inc_errors();
         }
+    }
+
+    // -- Helper methods for dual-write (called from pipeline hot loop) --------
+
+    pub fn inc_transform_error(&self) {
+        self.transform_errors.fetch_add(1, Ordering::Relaxed);
+        self.otel_transform_errors.add(1, &self.otel_attrs);
+    }
+
+    pub fn inc_flush_by_size(&self) {
+        self.flush_by_size.fetch_add(1, Ordering::Relaxed);
+        self.otel_flush_by_size.add(1, &self.otel_attrs);
+    }
+
+    pub fn inc_flush_by_timeout(&self) {
+        self.flush_by_timeout.fetch_add(1, Ordering::Relaxed);
+        self.otel_flush_by_timeout.add(1, &self.otel_attrs);
+    }
+
+    pub fn record_batch(&self, rows: u64, scan_ns: u64, transform_ns: u64, output_ns: u64) {
+        self.batches_total.fetch_add(1, Ordering::Relaxed);
+        self.batch_rows_total.fetch_add(rows, Ordering::Relaxed);
+        self.scan_nanos_total.fetch_add(scan_ns, Ordering::Relaxed);
+        self.transform_nanos_total
+            .fetch_add(transform_ns, Ordering::Relaxed);
+        self.output_nanos_total
+            .fetch_add(output_ns, Ordering::Relaxed);
+
+        self.otel_batches.add(1, &self.otel_attrs);
+        self.otel_batch_rows.add(rows, &self.otel_attrs);
+        self.otel_scan_nanos.add(scan_ns, &self.otel_attrs);
+        self.otel_transform_nanos
+            .add(transform_ns, &self.otel_attrs);
+        self.otel_output_nanos.add(output_ns, &self.otel_attrs);
+    }
+
+    pub fn inc_backpressure_stall(&self) {
+        self.backpressure_stalls.fetch_add(1, Ordering::Relaxed);
+        self.otel_backpressure_stalls.add(1, &self.otel_attrs);
     }
 }
 
@@ -546,7 +659,12 @@ mod tests {
 
     /// Build a server with one pipeline pre-populated with known counter values.
     fn server_with_test_pipeline(port: u16) -> DiagnosticsServer {
-        let mut pm = PipelineMetrics::new("default", "SELECT * FROM logs WHERE level != 'DEBUG'");
+        let meter = opentelemetry::global::meter("test");
+        let mut pm = PipelineMetrics::new(
+            "default",
+            "SELECT * FROM logs WHERE level != 'DEBUG'",
+            &meter,
+        );
 
         let inp = pm.add_input("pod_logs", "file");
         inp.inc_lines(1000);

--- a/crates/logfwd/Cargo.toml
+++ b/crates/logfwd/Cargo.toml
@@ -13,7 +13,11 @@ logfwd-transform = { path = "../logfwd-transform" }
 logfwd-output = { path = "../logfwd-output" }
 dhat = { version = "0.3", optional = true }
 memchr = "2"
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
 tiny_http = "0.12"
+tokio = { version = "1", features = ["rt-multi-thread", "time"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry_otlp::WithExportConfig;
+
 fn main() -> io::Result<()> {
     #[cfg(feature = "dhat-heap")]
     let _profiler = dhat::Profiler::new_heap();
@@ -177,13 +180,16 @@ fn run_blackhole(addr: &str) -> io::Result<()> {
 fn run_pipelines(config: logfwd_config::Config, dry_run: bool) -> io::Result<()> {
     use logfwd::pipeline::Pipeline;
     use logfwd_core::diagnostics::DiagnosticsServer;
-
     let shutdown = Arc::new(AtomicBool::new(false));
+
+    // Initialize OTel metrics.
+    let meter_provider = build_meter_provider(&config)?;
+    let meter = meter_provider.meter("logfwd");
 
     // Build pipelines.
     let mut pipelines = Vec::new();
     for (name, pipe_cfg) in &config.pipelines {
-        let pipeline = Pipeline::from_config(name, pipe_cfg).map_err(io::Error::other)?;
+        let pipeline = Pipeline::from_config(name, pipe_cfg, &meter).map_err(io::Error::other)?;
         eprintln!("  pipeline '{}' ready", name);
         pipelines.push(pipeline);
     }
@@ -227,7 +233,58 @@ fn run_pipelines(config: logfwd_config::Config, dry_run: bool) -> io::Result<()>
         let _ = h.join();
     }
 
+    // Flush any pending OTLP exports.
+    if let Err(e) = meter_provider.shutdown() {
+        eprintln!("warning: meter provider shutdown: {e}");
+    }
+
     Ok(())
+}
+
+/// Build an OTel MeterProvider. If `metrics_endpoint` is configured, adds a
+/// PeriodicReader that pushes metrics via OTLP HTTP. Otherwise returns a
+/// no-op provider (OTel counters still work, just nobody reads them).
+fn build_meter_provider(
+    config: &logfwd_config::Config,
+) -> io::Result<opentelemetry_sdk::metrics::SdkMeterProvider> {
+    use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+    if let Some(ref endpoint) = config.server.metrics_endpoint {
+        let interval_secs = config.server.metrics_interval_secs.unwrap_or(60);
+
+        // Create a tokio runtime for the periodic OTLP export.
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_time()
+            .enable_io()
+            .build()
+            .map_err(|e| io::Error::other(format!("tokio runtime: {e}")))?;
+
+        // Build OTLP exporter + periodic reader inside the runtime context.
+        let _guard = rt.enter();
+
+        let otlp_exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_endpoint(endpoint)
+            .build()
+            .map_err(|e| io::Error::other(format!("OTLP metric exporter: {e}")))?;
+
+        let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(otlp_exporter)
+            .with_interval(std::time::Duration::from_secs(interval_secs))
+            .build();
+
+        eprintln!("  metrics OTLP push: {endpoint} (every {interval_secs}s)");
+
+        // Leak the runtime so it lives for the process lifetime.
+        // The single worker thread is lightweight and we need it alive
+        // for the PeriodicReader's background export task.
+        std::mem::forget(rt);
+
+        Ok(SdkMeterProvider::builder().with_reader(reader).build())
+    } else {
+        // No OTLP endpoint — OTel counters still work (dual-write to atomics).
+        Ok(SdkMeterProvider::builder().build())
+    }
 }
 
 fn generate_json_log_file(num_lines: usize, output: &str) -> io::Result<()> {

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -9,6 +9,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use opentelemetry::metrics::Meter;
+
 use logfwd_config::{Format, InputConfig, InputType, PipelineConfig};
 use logfwd_core::diagnostics::{ComponentStats, PipelineMetrics};
 use logfwd_core::format::{CriParser, FormatParser, JsonParser, RawParser};
@@ -52,13 +54,13 @@ pub struct Pipeline {
 
 impl Pipeline {
     /// Construct a pipeline from parsed YAML config.
-    pub fn from_config(name: &str, config: &PipelineConfig) -> Result<Self, String> {
+    pub fn from_config(name: &str, config: &PipelineConfig, meter: &Meter) -> Result<Self, String> {
         let transform_sql = config.transform.as_deref().unwrap_or("SELECT * FROM logs");
         let transform = SqlTransform::new(transform_sql)?;
         let scan_config = transform.scan_config();
         let scanner = Scanner::new(scan_config, 8192);
 
-        let mut metrics = PipelineMetrics::new(name, transform_sql);
+        let mut metrics = PipelineMetrics::new(name, transform_sql, meter);
 
         // Build inputs (file only for now).
         let mut inputs = Vec::new();
@@ -151,11 +153,9 @@ impl Pipeline {
             if size_ready || time_ready {
                 // Track flush reason.
                 if size_ready {
-                    self.metrics.flush_by_size.fetch_add(1, Ordering::Relaxed);
+                    self.metrics.inc_flush_by_size();
                 } else {
-                    self.metrics
-                        .flush_by_timeout
-                        .fetch_add(1, Ordering::Relaxed);
+                    self.metrics.inc_flush_by_timeout();
                 }
 
                 let mut combined = Vec::new();
@@ -180,9 +180,7 @@ impl Pipeline {
                         let result = match self.transform.execute(batch) {
                             Ok(r) => r,
                             Err(e) => {
-                                self.metrics
-                                    .transform_errors
-                                    .fetch_add(1, Ordering::Relaxed);
+                                self.metrics.inc_transform_error();
                                 return Err(io::Error::other(format!("transform error: {e}")));
                             }
                         };
@@ -205,19 +203,12 @@ impl Pipeline {
                         let output_elapsed = t2.elapsed();
 
                         // Record batch-level metrics.
-                        self.metrics.batches_total.fetch_add(1, Ordering::Relaxed);
-                        self.metrics
-                            .batch_rows_total
-                            .fetch_add(num_rows, Ordering::Relaxed);
-                        self.metrics
-                            .scan_nanos_total
-                            .fetch_add(scan_elapsed.as_nanos() as u64, Ordering::Relaxed);
-                        self.metrics
-                            .transform_nanos_total
-                            .fetch_add(transform_elapsed.as_nanos() as u64, Ordering::Relaxed);
-                        self.metrics
-                            .output_nanos_total
-                            .fetch_add(output_elapsed.as_nanos() as u64, Ordering::Relaxed);
+                        self.metrics.record_batch(
+                            num_rows,
+                            scan_elapsed.as_nanos() as u64,
+                            transform_elapsed.as_nanos() as u64,
+                            output_elapsed.as_nanos() as u64,
+                        );
                     }
                 }
 
@@ -298,6 +289,10 @@ fn now_nanos() -> u64 {
 mod tests {
     use super::*;
     use logfwd_config::{Format, OutputConfig, OutputType};
+
+    fn test_meter() -> Meter {
+        opentelemetry::global::meter("test")
+    }
 
     #[test]
     fn test_build_output_sink_stdout() {
@@ -382,7 +377,7 @@ output:
         );
         let config = logfwd_config::Config::load_str(&yaml).unwrap();
         let pipe_cfg = &config.pipelines["default"];
-        let pipeline = Pipeline::from_config("default", pipe_cfg);
+        let pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter());
         assert!(pipeline.is_ok(), "got: {:?}", pipeline.err());
     }
 
@@ -407,7 +402,7 @@ output:
         );
         let config = logfwd_config::Config::load_str(&yaml).unwrap();
         let pipe_cfg = &config.pipelines["default"];
-        let pipeline = Pipeline::from_config("default", pipe_cfg);
+        let pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter());
         assert!(pipeline.is_ok(), "got: {:?}", pipeline.err());
     }
 
@@ -444,7 +439,7 @@ output:
         );
         let config = logfwd_config::Config::load_str(&yaml).unwrap();
         let pipe_cfg = &config.pipelines["default"];
-        let mut pipeline = Pipeline::from_config("default", pipe_cfg).unwrap();
+        let mut pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter()).unwrap();
 
         // Use a very short batch timeout so the test flushes quickly.
         pipeline.batch_timeout = Duration::from_millis(10);


### PR DESCRIPTION
## Summary

Adds OpenTelemetry SDK metrics alongside the existing hand-rolled atomics, enabling OTLP push export to a collector while preserving the existing Prometheus scrape endpoint.

### Architecture: dual-write

```
Pipeline hot loop
  input.stats.inc_lines(n)
    ├─► AtomicU64 fetch_add  (for /metrics + /api/pipelines — unchanged)
    └─► OTel Counter.add()   (for OTLP push to collector)
```

Every `inc_*` method writes to both. Zero additional locking — both paths use atomics internally.

### New config

```yaml
server:
  diagnostics: 0.0.0.0:9090
  metrics_endpoint: http://otel-collector:4318   # OTLP HTTP push
  metrics_interval_secs: 30                      # default: 60
```

When `metrics_endpoint` is not set, OTLP push is disabled. The /metrics scrape endpoint always works regardless.

### Dependency split
- `opentelemetry` (API only, lightweight) → added to **logfwd-core**
- `opentelemetry_sdk` + `opentelemetry-otlp` (heavier) → added to **binary crate only**

Library crates only depend on the lightweight API. The SDK/exporter cost is paid once in the final binary.

### What's unchanged
- `/metrics` Prometheus scrape endpoint — identical output
- `/api/pipelines` JSON endpoint — identical output
- `/health` endpoint — unchanged
- Dashboard — unchanged
- All existing metric names — unchanged

### What's new for sub-crates
Any crate in the workspace can now `use opentelemetry::metrics::Meter` and create its own counters by accepting a `&Meter` in constructors. The pattern is established — future PRs can add scanner, transform, or output-specific metrics without touching diagnostics.rs.

## Test plan
- [x] `cargo test --workspace` — 102 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: run with `metrics_endpoint` pointing at a local OTLP collector, verify metrics arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)