### PR TITLE
fix: scan_string cross-line safety + skip_nested delimiter tracking (#368, #369)

### DIFF
--- a/crates/logfwd-core/fuzz/fuzz_targets/structural_index.rs
+++ b/crates/logfwd-core/fuzz/fuzz_targets/structural_index.rs
@@ -36,7 +36,7 @@ fuzz_target!(|data: &[u8]| {
 
         // scan_string is only meaningful when starting at a `"` byte.
         if data[i] == b'"' {
-            if let Some((val, after)) = index.scan_string(data, i) {
+            if let Some((val, after)) = index.scan_string(data, i, data.len()) {
                 // Returned slice must be a valid sub-slice of `data`.
                 assert!(after <= data.len(), "scan_string: after={after} > len={}", data.len());
                 let val_start = val.as_ptr() as usize;
@@ -50,7 +50,7 @@ fuzz_target!(|data: &[u8]| {
 
         // skip_nested is only meaningful for `{` or `[`.
         if data[i] == b'{' || data[i] == b'[' {
-            let end = index.skip_nested(data, i);
+            let end = index.skip_nested(data, i, data.len());
             assert!(end <= data.len(), "skip_nested: end={end} > len={}", data.len());
         }
     }

--- a/crates/logfwd-core/src/scanner.rs
+++ b/crates/logfwd-core/src/scanner.rs
@@ -118,7 +118,7 @@ fn scan_line<B: ScanBuilder>(
         if buf[pos] != b'"' {
             break;
         }
-        let (key, after_key) = match index.scan_string(buf, pos) {
+        let (key, after_key) = match index.scan_string(buf, pos, end) {
             Some(r) => r,
             None => break,
         };
@@ -136,7 +136,7 @@ fn scan_line<B: ScanBuilder>(
         let wanted = config.is_wanted(key);
         match buf[pos] {
             b'"' => {
-                let (val, after) = match index.scan_string(buf, pos) {
+                let (val, after) = match index.scan_string(buf, pos, end) {
                     Some(r) => r,
                     None => break,
                 };
@@ -148,7 +148,7 @@ fn scan_line<B: ScanBuilder>(
             }
             b'{' | b'[' => {
                 let s = pos;
-                pos = index.skip_nested(buf, pos).min(end);
+                pos = index.skip_nested(buf, pos, end);
                 if wanted {
                     let idx = builder.resolve_field(key);
                     builder.append_str_by_idx(idx, &buf[s..pos]);

--- a/crates/logfwd-core/src/structural.rs
+++ b/crates/logfwd-core/src/structural.rs
@@ -318,27 +318,46 @@ impl StructuralIndex {
         (self.in_string[block] >> bit) & 1 == 1
     }
 
-    /// Scan a JSON string starting at `pos` (pointing to opening `"`).
+    /// Scan a JSON string starting at `pos` (pointing to opening `"`),
+    /// bounded by `end`. Returns None if the closing quote is not found
+    /// before `end`, preventing cross-line reads on malformed input (#368).
     #[inline(always)]
-    pub fn scan_string<'a>(&self, buf: &'a [u8], pos: usize) -> Option<(&'a [u8], usize)> {
+    pub fn scan_string<'a>(
+        &self,
+        buf: &'a [u8],
+        pos: usize,
+        end: usize,
+    ) -> Option<(&'a [u8], usize)> {
         debug_assert!(pos < buf.len() && buf[pos] == b'"');
         let start = pos + 1;
         if let Some(close) = self.next_quote(start) {
-            Some((&buf[start..close], close + 1))
+            if close < end {
+                Some((&buf[start..close], close + 1))
+            } else {
+                None // closing quote is beyond the line boundary
+            }
         } else {
             None
         }
     }
 
-    /// Skip a nested JSON object/array starting at `pos`.
+    /// Skip a nested JSON object/array starting at `pos`, bounded by `end`.
+    /// Tracks delimiter kind — `{` must close with `}`, `[` with `]`.
+    /// Returns `end` on mismatch instead of desynchronizing (#369).
     #[inline]
-    pub fn skip_nested(&self, buf: &[u8], mut pos: usize) -> usize {
-        let len = buf.len();
-        let mut depth: u32 = 0;
-        while pos < len {
+    pub fn skip_nested(&self, buf: &[u8], mut pos: usize, end: usize) -> usize {
+        // Small stack for delimiter tracking. Max nesting 32 levels — deeper
+        // nesting in a single NDJSON line is pathological.
+        let mut opener_stack = [0u8; 32];
+        let mut depth: usize = 0;
+
+        while pos < end {
             let b = buf[pos];
             match b {
                 b'{' | b'[' if !self.is_in_string(pos) => {
+                    if depth < 32 {
+                        opener_stack[depth] = b;
+                    }
                     depth += 1;
                     pos += 1;
                 }
@@ -347,14 +366,25 @@ impl StructuralIndex {
                         return pos;
                     }
                     depth -= 1;
+                    // Check delimiter match
+                    if depth < 32 {
+                        let expected_close = if opener_stack[depth] == b'{' {
+                            b'}'
+                        } else {
+                            b']'
+                        };
+                        if b != expected_close {
+                            return end; // mismatch — bail to line end
+                        }
+                    }
                     pos += 1;
                     if depth == 0 {
                         return pos;
                     }
                 }
-                b'"' if !self.is_in_string(pos) => match self.scan_string(buf, pos) {
+                b'"' if !self.is_in_string(pos) => match self.scan_string(buf, pos, end) {
                     Some((_, after)) => pos = after,
-                    None => return len,
+                    None => return end,
                 },
                 _ => pos += 1,
             }


### PR DESCRIPTION
## Summary

Two correctness fixes for StructuralIndex query methods:

### scan_string cross-line safety (#368)

`scan_string` now takes an `end` parameter. If the closing quote is beyond the line boundary, returns `None` instead of silently returning a cross-line slice. Prevents the scanner from consuming content from the next NDJSON line on malformed input.

### skip_nested delimiter tracking (#369)

`skip_nested` now tracks opener kind with a 32-level stack. `{` must close with `}`, `[` with `]`. On mismatch (e.g., `{]`), returns `end` instead of continuing with a desynchronized depth counter.

## What changed

- `scan_string(buf, pos)` → `scan_string(buf, pos, end)`
- `skip_nested(buf, pos)` → `skip_nested(buf, pos, end)`
- Scanner, fuzz target updated for new signatures

## Test plan

- [x] 267 core+arrow tests pass
- [x] Clippy clean
- [x] Fuzz target updated

Also closes #316 (already fixed) and #317 (already fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)