### PR TITLE
fix: add cargo check --all-targets to pre-commit hook

### DIFF
--- a/crates/logfwd-bench/benches/elasticsearch_arrow.rs
+++ b/crates/logfwd-bench/benches/elasticsearch_arrow.rs
@@ -100,7 +100,7 @@ fn generate_log_batch(num_rows: usize) -> RecordBatch {
 /// Index a batch of data into Elasticsearch.
 fn index_batch(sink: &mut ElasticsearchSink, batch: &RecordBatch) -> Result<(), std::io::Error> {
     let metadata = BatchMetadata {
-        resource_attrs: vec![],
+        resource_attrs: Arc::new(vec![]),
         observed_time_ns: 0,
     };
     sink.send_batch(batch, &metadata)

--- a/crates/logfwd-output/tests/elasticsearch_arrow_ipc.rs
+++ b/crates/logfwd-output/tests/elasticsearch_arrow_ipc.rs
@@ -54,7 +54,7 @@ fn setup_test_data(sink: &mut ElasticsearchSink) -> RecordBatch {
     .expect("batch creation failed");
 
     let metadata = BatchMetadata {
-        resource_attrs: vec![],
+        resource_attrs: Arc::new(vec![]),
         observed_time_ns: 0,
     };
 

--- a/crates/logfwd-output/tests/elasticsearch_integration.rs
+++ b/crates/logfwd-output/tests/elasticsearch_integration.rs
@@ -88,7 +88,7 @@ fn elasticsearch_sink_sends_bulk_data() {
     );
 
     let metadata = BatchMetadata {
-        resource_attrs: vec![],
+        resource_attrs: Arc::new(vec![]),
         observed_time_ns: 0,
     };
 
@@ -136,7 +136,7 @@ fn elasticsearch_sink_handles_empty_batch() {
     );
 
     let metadata = BatchMetadata {
-        resource_attrs: vec![],
+        resource_attrs: Arc::new(vec![]),
         observed_time_ns: 0,
     };
 
@@ -176,7 +176,7 @@ fn elasticsearch_sink_multiple_batches() {
     );
 
     let metadata = BatchMetadata {
-        resource_attrs: vec![],
+        resource_attrs: Arc::new(vec![]),
         observed_time_ns: 0,
     };
 

--- a/justfile
+++ b/justfile
@@ -254,7 +254,7 @@ install-hooks:
     set -euo pipefail
     HOOKS_DIR=$(git rev-parse --git-common-dir)/hooks
     mkdir -p "$HOOKS_DIR"
-    printf '#!/bin/sh\nset -e\nRUSTC_WRAPPER="" cargo fmt --check\nRUSTC_WRAPPER="" cargo clippy -- -D warnings\n' \
+    printf '#!/bin/sh\nset -e\nRUSTC_WRAPPER="" cargo fmt --check\nRUSTC_WRAPPER="" cargo clippy -- -D warnings\nRUSTC_WRAPPER="" cargo check --all-targets\n' \
         > "$HOOKS_DIR/pre-commit"
     chmod +x "$HOOKS_DIR/pre-commit"
     echo "Pre-commit hook installed ($HOOKS_DIR/pre-commit)"


### PR DESCRIPTION
## Summary

- Pre-commit hook only ran `fmt + clippy`, which skip `tests/`, `benches/`, and `examples/` targets — type errors in those files went undetected before commit
- Add `cargo check --all-targets` as the third step so compile errors in all targets are caught locally
- Fix the `Arc<Vec<...>>` type mismatch in ES tests/bench introduced by #678 (missed by the old hook)

## Test plan
- [ ] `just install-hooks` then attempt a commit with a type error in a test file — hook should reject it
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)