### PR TITLE
fix: add kani::cover!() guards to tag/bytes proofs; fix framed tests

### DIFF
--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -638,6 +638,10 @@ mod verification {
         let decoded_field = (tag_value >> 3) as u32;
         assert!(decoded_wire == wire_type, "wire type mismatch");
         assert!(decoded_field == field_number, "field number mismatch");
+
+        // Confirm both extremes of the constrained space are reachable
+        kani::cover!(field_number == 1 && wire_type == 0);
+        kani::cover!(field_number == 0x1FFFFFFF && wire_type == 5);
     }
 
     /// Prove days_from_civil never panics and produces reasonable values
@@ -713,6 +717,10 @@ mod verification {
             buf.len() == predicted,
             "bytes_field_size disagrees with encode_bytes_field"
         );
+
+        // Confirm both boundary cases are reachable
+        kani::cover!(field_number == 1 && data_len == 0);
+        kani::cover!(field_number == 1000 && data_len == 256);
     }
 
     // NOTE: parse_timestamp_nanos proofs deferred — Kani has trouble with

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -415,7 +415,11 @@ mod tests {
             }],
             vec![InputEvent::EndOfFile],
         ]);
-        let mut framed = FramedInput::new(Box::new(source), FormatProcessor::Passthrough, stats);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatProcessor::passthrough(stats.clone()),
+            stats,
+        );
 
         // First poll: data with no newline — goes to remainder, nothing emitted.
         let events1 = framed.poll().unwrap();
@@ -437,7 +441,11 @@ mod tests {
             }],
             vec![InputEvent::EndOfFile],
         ]);
-        let mut framed = FramedInput::new(Box::new(source), FormatProcessor::Passthrough, stats);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatProcessor::passthrough(stats.clone()),
+            stats,
+        );
 
         // First poll: "complete\n" is emitted; "partial" stays in remainder.
         let events1 = framed.poll().unwrap();
@@ -458,7 +466,11 @@ mod tests {
             }],
             vec![InputEvent::EndOfFile],
         ]);
-        let mut framed = FramedInput::new(Box::new(source), FormatProcessor::Passthrough, stats);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatProcessor::passthrough(stats.clone()),
+            stats,
+        );
 
         let events1 = framed.poll().unwrap();
         assert_eq!(collect_data(events1), b"line\n");


### PR DESCRIPTION
## Summary

- `verify_encode_tag`, `verify_bytes_field_size`: add 2 `kani::cover!()` guards each — CodeRabbit requires ≥2 cover guards in any proof using `assume()` to prove the constrained input space is non-vacuous (PR #761 comment)
- `framed.rs` EOF-flush tests: `FormatProcessor::Passthrough` became a struct variant in #755 but 3 tests weren't updated; now use `FormatProcessor::passthrough(stats.clone())` — was causing test compilation failure on master

## Test plan

- [ ] `cargo test -p logfwd-io` passes (previously failed due to framed.rs compile error)
- [ ] `cargo kani -p logfwd-core` passes with cover! goals satisfied
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)