### PR TITLE
fix: deny unknown fields in all config structs

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -21,6 +21,7 @@ use std::path::Path;
 /// Supports bearer tokens and arbitrary key/value header pairs.
 /// All values support `${ENV_VAR}` expansion at config-load time.
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct AuthConfig {
     /// Sets the `Authorization: Bearer <token>` header on every request.
     pub bearer_token: Option<String>,
@@ -176,6 +177,7 @@ pub enum Format {
 
 /// A single input source.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InputConfig {
     /// Optional friendly name (used in multi-input pipelines).
     pub name: Option<String>,
@@ -192,6 +194,7 @@ pub struct InputConfig {
 
 /// A single output destination.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OutputConfig {
     pub name: Option<String>,
     #[serde(rename = "type")]
@@ -235,6 +238,7 @@ pub enum GeoDatabaseFormat {
 ///     refresh_interval: 86400
 /// ```
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GeoDatabaseConfig {
     /// Database format.
     pub format: GeoDatabaseFormat,
@@ -261,6 +265,7 @@ pub enum EnrichmentConfig {
 
 /// One logical pipeline (inputs -> SQL transform -> outputs).
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PipelineConfig {
     #[serde(default, deserialize_with = "deserialize_one_or_many")]
     pub inputs: Vec<InputConfig>,
@@ -290,6 +295,7 @@ pub struct PipelineConfig {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ServerConfig {
     pub diagnostics: Option<String>,
     pub log_level: Option<String>,
@@ -304,6 +310,7 @@ pub struct ServerConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct StorageConfig {
     pub data_dir: Option<String>,
 }
@@ -315,6 +322,7 @@ pub struct StorageConfig {
 /// Raw top-level YAML — we use a flat struct with Options so serde can
 /// deserialise either layout, then we normalise into [`Config`].
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawConfig {
     // Simple form
     input: Option<InputConfig>,


### PR DESCRIPTION
## Summary

Closes #660. Adds `#[serde(deny_unknown_fields)]` to every config struct that accepts user YAML:

- `AuthConfig`, `InputConfig`, `OutputConfig`, `GeoDatabaseConfig`
- `PipelineConfig`, `ServerConfig`, `StorageConfig`, `RawConfig`

### Before

```yaml
output:
  type: otlp
  endpoint: http://localhost:4318
  compresion: zstd   # typo — silently ignored, pipeline ran uncompressed
```

### After

```
Config error: unknown field `compresion`, expected one of `name`, `type`, `endpoint`, `protocol`, `compression`, ...
```

## What this doesn't fix

- `EnrichmentConfig` uses `#[serde(tag = "type")]` on an enum — the inner `GeoDatabaseConfig` gets `deny_unknown_fields`, but the tag-dispatched enum itself is left as-is to avoid serde edge cases with tagged enums.

## Test plan

- [x] All 34 existing config tests pass — none relied on unknown fields being silently ignored
- [x] `cargo clippy -p logfwd-config -- -D warnings` clean

## Closed as already-fixed (found while investigating)

- #728 — GET-only method guard already exists in `diagnostics.rs:452`
- #715 — `/metrics` already returns 410 Gone with pointer to `/api/pipelines`
- #740 — `UInt64`/`Int32`/`Float32` all handled in `write_json_value()` lines 390–437
- #729 — `format: raw` implemented via `FormatProcessor::passthrough()`
- #415 — `collect_column_refs` handles `InList`, `IsNull`, `Like` (lines 336–378)
- #429 — `extract_except_fields` properly collects EXCEPT fields; no rewriting needed with struct conflict columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)