### PR TITLE
fix: correct competitive bench line counting for OTLP and NDJSON

### DIFF
--- a/crates/logfwd-competitive-bench/src/blackhole.rs
+++ b/crates/logfwd-competitive-bench/src/blackhole.rs
@@ -109,7 +109,10 @@ fn count_lines(body: &[u8], url: &str) -> u64 {
     if url.contains("/v1/logs") {
         // OTLP JSON: count exact logRecords from nested arrays when possible.
         // Falls back to lightweight body-key scanning or newline-based estimates.
-        let otlp_count = count_otlp_log_records(body).max(count_otlp_body_keys(body));
+        let otlp_count = match count_otlp_log_records(body) {
+            0 => count_otlp_body_keys(body),
+            n => n,
+        };
         if otlp_count > 0 {
             return otlp_count;
         }


### PR DESCRIPTION
## Summary
- fix blackhole line counting used by competitive benchmarks
- count OTLP `/v1/logs` records by parsing `resourceLogs[].scopeLogs[].logRecords[]`
- keep fallback to `"body":` scan when OTLP JSON parsing is unavailable
- fix NDJSON counting for payloads without trailing newline
- add regression tests for NDJSON, ES bulk, and OTLP log record counting

## Why
Benchmark throughput can be under-reported when payloads do not end with `\n` (notably affecting jsonline senders like vlagent), and OTLP payload counting should use log-record semantics rather than newline heuristics.

## Validation
- `cargo test -p logfwd-competitive-bench`
- `cargo check -p logfwd-competitive-bench`
- `just ci` in this environment is blocked by pre-existing `cargo deny` duplicate warnings unrelated to this patch

## Notes
I attempted focused docker benchmark runs for `otelcol` and `vlagent`, but benchmark execution is blocked/hangs in this environment. The code path and regression tests are in place for deterministic counting behavior.
