### PR TITLE
fix: add missing pull-requests: read permissions to AI workflows

### DIFF
--- a/.github/workflows/ai-duplicate-issues.yml
+++ b/.github/workflows/ai-duplicate-issues.yml
@@ -7,6 +7,7 @@ permissions:
   actions: read
   contents: read
   issues: write
+  pull-requests: read
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-duplicate-issue-detector.lock.yml@main

--- a/.github/workflows/ai-explore-proof-auditor.yml
+++ b/.github/workflows/ai-explore-proof-auditor.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 12 * * 2,5"
   workflow_dispatch:
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: read


### PR DESCRIPTION
Adds `pull-requests: read` to workflows that were failing due to missing permissions for nested jobs.