### PR TITLE
fix: add actions:read permission to proof auditor workflow

### DIFF
--- a/.github/workflows/ai-explore-proof-auditor.yml
+++ b/.github/workflows/ai-explore-proof-auditor.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 12 * * 2,5"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read


### PR DESCRIPTION
The `ai-explore-proof-auditor.yml` workflow calls `elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main`, which requires `actions: read`. The caller's permissions block omitted it, causing the nested job to fail with:

> The nested job 'agent' is requesting 'actions: read', but is only allowed 'actions: none'.

This was missed in #314 because the file was added after that PR's base commit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>