### PR TITLE
fix: benchmark reporting — detect timeouts, fix comparisons

### DIFF
--- a/crates/logfwd-competitive-bench/src/main.rs
+++ b/crates/logfwd-competitive-bench/src/main.rs
@@ -537,6 +537,7 @@ fn run_one(
                 mode: mode_label.to_string(),
                 lines_done: 0,
                 elapsed_ms: 0,
+                timed_out: false,
                 iteration,
                 samples: Vec::new(),
             });

--- a/crates/logfwd-competitive-bench/src/runner.rs
+++ b/crates/logfwd-competitive-bench/src/runner.rs
@@ -48,6 +48,9 @@ pub struct BenchResult {
     pub mode: String,
     pub lines_done: u64,
     pub elapsed_ms: u64,
+    /// True if the run hit the timeout before completing.
+    #[serde(default)]
+    pub timed_out: bool,
     /// Iteration index for repeated runs; defaults to `1` when omitted in input JSON.
     #[serde(default = "default_iteration")]
     pub iteration: usize,
@@ -103,7 +106,8 @@ pub fn run_agent(
     });
 
     let expected = (ctx.lines as f64 * scenario.expected_line_ratio()) as usize;
-    let lines_done = wait_blackhole_done(blackhole, expected, Duration::from_secs(120));
+    let (lines_done, timed_out) =
+        wait_blackhole_done(blackhole, expected, Duration::from_secs(120));
     let elapsed = start.elapsed();
 
     // Stop sampling and merge agent-specific stats.
@@ -135,6 +139,7 @@ pub fn run_agent(
         mode: "binary".to_string(),
         lines_done,
         elapsed_ms: elapsed.as_millis() as u64,
+        timed_out,
         iteration,
         samples,
     })
@@ -240,7 +245,8 @@ pub fn run_agent_docker(
         .map_err(|e| format!("failed to start docker container for {}: {e}", agent.name()))?;
 
     let expected = (ctx.lines as f64 * scenario.expected_line_ratio()) as usize;
-    let lines_done = wait_blackhole_done(blackhole, expected, Duration::from_secs(180));
+    let (lines_done, timed_out) =
+        wait_blackhole_done(blackhole, expected, Duration::from_secs(180));
     let elapsed = start.elapsed();
 
     // Stop the container.
@@ -259,6 +265,7 @@ pub fn run_agent_docker(
         mode: "docker".to_string(),
         lines_done,
         elapsed_ms: elapsed.as_millis() as u64,
+        timed_out,
         iteration,
         samples: Vec::new(), // TODO: Docker sampling
     })
@@ -333,7 +340,8 @@ pub fn run_agent_perf(
         .spawn()
         .map_err(|e| format!("failed to spawn perf record: {e}"))?;
 
-    let _lines_done = wait_blackhole_done(blackhole, ctx.lines, Duration::from_secs(120));
+    let (_lines_done, _timed_out) =
+        wait_blackhole_done(blackhole, ctx.lines, Duration::from_secs(120));
     let elapsed = start.elapsed();
 
     kill_and_wait(&mut child);
@@ -420,7 +428,8 @@ pub fn run_agent_dhat(
         .spawn()
         .map_err(|e| format!("failed to spawn dhat binary: {e}"))?;
 
-    let _lines_done = wait_blackhole_done(blackhole, ctx.lines, Duration::from_secs(120));
+    let (_lines_done, _timed_out) =
+        wait_blackhole_done(blackhole, ctx.lines, Duration::from_secs(120));
     let elapsed = start.elapsed();
 
     // dhat writes its output on clean exit, so send SIGTERM first.
@@ -588,7 +597,8 @@ fn clock_ticks_per_second() -> u64 {
 }
 
 /// Poll blackhole stats until lines reach expected count or bytes stabilize.
-fn wait_blackhole_done(blackhole: &Blackhole, expected: usize, timeout: Duration) -> u64 {
+/// Returns (lines_done, timed_out).
+fn wait_blackhole_done(blackhole: &Blackhole, expected: usize, timeout: Duration) -> (u64, bool) {
     let start = Instant::now();
     let mut prev_bytes = 0u64;
     let mut stable_count = 0u32;
@@ -596,22 +606,20 @@ fn wait_blackhole_done(blackhole: &Blackhole, expected: usize, timeout: Duration
     loop {
         if start.elapsed() > timeout {
             let (lines, _) = blackhole.stats();
-            return lines;
+            return (lines, true);
         }
 
         std::thread::sleep(Duration::from_millis(100));
         let (lines, bytes) = blackhole.stats();
 
-        // Fast path: line count reached expected.
         if lines >= expected as u64 {
-            return lines;
+            return (lines, false);
         }
 
-        // Slow path: bytes stopped flowing for 3s.
         if bytes == prev_bytes && bytes > 0 {
             stable_count += 1;
             if stable_count >= 30 {
-                return lines;
+                return (lines, false);
             }
         } else {
             stable_count = 0;

--- a/crates/logfwd-competitive-bench/src/summarize.rs
+++ b/crates/logfwd-competitive-bench/src/summarize.rs
@@ -16,6 +16,10 @@ struct AggResult {
 }
 
 impl AggResult {
+    fn any_timed_out(&self) -> bool {
+        self.runs.iter().any(|r| r.timed_out)
+    }
+
     fn avg_elapsed_ms(&self) -> u64 {
         let valid: Vec<u64> = self
             .runs
@@ -80,9 +84,15 @@ impl AggResult {
     fn individual_elapsed(&self) -> String {
         self.runs
             .iter()
-            .map(|r| r.elapsed_ms.to_string())
+            .map(|r| {
+                if r.timed_out {
+                    format!("{}ms(TIMEOUT)", r.elapsed_ms)
+                } else {
+                    format!("{}ms", r.elapsed_ms)
+                }
+            })
             .collect::<Vec<_>>()
-            .join("|")
+            .join(" | ")
     }
 }
 
@@ -218,7 +228,6 @@ fn print_markdown(groups: &[AggResult], scenarios: &[String]) {
         println!("|-------|------|--------:|---------:|-----------:|------|");
         for g in &sg {
             let avg_ms = g.avg_elapsed_ms();
-            let rate = fmt_rate(g.avg_lines_done(), avg_ms);
             if avg_ms == 0 {
                 println!(
                     "| {} | {} | FAILED | - | - | {} |",
@@ -226,7 +235,22 @@ fn print_markdown(groups: &[AggResult], scenarios: &[String]) {
                     g.mode,
                     g.individual_elapsed()
                 );
+            } else if g.any_timed_out() {
+                println!(
+                    "| {} | {} | **TIMEOUT** ({}ms) | {:.0}ms | {} | {} |",
+                    g.name,
+                    g.mode,
+                    avg_ms,
+                    g.stddev_elapsed_ms(),
+                    if g.avg_lines_done() == 0 {
+                        "0 lines (timed out)".to_string()
+                    } else {
+                        fmt_rate(g.avg_lines_done(), avg_ms)
+                    },
+                    g.individual_elapsed(),
+                );
             } else {
+                let rate = fmt_rate(g.avg_lines_done(), avg_ms);
                 println!(
                     "| {} | {} | {}ms | {:.0}ms | {} | {} |",
                     g.name,
@@ -238,27 +262,30 @@ fn print_markdown(groups: &[AggResult], scenarios: &[String]) {
                 );
             }
         }
-        if sg.len() > 1 {
-            let base = sg
+        // Only compare agents that completed without timeout.
+        let completed: Vec<&&AggResult> = sg
+            .iter()
+            .filter(|g| !g.any_timed_out() && g.avg_elapsed_ms() > 0)
+            .collect();
+        if completed.len() > 1 {
+            let base = completed
                 .iter()
                 .max_by_key(|g| g.avg_elapsed_ms())
                 .copied()
-                .unwrap_or(sg[0]);
+                .unwrap();
             let base_ms = base.avg_elapsed_ms();
-            if base_ms > 0 {
-                println!();
-                for g in &sg {
-                    if g.name == base.name && g.mode == base.mode {
-                        continue;
-                    }
-                    let g_ms = g.avg_elapsed_ms();
-                    if g_ms > 0 {
-                        let ratio = base_ms as f64 / g_ms as f64;
-                        println!(
-                            "> **{}** is **{:.1}x faster** than {}",
-                            g.name, ratio, base.name
-                        );
-                    }
+            println!();
+            for g in &completed {
+                if g.name == base.name && g.mode == base.mode {
+                    continue;
+                }
+                let g_ms = g.avg_elapsed_ms();
+                if g_ms > 0 {
+                    let ratio = base_ms as f64 / g_ms as f64;
+                    println!(
+                        "> **{}** is **{:.1}x faster** than {}",
+                        g.name, ratio, base.name
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Timeout detection**: `BenchResult.timed_out` flag set by `wait_blackhole_done`. Agents hitting the 120s timeout show **TIMEOUT** instead of "0 lines/sec".
- **Exclude timed-out agents from comparisons**: No more "filebeat is 1.2x faster than otelcol" when otelcol didn't finish.
- **Runs column clarity**: Shows `4203ms` not `4203`, and `120027ms(TIMEOUT)` for timed-out runs.

## Before (issue #322)

```
| otelcol | binary | 120027ms | 1ms | 0 lines/sec | 120027|120028|120027 |
> filebeat is 1.2x faster than otelcol
```

## After

```
| otelcol | binary | **TIMEOUT** (120027ms) | 1ms | 0 lines (timed out) | 120027ms(TIMEOUT) | ... |
```
Comparisons only include agents that completed.

## Test plan

- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] CI passes

Fixes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)