### PR TITLE
feat: build binaries on push to master, add Windows targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,159 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  # -----------------------------------------------------------------------
+  # Build the logfwd binary for each supported target platform.
+  # Linux targets are built with musl for fully static binaries.
+  # macOS targets are built on the native runners.
+  # Windows targets are built on windows-latest.
+  # -----------------------------------------------------------------------
+  build:
+    name: Build (${{ matrix.artifact }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            artifact: logfwd-linux-amd64
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            artifact: logfwd-linux-arm64
+            use_cross: true
+          - target: x86_64-apple-darwin
+            os: macos-13
+            artifact: logfwd-darwin-amd64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: logfwd-darwin-arm64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: logfwd-windows-amd64.exe
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            artifact: logfwd-windows-arm64.exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mozilla-actions/sccache-action@v0.0.7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install musl-tools (Linux x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Install cross (Linux ARM64)
+        if: matrix.use_cross == true
+        run: cargo install cross --locked
+
+      - name: Build (cross)
+        if: matrix.use_cross == true
+        run: cross build --release --bin logfwd --target ${{ matrix.target }}
+        env:
+          RUSTC_WRAPPER: ""
+
+      - name: Build (cargo)
+        if: matrix.use_cross != true
+        run: cargo build --release --bin logfwd --target ${{ matrix.target }}
+
+      - name: Rename binary (Unix)
+        if: runner.os != 'Windows'
+        run: cp target/${{ matrix.target }}/release/logfwd ${{ matrix.artifact }}
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        run: cp target/${{ matrix.target }}/release/logfwd.exe ${{ matrix.artifact }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
+
+  # -----------------------------------------------------------------------
+  # Create the GitHub Release and attach the binary artifacts.
+  # Only runs on tag pushes (v*).
+  # -----------------------------------------------------------------------
+  release:
+    name: Create GitHub Release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+
+  # -----------------------------------------------------------------------
+  # Build and push a multi-arch Docker image to ghcr.io.
+  # Only runs on tag pushes (v*).
+  # -----------------------------------------------------------------------
+  docker:
+    name: Docker (${{ github.ref_name }})
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,19 @@ pub mod diagnostics;
 pub mod compress;
 pub mod config;
 pub mod cri;
+#[cfg(unix)]
 pub mod daemon;
 pub mod e2e_bench;
 pub mod otlp;
 pub mod output;
 pub mod pipeline;
+#[cfg(unix)]
 pub mod pipeline_v2;
+#[cfg(unix)]
 pub mod read_tuner;
 pub mod scanner;
 pub mod sender;
+#[cfg(unix)]
 pub mod tail;
 pub mod transform;
 pub mod tuner;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,10 @@ use std::time::{Duration, Instant};
 use logfwd::chunk::ChunkConfig;
 use logfwd::compress::ChunkCompressor;
 use logfwd::otlp;
+#[cfg(unix)]
 use logfwd::daemon::{self, DaemonConfig};
 use logfwd::pipeline::{self, OutputMode, PipelineConfig, PipelineStats};
+#[cfg(unix)]
 use logfwd::tail::{FileTailer, TailConfig, TailEvent};
 
 fn main() -> io::Result<()> {
@@ -127,6 +129,7 @@ fn main() -> io::Result<()> {
     }
 
     // Handle --config mode (v2 Arrow pipeline from YAML config)
+    #[cfg(unix)]
     if args[1] == "--config" {
         if args.len() < 3 {
             eprintln!("Usage: logfwd --config <config.yaml> [--validate] [--dry-run]");
@@ -148,6 +151,7 @@ fn main() -> io::Result<()> {
     }
 
     // Handle --daemon mode
+    #[cfg(unix)]
     if args[1] == "--daemon" {
         let mut dc = DaemonConfig::default();
         let mut i = 2;
@@ -204,8 +208,14 @@ fn main() -> io::Result<()> {
         i += 1;
     }
 
+    #[cfg(unix)]
     if tail_mode {
         return run_tail(&path, &mode, level);
+    }
+    #[cfg(not(unix))]
+    if tail_mode {
+        eprintln!("Tail mode is not supported on this platform");
+        std::process::exit(1);
     }
 
     let mode_name = match mode {
@@ -434,6 +444,7 @@ fn run_blackhole(addr: &str) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn run_v2_pipelines(config: logfwd::config::Config, dry_run: bool) -> io::Result<()> {
     use logfwd::diagnostics::DiagnosticsServer;
     use logfwd::pipeline_v2::Pipeline;
@@ -488,6 +499,7 @@ fn run_v2_pipelines(config: logfwd::config::Config, dry_run: bool) -> io::Result
     Ok(())
 }
 
+#[cfg(unix)]
 fn run_tail(path: &Path, mode: &OutputMode, level: i32) -> io::Result<()> {
     let mode_name = match mode {
         OutputMode::RawChunk => "raw",
@@ -605,6 +617,7 @@ fn run_tail(path: &Path, mode: &OutputMode, level: i32) -> io::Result<()> {
 }
 
 /// Set up Ctrl-C to flip an AtomicBool. Portable, no sigaction needed.
+#[cfg(unix)]
 fn ctrlc_flag(flag: &Arc<AtomicBool>) {
     let f = flag.clone();
     let _ = std::thread::spawn(move || {


### PR DESCRIPTION
## Summary
- Trigger release workflow on push to master so binary artifacts are always available (not just on tag pushes)
- Add Windows x86_64 and ARM64 build targets to the matrix
- Gate Unix-only modules (`tail`, `daemon`, `pipeline_v2`, `read_tuner`) behind `#[cfg(unix)]` so Windows MSVC builds compile — these use `std::os::unix::fs::MetadataExt` for inode/device tracking
- Release creation and Docker push still only run on tag pushes (`v*`)

## Test plan
- [x] All 107 tests pass locally on macOS (unix)
- [ ] CI validates Linux + macOS builds
- [ ] Windows builds compile for the first time (new targets)
- [ ] Verify artifacts are uploaded on push to master
- [ ] Verify release/docker jobs are skipped on non-tag pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)