### PR TITLE
fix: compound SourceId + per-connection TCP identity (#798, #803)

### DIFF
--- a/crates/logfwd-io/src/tail.rs
+++ b/crates/logfwd-io/src/tail.rs
@@ -32,6 +32,26 @@ pub struct FileIdentity {
     pub fingerprint: u64,
 }
 
+impl FileIdentity {
+    /// Derive a stable `SourceId` from the compound key (device, inode, fingerprint).
+    ///
+    /// Hashing all three fields prevents collisions between files that share
+    /// the same first N bytes (same fingerprint) but live on different inodes.
+    /// Two files on the same inode+device are the same file, so the fingerprint
+    /// differentiates after inode reuse (e.g., log rotation).
+    pub fn source_id(&self) -> SourceId {
+        // Empty file sentinel: fingerprint 0 means no data to checkpoint.
+        if self.fingerprint == 0 {
+            return SourceId(0);
+        }
+        let mut h = xxhash_rust::xxh64::Xxh64::new(0);
+        h.update(&self.device.to_le_bytes());
+        h.update(&self.inode.to_le_bytes());
+        h.update(&self.fingerprint.to_le_bytes());
+        SourceId(h.digest())
+    }
+}
+
 /// State tracked per tailed file.
 struct TailedFile {
     #[expect(dead_code, reason = "retained for debug logging")]
@@ -695,13 +715,14 @@ impl FileTailer {
         Ok(())
     }
 
-    /// Restore a file offset by SourceId (fingerprint), not path.
+    /// Restore a file offset by SourceId (compound identity), not path.
     ///
-    /// Scans all tailed files for a matching fingerprint. Used for checkpoint
-    /// restore — the checkpoint stores fingerprint + offset, not path.
+    /// Scans all tailed files for a matching compound identity
+    /// (device + inode + fingerprint). Used for checkpoint restore — the
+    /// checkpoint stores source_id + offset, not path.
     pub fn set_offset_by_source(&mut self, source_id: SourceId, offset: u64) -> io::Result<()> {
         for tailed in self.files.values_mut() {
-            if SourceId(tailed.identity.fingerprint) == source_id {
+            if tailed.identity.source_id() == source_id {
                 tailed.offset = offset;
                 tailed.file.seek(SeekFrom::Start(offset))?;
                 return Ok(());
@@ -721,11 +742,8 @@ impl FileTailer {
     /// (fingerprint 0).
     pub fn source_id_for_path(&self, path: &Path) -> Option<SourceId> {
         self.files.get(path).and_then(|tailed| {
-            if tailed.identity.fingerprint != 0 {
-                Some(SourceId(tailed.identity.fingerprint))
-            } else {
-                None
-            }
+            let sid = tailed.identity.source_id();
+            if sid == SourceId(0) { None } else { Some(sid) }
         })
     }
 
@@ -737,12 +755,7 @@ impl FileTailer {
         self.files
             .iter()
             .filter(|(_, tailed)| tailed.identity.fingerprint != 0)
-            .map(|(_, tailed)| {
-                (
-                    SourceId(tailed.identity.fingerprint),
-                    ByteOffset(tailed.offset),
-                )
-            })
+            .map(|(_, tailed)| (tailed.identity.source_id(), ByteOffset(tailed.offset)))
             .collect()
     }
 
@@ -754,7 +767,7 @@ impl FileTailer {
         self.files
             .iter()
             .filter(|(_, tailed)| tailed.identity.fingerprint != 0)
-            .map(|(path, tailed)| (SourceId(tailed.identity.fingerprint), path.clone()))
+            .map(|(path, tailed)| (tailed.identity.source_id(), path.clone()))
             .collect()
     }
 }

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -1,10 +1,15 @@
 //! TCP input source. Listens on a TCP socket and produces newline-delimited
 //! log lines from connected clients. Multiple concurrent connections supported.
+//!
+//! Each accepted connection receives a unique `SourceId` derived from a
+//! monotonic counter so that `FramedInput`'s per-source remainder tracking
+//! can distinguish data from different peers.
 
 use std::io::{self, Read};
 use std::net::{TcpListener, TcpStream};
 use std::time::{Duration, Instant};
 
+use logfwd_core::pipeline::SourceId;
 use socket2::SockRef;
 
 use crate::input::{InputEvent, InputSource};
@@ -13,8 +18,8 @@ use crate::input::{InputEvent, InputSource};
 const MAX_CLIENTS: usize = 1024;
 
 /// Per-poll read buffer size (64 KiB). Shared across all connections within a
-/// single `poll` call; data is copied into `all_data` immediately, so one
-/// moderate buffer is sufficient.
+/// single `poll` call; data is copied into per-client buffers immediately, so
+/// one moderate buffer is sufficient.
 const READ_BUF_SIZE: usize = 64 * 1024;
 
 /// Default disconnect timeout for idle clients (no data received).
@@ -24,15 +29,32 @@ const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 /// Prevents a misbehaving sender from consuming unbounded memory.
 const MAX_LINE_LENGTH: usize = 1024 * 1024; // 1 MiB
 
+/// Derive a `SourceId` for a TCP connection from a monotonic counter.
+///
+/// The counter is hashed to avoid trivially predictable identifiers and to
+/// spread keys evenly in hash maps.
+fn source_id_for_connection(connection_seq: u64) -> SourceId {
+    // Use a domain-separated hash so TCP source ids never collide with
+    // file-based source ids (which hash device+inode+fingerprint).
+    let mut h = xxhash_rust::xxh64::Xxh64::new(0);
+    h.update(b"tcp:");
+    h.update(&connection_seq.to_le_bytes());
+    SourceId(h.digest())
+}
+
 /// A connected TCP client with an associated last-data timestamp.
 struct Client {
     stream: TcpStream,
+    source_id: SourceId,
     last_data: Instant,
     /// Bytes received since the last newline. Reset to 0 on every `\n`.
     bytes_since_newline: usize,
 }
 
 /// TCP input that accepts connections and reads newline-delimited data.
+///
+/// Each connection is assigned a unique `SourceId` so downstream components
+/// can track per-connection state (e.g., partial-line remainders).
 pub struct TcpInput {
     name: String,
     listener: TcpListener,
@@ -41,6 +63,8 @@ pub struct TcpInput {
     idle_timeout: Duration,
     /// Total connections accepted since creation (never decreases).
     connections_accepted: u64,
+    /// Monotonic counter for generating per-connection `SourceId` values.
+    next_connection_seq: u64,
 }
 
 impl TcpInput {
@@ -64,6 +88,7 @@ impl TcpInput {
             buf: vec![0u8; READ_BUF_SIZE],
             idle_timeout,
             connections_accepted: 0,
+            next_connection_seq: 0,
         })
     }
 
@@ -112,9 +137,12 @@ impl InputSource for TcpInput {
                         .with_interval(Duration::from_secs(10));
                     let _ = sock_ref.set_tcp_keepalive(&keepalive);
 
+                    let sid = source_id_for_connection(self.next_connection_seq);
+                    self.next_connection_seq += 1;
                     self.connections_accepted += 1;
                     self.clients.push(Client {
                         stream,
+                        source_id: sid,
                         last_data: Instant::now(),
                         bytes_since_newline: 0,
                     });
@@ -127,11 +155,12 @@ impl InputSource for TcpInput {
             }
         }
 
-        // Read from all clients.
-        let mut all_data = Vec::new();
+        // Read from all clients, collecting per-connection buffers.
         let now = Instant::now();
         // Track which connections are dead using a bitmap for O(1) lookup.
         let mut alive = vec![true; self.clients.len()];
+        // Per-client data buffers — only allocated when data arrives.
+        let mut client_data: Vec<Option<Vec<u8>>> = vec![None; self.clients.len()];
 
         for (i, client) in self.clients.iter_mut().enumerate() {
             let mut got_data = false;
@@ -168,7 +197,9 @@ impl InputSource for TcpInput {
                                 break;
                             }
                         }
-                        all_data.extend_from_slice(chunk);
+                        client_data[i]
+                            .get_or_insert_with(Vec::new)
+                            .extend_from_slice(chunk);
                     }
                     Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
                     Err(e) if e.kind() == io::ErrorKind::ConnectionReset => {
@@ -189,6 +220,20 @@ impl InputSource for TcpInput {
             }
         }
 
+        // Build events before removing dead connections — we need client_data
+        // indices to match the current clients vec.
+        let mut events = Vec::new();
+        for (i, data) in client_data.into_iter().enumerate() {
+            if let Some(bytes) = data {
+                if !bytes.is_empty() {
+                    events.push(InputEvent::Data {
+                        bytes,
+                        source_id: Some(self.clients[i].source_id),
+                    });
+                }
+            }
+        }
+
         // Remove dead connections, preserving order of remaining ones.
         // `retain` is cleaner than manual swap_remove with index tracking.
         let mut idx = 0;
@@ -197,14 +242,6 @@ impl InputSource for TcpInput {
             idx += 1;
             keep
         });
-
-        let mut events = Vec::new();
-        if !all_data.is_empty() {
-            events.push(InputEvent::Data {
-                bytes: all_data,
-                source_id: None,
-            });
-        }
 
         Ok(events)
     }
@@ -237,10 +274,11 @@ mod tests {
 
         // Should have accepted the connection and read data.
         assert_eq!(events.len(), 1);
-        if let InputEvent::Data { bytes, .. } = &events[0] {
+        if let InputEvent::Data { bytes, source_id } = &events[0] {
             let text = String::from_utf8_lossy(bytes);
             assert!(text.contains("hello"), "got: {text}");
             assert!(text.contains("world"), "got: {text}");
+            assert!(source_id.is_some(), "TCP data must have a source_id");
         }
     }
 
@@ -252,7 +290,7 @@ mod tests {
         {
             let mut client = StdTcpStream::connect(addr).unwrap();
             client.write_all(b"line1\n").unwrap();
-        } // client drops here → connection closed
+        } // client drops here -> connection closed
 
         std::thread::sleep(Duration::from_millis(50));
 
@@ -393,6 +431,49 @@ mod tests {
             input.client_count(),
             0,
             "all storm connections should be cleaned up (no fd leak)"
+        );
+    }
+
+    /// Two concurrent TCP connections must receive distinct `SourceId` values
+    /// so that `FramedInput` can track per-connection remainders independently.
+    #[test]
+    fn distinct_source_ids_per_connection() {
+        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let addr = input.local_addr().unwrap();
+
+        let mut client_a = StdTcpStream::connect(addr).unwrap();
+        let mut client_b = StdTcpStream::connect(addr).unwrap();
+
+        client_a.write_all(b"from_a\n").unwrap();
+        client_b.write_all(b"from_b\n").unwrap();
+        client_a.flush().unwrap();
+        client_b.flush().unwrap();
+
+        std::thread::sleep(Duration::from_millis(50));
+
+        let events = input.poll().unwrap();
+
+        // Collect all source_ids from data events.
+        let source_ids: Vec<SourceId> = events
+            .iter()
+            .filter_map(|e| match e {
+                InputEvent::Data { source_id, .. } => *source_id,
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            source_ids.len() >= 2,
+            "expected at least 2 data events (one per connection), got {}",
+            source_ids.len()
+        );
+
+        // All source_ids must be distinct.
+        let unique: std::collections::HashSet<u64> = source_ids.iter().map(|s| s.0).collect();
+        assert_eq!(
+            unique.len(),
+            source_ids.len(),
+            "each TCP connection must have a distinct SourceId"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Compound SourceId for files**: `SourceId` was derived from just the xxh64 fingerprint of a file's first N bytes, so two files with identical prefixes collided. Now `FileIdentity::source_id()` hashes `(device, inode, fingerprint)` together, making collision impossible for files on the same filesystem.
- **Per-connection TCP identity**: All TCP connections emitted `source_id: None`, breaking `FramedInput`'s per-source remainder tracking. Each accepted connection now gets a unique `SourceId` from a monotonic counter with domain-separated hashing (prefix `tcp:` prevents collision with file-based ids).
- **No read budget changes**: The existing 4 MiB `MAX_READ_PER_POLL` cap is unchanged.

Fixes #798, Fixes #803
Part of work-unit #872, #873

Extracted from #868 — only the collision fix and TCP identity changes, without the 256 KiB read fairness budget.

## Test plan

- [x] All 184 `logfwd-io` tests pass (`cargo test -p logfwd-io`)
- [x] New test `distinct_source_ids_per_connection` verifies two concurrent TCP connections produce different `SourceId` values
- [x] Existing `test_file_paths_matches_offsets` confirms `file_offsets()` and `file_paths()` still agree on SourceId values
- [x] `cargo clippy -p logfwd-io -- -D warnings` clean
- [x] Binary crate (`cargo check -p logfwd`) compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)