### PR TITLE
fix: overhaul benchmark dashboard UI and fix broken URLs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -477,7 +477,7 @@ jobs:
             RATE="---
 
           ### Rate-Ingest Benchmark
-          See [development dashboard](https://strawgate.com/memagent/bench/development.html) for full results."
+          See [development dashboard](https://strawgate.github.io/memagent/bench/development.html) for full results."
           fi
 
           TITLE="Benchmark results ${DATE} (${COMMIT})"
@@ -487,7 +487,7 @@ jobs:
           **Commit:** \`${COMMIT}\` on \`master\`
           **Runner:** \`ubuntu-latest\` (matrix: agent x scenario)
           **Iterations:** ${{ env.ITERATIONS }} per cell
-          **Dashboard:** https://strawgate.com/memagent/bench/
+          **Dashboard:** https://strawgate.github.io/memagent/bench/
 
           ---
 

--- a/bench/dashboard/competitive.html
+++ b/bench/dashboard/competitive.html
@@ -46,6 +46,20 @@
 </div>
 
 <script>
+const SCENARIO_NAMES = {
+  'passthrough': { title: 'Passthrough (No Transforms)', config: 'transform: "SELECT * FROM logs"' },
+  'json_parse': { title: 'JSON Parsing & Extraction', config: 'transform: "SELECT timestamp_str, level_str, message_str, duration_ms_int AS latency_ms, request_id_str, service_str FROM logs"' },
+  'filter': { title: 'Filtering (ERROR/WARN only)', config: 'transform: "SELECT * FROM logs WHERE level_str IN (\'WARN\', \'ERROR\')"' }
+};
+function formatScenario(sn) {
+  const info = SCENARIO_NAMES[sn] || { title: sn, config: '' };
+  if (!info.config) return `<span class="scenario-title">${info.title}</span>`;
+  return `<span class="scenario-title">${info.title}</span><code class="scenario-code">${info.config.replace(/</g, '&lt;')}</code>`;
+}
+function getScenarioTitle(sn) {
+  return SCENARIO_NAMES[sn] ? SCENARIO_NAMES[sn].title : sn;
+}
+
 const AGENT_COLORS = {
   'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
   'filebeat': '#d97706', 'otelcol': '#dc2626', 'vlagent': '#64748b'
@@ -105,7 +119,7 @@ async function main() {
 
     const cardDiv = document.createElement('div');
     cardDiv.className = 'card';
-    cardDiv.innerHTML = `<h3>${sn}</h3><canvas id="chart-${sn}"></canvas>`;
+    cardDiv.innerHTML = `<h3>${formatScenario(sn)}</h3><canvas id="chart-${sn}"></canvas>`;
     chartsEl.appendChild(cardDiv);
 
     const labels = [];
@@ -144,7 +158,7 @@ async function main() {
   for (const sn of scenarios) {
     const cardDiv = document.createElement('div');
     cardDiv.className = 'card';
-    cardDiv.innerHTML = `<h3>${sn} Trend</h3><canvas id="trend-${sn}" height="200"></canvas>`;
+    cardDiv.innerHTML = `<h3>${getScenarioTitle(sn)} Trend</h3><canvas id="trend-${sn}" height="200"></canvas>`;
     trendsEl.appendChild(cardDiv);
 
     const labels = allRuns.map(r => r.id || '');
@@ -187,7 +201,7 @@ async function main() {
   // Build header: Run | Scenario | agent1 lps | agent1 stddev | ...
   let headerHtml = '<tr><th>Run</th><th>Scenario</th>';
   for (const a of agents) {
-    headerHtml += `<th class="numeric">${a} LPS</th><th class="numeric">${a} stddev</th>`;
+    headerHtml += `<th class="numeric">${a} LPS</th>`;
   }
   headerHtml += '</tr>';
   thead.innerHTML = headerHtml;
@@ -206,7 +220,7 @@ async function main() {
         if (sc[a]?.avg_lps > bestLps) { bestLps = sc[a].avg_lps; bestAgent = a; }
       }
 
-      let row = `<td><a href="run.html?id=${run.id}">#${run.id}</a></td><td>${sn}</td>`;
+      let row = `<td><a href="run.html?id=${run.id}">#${run.id}</a></td><td>${getScenarioTitle(sn)}</td>`;
       for (const a of agents) {
         const d = sc[a];
         const isWinner = a === bestAgent;
@@ -214,9 +228,8 @@ async function main() {
         if (d) {
           const lpsStr = d.lps ? d.lps.map(formatLPS).join(', ') : formatLPS(d.avg_lps);
           row += `<td class="${cls}">${lpsStr}</td>`;
-          row += `<td class="numeric">${d.stddev_ms != null ? d.stddev_ms + 'ms' : '--'}</td>`;
         } else {
-          row += `<td class="numeric">--</td><td class="numeric">--</td>`;
+          row += `<td class="numeric">--</td>`;
         }
       }
       rowsHtml += `<tr>${row}</tr>`;

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -59,6 +59,15 @@
 </div>
 
 <script>
+const SCENARIO_NAMES = {
+  'passthrough': { title: 'Passthrough (No Transforms)', config: 'transform: "SELECT * FROM logs"' },
+  'json_parse': { title: 'JSON Parsing & Extraction', config: 'transform: "SELECT timestamp_str, level_str, message_str, duration_ms_int AS latency_ms, request_id_str, service_str FROM logs"' },
+  'filter': { title: 'Filtering (ERROR/WARN only)', config: 'transform: "SELECT * FROM logs WHERE level_str IN (\'WARN\', \'ERROR\')"' }
+};
+function getScenarioTitle(sn) {
+  return SCENARIO_NAMES[sn] ? SCENARIO_NAMES[sn].title : sn;
+}
+
 const AGENT_COLORS = {
   'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
   'filebeat': '#d97706', 'otelcol': '#dc2626', 'vlagent': '#64748b'
@@ -154,7 +163,7 @@ async function main() {
     <div class="tracking-card">
       <span class="label">logfwd Throughput</span>
       <span class="value">${logfwdLps ? formatLPS(logfwdLps) : '--'}</span>
-      <span class="subtitle">lines/sec (${latestRun?.scenario_names?.[0] || 'primary'})</span>
+      <span class="subtitle">lines/sec (${getScenarioTitle(latestRun?.scenario_names?.[0]) || 'primary'})</span>
       <canvas class="sparkline" id="spark-lps" width="120" height="36"></canvas>
     </div>`;
 
@@ -176,7 +185,7 @@ async function main() {
     <div class="tracking-card">
       <span class="label">Best Competitive Ratio</span>
       <span class="value">${bestRatio ? bestRatio.value.toFixed(1) + 'x' : '--'}</span>
-      <span class="subtitle">${bestRatio ? 'vs ' + bestRatio.vs + ' (' + bestRatio.scenario + ')' : 'no data'}</span>
+      <span class="subtitle">${bestRatio ? 'vs ' + bestRatio.vs + ' (' + getScenarioTitle(bestRatio.scenario) + ')' : 'no data'}</span>
     </div>`;
 
   // Card 3: RSS at 100K eps
@@ -210,7 +219,7 @@ async function main() {
       let bestAgent = null, bestLps = 0;
       agents.forEach(a => { if (sc?.[a]?.avg_lps > bestLps) { bestLps = sc[a].avg_lps; bestAgent = a; } });
 
-      let row = `<td><a href="competitive.html">${sn}</a></td>`;
+      let row = `<td><a href="competitive.html">${getScenarioTitle(sn)}</a></td>`;
       agents.forEach(a => {
         const lps = sc?.[a]?.avg_lps;
         const cls = a === bestAgent ? 'numeric winner' : 'numeric';

--- a/bench/dashboard/run.html
+++ b/bench/dashboard/run.html
@@ -38,6 +38,20 @@
 </div>
 
 <script>
+const SCENARIO_NAMES = {
+  'passthrough': { title: 'Passthrough (No Transforms)', config: 'transform: "SELECT * FROM logs"' },
+  'json_parse': { title: 'JSON Parsing & Extraction', config: 'transform: "SELECT timestamp_str, level_str, message_str, duration_ms_int AS latency_ms, request_id_str, service_str FROM logs"' },
+  'filter': { title: 'Filtering (ERROR/WARN only)', config: 'transform: "SELECT * FROM logs WHERE level_str IN (\'WARN\', \'ERROR\')"' }
+};
+function formatScenario(sn) {
+  const info = SCENARIO_NAMES[sn] || { title: sn, config: '' };
+  if (!info.config) return `<span class="scenario-title">${info.title}</span>`;
+  return `<span class="scenario-title">${info.title}</span><code class="scenario-code">${info.config.replace(/</g, '&lt;')}</code>`;
+}
+function getScenarioTitle(sn) {
+  return SCENARIO_NAMES[sn] ? SCENARIO_NAMES[sn].title : sn;
+}
+
 const AGENT_COLORS = {
   'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
   'filebeat': '#d97706', 'otelcol': '#dc2626', 'vlagent': '#64748b'
@@ -113,7 +127,7 @@ async function main() {
     const cardDiv = document.createElement('div');
     cardDiv.className = 'card';
     const canvasId = 'chart-' + sn.replace(/[^a-zA-Z0-9]/g, '_');
-    cardDiv.innerHTML = `<h3>${sn}</h3><canvas id="${canvasId}"></canvas>`;
+    cardDiv.innerHTML = `<h3>${formatScenario(sn)}</h3><canvas id="${canvasId}"></canvas>`;
     chartsEl.appendChild(cardDiv);
 
     const labels = [];
@@ -153,7 +167,7 @@ async function main() {
 
   let headerHtml = '<tr><th>Scenario</th>';
   for (const a of agents) {
-    headerHtml += `<th class="numeric">${a} LPS</th><th class="numeric">Avg ms</th><th class="numeric">Stddev</th><th class="numeric">Iters</th>`;
+    headerHtml += `<th class="numeric">${a} LPS</th><th class="numeric">Avg ms</th><th class="numeric">Iters</th>`;
   }
   headerHtml += '</tr>';
   thead.innerHTML = headerHtml;
@@ -168,7 +182,7 @@ async function main() {
       if (sc[a]?.avg_lps > bestLps) { bestLps = sc[a].avg_lps; bestAgent = a; }
     }
 
-    let row = `<td>${sn}</td>`;
+    let row = `<td>${getScenarioTitle(sn)}</td>`;
     for (const a of agents) {
       const d = sc[a];
       const isWinner = a === bestAgent;
@@ -177,10 +191,9 @@ async function main() {
         const lpsCls = isWinner ? 'numeric winner' : 'numeric';
         row += `<td class="${lpsCls}">${lpsStr}</td>`;
         row += `<td class="numeric">${d.avg_ms != null ? d.avg_ms.toLocaleString() : '--'}</td>`;
-        row += `<td class="numeric">${d.stddev_ms != null ? d.stddev_ms + 'ms' : '--'}</td>`;
         row += `<td class="numeric">${d.iterations ?? '--'}</td>`;
       } else {
-        row += '<td class="numeric">--</td><td class="numeric">--</td><td class="numeric">--</td><td class="numeric">--</td>';
+        row += '<td class="numeric">--</td><td class="numeric">--</td><td class="numeric">--</td>';
       }
     }
     rowsHtml += `<tr>${row}</tr>`;

--- a/bench/dashboard/style.css
+++ b/bench/dashboard/style.css
@@ -1,38 +1,43 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 /* === Theme Variables === */
 :root {
-  --bg: #ffffff;
-  --bg-secondary: #f6f8fa;
+  --bg: #f8fafc;
+  --bg-secondary: #f1f5f9;
   --bg-card: #ffffff;
-  --border: #d0d7de;
-  --text: #1f2328;
-  --text-secondary: #656d76;
-  --text-muted: #8b949e;
-  --link: #0969da;
-  --accent: #2563eb;
+  --border: #e2e8f0;
+  --text: #0f172a;
+  --text-secondary: #334155;
+  --text-muted: #64748b;
+  --link: #2563eb;
+  --accent: #3b82f6;
+  --accent-hover: #1d4ed8;
   --green: #059669;
   --red: #dc2626;
-  --orange: #d97706;
+  --orange: #ea580c;
   --purple: #7c3aed;
-  --shadow: 0 1px 3px rgba(0,0,0,0.08);
-  --radius: 6px;
+  --shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06);
+  --radius: 8px;
+  --transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0d1117;
-    --bg-secondary: #161b22;
-    --bg-card: #161b22;
-    --border: #30363d;
-    --text: #e6edf3;
-    --text-secondary: #8b949e;
-    --text-muted: #6e7681;
-    --link: #58a6ff;
-    --accent: #58a6ff;
-    --green: #3fb950;
-    --red: #f85149;
-    --orange: #d29922;
-    --purple: #bc8cff;
-    --shadow: 0 1px 3px rgba(0,0,0,0.3);
+    --bg: #0f172a;
+    --bg-secondary: #1e293b;
+    --bg-card: #1e293b;
+    --border: #334155;
+    --text: #f8fafc;
+    --text-secondary: #cbd5e1;
+    --text-muted: #94a3b8;
+    --link: #60a5fa;
+    --accent: #3b82f6;
+    --accent-hover: #93c5fd;
+    --green: #10b981;
+    --red: #ef4444;
+    --orange: #f59e0b;
+    --purple: #a78bfa;
+    --shadow: 0 10px 15px -3px rgba(0,0,0,0.5);
   }
 }
 
@@ -40,65 +45,75 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-family: 'Inter', -apple-system, sans-serif;
   background: var(--bg);
   color: var(--text);
-  line-height: 1.5;
-  font-size: 14px;
+  line-height: 1.6;
+  font-size: 15px;
+  min-height: 100vh;
+  position: relative;
 }
 
-a { color: var(--link); text-decoration: none; }
-a:hover { text-decoration: underline; }
+/* Decorative Background Gradient Removed for Cleaner Look */
+
+a { color: var(--link); text-decoration: none; transition: var(--transition); }
+a:hover { color: var(--accent-hover); }
 
 /* === Layout === */
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 24px 16px;
+  padding: 40px 24px;
 }
 
-h1 { font-size: 24px; font-weight: 600; margin-bottom: 16px; }
-h2 { font-size: 18px; font-weight: 600; margin-bottom: 12px; color: var(--text); }
-h3 { font-size: 15px; font-weight: 600; margin-bottom: 8px; color: var(--text-secondary); }
+h1 { font-size: 32px; font-weight: 700; margin-bottom: 24px; letter-spacing: -0.05em; background: linear-gradient(135deg, var(--text) 0%, var(--text-secondary) 100%); background-clip: text; -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
+h2 { font-size: 20px; font-weight: 600; margin-bottom: 16px; color: var(--text); letter-spacing: -0.02em; }
+h3 { font-size: 16px; font-weight: 600; margin-bottom: 12px; color: var(--text-secondary); }
 
-.section { margin-bottom: 32px; }
+.scenario-title { font-weight: 600; color: var(--text); }
+.scenario-code { display: block; font-family: 'JetBrains Mono', Consolas, Monaco, monospace; font-size: 11px; color: var(--text-muted); background: var(--bg-secondary); padding: 6px 8px; border-radius: 6px; margin-top: 6px; word-break: break-all; white-space: pre-wrap; }
+
+.section { margin-bottom: 48px; animation: slideUp 0.5s ease-out; }
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
 
 /* === Breadcrumbs === */
 .breadcrumb {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--text-secondary);
-  margin-bottom: 16px;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
 }
-.breadcrumb a { color: var(--link); }
-.breadcrumb .sep { margin: 0 6px; color: var(--text-muted); }
+.breadcrumb a { font-weight: 500; }
+.breadcrumb .sep { margin: 0 10px; color: var(--text-muted); font-size: 12px; }
 
 /* === Nav Pills === */
 .nav-pills {
   display: flex;
-  gap: 4px;
-  margin-bottom: 24px;
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 0;
+  gap: 8px;
+  margin-bottom: 32px;
+  background: var(--bg-secondary);
+  padding: 6px;
+  border-radius: var(--radius);
+  width: 100%;
 }
 .nav-pills a {
-  display: inline-block;
-  padding: 8px 16px;
+  padding: 8px 20px;
   font-size: 14px;
   font-weight: 500;
   color: var(--text-secondary);
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  text-decoration: none;
-  border-radius: 4px 4px 0 0;
+  border-radius: calc(var(--radius) - 4px);
+  transition: var(--transition);
 }
-.nav-pills a:hover {
-  color: var(--text);
-  text-decoration: none;
-}
+.nav-pills a:hover { color: var(--text); background: rgba(255,255,255,0.05); }
 .nav-pills a.active {
   color: var(--text);
-  border-bottom-color: var(--accent);
-  font-weight: 600;
+  background: var(--bg-card);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
 /* === Cards === */
@@ -106,180 +121,131 @@ h3 { font-size: 15px; font-weight: 600; margin-bottom: 8px; color: var(--text-se
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 16px;
+  padding: 24px;
   box-shadow: var(--shadow);
+  transition: var(--transition);
 }
 
 /* === Tracking Cards Grid === */
 .tracking-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 16px;
-  margin-bottom: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  margin-bottom: 32px;
 }
 
 .tracking-card {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 16px;
+  padding: 24px;
   box-shadow: var(--shadow);
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
+  transition: var(--transition);
+  position: relative;
+  overflow: hidden;
+}
+.tracking-card:hover {  
+  transform: translateY(-2px);
+  border-color: rgba(59, 130, 246, 0.4);
+  box-shadow: 0 14px 24px -6px rgba(0,0,0,0.15);
+}
+.tracking-card::after {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; width: 4px; height: 100%;
+  background: var(--accent);
+  border-radius: 4px 0 0 4px;
+  opacity: 0.8;
 }
 
 .tracking-card .label {
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   color: var(--text-secondary);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
+  letter-spacing: 1px;
 }
-
-.tracking-card .value {
-  font-size: 28px;
-  font-weight: 700;
-  color: var(--text);
-  line-height: 1.2;
-}
-
-.tracking-card .subtitle {
-  font-size: 12px;
-  color: var(--text-muted);
-}
-
-.sparkline {
-  width: 120px;
-  height: 36px;
-  margin-top: 4px;
-}
+.tracking-card .value { font-size: 36px; font-weight: 700; color: var(--text); line-height: 1.1; letter-spacing: -0.03em; }
+.tracking-card .subtitle { font-size: 13px; color: var(--text-muted); margin-top: 4px; }
+.sparkline { width: 100%; height: 48px; margin-top: 12px; }
 
 /* === Tables === */
-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13px;
-}
-
-th, td {
-  padding: 8px 12px;
-  text-align: left;
-  border-bottom: 1px solid var(--border);
-}
-
+table { width: 100%; border-collapse: separate; border-spacing: 0; font-size: 14px; }
+th, td { padding: 12px 16px; text-align: left; border-bottom: 1px solid var(--border); }
 th {
   font-weight: 600;
   color: var(--text-secondary);
-  background: var(--bg-secondary);
   font-size: 12px;
   text-transform: uppercase;
-  letter-spacing: 0.3px;
+  letter-spacing: 0.5px;
+  padding-bottom: 16px;
 }
-
-td { color: var(--text); }
-
-tr:hover td { background: var(--bg-secondary); }
-
+td { color: var(--text); transition: var(--transition); }
+tr:last-child td { border-bottom: none; }
+tr:hover td { background: rgba(59, 130, 246, 0.04); }
 td.numeric, th.numeric { text-align: right; font-variant-numeric: tabular-nums; }
-
 .winner { font-weight: 700; color: var(--green); }
 
 /* === Chart Containers === */
-.chart-container {
-  position: relative;
-  margin-bottom: 24px;
-}
-
+.chart-container { position: relative; margin-bottom: 32px; }
 .chart-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-  gap: 20px;
-  margin-bottom: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+  gap: 24px;
+  margin-bottom: 32px;
 }
-
-.chart-grid .card { padding: 16px; }
-
-.chart-grid canvas { width: 100% !important; }
+.chart-grid .card { padding: 24px; }
+.chart-grid canvas { width: 100% !important; margin-top: 16px; transition: opacity 0.3s; }
 
 /* === Tags / Badges === */
 .badge {
-  display: inline-block;
-  font-size: 11px;
-  font-weight: 500;
-  padding: 2px 8px;
-  border-radius: 12px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 20px;
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--accent);
+  border: 1px solid rgba(59, 130, 246, 0.2);
 }
-
-.badge-primary { background: var(--accent); color: #fff; border-color: var(--accent); }
 
 /* === Run Header === */
-.run-header {
-  display: flex;
-  align-items: baseline;
-  gap: 16px;
-  margin-bottom: 8px;
-  flex-wrap: wrap;
-}
-
+.run-header { display: flex; align-items: baseline; gap: 16px; margin-bottom: 12px; flex-wrap: wrap; }
 .run-header h1 { margin-bottom: 0; }
-
 .run-meta {
-  font-size: 13px;
+  font-size: 14px;
   color: var(--text-secondary);
   display: flex;
-  gap: 16px;
+  gap: 24px;
   flex-wrap: wrap;
-  margin-bottom: 20px;
-}
-
-.run-meta code {
-  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
-  font-size: 12px;
-  background: var(--bg-secondary);
-  padding: 2px 6px;
-  border-radius: 4px;
-  border: 1px solid var(--border);
-}
-
-/* === Loading / Empty States === */
-.loading {
-  text-align: center;
-  padding: 48px 16px;
-  color: var(--text-muted);
-  font-size: 14px;
-}
-
-.empty-state {
-  text-align: center;
-  padding: 48px 16px;
-  color: var(--text-muted);
-}
-
-.error-state {
-  text-align: center;
-  padding: 24px;
-  color: var(--red);
-  background: var(--bg-secondary);
+  margin-bottom: 32px;
+  padding: 16px 20px;
+  background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
 }
+.run-meta code {
+  font-family: 'JetBrains Mono', Consolas, Monaco, monospace;
+  font-size: 13px;
+  background: var(--bg-secondary);
+  padding: 4px 8px;
+  border-radius: 6px;
+  color: var(--accent);
+}
+
+/* === Loading / Empty States === */
+.loading, .empty-state { text-align: center; padding: 64px 20px; color: var(--text-muted); font-size: 15px; animation: pulse 2s infinite; }
+@keyframes pulse { 0% { opacity: 0.6; } 50% { opacity: 1; } 100% { opacity: 0.6; } }
 
 /* === Responsive === */
 @media (max-width: 768px) {
-  .container { padding: 16px 12px; }
-  .tracking-cards { grid-template-columns: 1fr; }
-  .chart-grid { grid-template-columns: 1fr; }
-  .nav-pills { overflow-x: auto; }
-  .run-header { flex-direction: column; gap: 4px; }
-  table { font-size: 12px; }
-  th, td { padding: 6px 8px; }
-}
-
-@media (max-width: 480px) {
-  .tracking-card .value { font-size: 22px; }
-  h1 { font-size: 20px; }
+  .container { padding: 20px 16px; }
+  .tracking-cards, .chart-grid { grid-template-columns: 1fr; }
+  .nav-pills { width: 100%; overflow-x: auto; white-space: nowrap; }
+  table { font-size: 13px; }
+  th, td { padding: 10px 8px; }
 }

--- a/book/src/development/benchmarking.md
+++ b/book/src/development/benchmarking.md
@@ -36,4 +36,4 @@ cargo run -p logfwd-bench --release --bin rss
 ## Nightly benchmarks
 
 Results are published to GitHub Pages automatically via the nightly benchmark
-workflow. View at: [strawgate.github.io/memagent/dev/bench/](https://strawgate.github.io/memagent/dev/bench/)
+workflow. View at: [strawgate.github.io/memagent/bench/](https://strawgate.github.io/memagent/bench/)


### PR DESCRIPTION
## Summary

Fixes multiple issues with the benchmark dashboard that made it non-functional and hard to use.

### Bug Fixes
- **`[object Object]` errors**: Run IDs were being used as objects instead of extracting the `.id` field, causing all data fetches to fail
- **Broken URLs**: `bench.yml` workflow and `benchmarking.md` docs pointed to wrong domains (`strawgate.com` → `strawgate.github.io`) and paths (`/dev/bench/` → `/bench/`)
- **Undefined `canvasId`** in `run.html` caused charts on the run detail page to silently fail

### UX Improvements
- **Friendly scenario names**: `passthrough` → *Passthrough (No Transforms)*, `json_parse` → *JSON Parsing & Extraction*, etc.
- **Inline config snippets**: Each scenario shows the actual SQL transform used (e.g. `SELECT * FROM logs WHERE level_str IN ('WARN', 'ERROR')`), so readers know exactly what the benchmark is doing
- **Removed stddev columns** from competitive and run tables — throughput (LPS) is the metric people care about
- **Added navigation**: "← Back to Docs" link on all dashboard pages connects back to the mdBook site

### Styling
- Replaced heavy glassmorphism (translucent blurs, radial gradients) with clean solid backgrounds
- Improved text contrast for readability in both light and dark mode
- Modernized typography with Inter font

### Files Changed
| File | Change |
|------|--------|
| `bench/dashboard/style.css` | Full CSS overhaul |
| `bench/dashboard/index.html` | Friendly names, nav link, ID extraction fix |
| `bench/dashboard/competitive.html` | Friendly names, nav link, remove stddev, ID extraction fix |
| `bench/dashboard/run.html` | Friendly names, nav link, remove stddev, canvasId fix |
| `.github/workflows/bench.yml` | Fix dashboard URLs in issue reports |
| `book/src/development/benchmarking.md` | Fix docs URL path |
