### PR TITLE
ci: parallelize lint, test, and release check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 jobs:
-  check:
-    name: Lint & Test (Linux)
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: ""
@@ -30,7 +30,6 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      # Install tools from pre-built binaries (not cargo install, which compiles from source).
       - name: Install tools
         run: |
           curl -sSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
@@ -55,11 +54,40 @@ jobs:
       - name: Typos
         uses: crate-ci/typos@v1
 
-      # Tests reuse clippy's compiled artifacts (same dev profile).
+  test-linux:
+    name: Test (Linux)
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Install just
+        run: curl -sSL https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+
       - name: Tests
         run: just test
 
-      # Verify release profile compiles (catches LTO issues, etc.)
+  release-check:
+    name: Release build check
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
       - name: Release check
         run: cargo check --release
 


### PR DESCRIPTION
## Summary

Split the single sequential CI job into 3 parallel jobs to reduce wall time.

**Before:** 1 job runs fmt → clippy → toml → deny → typos → test → release check sequentially.

**After:** 5 jobs run in parallel:
| Job | Steps |
|---|---|
| Lint | fmt, clippy, toml, deny, typos |
| Test (Linux) | cargo test |
| Test (macOS) | cargo test |
| Release build check | cargo check --release |
| Actionlint | workflow validation |

## Test plan

- [ ] All 5 jobs pass
- [ ] Total wall time is reduced (previously ~4-5 min sequential, now ~max of individual jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)