### PR TITLE
feat: mdBook documentation site + GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,57 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "book/**"
+      - "crates/**"
+      - "docs/**"
+      - "README.md"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install mdBook
+        run: |
+          curl -sSL https://github.com/rust-lang/mdBook/releases/latest/download/mdbook-v0.4.50-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+
+      - name: Build mdBook
+        run: mdbook build book
+
+      - name: Build rustdoc
+        run: |
+          cargo doc --workspace --no-deps --document-private-items
+          cp -r target/doc book/book/api
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: book/book
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,0 +1,11 @@
+[book]
+title = "logfwd"
+description = "Fast log forwarder with SQL transforms"
+authors = ["logfwd contributors"]
+language = "en"
+
+[output.html]
+default-theme = "navy"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/strawgate/memagent"
+edit-url-template = "https://github.com/strawgate/memagent/edit/master/{path}"

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -1,0 +1,153 @@
+# logfwd
+
+A high-performance log forwarder. Tails log files, parses JSON and CRI container format, transforms with SQL, and ships to OTLP, HTTP, or stdout.
+
+## Quick start
+
+```bash
+cargo build --release -p logfwd
+```
+
+Create `config.yaml`:
+
+```yaml
+input:
+  type: file
+  path: /var/log/pods/**/*.log
+  format: cri
+
+output:
+  type: stdout
+  format: json
+```
+
+Run:
+
+```bash
+./target/release/logfwd --config config.yaml
+```
+
+## Configuration
+
+logfwd uses YAML configuration with two modes:
+
+**Simple** (single pipeline):
+
+```yaml
+input:
+  type: file
+  path: /var/log/app/*.log
+  format: json
+
+transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+
+output:
+  type: otlp
+  endpoint: otel-collector:4317
+```
+
+**Advanced** (multiple pipelines):
+
+```yaml
+pipelines:
+  errors:
+    input:
+      type: file
+      path: /var/log/pods/**/*.log
+      format: cri
+    transform: SELECT * FROM logs WHERE level_str = 'ERROR'
+    output:
+      type: otlp
+      endpoint: otel-collector:4317
+
+  all-logs:
+    input:
+      type: file
+      path: /var/log/pods/**/*.log
+      format: cri
+    output:
+      type: stdout
+      format: json
+```
+
+### Input types
+
+| Type | Description | Status |
+|------|-------------|--------|
+| `file` | Tail log files by glob pattern | Implemented |
+| `tcp` | TCP listener | Not yet |
+| `udp` | UDP listener | Not yet |
+| `otlp` | Receive OTLP logs | Not yet |
+
+### Output types
+
+| Type | Description | Status |
+|------|-------------|--------|
+| `otlp` | OTLP protobuf over HTTP/gRPC | Implemented |
+| `http` | JSON lines over HTTP | Implemented |
+| `stdout` | Print to stdout (json or text) | Implemented |
+| `elasticsearch` | Elasticsearch bulk API | Stub |
+| `loki` | Grafana Loki push API | Stub |
+| `parquet` | Parquet files | Stub |
+
+### SQL transforms
+
+Transforms use DataFusion SQL. Column names follow the pattern `{field}_{type}`:
+
+```sql
+-- Filter by level
+SELECT * FROM logs WHERE level_str = 'ERROR'
+
+-- Extract fields
+SELECT level_str, status_int, duration_ms_float FROM logs
+
+-- Type casting
+SELECT int(status_str) AS status_int FROM logs
+
+-- Pattern matching
+SELECT grok('%{IP:client_ip} %{WORD:method}', msg_str) FROM logs
+```
+
+Available UDFs: `int()`, `float()`, `grok()`, `regexp_extract()`.
+
+### Enrichment
+
+Enrichment tables are available as DataFusion tables for SQL JOINs:
+
+```yaml
+enrichment:
+  static_labels:
+    type: static
+    fields:
+      environment: production
+      cluster: us-east-1
+
+  k8s:
+    type: k8s_path
+```
+
+```sql
+SELECT l.*, k.namespace, k.pod_name
+FROM logs l JOIN k8s k ON l._file_str = k.log_path_prefix
+```
+
+## CLI
+
+```
+logfwd --config <config.yaml>        Run pipeline
+logfwd --config <config.yaml> --validate   Validate config without running
+logfwd --config <config.yaml> --dry-run    Build pipelines, don't start
+logfwd --blackhole [bind_addr]       OTLP collector for benchmarks
+logfwd --generate-json <n> <file>    Generate synthetic test data
+logfwd --version                     Print version
+```
+
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [docs/CONFIG_REFERENCE.md](docs/CONFIG_REFERENCE.md) | All YAML fields, input/output types, SQL transforms, UDFs, enrichment |
+| [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Docker, Kubernetes DaemonSet, resource sizing, OTLP integration |
+| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Common errors, diagnosing dropped data, /api/pipelines, debug mode |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Pipeline data flow, crate map, scanner internals |
+| [DEVELOPING.md](DEVELOPING.md) | Build, test, lint, bench commands; hard-won implementation notes |

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,0 +1,34 @@
+# Summary
+
+[Introduction](./README.md)
+
+# Getting Started
+
+- [Installation](./getting-started/installation.md)
+- [Quick Start](./getting-started/quickstart.md)
+- [Your First Pipeline](./getting-started/first-pipeline.md)
+
+# Configuration
+
+- [Config Reference](./config/reference.md)
+- [Input Types](./config/inputs.md)
+- [Output Types](./config/outputs.md)
+- [SQL Transforms](./config/sql-transforms.md)
+
+# Deployment
+
+- [Kubernetes DaemonSet](./deployment/kubernetes.md)
+- [Docker](./deployment/docker.md)
+- [Monitoring & Diagnostics](./deployment/monitoring.md)
+
+# Architecture
+
+- [Pipeline Design](./architecture/pipeline.md)
+- [SIMD Scanner](./architecture/scanner.md)
+- [Performance](./architecture/performance.md)
+
+# Development
+
+- [Contributing](./development/contributing.md)
+- [Building & Testing](./development/building.md)
+- [Benchmarking](./development/benchmarking.md)

--- a/book/src/architecture/performance.md
+++ b/book/src/architecture/performance.md
@@ -1,0 +1,36 @@
+# Performance
+
+## Throughput targets
+
+logfwd targets 1M+ lines/sec on a single CPU core with CRI parsing and
+OTLP encoding.
+
+## Benchmark results
+
+| Stage | Time (100K lines) | % of total |
+|-------|-------------------|-----------|
+| Scan (JSON→Arrow) | 21ms | 57% |
+| Transform (SQL) | ~0ms | ~0% |
+| OTLP encode | 9ms | 27% |
+| zstd compress | 6ms | 16% |
+| **Total CPU** | **36ms** | **2.8M lines/sec** |
+
+## Key optimizations
+
+- **SIMD structural indexing**: Classifies JSON structure in one vectorized pass
+- **Zero-copy StringViewArray**: No string copies in the hot path
+- **Field pushdown**: Scanner skips unused fields based on SQL analysis
+- **Persistent zstd context**: Compression context reused across batches
+- **Connection pooling**: HTTP agent reused for output requests
+- **Block-in-place output**: Overlaps I/O with scanning via tokio
+
+## Memory profile
+
+At our default 4MB batch size (~23K lines):
+- Arrow RecordBatch overhead: ~2MB
+- Input buffer: 4MB (shared with StringView columns)
+- Total per batch: ~6MB
+
+For 1M lines (stress test only):
+- Real RSS: ~205MB (not 926MB as `get_array_memory_size()` reports)
+- StringViewArray shares the input buffer across all string columns

--- a/book/src/architecture/pipeline.md
+++ b/book/src/architecture/pipeline.md
@@ -1,0 +1,275 @@
+# Architecture
+
+## Data flow
+
+```
+Sources (file / TCP / UDP / OTLP receiver)
+    │
+    │  each source produces Bytes independently
+    ▼
+Format Parser (CRI / JSON / Raw)  ─per source─
+    │  strips CRI timestamp/stream prefix, accumulates NDJSON
+    ▼
+SIMD Scanner  ─per source─
+    │  one pass classifies entire buffer via ChunkIndex
+    │  walks structural positions directly into Arrow columns
+    │  injects _resource_* columns from source metadata
+    ▼
+RecordBatch per source
+    │
+    ├─→ [if queue.mode: pre-transform] write Arrow IPC segment → ack source
+    │
+    ├─→ register as partitions of `logs` MemTable
+    │   (DataFusion concatenates partitions during query)
+    ▼
+SQL Transform (DataFusion)
+    │  user SQL: SELECT, WHERE, GROUP BY + UDFs
+    │  enrichment tables available via JOIN
+    │  _resource_* columns flow through like any other column
+    ▼
+Post-transform RecordBatch
+    │
+    ├─→ [if queue.mode: post-transform] write Arrow IPC segment → ack source
+    │
+    ▼
+Output Sinks (OTLP / JSON lines / HTTP / stdout)
+    │  in-memory fan-out via bounded channels
+    │  group rows by _resource_* columns for OTLP ResourceLogs
+```
+
+## Persistence
+
+Arrow IPC is the universal segment format. Every persistence point
+writes Arrow IPC File format with atomic seal, and every persistence
+point can target local disk or object storage (S3/GCS/Azure Blob).
+
+**Queue mode is configurable per pipeline:**
+
+```yaml
+pipeline:
+  queue:
+    mode: pre-transform   # or post-transform, or none
+    storage: s3://my-bucket/logfwd/pipeline-a/
+    max_bytes: 10GB
+    max_age: 24h
+```
+
+**`pre-transform`:** Source segments are the queue. Each source writes
+its own Arrow IPC segments after scanning. Outputs replay from source
+segments and re-run the transform. Raw data is re-queryable with
+different SQL. One copy of data. Enrichment data may be stale on replay
+(`_resource_*` columns are always correct; enrichment table data
+reflects query-time state, not ingest-time).
+
+**`post-transform`:** Shared post-transform queue per pipeline.
+Transform runs once, result is persisted. All outputs share one queue
+with independent cursors. Enrichment baked in at ingest time — correct
+even on replay days later. Can't re-query with different SQL. Second
+copy of data (but usually smaller due to filtering).
+
+**`none` (default):** Pure in-memory fan-out. Transform runs once,
+RecordBatches passed to outputs via bounded channels. Batches drop on
+output failure. Lowest resource usage.
+
+## End-to-end ack
+
+Sources must NOT acknowledge to their upstream until persistence
+confirms durability. The ack chain:
+
+```
+Scanner produces RecordBatch
+  → FileWriter writes to .tmp
+  → fsync + rename (segment sealed)
+  → Ack source: "data through offset X is durable"
+  → Source advances checkpoint
+```
+
+Ack latency is scanner + IPC write + fsync, typically 5-15ms. Comparable
+to Kafka's acks=all (3-15ms).
+
+**File sources** don't need the ack latency to be fast — the log file is
+already durable. The checkpoint just tracks the file offset.
+
+**Network sources** see the full ack latency as their response time.
+
+**When `queue.mode: none`:** No persistence, no ack-after-write. Source
+checkpoints advance after in-memory fan-out. Data can be lost on crash.
+
+## Output delivery
+
+**Real-time path (all modes):** Transform runs once per batch cycle,
+result fans out to all outputs via bounded channels.
+
+**Replay (when queue is enabled):** If an output falls behind or
+restarts, it replays from the queue. With `pre-transform` mode, replay
+re-runs the transform. With `post-transform` mode, replay reads
+transformed segments directly.
+
+**Cursor tracking:** Each output tracks `{ segment_id, batch_offset }`.
+Persisted on each ack. On restart, resume from last position.
+
+**Retention:** TTL (`max_segment_age`) + size (`max_disk_bytes`). When
+either limit is hit, oldest segments are evicted regardless of cursor
+positions. Outputs pointing at evicted segments see a gap (tracked in
+`segments_dropped` metric).
+
+**Delivery semantics:** At-least-once when queue is enabled.
+Best-effort when queue is `none`.
+
+## Multi-source pipeline
+
+Each source scans independently and writes its own Arrow IPC segments.
+At transform time, the pipeline reads the latest segments from each
+source and registers them as partitions of the `logs` MemTable.
+DataFusion concatenates partitions during query execution.
+
+This means:
+
+- Each source can have a different `ScanConfig` (different wanted_fields
+  from predicate pushdown)
+- Schema differences between sources are handled by DataFusion's schema
+  merging (missing columns are null)
+- The StreamingBuilder's `Bytes` lifetime is per-source
+- A source with no data in a cycle contributes no partition
+
+## Resource metadata as columns
+
+Source identity and resource attributes are carried as `_resource_*`
+prefixed columns (e.g., `_resource_k8s_pod_name`,
+`_resource_k8s_namespace`, `_resource_service_name`). These are injected
+during scanning based on the source's configuration.
+
+This design:
+
+- Survives SQL transforms naturally (they're just columns)
+- Persists in the Arrow IPC segments (always correct, unlike enrichment)
+- Enables OTLP output to group rows by resource (group-by on
+  `_resource_*` columns, one `ResourceLogs` per distinct combination)
+- Uses dictionary encoding for efficiency (same pod name on every row
+  from one source costs ~one entry)
+- Output sinks exclude `_resource_*` columns from the payload (same
+  pattern as `_raw`)
+
+## Column naming conventions
+
+| Prefix | Purpose | Example |
+|--------|---------|---------|
+| `{field}_str` | String value from JSON | `message_str` |
+| `{field}_int` | Integer value from JSON | `status_int` |
+| `{field}_float` | Float value from JSON | `latency_float` |
+| `_raw` | Raw input line (optional) | `_raw` |
+| `_resource_*` | Source/resource metadata | `_resource_k8s_pod_name` |
+
+Type conflicts produce separate columns: `status_int` and `status_str`
+can coexist.
+
+## Arrow IPC segment format
+
+**Format:** Arrow IPC File format with atomic seal.
+
+**Write path:** `FileWriter` writes to `.tmp` file. On seal:
+`finish()` (writes footer) → `fsync` → atomic `rename` to final path.
+Readers never see incomplete files.
+
+**Segment lifecycle:**
+1. Pipeline writes batch(es) to `.tmp` file via `FileWriter`
+2. At size threshold (64 MB) or time threshold: seal segment
+3. On startup: delete orphaned `.tmp` files
+
+**Storage abstraction:** All persistence writes go through a
+`SegmentStore` trait with implementations for local filesystem and
+object storage (S3/GCS/Azure Blob). The same segment format and code
+path is used regardless of storage backend.
+
+## Deployment model
+
+logfwd scales by running more instances. One binary, one pipeline per
+instance. S3 is the coordination layer between instances.
+
+**Single instance:** Source → Scanner → Transform → Output, all in one
+process. Predicate pushdown works. In-memory fan-out. Simple.
+
+**Scaled out:** Multiple instances with different configs, sharing S3
+paths. Each instance is a full logfwd binary.
+
+```
+Instance A (edge collector):
+  file source → scanner → write Arrow IPC to s3://bucket/raw/
+
+Instance B (central processor):
+  s3 source (reads s3://bucket/raw/) → transform → output sinks
+  # or: → write to s3://bucket/transformed/ for another instance
+
+Instance C (dedicated sender):
+  s3 source (reads s3://bucket/transformed/) → output sinks
+```
+
+No custom RPC, no cluster coordination. Arrow IPC on S3 is the
+universal interface. Any instance can read any other's segments.
+
+## Scanner architecture
+
+The scanner is the performance-critical path. It has two stages:
+
+**Stage 1 — Chunk classification** (`chunk_classify.rs`): Process the
+entire NDJSON buffer in 64-byte blocks. For each block, find all quote
+and backslash positions, compute an escape-aware real-quote bitmask, and
+build a string-interior mask. Output: `ChunkIndex` with pre-computed
+bitmasks.
+
+**Stage 2 — Field extraction** (`scanner.rs`): A scalar state machine
+walks top-level JSON objects. For each field, it resolves the key to an
+index (HashMap, once per field per batch) and routes the value to the
+builder via `append_*_by_idx`. String scanning uses the pre-computed
+`ChunkIndex` for O(1) closing-quote lookup.
+
+The scan loop is generic over the `ScanBuilder` trait:
+
+- **`StorageBuilder`**: collects `(row, value)` records. Builds columns
+  independently at `finish_batch`. Correct by construction. For
+  persistence path (Arrow IPC segments).
+- **`StreamingBuilder`**: stores `(row, offset, len)` views into a
+  `bytes::Bytes` buffer. Builds `StringViewArray` columns with zero
+  copies. 20% faster. For real-time hot path when persistence is
+  disabled.
+
+## Async pipeline
+
+The pipeline runs on a tokio multi-thread runtime. Key components:
+
+- **Sources** implement `async fn run(&mut self, ctx: &mut SourceContext)`
+  (Arroyo-style source-owns-loop). File sources wrap FileTailer via
+  `spawn_blocking`.
+- **Scanner** runs on `spawn_blocking` (pure CPU, ~4MB per call).
+- **Transform** is `async fn execute()` (DataFusion is natively async).
+- **Sinks** implement `async fn send_batch()`. HTTP-based sinks use
+  async `reqwest` for connection pooling and timeouts.
+- **Shutdown** via `CancellationToken` (already implemented).
+
+## Crate map
+
+| Crate | Purpose |
+|-------|---------|
+| `logfwd` | Binary. CLI, pipeline orchestration, OTel metrics. |
+| `logfwd-core` | Scanner, builders, parsers, diagnostics, enrichment, OTLP encoder. |
+| `logfwd-config` | YAML config deserialization and validation. |
+| `logfwd-transform` | DataFusion SQL. UDFs: `grok()`, `regexp_extract()`, `int()`, `float()`. |
+| `logfwd-output` | Output sinks + async Sink trait. OTLP, JSON lines, HTTP, stdout. |
+| `logfwd-bench` | Criterion benchmarks. |
+
+## What's implemented vs not yet
+
+**Implemented:** file input, CRI/JSON/Raw parsing, SIMD scanner, two
+builder backends (StreamingBuilder default), DataFusion SQL transforms
+(async), custom UDFs (grok, regexp_extract, int, float), enrichment
+(K8s path, host info, static labels), OTLP output, JSON lines output,
+stdout output, diagnostics server, OTel metrics, signal handling
+(SIGINT/SIGTERM via CancellationToken), graceful shutdown, async Sink
+trait.
+
+**Not yet:** async pipeline runtime, async Source trait, Arrow IPC
+persistence (pre/post-transform), SegmentStore abstraction (local +
+S3/GCS), object storage upload, `_resource_*` column injection, OTLP
+resource grouping, output cursor tracking, TCP/UDP/OTLP input,
+Elasticsearch/Loki/Parquet output, file offset checkpointing, SQL
+rewriter, S3 source (for scaled-out deployment).

--- a/book/src/architecture/scanner.md
+++ b/book/src/architecture/scanner.md
@@ -1,0 +1,35 @@
+# SIMD Scanner
+
+The scanner converts newline-delimited JSON into Apache Arrow RecordBatches
+using SIMD-accelerated structural classification.
+
+## How it works
+
+1. **Stage 1 (SIMD)**: Classify the entire buffer in one pass. Find all quotes
+   and backslashes using platform-specific SIMD: AVX2/SSE2 on x86_64, NEON on
+   aarch64. This produces 64-bit bitmasks for O(1) string boundary lookups.
+
+2. **Stage 2 (Scalar)**: Walk the JSON structure using the pre-computed bitmasks.
+   Extract field names and values, detect types (int/float/string), and build
+   Arrow columns directly.
+
+## Zero-copy mode
+
+`StreamingSimdScanner` uses Arrow's `StringViewArray` to create 16-byte views
+into the input buffer. String data is never copied — the original input buffer
+is shared via reference counting.
+
+## Field pushdown
+
+The SQL transform is analyzed before scanning. If the query only references
+`level` and `message`, the scanner skips extracting all other fields. On
+wide data (20+ fields), this provides 2-3x throughput improvement.
+
+## Performance
+
+| Dataset | Fields | Throughput |
+|---------|--------|-----------|
+| Narrow (3 fields) | 3 | 3.4M lines/sec |
+| Simple (6 fields) | 6 | 2.0M lines/sec |
+| Wide (20 fields) | 20 | 560K lines/sec |
+| Wide (2 fields projected) | 20→2 | 1.4M lines/sec |

--- a/book/src/config/inputs.md
+++ b/book/src/config/inputs.md
@@ -1,0 +1,20 @@
+# Input Types
+
+## File
+
+Tail one or more log files with glob pattern support.
+
+```yaml
+input:
+  type: file
+  path: /var/log/pods/**/*.log
+  format: cri      # cri | json | raw | auto
+```
+
+- **Glob re-scanning**: New files matching the pattern are discovered automatically (every 5s).
+- **Rotation handling**: Detects file rotation (rename + create) and switches to the new file. Drains remaining data from the old file before switching.
+- **Formats**: CRI (Kubernetes container runtime), JSON (newline-delimited), raw (plain text, each line becomes `{"_raw": "..."}`)
+
+## UDP / TCP / OTLP (planned)
+
+Network input sources are defined in the config schema but not yet implemented.

--- a/book/src/config/outputs.md
+++ b/book/src/config/outputs.md
@@ -1,0 +1,54 @@
+# Output Types
+
+## OTLP
+
+Send logs as OpenTelemetry protobuf over HTTP or gRPC.
+
+```yaml
+output:
+  type: otlp
+  endpoint: https://collector:4318
+  protocol: http       # http | grpc
+  compression: zstd    # zstd | gzip | none
+  auth:
+    bearer_token: "${OTEL_TOKEN}"
+```
+
+## HTTP (JSON Lines)
+
+POST newline-delimited JSON to any HTTP endpoint.
+
+```yaml
+output:
+  type: http
+  endpoint: https://logging-service:9200
+  auth:
+    headers:
+      X-API-Key: "${API_KEY}"
+```
+
+## Stdout
+
+Print to stdout for debugging/testing.
+
+```yaml
+output:
+  type: stdout
+  format: console    # console | json | text
+```
+
+- **console**: Colored, human-readable (timestamp, level, message, key=value pairs)
+- **json**: One JSON object per line (machine-parseable)
+- **text**: Raw text (uses `_raw` column if available)
+
+## Multiple outputs (fan-out)
+
+```yaml
+outputs:
+  - name: collector
+    type: otlp
+    endpoint: https://collector:4318
+  - name: debug
+    type: stdout
+    format: console
+```

--- a/book/src/config/reference.md
+++ b/book/src/config/reference.md
@@ -1,0 +1,521 @@
+# Configuration Reference
+
+logfwd is configured with a YAML file passed via `--config <path>`.
+
+## Overview
+
+logfwd supports two layout styles:
+
+- **Simple** — single pipeline with top-level `input`, `transform`, and `output` keys.
+- **Advanced** — multiple named pipelines under a `pipelines` map.
+
+Environment variables are expanded using `${VAR}` syntax anywhere in the file. If a
+variable is not set the placeholder is left as-is.
+
+---
+
+## Simple layout
+
+```yaml
+input:
+  type: file
+  path: /var/log/app/*.log
+  format: json
+
+transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+
+output:
+  type: otlp
+  endpoint: otel-collector:4317
+  compression: zstd
+
+server:
+  diagnostics: 0.0.0.0:9090
+  log_level: info
+```
+
+## Advanced layout
+
+```yaml
+pipelines:
+  errors:
+    inputs:
+      - name: pod_logs
+        type: file
+        path: /var/log/pods/**/*.log
+        format: cri
+    transform: SELECT * FROM logs WHERE level_str = 'ERROR'
+    outputs:
+      - type: otlp
+        endpoint: otel-collector:4317
+
+  debug:
+    inputs:
+      - type: file
+        path: /var/log/pods/**/*.log
+        format: cri
+    outputs:
+      - type: stdout
+        format: json
+
+server:
+  diagnostics: 0.0.0.0:9090
+```
+
+The two layouts cannot be mixed: specifying both `input`/`output` at the top level and
+a `pipelines` map is a validation error.
+
+---
+
+## Input configuration
+
+Each pipeline requires at least one input. Use a single mapping for one input or a
+YAML sequence for multiple inputs.
+
+### Common fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Input type. See [Input types](#input-types). |
+| `name` | string | No | Friendly name shown in diagnostics. |
+| `format` | string | No | Log format. See [Formats](#formats). Defaults to `auto`. |
+
+### `file` input
+
+Tail one or more log files that match a glob pattern.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | Yes | Glob pattern, e.g. `/var/log/pods/**/*.log`. |
+
+```yaml
+input:
+  type: file
+  path: /var/log/pods/**/*.log
+  format: cri
+```
+
+### `udp` input *(not yet implemented)*
+
+Listen for log lines on a UDP socket.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `listen` | string | Yes | `host:port`, e.g. `0.0.0.0:514`. |
+
+```yaml
+input:
+  type: udp
+  listen: 0.0.0.0:514
+  format: syslog
+```
+
+### `tcp` input *(not yet implemented)*
+
+Accept log lines on a TCP socket.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `listen` | string | Yes | `host:port`, e.g. `0.0.0.0:5140`. |
+
+```yaml
+input:
+  type: tcp
+  listen: 0.0.0.0:5140
+  format: json
+```
+
+### `otlp` input *(not yet implemented)*
+
+Receive OTLP log records from another agent or SDK.
+
+No extra fields required; the listen address will be configurable in a future release.
+
+---
+
+## Input types
+
+| Value | Status | Description |
+|-------|--------|-------------|
+| `file` | Implemented | Tail files matching a glob pattern. |
+| `udp` | Planned | Receive log lines over UDP. |
+| `tcp` | Planned | Accept log lines over TCP. |
+| `otlp` | Planned | Receive OTLP logs. |
+
+---
+
+## Formats
+
+The `format` field controls how raw bytes from the input are parsed into log records.
+
+| Value | Description |
+|-------|-------------|
+| `auto` | Auto-detect (default). Tries CRI first, then JSON, then raw. |
+| `cri` | CRI container log format (`<timestamp> <stream> <flags> <message>`). Multi-line log reassembly via the `P` partial flag is supported. |
+| `json` | Newline-delimited JSON. Each line must be a single JSON object. |
+| `raw` | Treat each line as an opaque string stored in `_raw_str`. |
+| `logfmt` | Key=value pairs (e.g. `level=info msg="hello"`). *Not yet implemented.* |
+| `syslog` | RFC 5424 syslog. *Not yet implemented.* |
+| `console` | Human-readable coloured output for interactive debugging. Output mode only. |
+
+---
+
+## Output configuration
+
+Each pipeline requires at least one output.
+
+### Common fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | Yes | Output type. See [Output types](#output-types). |
+| `name` | string | No | Friendly name shown in diagnostics. |
+
+### `otlp` output
+
+Send log records as OTLP protobuf to an OpenTelemetry collector.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `endpoint` | string | Yes | — | Collector address, e.g. `otel-collector:4317` (gRPC) or `http://otel-collector:4318` (HTTP). |
+| `protocol` | string | No | `http` | `http` or `grpc`. |
+| `compression` | string | No | none | `zstd` to compress the request body. |
+
+```yaml
+output:
+  type: otlp
+  endpoint: otel-collector:4317
+  protocol: grpc
+  compression: zstd
+```
+
+### `http` output
+
+POST log records as newline-delimited JSON to an HTTP endpoint.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `endpoint` | string | Yes | Full URL, e.g. `http://ingest.example.com/logs`. |
+| `compression` | string | No | `zstd` to compress the request body. |
+
+```yaml
+output:
+  type: http
+  endpoint: http://ingest.example.com/logs
+  compression: zstd
+```
+
+### `stdout` output
+
+Print records to standard output for local debugging.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `format` | string | No | `json` | `json` (newline-delimited JSON) or `console` (coloured text). |
+
+```yaml
+output:
+  type: stdout
+  format: console
+```
+
+### `elasticsearch` output *(stub)*
+
+Ship to Elasticsearch via the bulk API. Not yet functional.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `endpoint` | string | Yes | Elasticsearch base URL. |
+
+### `loki` output *(stub)*
+
+Push to Grafana Loki. Not yet functional.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `endpoint` | string | Yes | Loki push URL. |
+
+### `file_out` output *(partial)*
+
+Write records to a file.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | Yes | Destination file path. |
+
+### `parquet` output *(stub)*
+
+Write records to Parquet files. Not yet functional.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | Yes | Destination file path. |
+
+---
+
+## Output types
+
+| Value | Status | Description |
+|-------|--------|-------------|
+| `otlp` | Implemented | OTLP protobuf over HTTP or gRPC. |
+| `http` | Implemented | JSON lines over HTTP POST. |
+| `stdout` | Implemented | Print to stdout (JSON or coloured text). |
+| `elasticsearch` | Stub | Elasticsearch bulk API. |
+| `loki` | Stub | Grafana Loki push API. |
+| `file_out` | Partial | Write to a file. |
+| `parquet` | Stub | Write Parquet files. |
+
+---
+
+## SQL transform
+
+The optional `transform` field contains a DataFusion SQL query that is applied to every
+Arrow `RecordBatch` produced by the scanner. The source table is always named `logs`.
+
+```yaml
+transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+```
+
+Multi-line SQL is supported with YAML block scalars:
+
+```yaml
+transform: |
+  SELECT
+    level_str,
+    msg_str,
+    regexp_extract(msg_str, 'request_id=([a-f0-9-]+)', 1) AS request_id_str,
+    status_int
+  FROM logs
+  WHERE level_str IN ('ERROR', 'WARN')
+    AND status_int >= 400
+```
+
+### Column naming convention
+
+The scanner maps each JSON field to one or more typed Arrow columns following the
+`{field}_{type}` naming convention:
+
+| JSON value type | Arrow column type | Column name pattern | Example |
+|-----------------|-------------------|---------------------|---------|
+| String | StringArray | `{field}_str` | `level_str` |
+| Integer | Int64Array | `{field}_int` | `status_int` |
+| Float | Float64Array | `{field}_float` | `latency_ms_float` |
+| Boolean | StringArray (`"true"`/`"false"`) | `{field}_str` | `enabled_str` |
+| Null | null in all type columns | — | — |
+| Object / Array | StringArray (raw JSON) | `{field}_str` | `metadata_str` |
+
+When a field contains mixed types across rows, separate columns are emitted:
+`status_int` and `status_str` can coexist in the same batch.
+
+Special columns added by the scanner:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `_file_str` | string | Absolute path of the source file (file inputs only). |
+| `_raw_str` | string | Original JSON line (only when `keep_raw: true`). |
+| `_time_ns_int` | int64 | Timestamp from CRI header in nanoseconds (CRI inputs only). |
+| `_stream_str` | string | CRI stream name (`stdout`/`stderr`). |
+
+### Built-in UDFs
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `int(expr)` | `int(any) → int64` | Cast any value to int64. Returns NULL on failure. |
+| `float(expr)` | `float(any) → float64` | Cast any value to float64. Returns NULL on failure. |
+| `grok(pattern, input)` | `grok(utf8, utf8) → utf8` | Apply a Grok pattern to `input` and return the first capture as JSON. |
+| `regexp_extract(input, pattern, group)` | `regexp_extract(utf8, utf8, int64) → utf8` | Return capture group `group` from a regex match. |
+
+Examples:
+
+```sql
+-- Cast a string column to int
+SELECT int(status_str) AS status_int FROM logs
+
+-- Extract a field with Grok
+SELECT grok('%{IP:client} %{WORD:method} %{URIPATHPARAM:path}', msg_str) AS parsed_str FROM logs
+
+-- Extract a named group with regex
+SELECT regexp_extract(msg_str, 'user=([a-z]+)', 1) AS user_str FROM logs
+
+-- Type-cast from environment-injected string
+SELECT float(duration_str) AS duration_ms_float FROM logs
+```
+
+---
+
+## Enrichment tables
+
+Enrichment tables are made available as SQL tables that can be joined in the transform
+query. They are declared under the top-level `enrichment` key.
+
+```yaml
+enrichment:
+  k8s:
+    type: k8s_path
+
+  host:
+    type: host_info
+
+  labels:
+    type: static
+    fields:
+      environment: production
+      region: us-east-1
+```
+
+### `k8s_path` enrichment
+
+Parses Kubernetes pod log paths (e.g.
+`/var/log/pods/<namespace>_<pod>_<uid>/<container>/`) to extract metadata.
+
+```sql
+SELECT l.level_str, l.msg_str, k.namespace, k.pod_name, k.container_name
+FROM logs l
+JOIN k8s k ON l._file_str = k.log_path_prefix
+```
+
+Columns exposed by `k8s`:
+
+| Column | Description |
+|--------|-------------|
+| `log_path_prefix` | Directory prefix used as join key. |
+| `namespace` | Kubernetes namespace. |
+| `pod_name` | Pod name. |
+| `pod_uid` | Pod UID. |
+| `container_name` | Container name. |
+
+### `host_info` enrichment
+
+Exposes the hostname of the machine running logfwd.
+
+| Column | Description |
+|--------|-------------|
+| `hostname` | System hostname. |
+
+### `static` enrichment
+
+A table with one row containing user-defined label columns.
+
+```yaml
+enrichment:
+  labels:
+    type: static
+    fields:
+      environment: production
+      cluster: us-east-1
+      tier: backend
+```
+
+```sql
+SELECT l.*, lbl.environment, lbl.cluster
+FROM logs l CROSS JOIN labels lbl
+```
+
+---
+
+## Server configuration
+
+The optional `server` block controls the diagnostics server and observability settings.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `diagnostics` | string | none | `host:port` to listen for HTTP diagnostics. Exposes `/metrics` and `/api/pipelines`. |
+| `log_level` | string | `info` | Log verbosity. One of `error`, `warn`, `info`, `debug`, `trace`. |
+| `metrics_endpoint` | string | none | OTLP endpoint for periodic metrics push, e.g. `http://otel-collector:4318`. |
+| `metrics_interval_secs` | integer | `60` | Push interval for OTLP metrics in seconds. |
+
+```yaml
+server:
+  diagnostics: 0.0.0.0:9090
+  log_level: info
+  metrics_endpoint: http://otel-collector:4318
+  metrics_interval_secs: 30
+```
+
+---
+
+## Storage configuration
+
+The optional `storage` block controls where logfwd persists state (checkpoints, disk
+queue).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `data_dir` | string | none | Directory for state files. Created if it does not exist. |
+
+```yaml
+storage:
+  data_dir: /var/lib/logfwd
+```
+
+---
+
+## Environment variable substitution
+
+Any value in the config file can reference an environment variable with `${VAR}`:
+
+```yaml
+output:
+  type: otlp
+  endpoint: ${OTEL_COLLECTOR_ADDR}
+
+server:
+  metrics_endpoint: ${METRICS_PUSH_URL}
+```
+
+If the variable is not set, the placeholder is left as-is (no error).
+
+---
+
+## Complete example
+
+```yaml
+pipelines:
+  app:
+    inputs:
+      - name: pod_logs
+        type: file
+        path: /var/log/pods/**/*.log
+        format: cri
+    transform: |
+      SELECT
+        l.level_str,
+        l.msg_str,
+        l.status_int,
+        k.namespace,
+        k.pod_name,
+        k.container_name,
+        lbl.environment
+      FROM logs l
+      LEFT JOIN k8s k ON l._file_str = k.log_path_prefix
+      CROSS JOIN labels lbl
+      WHERE l.level_str IN ('ERROR', 'WARN')
+        OR l.status_int >= 500
+    outputs:
+      - name: collector
+        type: otlp
+        endpoint: ${OTEL_ENDPOINT}
+        protocol: grpc
+        compression: zstd
+      - name: debug
+        type: stdout
+        format: console
+
+enrichment:
+  k8s:
+    type: k8s_path
+  labels:
+    type: static
+    fields:
+      environment: ${ENVIRONMENT}
+      cluster: ${CLUSTER_NAME}
+
+server:
+  diagnostics: 0.0.0.0:9090
+  log_level: info
+  metrics_endpoint: ${OTEL_ENDPOINT}
+  metrics_interval_secs: 60
+
+storage:
+  data_dir: /var/lib/logfwd
+```

--- a/book/src/config/sql-transforms.md
+++ b/book/src/config/sql-transforms.md
@@ -1,0 +1,75 @@
+# SQL Transforms
+
+logfwd uses Apache DataFusion to run SQL queries on your log data. Every log
+line becomes a row in a virtual `logs` table.
+
+## Column naming
+
+The JSON scanner creates typed columns with suffixes:
+- `field_str` — string value (Utf8)
+- `field_int` — integer value (Int64)
+- `field_float` — float value (Float64)
+
+The SQL rewriter automatically translates bare column names, so you can write:
+
+```sql
+SELECT * FROM logs WHERE level = 'ERROR'
+-- automatically becomes: WHERE level_str = 'ERROR'
+```
+
+## Examples
+
+### Filter by severity
+```yaml
+transform: "SELECT * FROM logs WHERE level IN ('ERROR', 'WARN')"
+```
+
+### Drop fields
+```yaml
+transform: "SELECT * EXCEPT (request_id, trace_id) FROM logs"
+```
+
+### Rename fields
+```yaml
+transform: "SELECT duration_ms AS latency_ms, * EXCEPT (duration_ms) FROM logs"
+```
+
+### Computed fields
+```yaml
+transform: |
+  SELECT *,
+    CASE WHEN duration_ms > 200 THEN 'slow' ELSE 'fast' END AS speed
+  FROM logs
+```
+
+### Aggregation
+```yaml
+transform: |
+  SELECT level, COUNT(*) as count, AVG(duration_ms) as avg_latency
+  FROM logs
+  GROUP BY level
+```
+
+### Regular expressions
+```yaml
+transform: |
+  SELECT *, regexp_extract(message, 'status=(\d+)', 1) AS status_code
+  FROM logs
+```
+
+### Grok patterns
+```yaml
+transform: |
+  SELECT *, grok(message, '%{WORD:method} %{URIPATH:path} %{NUMBER:status}')
+  FROM logs
+```
+
+### GeoIP enrichment
+```yaml
+enrichment:
+  - type: geo_database
+    path: /data/GeoLite2-City.mmdb
+transform: |
+  SELECT *, geo_lookup(source_ip, 'city') as city
+  FROM logs
+```

--- a/book/src/deployment/docker.md
+++ b/book/src/deployment/docker.md
@@ -1,0 +1,17 @@
+# Docker Deployment
+
+## Quick start
+
+```bash
+docker run -v /var/log:/var/log:ro \
+  -v ./config.yaml:/etc/logfwd/config.yaml:ro \
+  ghcr.io/strawgate/memagent:latest \
+  --config /etc/logfwd/config.yaml
+```
+
+## Dockerfile
+
+The release workflow builds multi-arch images for `linux/amd64` and
+`linux/arm64` using a distroless base image.
+
+See `Dockerfile` and `.github/workflows/release.yml` for details.

--- a/book/src/deployment/kubernetes.md
+++ b/book/src/deployment/kubernetes.md
@@ -1,0 +1,343 @@
+# Deployment Guide
+
+This guide covers running logfwd in production environments.
+
+---
+
+## Docker — standalone container
+
+### Build the image
+
+```bash
+docker build -t logfwd:latest .
+```
+
+The multi-stage `Dockerfile` at the repository root compiles a statically-linked
+release binary and copies it into a minimal `debian:bookworm-slim` image.
+
+### Run with a config file
+
+Create `config.yaml`:
+
+```yaml
+input:
+  type: file
+  path: /var/log/app/*.log
+  format: json
+
+output:
+  type: otlp
+  endpoint: otel-collector:4317
+  protocol: grpc
+
+server:
+  diagnostics: 0.0.0.0:9090
+```
+
+Run the container, mounting the log directory and config:
+
+```bash
+docker run -d \
+  --name logfwd \
+  -v /var/log:/var/log:ro \
+  -v $(pwd)/config.yaml:/etc/logfwd/config.yaml:ro \
+  -p 9090:9090 \
+  logfwd:latest \
+  --config /etc/logfwd/config.yaml
+```
+
+### Environment variable substitution
+
+Pass secrets and environment-specific values via environment variables instead of
+baking them into the config file:
+
+```yaml
+output:
+  type: otlp
+  endpoint: ${OTEL_ENDPOINT}
+```
+
+```bash
+docker run -d \
+  -e OTEL_ENDPOINT=otel-collector:4317 \
+  -v /var/log:/var/log:ro \
+  -v $(pwd)/config.yaml:/etc/logfwd/config.yaml:ro \
+  logfwd:latest --config /etc/logfwd/config.yaml
+```
+
+---
+
+## Kubernetes — DaemonSet
+
+A DaemonSet is the recommended way to deploy logfwd in a Kubernetes cluster. Each
+node runs one logfwd pod that reads container logs from `/var/log` on the host.
+
+A ready-to-use manifest is provided at `deploy/daemonset.yml`.
+
+### Minimal DaemonSet
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: collectors
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: logfwd
+  namespace: collectors
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logfwd-config
+  namespace: collectors
+data:
+  config.yaml: |
+    input:
+      type: file
+      path: /var/log/pods/**/*.log
+      format: cri
+
+    transform: |
+      SELECT
+        level_str,
+        msg_str,
+        _time_ns_int,
+        _stream_str
+      FROM logs
+      WHERE level_str != 'DEBUG'
+
+    output:
+      type: otlp
+      endpoint: ${OTEL_ENDPOINT}
+      protocol: grpc
+      compression: zstd
+
+    server:
+      diagnostics: 0.0.0.0:9090
+      log_level: info
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: logfwd
+  namespace: collectors
+  labels:
+    app: logfwd
+spec:
+  selector:
+    matchLabels:
+      app: logfwd
+  template:
+    metadata:
+      labels:
+        app: logfwd
+    spec:
+      serviceAccountName: logfwd
+      tolerations:
+        - operator: Exists  # run on all nodes including control-plane
+      containers:
+        - name: logfwd
+          image: logfwd:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config
+            - /etc/logfwd/config.yaml
+          env:
+            - name: OTEL_ENDPOINT
+              value: otel-collector.monitoring.svc.cluster.local:4317
+          ports:
+            - name: diagnostics
+              containerPort: 9090
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "128Mi"
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: config
+              mountPath: /etc/logfwd
+              readOnly: true
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: config
+          configMap:
+            name: logfwd-config
+```
+
+Apply it:
+
+```bash
+kubectl apply -f deploy/daemonset.yml
+kubectl -n collectors rollout status daemonset/logfwd
+```
+
+### Kubernetes metadata enrichment
+
+Use the `k8s_path` enrichment table to attach namespace, pod, and container labels to
+every log record:
+
+```yaml
+enrichment:
+  k8s:
+    type: k8s_path
+
+transform: |
+  SELECT
+    l.level_str,
+    l.msg_str,
+    k.namespace,
+    k.pod_name,
+    k.container_name
+  FROM logs l
+  LEFT JOIN k8s k ON l._file_str = k.log_path_prefix
+```
+
+### Namespace filtering
+
+To collect logs only from specific namespaces, filter in the transform:
+
+```yaml
+transform: |
+  SELECT l.*, k.namespace, k.pod_name, k.container_name
+  FROM logs l
+  LEFT JOIN k8s k ON l._file_str = k.log_path_prefix
+  WHERE k.namespace IN ('production', 'staging')
+```
+
+### Scraping the diagnostics endpoint with Prometheus
+
+Expose port 9090 in the pod spec and add a Prometheus scrape annotation:
+
+```yaml
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+    prometheus.io/path: "/metrics"
+```
+
+---
+
+## OTLP collector integration
+
+logfwd sends log records as OTLP protobuf. Any OpenTelemetry-compatible collector
+can receive them.
+
+### OpenTelemetry Collector
+
+Add a `otlp` receiver to your collector config and enable the `logs` pipeline:
+
+```yaml
+# otel-collector-config.yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: normal
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug, otlphttp/loki]
+```
+
+Point logfwd at the collector:
+
+```yaml
+output:
+  type: otlp
+  endpoint: otel-collector:4317
+  protocol: grpc
+  compression: zstd
+```
+
+### Grafana Alloy / Agent
+
+Grafana Alloy can receive OTLP logs and forward them to Loki or Tempo. Configure an
+`otelcol.receiver.otlp` component and connect it to your exporter pipeline.
+
+---
+
+## Resource sizing guidelines
+
+logfwd is designed to process logs on a single CPU core. The pipeline runs as a set
+of blocking OS threads — one per input plus shared coordinator threads.
+
+### Baseline
+
+| Scenario | CPU | Memory |
+|----------|-----|--------|
+| Quiet node (< 1 MB/s) | 50 m | 64 Mi |
+| Typical node (1–10 MB/s) | 250 m | 128 Mi |
+| High-throughput node (> 10 MB/s) | 500 m – 1 CPU | 256 Mi |
+
+### Memory breakdown
+
+| Component | Typical size |
+|-----------|-------------|
+| Arrow RecordBatch (per batch, 8 KB read) | ~512 Ki |
+| DataFusion query plan | ~4 Mi |
+| OTLP request buffer | ~2 Mi |
+| Enrichment tables | < 1 Mi |
+| Per-pipeline overhead | ~16 Mi |
+
+### Tuning tips
+
+- **Reduce memory**: avoid `keep_raw: true` (disabled by default) — it stores the full
+  JSON line and accounts for up to 65 % of table memory.
+- **Reduce CPU**: use a `WHERE` clause in the transform to drop unwanted records early.
+- **Multiple pipelines**: each pipeline occupies its own thread. Add CPU budget
+  proportionally.
+
+### Kubernetes resource example
+
+```yaml
+resources:
+  requests:
+    cpu: "250m"
+    memory: "128Mi"
+  limits:
+    cpu: "1"
+    memory: "512Mi"
+```
+
+Set the limit higher than the request so logfwd can burst during log spikes without
+being OOM-killed.
+
+---
+
+## Validating before deploy
+
+Use `--validate` to parse and validate the config without starting the pipeline:
+
+```bash
+logfwd --config config.yaml --validate
+```
+
+Use `--dry-run` to build all pipeline objects without starting them (catches errors
+such as SQL syntax issues):
+
+```bash
+logfwd --config config.yaml --dry-run
+```
+
+Both commands exit 0 on success and print an error to stderr on failure.

--- a/book/src/deployment/monitoring.md
+++ b/book/src/deployment/monitoring.md
@@ -1,0 +1,35 @@
+# Monitoring & Diagnostics
+
+Enable the diagnostics server in your config:
+
+```yaml
+server:
+  diagnostics: 0.0.0.0:9090
+```
+
+## Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /health` | Health check (uptime, version) |
+| `GET /metrics` | Prometheus exposition format |
+| `GET /api/pipelines` | Detailed JSON with per-stage metrics |
+| `GET /` | HTML dashboard |
+
+## Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `logfwd_input_lines_total` | Lines read per input |
+| `logfwd_transform_lines_in` | Lines entering SQL transform |
+| `logfwd_transform_lines_out` | Lines after filtering |
+| `logfwd_stage_seconds_total` | Time per stage (scan, transform, output) |
+| `logfwd_flush_reason_total` | Flush triggers (size vs timeout) |
+
+## OTLP metrics push
+
+```yaml
+server:
+  metrics_endpoint: http://otel-collector:4318
+  metrics_interval_secs: 60
+```

--- a/book/src/development/benchmarking.md
+++ b/book/src/development/benchmarking.md
@@ -1,0 +1,39 @@
+# Benchmarking
+
+## Criterion microbenchmarks
+
+```bash
+just bench
+```
+
+Measures scanner throughput, OTLP encoding speed, and compression performance.
+
+## Competitive benchmarks
+
+Compare logfwd against vector, fluent-bit, filebeat, otelcol, and vlagent:
+
+```bash
+# Binary mode (local dev)
+just bench-competitive --lines 1000000 --scenarios passthrough,json_parse,filter
+
+# Docker mode (resource-limited)
+just bench-competitive --lines 5000000 --docker --cpus 1 --memory 1g --markdown
+```
+
+## Exploratory profiling
+
+```bash
+# Stage-by-stage profile
+cargo run -p logfwd-bench --release --bin e2e-profile
+
+# Memory analysis
+cargo run -p logfwd-bench --release --bin sizes
+
+# Real RSS measurement
+cargo run -p logfwd-bench --release --bin rss
+```
+
+## Nightly benchmarks
+
+Results are published to GitHub Pages automatically via the nightly benchmark
+workflow. View at: [strawgate.github.io/memagent/dev/bench/](https://strawgate.github.io/memagent/dev/bench/)

--- a/book/src/development/building.md
+++ b/book/src/development/building.md
@@ -1,0 +1,36 @@
+# Building & Testing
+
+## Prerequisites
+
+```bash
+# Install Rust stable
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Install task runner
+cargo install just
+
+# Install development tools
+just install-tools
+```
+
+## Common commands
+
+```bash
+just ci          # Run full CI suite (lint + test)
+just fmt         # Format code
+just clippy      # Run lints
+just test        # Run all tests
+just bench       # Run Criterion microbenchmarks
+just build       # Build release binary
+```
+
+## Project structure
+
+```
+crates/logfwd/           # Binary entry point, CLI, pipeline orchestrator
+crates/logfwd-core/      # SIMD scanner, file tailer, CRI parser, diagnostics
+crates/logfwd-config/    # YAML config parser
+crates/logfwd-output/    # Output sinks (OTLP, HTTP, stdout)
+crates/logfwd-transform/ # SQL transforms via DataFusion, UDFs
+crates/logfwd-bench/     # Benchmarks (Criterion + exploratory)
+```

--- a/book/src/development/contributing.md
+++ b/book/src/development/contributing.md
@@ -1,0 +1,92 @@
+# Developing logfwd
+
+## Workspace layout
+
+```
+crates/
+  logfwd/              Binary crate. CLI, pipeline orchestration.
+  logfwd-core/         Scanner, builders, parsers, diagnostics. The hot path.
+  logfwd-config/       YAML config parsing and validation.
+  logfwd-transform/    DataFusion SQL transforms, UDFs (grok, regexp_extract).
+  logfwd-output/       Output sinks (OTLP, JSON lines, HTTP, stdout).
+  logfwd-bench/        Criterion benchmarks for the scanner pipeline.
+  logfwd-competitive-bench/  Comparative benchmarks vs other log agents.
+```
+
+## Build, test, lint, bench, fuzz
+
+```bash
+just test                    # All tests
+just lint                    # fmt + clippy + toml + deny + typos
+cargo test -p logfwd-core    # Core crate only (fastest iteration)
+
+RUSTFLAGS="-C target-cpu=native" cargo bench --bench scanner -p logfwd-core
+
+cd crates/logfwd-core && cargo +nightly fuzz run scanner -- -max_total_time=300
+```
+
+---
+
+## Things that will bite you
+
+Hard-won lessons from building the scanner and builder pipeline.
+
+### The deferred builder pattern exists because incremental null-padding is broken
+
+`StorageBuilder` collects `(row, value)` records during scanning and bulk-builds Arrow columns at `finish_batch`. This seems roundabout — why not write directly to Arrow builders?
+
+Because maintaining column alignment across multiple type builders (str, int, float) per field is a coordination nightmare. When you write an int, you must pad the str and float builders with null. When `end_row` fires, pad all unwritten fields. When a new field appears mid-batch, back-fill all prior rows. We tried this (`IndexedBatchBuilder`); proptest found column length mismatches on multi-line NDJSON with varying field sets.
+
+The deferred pattern is correct by construction: each column is built independently. Gaps are nulls. Columns can never mismatch.
+
+### Chunk-level SIMD classification beats per-line SIMD
+
+We tried three approaches:
+1. **Per-line SIMD**: load 16 bytes, compare for `"` and `\`. Slower than scalar on short strings.
+2. **sonic-rs DOM**: SIMD JSON parser builds a DOM per line. The DOM allocation is the bottleneck.
+3. **Chunk-level classification** (`ChunkIndex`): one NEON/SSE pass over the entire buffer at ~16 GiB/s, pre-computes all quote positions. Then `scan_string` is a single `trailing_zeros` bit-scan.
+
+Approach 3 wins everywhere because classification is amortized across all strings and per-string lookup is O(1).
+
+### The prefix_xor escape detection has a subtle correctness requirement
+
+The simdjson `prefix_xor` algorithm detects escaped quotes by computing backslash-run parity. It works for **consecutive** backslashes (`\\\"` = escaped quote). But for **non-consecutive** backslashes like `\n\"`, `prefix_xor` gives wrong results because it counts ALL backslashes, not per-run.
+
+Our implementation iterates each backslash: mark next byte as escaped, skip escaped backslashes. Fast because most JSON has zero or few backslashes. The carry between 64-byte blocks must be handled.
+
+### The scanner assumes UTF-8 input
+
+`from_utf8_unchecked` throughout the scanner and builders. JSON is UTF-8 by spec, so this holds in practice. But the scanner does NOT validate — non-UTF-8 input is UB. The fuzz target guards against this; production code currently doesn't. See issue #76.
+
+### HashMap field lookup was 60% of total scan time
+
+Profiling showed `get_or_create_field` dominating — SipHash + probe per field per row. Fix: `resolve_field` does the HashMap lookup once per batch. Subsequent rows use the returned index directly. The `ScanBuilder` trait's `resolve_field` + `append_*_by_idx` pattern encodes this.
+
+### StringViewArray memory reporting is misleading
+
+Arrow's `get_array_memory_size()` counts the backing buffer for every column sharing it. If 5 string columns point into the same buffer, reported memory is 5x actual. The `StreamingBuilder` produces shared-buffer columns; memory reports overcount significantly.
+
+### Arrow IPC compression is just a flag
+
+Compressed Arrow IPC is `StreamWriter` with `IpcWriteOptions::try_with_compression(Some(CompressionType::ZSTD))`. Any `RecordBatch` can be compressed. No special builder needed.
+
+### `keep_raw` costs 65% of table memory
+
+The `_raw` column stores the full JSON line. Larger than all other columns combined. Default is `keep_raw: false`.
+
+### CI clippy catches things local clippy misses
+
+Conditional SIMD compilation means dead code warnings differ between aarch64 (macOS) and x86_64 (CI Linux). Always check CI.
+
+### proptest finds bugs unit tests can't
+
+Every time we thought the scanner was correct, proptest broke it. Escapes crossing 64-byte boundaries, fields in different orders, duplicate keys with different types. Run `PROPTEST_CASES=2000` minimum.
+
+Oracle tests compare against sonic-rs as ground truth. Our scanner does first-writer-wins for duplicate keys; sonic-rs does last-writer-wins. Both valid per RFC 8259; oracle tests skip duplicate-key inputs.
+
+### Two builders serve different purposes
+
+- **`StorageBuilder`**: copies values into self-contained Arrow arrays. Input buffer can be freed. For persistence and compression.
+- **`StreamingBuilder`**: zero-copy `StringViewArray` views into `bytes::Bytes` buffer. 20% faster. Buffer must stay alive. For real-time query-then-discard.
+
+Both implement `ScanBuilder` trait, sharing the generic `scan_into()` loop.

--- a/book/src/getting-started/first-pipeline.md
+++ b/book/src/getting-started/first-pipeline.md
@@ -1,0 +1,57 @@
+# Your First Pipeline
+
+This guide walks through setting up logfwd to tail application logs, filter
+by severity, and forward to an OpenTelemetry collector.
+
+## The config
+
+```yaml
+input:
+  type: file
+  path: /var/log/app/*.log
+  format: json
+
+transform: |
+  SELECT * FROM logs WHERE level IN ('ERROR', 'WARN')
+
+output:
+  type: otlp
+  endpoint: https://otel-collector:4318
+  protocol: http
+  compression: zstd
+
+server:
+  diagnostics: 0.0.0.0:9090
+```
+
+## Run it
+
+```bash
+logfwd --config pipeline.yaml
+```
+
+## Monitor it
+
+```bash
+# Health check
+curl http://localhost:9090/health
+
+# Live metrics
+curl http://localhost:9090/metrics
+
+# Pipeline details (JSON)
+curl http://localhost:9090/api/pipelines | jq .
+```
+
+## Validate config without running
+
+```bash
+logfwd --config pipeline.yaml --validate
+# config ok: 1 pipeline(s)
+
+logfwd --config pipeline.yaml --dry-run
+# logfwd v0.1.0
+#   pipeline default: 1 input(s) -> SELECT * FROM logs WHERE ... -> 1 output(s)
+#   ready: default
+# dry run ok: 1 pipeline(s) constructed
+```

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -1,0 +1,22 @@
+# Installation
+
+## From source (recommended)
+
+```bash
+git clone https://github.com/strawgate/memagent.git
+cd memagent
+cargo build --release
+# Binary at ./target/release/logfwd
+```
+
+## Prerequisites
+
+- Rust stable toolchain (1.86+)
+- `just` task runner: `cargo install just`
+
+## Verify installation
+
+```bash
+./target/release/logfwd --version
+./target/release/logfwd --help
+```

--- a/book/src/getting-started/quickstart.md
+++ b/book/src/getting-started/quickstart.md
@@ -1,0 +1,32 @@
+# Quick Start
+
+## Generate test data
+
+```bash
+logfwd --generate-json 10000 /tmp/test.jsonl
+```
+
+## Process with SQL and output to console
+
+```yaml
+# pipeline.yaml
+input:
+  type: file
+  path: /tmp/test.jsonl
+  format: json
+transform: "SELECT * FROM logs WHERE level = 'ERROR'"
+output:
+  type: stdout
+  format: console
+```
+
+```bash
+logfwd --config pipeline.yaml
+```
+
+You'll see colored output:
+
+```
+10:30:00.003Z  ERROR  request handled GET /health/10021  duration_ms=40 service=myapp
+10:30:00.007Z  ERROR  request handled GET /api/v2/products/10049  duration_ms=92 ...
+```


### PR DESCRIPTION
## Summary

Comprehensive docs site using mdBook, deployed to GitHub Pages alongside rustdoc API reference.

### Site structure
- **`/`** — mdBook guide (getting started, config reference, SQL examples, deployment, architecture)
- **`/api/`** — rustdoc API reference (auto-generated)
- **`/dev/bench/`** — benchmark dashboard (from nightly workflow)

### Content (20 pages, ~1,900 lines)
| Section | Pages | Source |
|---------|-------|--------|
| Getting Started | 3 | New content |
| Configuration | 4 | Adapted from docs/CONFIG_REFERENCE.md |
| Deployment | 3 | Adapted from docs/DEPLOYMENT.md |
| Architecture | 3 | Adapted from docs/ARCHITECTURE.md + benchmark data |
| Development | 3 | Adapted from DEVELOPING.md |

### Deployment
Builds on push to master (when book/, crates/, or docs/ change).
Uses `actions/deploy-pages` — requires GitHub Pages set to "GitHub Actions" source.

## Test plan
- [x] `actionlint` passes on docs.yml
- [ ] Enable GitHub Pages (Settings → Pages → Source: GitHub Actions)
- [ ] Merge and verify site deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)