### PR TITLE
fix: Correct AI workflow inputs to match upstream schemas

### DIFF
--- a/.github/workflows/ai-duplicate-issues.yml
+++ b/.github/workflows/ai-duplicate-issues.yml
@@ -2,13 +2,12 @@ name: "AI: Duplicate Issue Detector"
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
 permissions:
   contents: read
   issues: write
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main
-    with:
-      title-prefix: "[duplicate]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/ai-pr-conflict-addresser.yml
+++ b/.github/workflows/ai-pr-conflict-addresser.yml
@@ -2,14 +2,42 @@ name: "AI: Address Merge Conflicts"
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  actions: write
+  contents: read
+  issues: read
+  pull-requests: read
+concurrency:
+  group: merge-conflict-addresser-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
-  run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-conflict-addresser.lock.yml@main
-    with:
-      title-prefix: "[merge-conflict]"
-    secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+  detect-conflicted-prs:
+    runs-on: ubuntu-latest
+    outputs:
+      prs: ${{ steps.detect.outputs.prs }}
+      count: ${{ steps.detect.outputs.count }}
+    steps:
+      - name: Detect open PRs with merge conflicts
+        id: detect
+        uses: elastic/ai-github-actions/.github/actions/get-prs-with-merge-conflicts@46127f22f5181c27e5cdb55beefedae0877cc196
+        with:
+          github-token: ${{ github.token }}
+          settle-seconds: "60"
+  dispatch-conflict-fixers:
+    needs: detect-conflicted-prs
+    if: needs.detect-conflicted-prs.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        pr: ${{ fromJson(needs.detect-conflicted-prs.outputs.prs) }}
+    steps:
+      - name: Dispatch conflict resolution for PR #${{ matrix.pr.number }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run ai-pr-conflict-fix.yml \
+            --repo "${{ github.repository }}" \
+            --field pr-number="${{ matrix.pr.number }}"

--- a/.github/workflows/ai-pr-conflict-fix.yml
+++ b/.github/workflows/ai-pr-conflict-fix.yml
@@ -1,0 +1,30 @@
+name: "AI: Fix Merge Conflict (single PR)"
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "PR number to resolve merge conflicts for"
+        required: true
+        type: string
+permissions:
+  actions: read
+  contents: write
+  issues: write
+  pull-requests: write
+concurrency:
+  group: address-merge-conflict-${{ inputs.pr-number }}
+  cancel-in-progress: true
+jobs:
+  run:
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr-by-id.lock.yml@main
+    with:
+      target-pr-number: ${{ inputs.pr-number }}
+      prompt: "Resolve merge conflicts with the current base branch."
+      additional-instructions: |
+        Work only on PR #${{ inputs.pr-number }}.
+        If the PR has merge conflicts, resolve them by merging the latest
+        origin/master into the PR branch and push.
+        If there are no merge conflicts anymore, post a short note and
+        make no code changes.
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/ai-pr-review-addresser.yml
+++ b/.github/workflows/ai-pr-review-addresser.yml
@@ -3,14 +3,36 @@ on:
   pull_request_review:
     types: [submitted]
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write
+concurrency:
+  group: pr-address-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
   run:
-    if: github.event.review.state == 'changes_requested'
+    if: >-
+      github.event.review.user.type == 'Bot' &&
+      github.event.pull_request.draft == false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review-addresser.lock.yml@main
     with:
-      title-prefix: "[review-fix]"
+      allowed-bot-users: "coderabbitai[bot],github-actions[bot]"
+      additional-instructions: |
+        Focus on minor and straightforward fixes only:
+        - Typos, naming, formatting
+        - Missing or incorrect types
+        - Simple logic corrections with obvious fixes
+        - Import cleanup or unused variable removal
+        - Documentation or comment improvements
+
+        Do NOT attempt:
+        - Architectural or design changes
+        - Complex logic rewrites
+        - Performance optimizations needing benchmarks
+        - Changes requiring deep domain knowledge
+
+        When in doubt, reply explaining why you're skipping rather than
+        making a potentially incorrect fix.
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -1,7 +1,7 @@
 name: "AI: PR Review"
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   actions: read
   contents: read
@@ -15,6 +15,7 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review.lock.yml@main
     with:
-      title-prefix: "[pr-review]"
+      intensity: aggressive
+      minimum_severity: nitpick
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes workflow validation errors from #120. Several workflows used inputs not defined in the upstream reusable workflows.

| Workflow | Problem | Fix |
|----------|---------|-----|
| `ai-pr-review` | Used `title-prefix` (not a valid input) | Use `intensity` + `minimum_severity`, switch to `pull_request_target` |
| `ai-pr-conflict-addresser` | Used `title-prefix` on conflict addresser | Split into detector + per-PR fixer (matches playground pattern) |
| `ai-pr-review-addresser` | Used `title-prefix`, missing scope guidance | Add `allowed-bot-users`, `additional-instructions` with fix scope |
| `ai-duplicate-issues` | Used `title-prefix` (not a valid input) | Remove `with:` block entirely |

New file: `ai-pr-conflict-fix.yml` — dispatched per-PR by the conflict detector.

All inputs verified against the actual playground repo (`elastic/ai-github-actions-playground`).

## Test plan
- [x] `actionlint` passes on all workflow files
- [ ] Trigger `ai-pr-review` on a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)