### PR TITLE
fix: resolve GitHub Actions workflow issues

### DIFF
--- a/.github/workflows/ai-breaking-changes.yml
+++ b/.github/workflows/ai-breaking-changes.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 11 * * 1-5"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-code-duplication.yml
+++ b/.github/workflows/ai-code-duplication.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 10 * * 1"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-code-quality.yml
+++ b/.github/workflows/ai-code-quality.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-docs-patrol.yml
+++ b/.github/workflows/ai-docs-patrol.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 16 * * 1"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-duplicate-issues.yml
+++ b/.github/workflows/ai-duplicate-issues.yml
@@ -4,6 +4,7 @@ on:
     types: [opened]
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
 jobs:

--- a/.github/workflows/ai-explore-arrow-best-practices.yml
+++ b/.github/workflows/ai-explore-arrow-best-practices.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 8 * * 3"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-explore-correctness.yml
+++ b/.github/workflows/ai-explore-correctness.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 10 * * 3"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-explore-new-user.yml
+++ b/.github/workflows/ai-explore-new-user.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 11 * * 3"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-explore-panic-hunter.yml
+++ b/.github/workflows/ai-explore-panic-hunter.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 9 * * 3"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-performance-profiler.yml
+++ b/.github/workflows/ai-performance-profiler.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 12 * * 1-5"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-test-coverage.yml
+++ b/.github/workflows/ai-test-coverage.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 15 * * 1"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/ai-text-auditor.yml
+++ b/.github/workflows/ai-text-auditor.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 13 * * 1"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Rename binary
         run: cp target/${{ matrix.target }}/release/logfwd ${{ matrix.artifact }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary

Fix 14 issues across 13 workflow files found during audit.

### `release.yml` — broken artifact actions
- `actions/upload-artifact@v7` → `@v4` (v7 doesn't exist)
- `actions/download-artifact@v8` → `@v4` (v8 doesn't exist)

### 12 AI workflows — missing `actions: read` permission
When a caller specifies explicit `permissions:`, omitted permissions default to `none`. The called `elastic/ai-github-actions` reusable workflows need `actions: read` (as evidenced by `ai-refactor-opportunist.yml` which already had it).

**Fixed workflows:** ai-breaking-changes, ai-code-duplication, ai-code-quality, ai-docs-patrol, ai-duplicate-issues, ai-explore-arrow-best-practices, ai-explore-correctness, ai-explore-new-user, ai-explore-panic-hunter, ai-performance-profiler, ai-test-coverage, ai-text-auditor

### Not addressed (policy decisions needed)
- 17 `elastic/ai-github-actions` calls use `@main` — consider pinning to SHA
- `ai-pr-review.yml` uses `pull_request_target` with external workflow
- `ci.yml`/`bench.yml` pipe `curl | bash` for tool installs without checksums
- Mutable action tags throughout — consider SHA pinning