### PR TITLE
fix: cargo fmt across workspace

### DIFF
--- a/crates/logfwd-core/src/checkpoint.rs
+++ b/crates/logfwd-core/src/checkpoint.rs
@@ -124,8 +124,8 @@ impl CheckpointStore for FileCheckpointStore {
         use std::io::Write as _;
 
         let list: Vec<&SourceCheckpoint> = self.checkpoints.values().collect();
-        let json =
-            serde_json::to_vec_pretty(&list).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let json = serde_json::to_vec_pretty(&list)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         let tmp = self.tmp_path();
         let final_path = self.checkpoints_path();
@@ -302,7 +302,9 @@ mod tests {
 
         // Simulate crash: "Process 2" opens the store without previous state.
         let store = FileCheckpointStore::open(dir.path()).unwrap();
-        let cp = store.load(42).expect("checkpoint lost after simulated crash");
+        let cp = store
+            .load(42)
+            .expect("checkpoint lost after simulated crash");
         assert_eq!(cp.offset, 8192);
     }
 

--- a/crates/logfwd-core/tests/compliance_data.rs
+++ b/crates/logfwd-core/tests/compliance_data.rs
@@ -38,7 +38,8 @@ fn scan_storage_raw(input: &[u8]) -> RecordBatch {
         ..ScanConfig::default()
     };
     let mut s = SimdScanner::new(config);
-    s.scan(input).expect("StorageBuilder scan (keep_raw) failed")
+    s.scan(input)
+        .expect("StorageBuilder scan (keep_raw) failed")
 }
 
 /// Extract a string column value from a RecordBatch.
@@ -127,10 +128,7 @@ where
         .collect();
     s_names.sort();
     st_names.sort();
-    assert_eq!(
-        s_names, st_names,
-        "Column name mismatch between builders"
-    );
+    assert_eq!(s_names, st_names, "Column name mismatch between builders");
 
     check(&sb);
     check(&stb);
@@ -233,10 +231,7 @@ fn compliance_type_conflict() {
 
         // Row 1: status_int=null, status_str="OK"
         assert_null(batch, "status_int", 1);
-        assert_eq!(
-            get_str(batch, "status_str", 1),
-            Some("OK".to_string())
-        );
+        assert_eq!(get_str(batch, "status_str", 1), Some("OK".to_string()));
     });
 }
 
@@ -244,8 +239,8 @@ fn compliance_type_conflict() {
 fn compliance_integer_boundaries() {
     let input = format!(
         "{{\"n\":{}}}\n{{\"n\":{}}}\n{{\"n\":{}}}\n",
-        i64::MAX,  // 9223372036854775807
-        i64::MIN,  // -9223372036854775808
+        i64::MAX,              // 9223372036854775807
+        i64::MIN,              // -9223372036854775808
         "9223372036854775808"  // i64::MAX + 1 -> overflow to float
     );
     assert_both_scanners(input.as_bytes(), |batch| {
@@ -271,7 +266,10 @@ fn compliance_float_precision() {
         assert_eq!(batch.num_rows(), 4);
 
         let v0 = get_float(batch, "f_float", 0).expect("pi");
-        assert!((v0 - std::f64::consts::PI).abs() < 1e-15, "pi mismatch: {v0}");
+        assert!(
+            (v0 - std::f64::consts::PI).abs() < 1e-15,
+            "pi mismatch: {v0}"
+        );
 
         let v1 = get_float(batch, "f_float", 1).expect("1e308");
         assert!((v1 - 1e308).abs() < 1e292, "1e308 mismatch: {v1}");
@@ -433,10 +431,7 @@ fn compliance_non_object_lines() {
     assert_both_scanners(input, |batch| {
         assert_eq!(batch.num_rows(), 6);
         // Only the last row should have a non-null value.
-        assert_eq!(
-            get_str(batch, "valid_str", 5),
-            Some("object".to_string())
-        );
+        assert_eq!(get_str(batch, "valid_str", 5), Some("object".to_string()));
         // Rows 0-4 should have null for the valid_str column.
         for row in 0..5 {
             assert_null(batch, "valid_str", row);
@@ -451,10 +446,7 @@ fn compliance_trailing_no_newline() {
     let input = b"{\"a\":\"complete\"}\n{\"b\":\"no newline at end\"}";
     assert_both_scanners(input, |batch| {
         assert_eq!(batch.num_rows(), 2);
-        assert_eq!(
-            get_str(batch, "a_str", 0),
-            Some("complete".to_string())
-        );
+        assert_eq!(get_str(batch, "a_str", 0), Some("complete".to_string()));
         assert_eq!(
             get_str(batch, "b_str", 1),
             Some("no newline at end".to_string())
@@ -475,10 +467,7 @@ fn compliance_cri_format() {
     // The CRI parser emits the message portion as a line.
     let batch = scan_storage(&json_out);
     assert_eq!(batch.num_rows(), 1);
-    assert_eq!(
-        get_str(&batch, "msg_str", 0),
-        Some("hello".to_string())
-    );
+    assert_eq!(get_str(&batch, "msg_str", 0), Some("hello".to_string()));
 }
 
 #[test]
@@ -490,7 +479,10 @@ fn compliance_cri_partial_lines() {
     let count = parser.process(cri_input, &mut json_out);
 
     // The partial + full should reassemble into one line.
-    assert!(count >= 1, "CRI partial reassembly should emit at least 1 line");
+    assert!(
+        count >= 1,
+        "CRI partial reassembly should emit at least 1 line"
+    );
 
     // The reassembled line contains the combined message.
     let output_str = String::from_utf8_lossy(&json_out);
@@ -593,10 +585,7 @@ fn compliance_numeric_string_not_coerced() {
     let input = b"{\"port\":\"8080\"}\n";
     assert_both_scanners(input, |batch| {
         assert_eq!(batch.num_rows(), 1);
-        assert_eq!(
-            get_str(batch, "port_str", 0),
-            Some("8080".to_string())
-        );
+        assert_eq!(get_str(batch, "port_str", 0), Some("8080".to_string()));
         // Should NOT appear as an int column.
         assert!(
             batch.column_by_name("port_int").is_none(),
@@ -659,10 +648,7 @@ fn compliance_batch_reuse_isolation() {
     if b2.column_by_name("a_str").is_some() {
         assert_null(&b2, "a_str", 0);
     }
-    assert_eq!(
-        get_str(&b2, "b_str", 0),
-        Some("second".to_string())
-    );
+    assert_eq!(get_str(&b2, "b_str", 0), Some("second".to_string()));
 }
 
 #[test]

--- a/crates/logfwd-transform/src/lib.rs
+++ b/crates/logfwd-transform/src/lib.rs
@@ -582,9 +582,9 @@ impl SqlTransform {
         ctx.register_udf(ScalarUDF::from(crate::udf::RegexpExtractUdf::new()));
         ctx.register_udf(ScalarUDF::from(crate::udf::GrokUdf::new()));
         if let Some(ref db) = self.geo_database {
-            ctx.register_udf(ScalarUDF::from(
-                crate::udf::geo_lookup::GeoLookupUdf::new(Arc::clone(db)),
-            ));
+            ctx.register_udf(ScalarUDF::from(crate::udf::geo_lookup::GeoLookupUdf::new(
+                Arc::clone(db),
+            )));
         }
 
         // Register the batch as a MemTable named "logs".

--- a/crates/logfwd-transform/src/udf/geo_lookup.rs
+++ b/crates/logfwd-transform/src/udf/geo_lookup.rs
@@ -21,7 +21,9 @@ use std::any::Any;
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, AsArray, Float64Builder, Int64Builder, StringBuilder, StructArray};
+use arrow::array::{
+    Array, ArrayRef, AsArray, Float64Builder, Int64Builder, StringBuilder, StructArray,
+};
 use arrow::datatypes::{DataType, Field, Fields};
 
 use datafusion::common::Result as DfResult;
@@ -258,9 +260,7 @@ fn build_struct_array(
 }
 
 /// Convert a single `GeoResult` into a DataFusion `ScalarValue::Struct`.
-fn geo_result_to_scalar(
-    result: Option<&GeoResult>,
-) -> DfResult<datafusion::common::ScalarValue> {
+fn geo_result_to_scalar(result: Option<&GeoResult>) -> DfResult<datafusion::common::ScalarValue> {
     let fields = match geo_result_type() {
         DataType::Struct(f) => f,
         _ => unreachable!(),
@@ -335,10 +335,18 @@ impl MmdbDatabase {
     ///
     /// Returns an error if the file cannot be read or is not a valid MMDB.
     pub fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Self, String> {
-        let data = std::fs::read(path.as_ref())
-            .map_err(|e| format!("failed to read MMDB file '{}': {e}", path.as_ref().display()))?;
-        let reader = maxminddb::Reader::from_source(data)
-            .map_err(|e| format!("failed to parse MMDB file '{}': {e}", path.as_ref().display()))?;
+        let data = std::fs::read(path.as_ref()).map_err(|e| {
+            format!(
+                "failed to read MMDB file '{}': {e}",
+                path.as_ref().display()
+            )
+        })?;
+        let reader = maxminddb::Reader::from_source(data).map_err(|e| {
+            format!(
+                "failed to parse MMDB file '{}': {e}",
+                path.as_ref().display()
+            )
+        })?;
         Ok(Self { reader })
     }
 }
@@ -685,4 +693,3 @@ mod tests {
         assert_eq!(cc.value(3), "DE");
     }
 }
-

--- a/crates/logfwd/tests/compliance.rs
+++ b/crates/logfwd/tests/compliance.rs
@@ -174,9 +174,7 @@ fn verify_batches(
                         }
                         let val = match col.data_type() {
                             arrow::datatypes::DataType::Utf8 => col.as_string::<i32>().value(row),
-                            arrow::datatypes::DataType::Utf8View => {
-                                col.as_string_view().value(row)
-                            }
+                            arrow::datatypes::DataType::Utf8View => col.as_string_view().value(row),
                             _ => "",
                         };
                         val == source_id
@@ -474,10 +472,7 @@ output:
     }
 
     let report = verify_batches(&batches, count, "");
-    assert!(
-        report.gaps.is_empty(),
-        "select compliance: {report}"
-    );
+    assert!(report.gaps.is_empty(), "select compliance: {report}");
     assert!(
         report.duplicates.is_empty(),
         "select compliance has duplicates: {report}"

--- a/crates/logfwd/tests/compliance_file.rs
+++ b/crates/logfwd/tests/compliance_file.rs
@@ -174,10 +174,7 @@ fn compliance_file_rotate_copytruncate() {
 
     // Write new data (sequence continues from 5000).
     {
-        let mut f = fs::OpenOptions::new()
-            .write(true)
-            .open(&log_path)
-            .unwrap();
+        let mut f = fs::OpenOptions::new().write(true).open(&log_path).unwrap();
         f.write_all(generate_lines(5000, 5000).as_bytes()).unwrap();
         f.flush().unwrap();
     }
@@ -229,19 +226,13 @@ fn compliance_file_truncate() {
 
     // Truncate the file in-place (same inode) and write new data.
     {
-        let f = fs::OpenOptions::new()
-            .write(true)
-            .open(&log_path)
-            .unwrap();
+        let f = fs::OpenOptions::new().write(true).open(&log_path).unwrap();
         f.set_len(0).unwrap();
     }
     std::thread::sleep(Duration::from_millis(200));
 
     {
-        let mut f = fs::OpenOptions::new()
-            .append(true)
-            .open(&log_path)
-            .unwrap();
+        let mut f = fs::OpenOptions::new().append(true).open(&log_path).unwrap();
         f.write_all(generate_lines(1000, 1000).as_bytes()).unwrap();
         f.flush().unwrap();
     }


### PR DESCRIPTION
## Summary
- Fixes `cargo fmt` inconsistencies on master introduced by recent merges (#179, #181)
- Fixes the Lint CI failure on master

## Test plan
- [x] `cargo fmt --all --check` passes

Generated with [Claude Code](https://claude.com/claude-code)