### PR TITLE
fix: add apt-get update before ARM64 cross-compile install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,9 @@ jobs:
           key: aarch64-unknown-linux-gnu
 
       - name: Install cross-compilation toolchain
-        run: sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
 
       - name: Cross-compile check
         run: cargo check --target aarch64-unknown-linux-gnu


### PR DESCRIPTION
## Summary
- Adds `apt-get update` before `apt-get install gcc-aarch64-linux-gnu` in the ARM64 cross-compile CI job
- Fixes intermittent CI failures when GitHub Actions runners have stale package mirror indexes

## Test plan
- [x] CI passes on this PR

Generated with [Claude Code](https://claude.com/claude-code)