### PR TITLE
fix: replace unsafe .unwrap() in grok UDF with proper error handling

### DIFF
--- a/crates/logfwd-transform/src/udf/grok.rs
+++ b/crates/logfwd-transform/src/udf/grok.rs
@@ -256,13 +256,15 @@ impl ScalarUDFImpl for GrokUdf {
                     })
                     .collect();
 
+                let fields_and_arrays = fields
+                    .into_iter()
+                    .zip(values)
+                    .map(|(f, v)| Ok((Arc::new(f), v.to_array()? as ArrayRef)))
+                    .collect::<Result<Vec<_>, arrow::error::ArrowError>>()?;
+
                 Ok(ColumnarValue::Scalar(
                     datafusion::common::ScalarValue::Struct(Arc::new(StructArray::from(
-                        fields
-                            .into_iter()
-                            .zip(values)
-                            .map(|(f, v)| (Arc::new(f), v.to_array().unwrap() as ArrayRef))
-                            .collect::<Vec<_>>(),
+                        fields_and_arrays,
                     ))),
                 ))
             }


### PR DESCRIPTION
The `grok` UDF in `crates/logfwd-transform/src/udf/grok.rs` could previously panic if `ScalarValue::to_array()` failed on user data, potentially crashing the entire log processing pipeline. This PR replaces that `.unwrap()` call with proper error propagation using the `?` operator.

Changes:
- Modified `invoke_with_args` in `GrokUdf` to safely handle `ScalarValue::to_array()` results.
- Collected scalar conversion results into a `Result` to allow early exit on `ArrowError`.
- Verified the fix with existing tests and workspace-wide linting.

Fixes #542

---
*PR created automatically by Jules for task [2832844499801993238](https://jules.google.com/task/2832844499801993238) started by @strawgate*