### PR TITLE
Add proptest: SIMD find_structural_chars ≡ scalar reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/logfwd-core/src/structural.rs
+++ b/crates/logfwd-core/src/structural.rs
@@ -75,7 +75,7 @@ pub fn prefix_xor(mut bitmask: u64) -> u64 {
 /// These are "raw" — quotes may be escaped, structural characters may be
 /// inside strings. Use [`StreamingClassifier::process_block`] to produce
 /// escape-aware, string-masked bitmasks.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct RawBlockMasks {
     pub newline: u64,
     pub space: u64,
@@ -454,6 +454,23 @@ pub fn find_structural_chars(block: &[u8; 64]) -> RawBlockMasks {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn simd_eq_scalar(
+            block in (any::<[u8; 32]>(), any::<[u8; 32]>()).prop_map(|(a, b)| {
+                let mut res = [0u8; 64];
+                res[..32].copy_from_slice(&a);
+                res[32..].copy_from_slice(&b);
+                res
+            })
+        ) {
+            let scalar = find_structural_chars_scalar(&block);
+            let simd = find_structural_chars(&block);
+            prop_assert_eq!(scalar, simd);
+        }
+    }
 
     #[test]
     fn scalar_detects_all_chars() {


### PR DESCRIPTION
I've added a property-based test to verify the correctness of the SIMD-accelerated `find_structural_chars` function against its scalar reference implementation.

Specifically:
- Updated `RawBlockMasks` to derive `PartialEq` and `Eq` for easier testing.
- Added `simd_eq_scalar` to `mod tests` in `crates/logfwd-core/src/structural.rs`.
- Implemented a custom proptest strategy to generate `[u8; 64]` inputs.
- Verified that all 124 tests in `logfwd-core` pass, including the new proptest.

Fixes #334

---
*PR created automatically by Jules for task [18054625997421183051](https://jules.google.com/task/18054625997421183051) started by @strawgate*