### PR TITLE
fix: Disable sccache in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Cargo doc fails because sccache isn't installed. Set RUSTC_WRAPPER="" to disable.