### PR TITLE
fix: Run cargo fmt + fix clippy on master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.json
 build
 /actionlint
+.claude/worktrees/
+.worktrees/

--- a/crates/logfwd-core/benches/scanner.rs
+++ b/crates/logfwd-core/benches/scanner.rs
@@ -284,7 +284,13 @@ macro_rules! bench_scenario {
 
             group.bench_function("SIMD scanner", |b| {
                 let mut scanner = SimdScanner::new($config());
-                b.iter(|| black_box(scanner.scan(black_box(&data)).expect("bench: scan should not fail")))
+                b.iter(|| {
+                    black_box(
+                        scanner
+                            .scan(black_box(&data))
+                            .expect("bench: scan should not fail"),
+                    )
+                })
             });
 
             group.bench_function("sonic-rs DOM", |b| {

--- a/crates/logfwd-core/src/chunk_classify.rs
+++ b/crates/logfwd-core/src/chunk_classify.rs
@@ -778,8 +778,7 @@ mod tests {
             let expected_bs = scalar_mask(&data, b'\\');
 
             // SSE2 (always available on x86_64)
-            let (q_sse2, bs_sse2) =
-                unsafe { find_quotes_and_backslashes_sse2(&data) };
+            let (q_sse2, bs_sse2) = unsafe { find_quotes_and_backslashes_sse2(&data) };
             assert_eq!(
                 q_sse2, expected_q,
                 "SSE2 quote mismatch at positions {positions:?}"
@@ -791,8 +790,7 @@ mod tests {
 
             // AVX2 (skip at runtime if not available)
             if is_x86_feature_detected!("avx2") {
-                let (q_avx2, bs_avx2) =
-                    unsafe { find_quotes_and_backslashes_avx2(&data) };
+                let (q_avx2, bs_avx2) = unsafe { find_quotes_and_backslashes_avx2(&data) };
                 assert_eq!(
                     q_avx2, expected_q,
                     "AVX2 quote mismatch at positions {positions:?}"
@@ -837,14 +835,12 @@ mod tests {
             let expected_q = scalar_mask(&data, b'"');
             let expected_bs = scalar_mask(&data, b'\\');
 
-            let (q_sse2, bs_sse2) =
-                unsafe { find_quotes_and_backslashes_sse2(&data) };
+            let (q_sse2, bs_sse2) = unsafe { find_quotes_and_backslashes_sse2(&data) };
             assert_eq!(q_sse2, expected_q);
             assert_eq!(bs_sse2, expected_bs);
 
             if is_x86_feature_detected!("avx2") {
-                let (q_avx2, bs_avx2) =
-                    unsafe { find_quotes_and_backslashes_avx2(&data) };
+                let (q_avx2, bs_avx2) = unsafe { find_quotes_and_backslashes_avx2(&data) };
                 assert_eq!(q_avx2, expected_q);
                 assert_eq!(bs_avx2, expected_bs);
             }
@@ -861,7 +857,11 @@ mod tests {
 
                 let data = block_with(&[pos], b'\\');
                 let (_, bs) = super::super::find_quotes_and_backslashes(&data);
-                assert_eq!(bs, 1u64 << pos, "dispatcher backslash mismatch at pos {pos}");
+                assert_eq!(
+                    bs,
+                    1u64 << pos,
+                    "dispatcher backslash mismatch at pos {pos}"
+                );
             }
         }
     }
@@ -914,11 +914,19 @@ mod tests {
             for pos in 0..64usize {
                 let data = block_with(&[pos], b'"');
                 let (q, _) = super::super::find_quotes_and_backslashes(&data);
-                assert_eq!(q, 1u64 << pos, "NEON dispatcher quote mismatch at pos {pos}");
+                assert_eq!(
+                    q,
+                    1u64 << pos,
+                    "NEON dispatcher quote mismatch at pos {pos}"
+                );
 
                 let data = block_with(&[pos], b'\\');
                 let (_, bs) = super::super::find_quotes_and_backslashes(&data);
-                assert_eq!(bs, 1u64 << pos, "NEON dispatcher backslash mismatch at pos {pos}");
+                assert_eq!(
+                    bs,
+                    1u64 << pos,
+                    "NEON dispatcher backslash mismatch at pos {pos}"
+                );
             }
         }
     }

--- a/crates/logfwd-core/src/compress.rs
+++ b/crates/logfwd-core/src/compress.rs
@@ -72,10 +72,8 @@ impl ChunkCompressor {
         let compressed_size = self.compressor.compress_to_buffer(raw, &mut cursor)?;
 
         // Compute checksum over the compressed payload.
-        let checksum = xxhash_rust::xxh32::xxh32(
-            &self.out_buf[HEADER_SIZE..HEADER_SIZE + compressed_size],
-            0,
-        );
+        let checksum =
+            xxhash_rust::xxh32::xxh32(&self.out_buf[HEADER_SIZE..HEADER_SIZE + compressed_size], 0);
 
         // Fill in the header.
         self.out_buf[0..2].copy_from_slice(&MAGIC.to_le_bytes());

--- a/crates/logfwd-core/src/diagnostics.rs
+++ b/crates/logfwd-core/src/diagnostics.rs
@@ -321,11 +321,9 @@ impl DiagnosticsServer {
         &self,
         request: tiny_http::Request,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let header = tiny_http::Header::from_bytes(
-            &b"Content-Type"[..],
-            &b"text/html; charset=utf-8"[..],
-        )
-        .map_err(|()| io::Error::other("invalid HTTP header"))?;
+        let header =
+            tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..])
+                .map_err(|()| io::Error::other("invalid HTTP header"))?;
         let resp = tiny_http::Response::from_string(DASHBOARD_HTML).with_header(header);
         request.respond(resp)?;
         Ok(())
@@ -337,9 +335,8 @@ impl DiagnosticsServer {
             r#"{{"status":"ok","uptime_seconds":{},"version":"{}"}}"#,
             uptime, VERSION,
         );
-        let header =
-            tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
-                .map_err(|()| io::Error::other("invalid HTTP header"))?;
+        let header = tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+            .map_err(|()| io::Error::other("invalid HTTP header"))?;
         let resp = tiny_http::Response::from_string(body).with_header(header);
         request.respond(resp)?;
         Ok(())
@@ -429,9 +426,8 @@ impl DiagnosticsServer {
             VERSION,
         );
 
-        let header =
-            tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
-                .map_err(|()| io::Error::other("invalid HTTP header"))?;
+        let header = tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+            .map_err(|()| io::Error::other("invalid HTTP header"))?;
         let resp = tiny_http::Response::from_string(body).with_header(header);
         request.respond(resp)?;
         Ok(())

--- a/crates/logfwd-core/src/scanner.rs
+++ b/crates/logfwd-core/src/scanner.rs
@@ -388,13 +388,17 @@ mod tests {
     }
     #[test]
     fn test_type_conflict() {
-        let batch = default_scanner(4).scan(b"{\"s\":200}\n{\"s\":\"OK\"}\n").unwrap();
+        let batch = default_scanner(4)
+            .scan(b"{\"s\":200}\n{\"s\":\"OK\"}\n")
+            .unwrap();
         assert!(batch.column_by_name("s_int").is_some());
         assert!(batch.column_by_name("s_str").is_some());
     }
     #[test]
     fn test_missing_fields() {
-        let batch = default_scanner(4).scan(b"{\"a\":\"hello\"}\n{\"b\":\"world\"}\n").unwrap();
+        let batch = default_scanner(4)
+            .scan(b"{\"a\":\"hello\"}\n{\"b\":\"world\"}\n")
+            .unwrap();
         assert_eq!(batch.num_rows(), 2);
         let a = batch.column_by_name("a_str").unwrap();
         assert!(!a.is_null(0));
@@ -447,7 +451,9 @@ mod tests {
             keep_raw: true,
             validate_utf8: false,
         };
-        let batch = SimdScanner::new(config).scan(b"{\"msg\":\"hi\"}\n").unwrap();
+        let batch = SimdScanner::new(config)
+            .scan(b"{\"msg\":\"hi\"}\n")
+            .unwrap();
         assert!(batch.column_by_name("_raw").is_some());
     }
     #[test]
@@ -459,7 +465,9 @@ mod tests {
     }
     #[test]
     fn test_bool_null() {
-        let batch = default_scanner(4).scan(b"{\"a\":true,\"b\":false,\"c\":null}\n").unwrap();
+        let batch = default_scanner(4)
+            .scan(b"{\"a\":true,\"b\":false,\"c\":null}\n")
+            .unwrap();
         assert_eq!(
             batch
                 .column_by_name("a_str")
@@ -487,7 +495,9 @@ mod tests {
     }
     #[test]
     fn test_i64_overflow() {
-        let batch = default_scanner(4).scan(b"{\"big\":99999999999999999999}\n").unwrap();
+        let batch = default_scanner(4)
+            .scan(b"{\"big\":99999999999999999999}\n")
+            .unwrap();
         assert!(batch.column_by_name("big_float").is_some());
     }
     #[test]
@@ -575,8 +585,12 @@ mod tests {
     #[test]
     fn test_streaming_reuse() {
         let mut s = StreamingSimdScanner::new(ScanConfig::default());
-        let _ = s.scan(bytes::Bytes::from_static(b"{\"x\":\"a\"}\n")).unwrap();
-        let b = s.scan(bytes::Bytes::from_static(b"{\"x\":\"b\"}\n")).unwrap();
+        let _ = s
+            .scan(bytes::Bytes::from_static(b"{\"x\":\"a\"}\n"))
+            .unwrap();
+        let b = s
+            .scan(bytes::Bytes::from_static(b"{\"x\":\"b\"}\n"))
+            .unwrap();
         assert_eq!(b.num_rows(), 1);
     }
 
@@ -587,7 +601,9 @@ mod tests {
             validate_utf8: true,
             ..ScanConfig::default()
         };
-        let batch = SimdScanner::new(config).scan(b"{\"msg\":\"hello\"}\n").unwrap();
+        let batch = SimdScanner::new(config)
+            .scan(b"{\"msg\":\"hello\"}\n")
+            .unwrap();
         assert_eq!(batch.num_rows(), 1);
     }
 
@@ -620,8 +636,8 @@ mod tests {
             validate_utf8: true,
             ..ScanConfig::default()
         };
-        let result =
-            StreamingSimdScanner::new(config).scan(bytes::Bytes::from_static(b"{\"msg\":\"\xFF\"}\n"));
+        let result = StreamingSimdScanner::new(config)
+            .scan(bytes::Bytes::from_static(b"{\"msg\":\"\xFF\"}\n"));
         assert!(result.is_err());
     }
 }

--- a/crates/logfwd-core/src/tail.rs
+++ b/crates/logfwd-core/src/tail.rs
@@ -247,10 +247,10 @@ impl FileTailer {
 
         for path in new_paths {
             // Watch the parent directory for future events.
-            if let Some(parent) = path.parent() {
-                if let Err(e) = self.watch_dir(parent) {
-                    eprintln!("warn: could not watch {}: {e}", parent.display());
-                }
+            if let Some(parent) = path.parent()
+                && let Err(e) = self.watch_dir(parent)
+            {
+                eprintln!("warn: could not watch {}: {e}", parent.display());
             }
 
             // Open the file (new files from glob discovery always read from the beginning).
@@ -360,10 +360,7 @@ impl FileTailer {
                     }
                     Ok(None) => {}
                     Err(e) => {
-                        eprintln!(
-                            "warn: error draining rotated file {}: {e}",
-                            path.display()
-                        );
+                        eprintln!("warn: error draining rotated file {}: {e}", path.display());
                     }
                 }
 

--- a/crates/logfwd-core/tests/scanner_conformance.rs
+++ b/crates/logfwd-core/tests/scanner_conformance.rs
@@ -311,7 +311,9 @@ fn assert_builders_consistent(input: &[u8]) {
     let mut streaming = StreamingSimdScanner::new(ScanConfig::default());
 
     let sb = storage.scan(input).expect("scan should succeed");
-    let stb = streaming.scan(bytes::Bytes::from(input.to_vec())).expect("scan should succeed");
+    let stb = streaming
+        .scan(bytes::Bytes::from(input.to_vec()))
+        .expect("scan should succeed");
 
     assert_eq!(
         sb.num_rows(),
@@ -596,21 +598,27 @@ fn edge_duplicate_keys_different_types() {
 fn no_panic_truncated_string() {
     let input = b"{\"a\":\"unterminated\n";
     let mut simd = SimdScanner::new(ScanConfig::default());
-    let _batch = simd.scan(input).expect("scan should not fail on malformed JSON");
+    let _batch = simd
+        .scan(input)
+        .expect("scan should not fail on malformed JSON");
 }
 
 #[test]
 fn no_panic_truncated_object() {
     let input = b"{\"a\":1,\"b\"\n";
     let mut simd = SimdScanner::new(ScanConfig::default());
-    let _batch = simd.scan(input).expect("scan should not fail on malformed JSON");
+    let _batch = simd
+        .scan(input)
+        .expect("scan should not fail on malformed JSON");
 }
 
 #[test]
 fn no_panic_garbage() {
     let input = b"not json at all\n";
     let mut simd = SimdScanner::new(ScanConfig::default());
-    let _batch = simd.scan(input).expect("scan should not fail on malformed JSON");
+    let _batch = simd
+        .scan(input)
+        .expect("scan should not fail on malformed JSON");
 }
 
 #[test]
@@ -622,21 +630,27 @@ fn no_panic_random_bytes() {
         .as_bytes()
         .to_vec();
     let mut simd = SimdScanner::new(ScanConfig::default());
-    let _batch = simd.scan(&input).expect("scan should not fail on valid UTF-8");
+    let _batch = simd
+        .scan(&input)
+        .expect("scan should not fail on valid UTF-8");
 }
 
 #[test]
 fn no_panic_only_quotes() {
     let input = b"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"";
     let mut simd = SimdScanner::new(ScanConfig::default());
-    let _batch = simd.scan(input).expect("scan should not fail on malformed JSON");
+    let _batch = simd
+        .scan(input)
+        .expect("scan should not fail on malformed JSON");
 }
 
 #[test]
 fn no_panic_only_backslashes() {
     let input = b"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\";
     let mut simd = SimdScanner::new(ScanConfig::default());
-    let _batch = simd.scan(input).expect("scan should not fail on malformed JSON");
+    let _batch = simd
+        .scan(input)
+        .expect("scan should not fail on malformed JSON");
 }
 
 #[test]
@@ -652,5 +666,7 @@ fn no_panic_deeply_nested() {
     }
     input.push_str("}\n");
     let mut simd = SimdScanner::new(ScanConfig::default());
-    let _batch = simd.scan(input.as_bytes()).expect("scan should not fail on valid UTF-8");
+    let _batch = simd
+        .scan(input.as_bytes())
+        .expect("scan should not fail on valid UTF-8");
 }

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -43,7 +43,9 @@ impl OtlpSink {
         compression: Compression,
     ) -> Self {
         let compressor = match compression {
-            Compression::Zstd => Some(ChunkCompressor::new(1).expect("zstd level 1 is always valid")),
+            Compression::Zstd => {
+                Some(ChunkCompressor::new(1).expect("zstd level 1 is always valid"))
+            }
             _ => None,
         };
         let http_agent = ureq::config::Config::builder()


### PR DESCRIPTION
Master CI is failing due to formatting issues from multiple Copilot PRs that were merged without running `cargo fmt`.

- Runs `cargo fmt` across the entire workspace (8 files)
- Fixes a `collapsible_if` clippy warning in `tail.rs`
- Adds `.claude/worktrees/` and `.worktrees/` to `.gitignore`

All tests pass locally. `cargo clippy -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)