### PR TITLE
fix: README quickstart SQL example fails due to schema mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The transform is the main reason to use logfwd over a plain forwarder. Every bat
 
 ```sql
 -- Forward only errors and slow requests
-SELECT level_str, msg_str, duration_ms_int, status_int
+SELECT level_str, message_str, duration_ms_int, status_int
 FROM logs
 WHERE level_str = 'ERROR'
    OR duration_ms_int > 1000
@@ -111,8 +111,8 @@ WHERE level_str = 'ERROR'
 -- Extract a field with regex, rename columns
 SELECT
   level_str,
-  msg_str,
-  regexp_extract(msg_str, 'request_id=([a-f0-9-]+)', 1) AS request_id_str,
+  message_str,
+  regexp_extract(message_str, 'request_id=([a-f0-9-]+)', 1) AS request_id_str,
   status_int
 FROM logs
 WHERE level_str IN ('ERROR', 'WARN')
@@ -145,7 +145,7 @@ input:
   path: /var/log/app/*.log
   format: json
 
-transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+transform: SELECT level_str, message_str, status_int FROM logs WHERE status_int >= 400
 
 output:
   type: otlp
@@ -196,7 +196,7 @@ Every CRI record gets these extra columns:
 Use `_file_str` to identify which pod and container generated a record, or filter by stream:
 
 ```sql
-SELECT _time_ns_int, _stream_str, level_str, msg_str
+SELECT _time_ns_int, _stream_str, level_str, message_str
 FROM logs
 WHERE _stream_str = 'stderr'
   AND level_str = 'ERROR'

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -39,7 +39,7 @@ input:
   path: /var/log/app/*.log
   format: json
 
-transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+transform: SELECT level_str, message_str, status_int FROM logs WHERE status_int >= 400
 
 output:
   type: otlp
@@ -105,7 +105,7 @@ SELECT level_str, status_int, duration_ms_float FROM logs
 SELECT int(status_str) AS status_int FROM logs
 
 -- Pattern matching
-SELECT grok('%{IP:client_ip} %{WORD:method}', msg_str) FROM logs
+SELECT grok('%{IP:client_ip} %{WORD:method}', message_str) FROM logs
 ```
 
 Available UDFs: `int()`, `float()`, `grok()`, `regexp_extract()`.

--- a/book/src/config/reference.md
+++ b/book/src/config/reference.md
@@ -22,7 +22,7 @@ input:
   path: /var/log/app/*.log
   format: json
 
-transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+transform: SELECT level_str, message_str, status_int FROM logs WHERE status_int >= 400
 
 output:
   type: otlp
@@ -273,7 +273,7 @@ The optional `transform` field contains a DataFusion SQL query that is applied t
 Arrow `RecordBatch` produced by the scanner. The source table is always named `logs`.
 
 ```yaml
-transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+transform: SELECT level_str, message_str, status_int FROM logs WHERE status_int >= 400
 ```
 
 Multi-line SQL is supported with YAML block scalars:
@@ -282,8 +282,8 @@ Multi-line SQL is supported with YAML block scalars:
 transform: |
   SELECT
     level_str,
-    msg_str,
-    regexp_extract(msg_str, 'request_id=([a-f0-9-]+)', 1) AS request_id_str,
+    message_str,
+    regexp_extract(message_str, 'request_id=([a-f0-9-]+)', 1) AS request_id_str,
     status_int
   FROM logs
   WHERE level_str IN ('ERROR', 'WARN')
@@ -332,10 +332,10 @@ Examples:
 SELECT int(status_str) AS status_int FROM logs
 
 -- Extract a field with Grok
-SELECT grok('%{IP:client} %{WORD:method} %{URIPATHPARAM:path}', msg_str) AS parsed_str FROM logs
+SELECT grok('%{IP:client} %{WORD:method} %{URIPATHPARAM:path}', message_str) AS parsed_str FROM logs
 
 -- Extract a named group with regex
-SELECT regexp_extract(msg_str, 'user=([a-z]+)', 1) AS user_str FROM logs
+SELECT regexp_extract(message_str, 'user=([a-z]+)', 1) AS user_str FROM logs
 
 -- Type-cast from environment-injected string
 SELECT float(duration_str) AS duration_ms_float FROM logs
@@ -369,7 +369,7 @@ Parses Kubernetes pod log paths (e.g.
 `/var/log/pods/<namespace>_<pod>_<uid>/<container>/`) to extract metadata.
 
 ```sql
-SELECT l.level_str, l.msg_str, k.namespace, k.pod_name, k.container_name
+SELECT l.level_str, l.message_str, k.namespace, k.pod_name, k.container_name
 FROM logs l
 JOIN k8s k ON l._file_str = k.log_path_prefix
 ```
@@ -480,7 +480,7 @@ pipelines:
     transform: |
       SELECT
         l.level_str,
-        l.msg_str,
+        l.message_str,
         l.status_int,
         k.namespace,
         k.pod_name,

--- a/book/src/deployment/kubernetes.md
+++ b/book/src/deployment/kubernetes.md
@@ -103,7 +103,7 @@ data:
     transform: |
       SELECT
         level_str,
-        msg_str,
+        message_str,
         _time_ns_int,
         _stream_str
       FROM logs
@@ -194,7 +194,7 @@ enrichment:
 transform: |
   SELECT
     l.level_str,
-    l.msg_str,
+    l.message_str,
     k.namespace,
     k.pod_name,
     k.container_name

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -739,16 +739,18 @@ fn generate_json_log_file(num_lines: usize, output: &str) -> io::Result<()> {
         let id = 10000 + (i * 7) % 90000;
         let dur = 1 + (i * 13) % 500;
         let rid = format!("{:016x}", (i as u64).wrapping_mul(0x517cc1b727220a95));
+        let status = [200, 201, 400, 404, 500, 503][i % 6];
 
         write!(
             writer,
-            r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{}","service":"myapp"}}"#,
+            r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{}","service":"myapp","status":{}}}"#,
             i % 1000,
             level,
             path,
             id,
             dur,
             rid,
+            status,
         )?;
         writer.write_all(b"\n")?;
     }

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -22,7 +22,7 @@ input:
   path: /var/log/app/*.log
   format: json
 
-transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+transform: SELECT level_str, message_str, status_int FROM logs WHERE status_int >= 400
 
 output:
   type: otlp
@@ -273,7 +273,7 @@ The optional `transform` field contains a DataFusion SQL query that is applied t
 Arrow `RecordBatch` produced by the scanner. The source table is always named `logs`.
 
 ```yaml
-transform: SELECT level_str, msg_str, status_int FROM logs WHERE status_int >= 400
+transform: SELECT level_str, message_str, status_int FROM logs WHERE status_int >= 400
 ```
 
 Multi-line SQL is supported with YAML block scalars:
@@ -282,8 +282,8 @@ Multi-line SQL is supported with YAML block scalars:
 transform: |
   SELECT
     level_str,
-    msg_str,
-    regexp_extract(msg_str, 'request_id=([a-f0-9-]+)', 1) AS request_id_str,
+    message_str,
+    regexp_extract(message_str, 'request_id=([a-f0-9-]+)', 1) AS request_id_str,
     status_int
   FROM logs
   WHERE level_str IN ('ERROR', 'WARN')
@@ -332,10 +332,10 @@ Examples:
 SELECT int(status_str) AS status_int FROM logs
 
 -- Extract a field with Grok
-SELECT grok('%{IP:client} %{WORD:method} %{URIPATHPARAM:path}', msg_str) AS parsed_str FROM logs
+SELECT grok('%{IP:client} %{WORD:method} %{URIPATHPARAM:path}', message_str) AS parsed_str FROM logs
 
 -- Extract a named group with regex
-SELECT regexp_extract(msg_str, 'user=([a-z]+)', 1) AS user_str FROM logs
+SELECT regexp_extract(message_str, 'user=([a-z]+)', 1) AS user_str FROM logs
 
 -- Type-cast from environment-injected string
 SELECT float(duration_str) AS duration_ms_float FROM logs
@@ -369,7 +369,7 @@ Parses Kubernetes pod log paths (e.g.
 `/var/log/pods/<namespace>_<pod>_<uid>/<container>/`) to extract metadata.
 
 ```sql
-SELECT l.level_str, l.msg_str, k.namespace, k.pod_name, k.container_name
+SELECT l.level_str, l.message_str, k.namespace, k.pod_name, k.container_name
 FROM logs l
 JOIN k8s k ON l._file_str = k.log_path_prefix
 ```
@@ -480,7 +480,7 @@ pipelines:
     transform: |
       SELECT
         l.level_str,
-        l.msg_str,
+        l.message_str,
         l.status_int,
         k.namespace,
         k.pod_name,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -103,7 +103,7 @@ data:
     transform: |
       SELECT
         level_str,
-        msg_str,
+        message_str,
         _time_ns_int,
         _stream_str
       FROM logs
@@ -194,7 +194,7 @@ enrichment:
 transform: |
   SELECT
     l.level_str,
-    l.msg_str,
+    l.message_str,
     k.namespace,
     k.pod_name,
     k.container_name

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -349,7 +349,7 @@ input:
   format: json
 
 transform: |
-  SELECT level_str, msg_str FROM logs WHERE status_int >= 500
+  SELECT level_str, message_str FROM logs WHERE status_int >= 500
 
 output:
   type: stdout

--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -75,7 +75,7 @@ transform: |
     _time_ns_int,
     _stream_str,
     level_str,
-    msg_str,
+    message_str,
     status_int,
     duration_ms_float,
     regexp_extract(_file_str, '/([^/]+)/[^/]+\\.log$', 1) AS pod_name_str
@@ -157,7 +157,7 @@ transform: |
     _time_ns_int AS timestamp_ns_int,
     _stream_str AS stream_str,
     level_str,
-    msg_str,
+    message_str,
     _file_str AS source_file_str
   FROM logs
 

--- a/examples/elasticsearch/with-auth-and-filter.yaml
+++ b/examples/elasticsearch/with-auth-and-filter.yaml
@@ -6,7 +6,7 @@ input:
 transform: |
   SELECT
     level_str,
-    msg_str,
+    message_str,
     status_int,
     duration_ms_float
   FROM logs


### PR DESCRIPTION
Fixed a critical onboarding failure where the README's primary SQL example failed because of a mismatch between the documented field names (`msg_str`, `status_int`) and the actual data produced by the `--generate-json` tool (`message_str`, and no status field).

I updated the generator to include a `status` field and performed a repository-wide replacement of `msg_str` with `message_str` in public-facing documentation and examples. verified the fix with a `--dry-run` validation against generated data.

Fixes #733

---
*PR created automatically by Jules for task [18036355925283511074](https://jules.google.com/task/18036355925283511074) started by @strawgate*