### PR TITLE
fix: Use peaceiris/actions-mdbook for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,15 +29,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install mdBook
-        run: |
-          curl -sSL https://github.com/rust-lang/mdBook/releases/latest/download/mdbook-v0.4.50-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /usr/local/bin
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: latest
 
       - name: Build mdBook
         run: mdbook build book
 
-      - name: Build rustdoc
+      - name: Build rustdoc (public API only)
         run: |
-          cargo doc --workspace --no-deps --document-private-items
+          cargo doc --no-deps \
+            -p logfwd \
+            -p logfwd-core \
+            -p logfwd-config \
+            -p logfwd-output \
+            -p logfwd-transform
           cp -r target/doc book/book/api
 
       - name: Upload Pages artifact


### PR DESCRIPTION
Fixes the broken mdBook install (hardcoded v0.4.50 URL → 404). Uses the official GitHub Action instead. Also scopes cargo doc to public crates only. Verified locally — mdBook builds clean on v0.5.2.