### PR TITLE
fix: glob path support in pipeline + tokio runtime nesting

### DIFF
--- a/crates/logfwd-core/src/input.rs
+++ b/crates/logfwd-core/src/input.rs
@@ -39,6 +39,15 @@ impl FileInput {
         let tailer = FileTailer::new(paths, config)?;
         Ok(FileInput { name, tailer })
     }
+
+    /// Create a new `FileInput` from glob patterns.
+    ///
+    /// Patterns are expanded immediately and re-evaluated periodically to
+    /// discover files created after startup (e.g., new Kubernetes pods).
+    pub fn new_with_globs(name: String, patterns: &[&str], config: TailConfig) -> io::Result<Self> {
+        let tailer = FileTailer::new_with_globs(patterns, config)?;
+        Ok(FileInput { name, tailer })
+    }
 }
 
 impl InputSource for FileInput {

--- a/crates/logfwd-transform/src/lib.rs
+++ b/crates/logfwd-transform/src/lib.rs
@@ -632,15 +632,24 @@ impl SqlTransform {
     }
 
     /// Synchronous wrapper around [`execute`](Self::execute) for callers that
-    /// are not yet async. Creates a short-lived tokio runtime per call.
+    /// are not yet async. When called from within a tokio runtime, uses
+    /// `block_in_place` + the current handle. Otherwise creates a temporary
+    /// runtime.
     ///
     /// When the calling code is made async, switch to `execute().await` directly.
     pub fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, String> {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| format!("Failed to create tokio runtime: {e}"))?;
-        rt.block_on(self.execute(batch))
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                tokio::task::block_in_place(|| handle.block_on(self.execute(batch)))
+            }
+            Err(_) => {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| format!("Failed to create tokio runtime: {e}"))?;
+                rt.block_on(self.execute(batch))
+            }
+        }
     }
 
     /// Get the ScanConfig for field pushdown.

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -252,7 +252,6 @@ fn build_input_state(
                 .path
                 .as_ref()
                 .ok_or_else(|| format!("input '{name}': file input requires 'path'"))?;
-            let paths = vec![PathBuf::from(path)];
             let format = cfg.format.clone().unwrap_or(Format::Auto);
             let tail_config = TailConfig {
                 start_from_end: false,
@@ -260,8 +259,13 @@ fn build_input_state(
                 read_buf_size: 256 * 1024,
                 ..Default::default()
             };
-            let source = FileInput::new(name.to_string(), &paths, tail_config)
-                .map_err(|e| format!("input '{name}': failed to create tailer: {e}"))?;
+            let is_glob = path.contains('*') || path.contains('?') || path.contains('[');
+            let source = if is_glob {
+                FileInput::new_with_globs(name.to_string(), &[path.as_str()], tail_config)
+            } else {
+                FileInput::new(name.to_string(), &[PathBuf::from(path)], tail_config)
+            }
+            .map_err(|e| format!("input '{name}': failed to create tailer: {e}"))?;
 
             Ok(InputState {
                 name: name.to_string(),


### PR DESCRIPTION
## Summary
- Pipeline now uses `FileTailer::new_with_globs` when the input path contains glob characters (`*`, `?`, `[`), fixing container log collection with patterns like `/var/log/pods/**/*.log`
- `execute_blocking` uses `try_current()` to detect whether it's inside a tokio runtime and uses `block_in_place`, avoiding the nested-runtime panic introduced by `#[tokio::main]` in #139

Both bugs were found by the KIND e2e test (#159) — glob paths caused "No such file or directory" and the tokio nesting caused a panic on every SQL transform execution.

## Test plan
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy` on affected crates — clean
- [x] Validated end-to-end via KIND e2e test (10/10 marker lines received)

Generated with [Claude Code](https://claude.com/claude-code)