### PR TITLE
fix: escape all JSON control characters (RFC 8259 compliance)

### DIFF
--- a/crates/logfwd-io/src/format.rs
+++ b/crates/logfwd-io/src/format.rs
@@ -259,6 +259,22 @@ mod tests {
     }
 
     #[test]
+    fn test_raw_parser_control_char_escaping() {
+        let mut parser = RawParser::new();
+        let mut out = Vec::new();
+        // msg contains a backspace (\x08)
+        let (n, _) = parser.process(b"has\x08raw_byte\n", &mut out);
+        assert_eq!(n, 1);
+        let s = String::from_utf8(out).unwrap();
+        // RFC 8259 mandates control characters be escaped. \x08 should be \u0008.
+        assert!(
+            s.contains(r#""_raw":"has\u0008raw_byte""#),
+            "Expected escaped backspace, got: {}",
+            s
+        );
+    }
+
+    #[test]
     fn cri_basic() {
         let mut parser = CriParser::new(2 * 1024 * 1024);
         let mut out = Vec::new();

--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -198,6 +198,9 @@ pub(crate) fn write_row_json(batch: &RecordBatch, row: usize, cols: &[ColInfo], 
                         b'\n' => out.extend_from_slice(b"\\n"),
                         b'\r' => out.extend_from_slice(b"\\r"),
                         b'\t' => out.extend_from_slice(b"\\t"),
+                        b if b < 0x20 => {
+                            let _ = std::io::Write::write_fmt(out, format_args!("\\u{:04x}", b));
+                        }
                         _ => out.push(b),
                     }
                 }
@@ -688,6 +691,26 @@ mod tests {
         };
         let sink = build_output_sink("auth-sink", &cfg).unwrap();
         assert_eq!(sink.name(), "auth-sink");
+    }
+
+    #[test]
+    fn test_json_control_char_escaping() {
+        let schema = Arc::new(Schema::new(vec![Field::new("msg", DataType::Utf8, true)]));
+        // msg contains a backspace (\x08)
+        let msg = StringArray::from(vec![Some("has\x08raw_byte")]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(msg)]).unwrap();
+
+        let cols = build_col_infos(&batch);
+        let mut out = Vec::new();
+        write_row_json(&batch, 0, &cols, &mut out);
+
+        let output = String::from_utf8(out).unwrap();
+        // RFC 8259 mandates control characters be escaped. \x08 should be \u0008.
+        assert!(
+            output.contains(r#""msg":"has\u0008raw_byte""#),
+            "Expected escaped backspace, got: {}",
+            output
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
This PR ensures that all control characters in string values are properly escaped in the JSON output, complying with RFC 8259. It addresses the issue where characters like backspace (`\x08`) were being emitted raw, causing downstream parsing errors. The fix was applied to `write_row_json` in `logfwd-output` and verified in `RawParser` in `logfwd-io`. Unit tests and an end-to-end reproduction script confirm the fix and prevent regressions.

Fixes #405

---
*PR created automatically by Jules for task [5004343701183992682](https://jules.google.com/task/5004343701183992682) started by @strawgate*