### PR TITLE
dev: add local OTLP profiling workflow

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -45,6 +45,44 @@ To temporarily **disable** sccache (e.g. for debugging):
 RUSTC_WRAPPER="" cargo build
 ```
 
+## Local CPU profiling (macOS)
+
+The `cpu-profiling` feature works locally on macOS, but the shutdown path matters:
+the profiled `logfwd` process must receive `SIGTERM` directly so it can build and
+write `flamegraph.svg` before exiting.
+
+The easiest way to run the full File -> OTLP path locally is:
+
+```bash
+just profile-otlp-local
+```
+
+This recipe:
+
+- builds `logfwd` with `--features cpu-profiling`
+- generates a JSON input file
+- starts a local OTLP blackhole on a fresh port
+- runs `logfwd` with a file input and OTLP output
+- sends `SIGTERM` to the real `logfwd` child process after a short run
+- leaves a temp directory containing `config.yaml`, `logs.json`, `pipeline.log`,
+  `blackhole.log`, and `flamegraph.svg`
+
+Useful variants:
+
+```bash
+just profile-otlp-local 1000000 10
+```
+
+Caveats:
+
+- Avoid reusing a diagnostics port from another local run; the helper recipe
+  omits diagnostics entirely to keep the profile loop simple.
+- If the `cpu-profiling` release build fails with `No space left on device`,
+  run `RUSTC_WRAPPER= cargo clean` and retry. The profiled release build is
+  large because `release` keeps debug info for flamegraphs.
+- Killing a wrapper shell is not sufficient; the `SIGTERM` must reach the
+  actual `logfwd` process.
+
 ---
 
 ## Things that will bite you

--- a/justfile
+++ b/justfile
@@ -85,6 +85,64 @@ bench-docker:
         --lines 5000000 --docker --cpus 1 --memory 1g --markdown \
         --profile ./profiles --dhat-binary ./target/release/logfwd-dhat
 
+# Run a local File -> OTLP profile with pprof-rs.
+# Outputs a temp directory containing config.yaml, logs.json, pipeline.log,
+# blackhole.log, and flamegraph.svg.
+profile-otlp-local lines="500000" seconds="6":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    ROOT=$(mktemp -d /tmp/logfwd-pprof.XXXXXX)
+    PORT=$(python3 -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
+
+    echo "==> Build cpu-profiling binary"
+    RUSTC_WRAPPER= cargo build --release --features cpu-profiling -p logfwd
+
+    mkdir -p "${ROOT}/bin"
+    cp target/release/logfwd "${ROOT}/bin/logfwd-prof"
+
+    echo "==> Generate test data ({{lines}} lines)"
+    "${ROOT}/bin/logfwd-prof" --generate-json "{{lines}}" "${ROOT}/logs.json"
+
+    printf '%s\n' \
+      "input:" \
+      "  type: file" \
+      "  path: ${ROOT}/logs.json" \
+      "  format: json" \
+      "transform: |" \
+      "  SELECT * FROM logs" \
+      "output:" \
+      "  type: otlp" \
+      "  endpoint: http://127.0.0.1:${PORT}" \
+      "  protocol: http" \
+      "  compression: zstd" \
+      > "${ROOT}/config.yaml"
+
+    echo "==> Start blackhole on ${PORT}"
+    "${ROOT}/bin/logfwd-prof" --blackhole "127.0.0.1:${PORT}" > "${ROOT}/blackhole.log" 2>&1 &
+    BLACKHOLE_PID=$!
+    cleanup() {
+        kill -TERM "${BLACKHOLE_PID}" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    echo "==> Run profiled pipeline for {{seconds}}s"
+    pushd "${ROOT}" >/dev/null
+    "${ROOT}/bin/logfwd-prof" --config "${ROOT}/config.yaml" > pipeline.log 2>&1 &
+    PIPELINE_PID=$!
+    sleep "{{seconds}}"
+    kill -TERM "${PIPELINE_PID}"
+    wait "${PIPELINE_PID}" || true
+    popd >/dev/null
+
+    echo "==> Output directory: ${ROOT}"
+    ls -lah "${ROOT}"
+    if [ -f "${ROOT}/flamegraph.svg" ]; then
+        du -h "${ROOT}/flamegraph.svg"
+    else
+        echo "flamegraph.svg missing"
+        exit 1
+    fi
+
 # Generate microbenchmark report (markdown)
 bench-report:
     cargo run -p logfwd-bench


### PR DESCRIPTION
## Summary
- add a `just profile-otlp-local` helper that runs the File -> OTLP path locally with `cpu-profiling`, generates input data, starts a fresh local blackhole, and emits `flamegraph.svg`
- document the working macOS pprof-rs shutdown flow and local caveats in `DEVELOPING.md`, including direct `SIGTERM` delivery and disk-space cleanup guidance
- capture a repeatable local profiling loop so performance investigation no longer depends on CI artifacts

## Test plan
- [x] `just profile-otlp-local 10000 2`
- [x] Verified the recipe produced a temp output directory with `flamegraph.svg`
- [x] Verified the File -> OTLP profile on macOS showed scanner and OTLP sink hotspots suitable for local investigation


Made with [Cursor](https://cursor.com)