### PR TITLE
fix: install-hooks works from any git worktree

### DIFF
--- a/justfile
+++ b/justfile
@@ -248,17 +248,21 @@ install-tools:
     @echo "Optional: cargo install cargo-nextest inferno"
     @echo "Install just: https://just.systems/man/en/installation.html"
 
-# Set up git pre-commit hook
+# Set up git pre-commit hook (works from any worktree)
 install-hooks:
-    @echo '#!/bin/sh' > .git/hooks/pre-commit
-    @echo 'set -e' >> .git/hooks/pre-commit
-    @echo 'cargo fmt --check' >> .git/hooks/pre-commit
-    @echo 'cargo clippy -- -D warnings' >> .git/hooks/pre-commit
-    @chmod +x .git/hooks/pre-commit
-    @echo "Pre-commit hook installed (.git/hooks/pre-commit)"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HOOKS_DIR=$(git rev-parse --git-common-dir)/hooks
+    mkdir -p "$HOOKS_DIR"
+    printf '#!/bin/sh\nset -e\nRUSTC_WRAPPER="" cargo fmt --check\nRUSTC_WRAPPER="" cargo clippy -- -D warnings\n' \
+        > "$HOOKS_DIR/pre-commit"
+    chmod +x "$HOOKS_DIR/pre-commit"
+    echo "Pre-commit hook installed ($HOOKS_DIR/pre-commit)"
 
 # Remove git pre-commit hook
 uninstall-hooks:
-    @rm -f .git/hooks/pre-commit
-    @echo "Pre-commit hook removed"
+    #!/usr/bin/env bash
+    HOOKS_DIR=$(git rev-parse --git-common-dir)/hooks
+    rm -f "$HOOKS_DIR/pre-commit"
+    echo "Pre-commit hook removed"
 


### PR DESCRIPTION
## Problem

`just install-hooks` writes to `.git/hooks/pre-commit` using a hardcoded path. Inside a git worktree, `.git` is a **file** (not a directory) — it contains a pointer like `gitdir: /path/to/main/.git/worktrees/<name>`. Writing to `.git/hooks/...` in a worktree fails with *"Not a directory"*.

## Fix

Use `git rev-parse --git-common-dir` which always resolves to the main repo's `.git/` directory regardless of which worktree you run from. This is the canonical git API for finding shared state across worktrees.

Also clears `RUSTC_WRAPPER` in the hook so that globally-configured sccache (e.g. via `~/.cargo/config.toml`) doesn't break local commits on machines where the sccache binary isn't installed.

## Test plan
- [ ] `just install-hooks` from main repo root
- [ ] `just install-hooks` from a git worktree (e.g. `/tmp/some-worktree`)
- [ ] Verify `.git/hooks/pre-commit` exists in the main repo's hooks dir in both cases
- [ ] Verify `just uninstall-hooks` also works from a worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)