### PR TITLE
fix: Add typos config for intentional test strings

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,4 @@
+[default.extend-words]
+# Intentional partial strings in test data and example error messages.
+hel = "hel"
+leve = "leve"


### PR DESCRIPTION
Fixes CI lint failure. The typos checker flags `hel` and `leve` as misspellings — both are intentional (partial CRI test line and example error message).