### PR TITLE
fix: checkpoint safety — directory fsync, evicted offset persistence, fingerprint verification

### DIFF
--- a/crates/logfwd-io/src/checkpoint.rs
+++ b/crates/logfwd-io/src/checkpoint.rs
@@ -147,8 +147,10 @@ impl CheckpointStore for FileCheckpointStore {
         // fsync the parent directory so the rename entry is durable.
         // On ext4, rename metadata lives in the directory — without this
         // fsync a power failure can revert the rename, losing the checkpoint.
+        // sync_data() suffices: we only need data (directory entries), not
+        // file metadata like mtime/permissions.
         let dir = std::fs::File::open(&self.data_dir)?;
-        dir.sync_all()?;
+        dir.sync_data()?;
 
         Ok(())
     }

--- a/crates/logfwd-io/src/tail.rs
+++ b/crates/logfwd-io/src/tail.rs
@@ -71,6 +71,8 @@ struct TailedFile {
 struct EvictedFile {
     identity: FileIdentity,
     offset: u64,
+    path: PathBuf,
+    source_id: SourceId,
 }
 
 /// Internal result from read_new_data — distinguishes truncation from no-data.
@@ -374,14 +376,14 @@ impl FileTailer {
             // saved offset. If the file was deleted and a new file appeared
             // at the same path, the fingerprint will differ and we must not
             // seek to the stale offset — that would skip data. (#817)
-            if evicted.identity.fingerprint == identity.fingerprint {
+            if evicted.identity == identity {
                 file.seek(SeekFrom::Start(evicted.offset))?
             } else {
                 tracing::warn!(
                     path = %path.display(),
-                    saved_fingerprint = evicted.identity.fingerprint,
-                    current_fingerprint = identity.fingerprint,
-                    "evicted offset fingerprint mismatch — ignoring saved offset"
+                    evicted_identity = ?evicted.identity,
+                    current_identity = ?identity,
+                    "evicted offset identity mismatch — ignoring saved offset"
                 );
                 if start_from_end {
                     file.seek(SeekFrom::End(0))?
@@ -621,12 +623,15 @@ impl FileTailer {
             by_age.sort_by_key(|(_, last_read)| *last_read);
             let to_remove = self.files.len() - self.config.max_open_files;
             for (path, _) in by_age.into_iter().take(to_remove) {
-                if let Some(evicted) = self.files.remove(&path) {
+                if let Some(tailed) = self.files.remove(&path) {
+                    let source_id = tailed.identity.source_id();
                     self.evicted_offsets.insert(
-                        path,
+                        path.clone(),
                         EvictedFile {
-                            identity: evicted.identity,
-                            offset: evicted.offset,
+                            identity: tailed.identity,
+                            offset: tailed.offset,
+                            path,
+                            source_id,
                         },
                     );
                 }
@@ -798,21 +803,30 @@ impl FileTailer {
             .evicted_offsets
             .values()
             .filter(|e| e.identity.fingerprint != 0)
-            .map(|e| (e.identity.source_id(), ByteOffset(e.offset)));
+            .map(|e| (e.source_id, ByteOffset(e.offset)));
 
         active.chain(evicted).collect()
     }
 
     /// Cold path: source identity + canonical path for all tailed files.
     ///
+    /// Includes evicted files so checkpoint paths stay consistent with offsets.
     /// Called on file open/close/rotate, not per-batch. PathBuf cloning is
     /// acceptable here since this runs infrequently.
     pub fn file_paths(&self) -> Vec<(SourceId, PathBuf)> {
-        self.files
+        let active = self
+            .files
             .iter()
             .filter(|(_, tailed)| tailed.identity.fingerprint != 0)
-            .map(|(path, tailed)| (tailed.identity.source_id(), path.clone()))
-            .collect()
+            .map(|(path, tailed)| (tailed.identity.source_id(), path.clone()));
+
+        let evicted = self
+            .evicted_offsets
+            .values()
+            .filter(|e| e.identity.fingerprint != 0)
+            .map(|e| (e.source_id, e.path.clone()));
+
+        active.chain(evicted).collect()
     }
 }
 


### PR DESCRIPTION
## Summary

- **#386** — Add directory fsync after atomic rename in `checkpoint.rs` flush. On ext4, rename metadata lives in the directory entry; without this fsync a power failure can revert the rename.
- **#697** — Include evicted file offsets in `file_offsets()` checkpoint data. Previously the `evicted_offsets` HashMap was in-memory only — a crash while files were in the evicted LRU state lost their read progress.
- **#817** — Verify fingerprint before restoring evicted offset in `open_file_at`. If a file is deleted and recreated at the same path, the stale offset is now rejected.

## Closes

Closes #386
Closes #697
Closes #817

## Test plan

- [x] `test_flush_directory_fsync` — exercises full flush path including directory fsync
- [x] `test_evicted_offsets_in_checkpoint_data` — verifies evicted files appear in `file_offsets()` (3 files, max_open=2, assert len=3)
- [x] `test_evicted_offset_fingerprint_mismatch` — evict file, delete, recreate with different content, verify read from beginning
- [x] All 24 tail tests pass
- [x] All 15 transport e2e tests pass
- [x] Checkpoint state machine test passes
- [x] Full workspace compiles clean
- [x] Clippy clean (`-D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix checkpoint safety with directory fsync, evicted offset persistence, and fingerprint verification
> - After renaming the temp checkpoints file into place, [checkpoint.rs](https://github.com/strawgate/memagent/pull/921/files#diff-ebe14b4939d3385df0545dc61beb87028ac0a7709e7b903591929befed69c763) now fsyncs the parent directory to make the rename durable on crash-prone filesystems like ext4.
> - `FileTailer` in [tail.rs](https://github.com/strawgate/memagent/pull/921/files#diff-eb28129757c059684e16401c616b90f230c604b673f2aaf1f985be40db02079f) replaces the bare `HashMap<PathBuf, u64>` evicted offsets map with a richer `EvictedFile` struct that also stores file identity and `source_id`.
> - `file_offsets()` and `file_paths()` now include evicted files, so checkpointing persists their offsets across LRU eviction cycles.
> - On reopening an evicted file, the saved identity is compared against the current file's identity; a mismatch logs a warning and resets the read position to EOF or 0 instead of seeking to the stale offset.
> - Behavioral Change: files evicted from the open-file LRU cache are no longer silently re-read from a stale offset if the file was replaced while evicted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e664b2b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->