### PR TITLE
fix: competitive bench broken — SQL references nonexistent suffixed columns (#838)

### DIFF
--- a/crates/logfwd-competitive-bench/src/agents/logfwd.rs
+++ b/crates/logfwd-competitive-bench/src/agents/logfwd.rs
@@ -22,14 +22,15 @@ impl Agent for Logfwd {
 
     fn write_config(&self, ctx: &BenchContext, scenario: Scenario) -> Result<PathBuf, String> {
         let cfg_path = ctx.bench_dir.join("logfwd.yaml");
-        // logfwd's scanner creates type-suffixed columns: level_str, duration_ms_int, etc.
+        // Since the type-suffix redesign (#684), columns are only suffixed on
+        // type conflict. With uniform test data, columns are unsuffixed.
         let transform = match scenario {
             Scenario::Passthrough => "SELECT * FROM logs".to_string(),
             Scenario::JsonParse => {
-                "SELECT timestamp_str, level_str, message_str, duration_ms_int AS latency_ms, request_id_str, service_str FROM logs".to_string()
+                "SELECT timestamp, level, message, duration_ms AS latency_ms, request_id, service FROM logs".to_string()
             }
             Scenario::Filter => {
-                "SELECT * FROM logs WHERE level_str IN ('WARN', 'ERROR')".to_string()
+                "SELECT * FROM logs WHERE level IN ('WARN', 'ERROR')".to_string()
             }
         };
         let config = format!(


### PR DESCRIPTION
## Summary

The competitive benchmark produces **0 output lines** and **7.2 GB RSS** for logfwd because the SQL transform references columns that no longer exist.

**Root cause:** PR #684 (type-suffix redesign) changed column naming — columns are now only suffixed on type conflict. The bench SQL still used `timestamp_str`, `level_str`, `duration_ms_int`, etc., causing every batch to fail with `No field named timestamp_str` and be silently dropped.

**Fix:** Update SQL to use unsuffixed column names (`timestamp`, `level`, `message`, `duration_ms`, etc.).

**Before:** 0 lines, 7.2 GB RSS, TIMEOUT
**After:** 100k lines delivered instantly in local test

Fixes #838

## Test plan

- [x] Local test: `logfwd` with fixed SQL delivers all 100k lines to blackhole
- [x] `cargo check -p logfwd-competitive-bench`

🤖 Generated with [Claude Code](https://claude.com/claude-code)