### PR TITLE
fix: dashboard source — timing fields, favicon, CPU chart consistency

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>dashboard</title>
   </head>

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -44,7 +44,6 @@ const HISTORY_MAP: Record<string, { series: string; mode: "gauge" | "counter" }>
   input_lines: { series: "lps", mode: "counter" },
   input_bytes: { series: "bps", mode: "counter" },
   output_errors: { series: "err", mode: "counter" },
-  cpu_user_ms: { series: "cpu", mode: "counter" },
   mem_allocated: { series: "mem", mode: "gauge" },
 };
 
@@ -92,6 +91,29 @@ export function App() {
           }
         }
       }
+      // CPU: sum cpu_user_ms + cpu_sys_ms deltas to match live path.
+      const cpuUser = hist["cpu_user_ms"];
+      const cpuSys = hist["cpu_sys_ms"];
+      if (cpuUser && cpuSys && cpuUser.length >= 2 && cpuSys.length >= 2) {
+        const cpuS = series.find((s) => s.id === "cpu");
+        if (cpuS) {
+          // Build a map from time → value for cpuSys for quick lookup.
+          const sysMap = new Map<number, number>(cpuSys.map(([t, v]) => [t, v]));
+          const latestT = cpuUser[cpuUser.length - 1][0];
+          for (let i = 1; i < cpuUser.length; i++) {
+            const dt = cpuUser[i][0] - cpuUser[i - 1][0];
+            if (dt <= 0) continue;
+            const prevSys = sysMap.get(cpuUser[i - 1][0]);
+            const curSys = sysMap.get(cpuUser[i][0]);
+            if (prevSys == null || curSys == null) continue;
+            const totalMs = (cpuUser[i][1] - cpuUser[i - 1][1]) + (curSys - prevSys);
+            let rate = totalMs / dt / 10; // ms/s → %
+            if (rate < 0) rate = 0;
+            cpuS.ring.pushRaw(now - (latestT - cpuUser[i][0]) * 1000, rate);
+          }
+        }
+      }
+
       forceUpdate((n) => n + 1);
     });
   }, []);

--- a/dashboard/src/components/PipelineView.tsx
+++ b/dashboard/src/components/PipelineView.tsx
@@ -95,8 +95,8 @@ export function PipelineView({ pipeline: p }: Props) {
             <div class="insp-kv"><div class="ik-l">Lines In</div><div class="ik-v">{fmt(p.transform.lines_in)}</div></div>
             <div class="insp-kv"><div class="ik-l">Lines Out</div><div class="ik-v">{fmt(p.transform.lines_out)}</div></div>
             <div class="insp-kv"><div class="ik-l">Drop Rate</div><div class="ik-v">{(p.transform.filter_drop_rate * 100).toFixed(1)}%</div></div>
-            {p.scan_sec != null && <div class="insp-kv"><div class="ik-l">Scan Time</div><div class="ik-v">{p.scan_sec.toFixed(3)}s</div></div>}
-            {p.transform_sec != null && <div class="insp-kv"><div class="ik-l">Transform Time</div><div class="ik-v">{p.transform_sec.toFixed(3)}s</div></div>}
+            {p.stage_seconds?.scan != null && <div class="insp-kv"><div class="ik-l">Scan Time</div><div class="ik-v">{p.stage_seconds.scan.toFixed(3)}s</div></div>}
+            {p.stage_seconds?.transform != null && <div class="insp-kv"><div class="ik-l">Transform Time</div><div class="ik-v">{p.stage_seconds.transform.toFixed(3)}s</div></div>}
           </div>
         </div>
       )}

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -22,9 +22,7 @@ export interface PipelineData {
   transform: TransformData;
   outputs: ComponentData[];
   batches?: number;
-  scan_sec?: number;
-  transform_sec?: number;
-  output_sec?: number;
+  stage_seconds?: { scan: number; transform: number; output: number };
   backpressure_stalls?: number;
 }
 


### PR DESCRIPTION
## Summary

- **PipelineView timing fields**: Changed `PipelineData` interface to use `stage_seconds?: { scan, transform, output }` instead of separate `scan_sec`/`transform_sec`/`output_sec` fields, matching the actual `/api/pipelines` response structure. Updated `PipelineView.tsx` to read `p.stage_seconds?.scan` / `p.stage_seconds?.transform`.
- **Favicon dead link**: Removed `<link rel="icon" href="/favicon.svg" />` from `index.html` since the diagnostics server doesn't serve static assets.
- **CPU chart history vs live inconsistency**: History backfill now sums both `cpu_user_ms` and `cpu_sys_ms` deltas to match the live refresh path. Previously history showed user-only CPU while live showed total (user+sys).

## Test plan

- [ ] Verify dashboard builds cleanly (`cd dashboard && npm run build`)
- [ ] Confirm pipeline inspector shows scan/transform times from `stage_seconds`
- [ ] Confirm no 404 for favicon in browser devtools
- [ ] Confirm CPU chart history and live values are consistent (both show user+sys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)