### PR TITLE
ci: skip CI and E2E workflows on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -16,6 +17,7 @@ permissions:
 jobs:
   lint:
     name: Lint
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -63,6 +65,7 @@ jobs:
 
   test-linux:
     name: Test (Linux)
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -82,6 +85,7 @@ jobs:
 
   release-check:
     name: Release build check
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -99,6 +103,7 @@ jobs:
 
   cross-compile-arm64:
     name: Cross-compile check (ARM64)
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -126,6 +131,7 @@ jobs:
 
   test-macos:
     name: Test (macOS)
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -143,6 +149,7 @@ jobs:
 
   actionlint:
     name: Actionlint
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: e2e-${{ github.head_ref || github.run_id }}
@@ -16,6 +17,7 @@ permissions:
 jobs:
   e2e:
     name: KIND e2e
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

Draft PRs (e.g., from Copilot) were triggering full CI (lint, test-linux, test-macos, release-check, cross-compile-arm64, actionlint) and E2E (KIND cluster) on every push. This wastes CI minutes on work-in-progress code.

## Changes

**`ci.yml`** — all 6 jobs now skip draft PRs:
- Added `types: [opened, synchronize, reopened, ready_for_review]` to the `pull_request` trigger
- Added `if: github.event_name == 'push' || github.event.pull_request.draft == false` to each job

**`e2e.yml`** — same pattern for the KIND e2e job.

## How it works

- **Draft PR created or updated** → all jobs skipped
- **PR marked as ready for review** → `ready_for_review` event fires → all jobs run
- **Push to master** → always runs (the `github.event_name == 'push'` guard)

The `ai-pr-review.yml` and `ai-pr-review-addresser.yml` workflows already had this pattern (`github.event.pull_request.draft == false`).