### PR TITLE
feat: add pre-commit hooks and update contribution guidelines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+-   repo: local
+    hooks:
+    -   id: cargo-fmt
+        name: cargo fmt
+        description: Check if all rust files are formatted.
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+    -   id: cargo-clippy
+        name: cargo clippy
+        description: Run clippy on all packages.
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,13 @@
 
 ## Pre-Commit Checklist
 
-Run these before every commit:
+We use [pre-commit](https://pre-commit.com/) to automatically run fast checks (formatting and linting) before every commit. 
+
+To set it up:
+1. Install pre-commit: `pip install pre-commit` (or your preferred manager)
+2. Install the hooks: `pre-commit install`
+
+If you prefer manual checks, run these before every commit:
 
 ```bash
 # Format code
@@ -26,7 +32,7 @@ just ci
 
 ## Pre-Push Checklist
 
-Before pushing to a branch or creating a PR:
+Before pushing to a branch or creating a PR, you **MUST** ensure the full CI suite passes locally:
 
 ```bash
 # Full CI suite (format + clippy + TOML + deny + test)


### PR DESCRIPTION
This PR introduces a [pre-commit](https://pre-commit.com/) configuration to automate fast checks (formatting and linting) before every commit. 

It also updates  with:
- Instructions on how to set up and use the automated pre-commit hooks.
- A mandatory requirement to run the full CI suite () locally before pushing or creating a PR.