### PR TITLE
feat: exclusive instance lock — prevent duplicate file processing (#737)

### DIFF
--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -399,9 +399,18 @@ async fn run_pipelines(
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
-    // Acquire exclusive lock to prevent multiple instances processing
-    // the same files (#737). The lock is held until this function returns.
-    let _lock_guard = acquire_instance_lock(&config)?;
+    // Acquire exclusive lock only when tailing files — OTLP-only and
+    // blackhole pipelines don't need filesystem locking (#737).
+    let has_file_inputs = config.pipelines.values().any(|pipe| {
+        pipe.inputs
+            .iter()
+            .any(|input| matches!(input.input_type, logfwd_config::InputType::File))
+    });
+    let _lock_guard = if has_file_inputs {
+        acquire_instance_lock(&config)?
+    } else {
+        None
+    };
 
     let shutdown = CancellationToken::new();
 
@@ -661,11 +670,11 @@ fn acquire_instance_lock(
             }
             return Err(CliError::Runtime(err));
         }
-        tracing::debug!(path = %lock_path.display(), "acquired instance lock");
+        // Note: tracing subscriber not yet initialized at this point.
     }
 
     #[cfg(not(unix))]
-    tracing::warn!("file-based instance locking not supported on this platform");
+    eprintln!("warn: file-based instance locking not supported on this platform");
 
     // Return the File so the lock is held until the caller drops it.
     Ok(Some(lock_file))


### PR DESCRIPTION
## Summary

Extracts the flock feature from #805 (closed) with a critical bug fix: #805 called `drop(lock_file)` which released the lock immediately. This version keeps the `File` handle alive as a guard for the duration of `run_pipelines()`.

### How it works

On startup, `acquire_instance_lock()` opens `{data_dir}/logfwd.lock` and acquires an exclusive advisory lock via `flock(LOCK_EX | LOCK_NB)`. If another instance holds the lock, exits with:

```
another logfwd instance is already running (lock: /var/lib/logfwd/logfwd.lock)
```

The lock is automatically released when the `File` handle is dropped (function return or crash).

### Platform support

- **Unix**: `libc::flock` with SAFETY comment
- **Non-Unix**: warns and continues (no locking)

Closes #737

## Test plan

- [x] `cargo clippy -p logfwd -- -D warnings` — clean
- [ ] Manual: two instances on same data_dir, second fails
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)