### PR TITLE
fix: stabilize flaky allocation regression test

### DIFF
--- a/crates/logfwd-output/tests/allocation_regression.rs
+++ b/crates/logfwd-output/tests/allocation_regression.rs
@@ -50,6 +50,13 @@ fn assert_stable_or_zero(label: &str, alloc1: usize, alloc2: usize) {
     if alloc1 == 0 && alloc2 == 0 {
         return;
     }
+    // Small one-off allocations (< 4 KiB) from the system allocator or
+    // runtime (glibc tcache, thread-local state) are noise, not regressions.
+    // Only check the ratio when both windows report meaningful work.
+    const NOISE_FLOOR: usize = 4096;
+    if alloc1 < NOISE_FLOOR && alloc2 < NOISE_FLOOR {
+        return;
+    }
     let growth = alloc2 as f64 / alloc1.max(1) as f64;
     assert!(
         (0.5..2.0).contains(&growth),
@@ -65,13 +72,11 @@ fn write_row_json_stable_across_batches() {
     let cols = build_col_infos(&batch);
     let mut buf = Vec::with_capacity(4096);
 
-    // Two warmup passes: the first grows the buffer and triggers any lazy
-    // one-time allocations (Arrow downcast caches, thread-local state, etc.).
-    // The second pass runs with the final buffer capacity so that the
-    // measured windows start from a fully settled state.  Without this,
-    // glibc's allocator on Linux can leave a single reallocation in window 1
-    // that window 2 no longer needs, making the ratio 0.
-    for _ in 0..2 {
+    // Warmup: run several passes to flush lazy one-time allocations (Arrow
+    // downcast caches, thread-local state, glibc tcache warming, etc.).
+    // Two passes were not always sufficient on Linux CI — glibc can defer
+    // internal bookkeeping allocations past the second pass.
+    for _ in 0..5 {
         for row in 0..batch.num_rows() {
             let _ = write_row_json(&batch, row, &cols, &mut buf);
         }


### PR DESCRIPTION
## Problem

The `write_row_json_stable_across_batches` test introduced in #917 is non-deterministic on Linux CI. Lazy system allocations (glibc tcache warming, thread-local state) can land in either measurement window, producing:

- `window 1=0 bytes, window 2=900 bytes (ratio=900.00)`
- `window 1=900 bytes, window 2=0 bytes (ratio=0.00)`

## Fix

Two changes to make the test robust:

1. **Increase warmup from 2 → 5 passes** — better settles allocator internal state before measuring
2. **Add 4 KiB noise floor to `assert_stable_or_zero`** — small one-off system allocations (<4 KiB) in either window are noise, not regressions. The ratio check still applies for meaningful allocations above the threshold.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky allocation regression test in `write_row_json_stable_across_batches`
> - Adds a noise floor to `assert_stable_or_zero` in [allocation_regression.rs](https://github.com/strawgate/memagent/pull/940/files#diff-44c013b8cf2f25fef85412e570d13c87b17dbf20e4aac04ded89803c43863f4c): if both measured allocation windows are below 4096 bytes, the function returns early without checking the growth ratio.
> - Increases warmup iterations from 2 to 5 before measurement to flush one-time allocations more reliably.
> - Behavioral Change: `assert_stable_or_zero` no longer asserts on growth ratios for small allocations, treating sub-4096-byte measurements as noise.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0d16e80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->