### PR TITLE
fix: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ book/book/
 .DS_Store
 crates/logfwd-io/src/dashboard-dist/
 .playwright-mcp/
+*.env
+.env


### PR DESCRIPTION
Prevents `.env` files from being committed. An agent accidentally committed credentials in #789 — this ensures it can't happen again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)