### PR TITLE
refactor: rename cleanup — CheckpointAdvance, sink names, OutputType variants, FormatDecoder, ZeroCopyScanner

### DIFF
--- a/bench/scenarios/tcp-sender.yaml
+++ b/bench/scenarios/tcp-sender.yaml
@@ -1,5 +1,5 @@
 input:
   type: generator
 output:
-  type: tcp_out
+  type: tcp
   endpoint: 127.0.0.1:15140

--- a/bench/scenarios/udp-sender.yaml
+++ b/bench/scenarios/udp-sender.yaml
@@ -1,5 +1,5 @@
 input:
   type: generator
 output:
-  type: udp_out
+  type: udp
   endpoint: 127.0.0.1:15514

--- a/book/src/architecture/scanner.md
+++ b/book/src/architecture/scanner.md
@@ -15,7 +15,7 @@ using SIMD-accelerated structural classification.
 
 ## Zero-copy mode
 
-`StreamingSimdScanner` uses Arrow's `StringViewArray` to create 16-byte views
+`ZeroCopyScanner` uses Arrow's `StringViewArray` to create 16-byte views
 into the input buffer. String data is never copied — the original input buffer
 is shared via reference counting.
 

--- a/book/src/config/reference.md
+++ b/book/src/config/reference.md
@@ -236,7 +236,7 @@ Push to Grafana Loki.
 |-------|------|----------|-------------|
 | `endpoint` | string | Yes | Loki push URL. |
 
-### `file_out` output *(partial)*
+### `file` output *(partial)*
 
 Write records to a file.
 
@@ -263,7 +263,7 @@ Write records to Parquet files. Not yet functional.
 | `stdout` | Implemented | Print to stdout (JSON or coloured text). |
 | `elasticsearch` | Implemented | Elasticsearch bulk API with retry and compression. |
 | `loki` | Implemented | Grafana Loki push API with label grouping. |
-| `file_out` | Partial | Write to a file. |
+| `file` | Partial | Write to a file. |
 | `parquet` | Stub | Write Parquet files. |
 
 ---

--- a/crates/logfwd-arrow/README.md
+++ b/crates/logfwd-arrow/README.md
@@ -15,4 +15,4 @@ Arrow integration layer. Implements logfwd-core's ScanBuilder trait to produce R
 - `streaming_builder.rs` — Zero-copy StringViewArray builder (hot path)
 - `storage_builder.rs` — Owned-buffer builder for persistence
 - `conflict_schema.rs` — StructArray conflict column detection + normalization
-- `scanner.rs` — SimdScanner and StreamingSimdScanner wrappers
+- `scanner.rs` — CopyScanner and ZeroCopyScanner wrappers

--- a/crates/logfwd-arrow/src/lib.rs
+++ b/crates/logfwd-arrow/src/lib.rs
@@ -39,6 +39,6 @@ pub(crate) fn check_dup_bits(written_bits: &mut u64, idx: usize) -> bool {
 }
 
 // Re-export scanner types for convenience
-pub use scanner::{SimdScanner, StreamingSimdScanner};
+pub use scanner::{CopyScanner, ZeroCopyScanner};
 pub use storage_builder::StorageBuilder;
 pub use streaming_builder::StreamingBuilder;

--- a/crates/logfwd-arrow/src/materialize.rs
+++ b/crates/logfwd-arrow/src/materialize.rs
@@ -172,13 +172,13 @@ fn cast_column(field: &Arc<Field>, col: &ArrayRef) -> (Arc<Field>, ArrayRef) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::StreamingSimdScanner;
+    use crate::ZeroCopyScanner;
     use bytes::Bytes;
     use logfwd_core::scan_config::ScanConfig;
 
     fn scan(input: &[u8]) -> (RecordBatch, Bytes) {
         let buf = Bytes::from(input.to_vec());
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let batch = scanner.scan(buf.clone()).unwrap();
         (batch, buf)
     }

--- a/crates/logfwd-arrow/src/scanner.rs
+++ b/crates/logfwd-arrow/src/scanner.rs
@@ -94,21 +94,21 @@ impl ScanBuilder for StreamingBuilder {
 }
 
 // ---------------------------------------------------------------------------
-// SimdScanner — StorageBuilder (self-contained, compressible)
+// CopyScanner — StorageBuilder (self-contained, compressible)
 // ---------------------------------------------------------------------------
 
 /// SIMD scanner producing self-contained `RecordBatch` via `StorageBuilder`.
 ///
 /// Output owns all its data — the input buffer can be freed after `scan()`.
-pub struct SimdScanner {
+pub struct CopyScanner {
     builder: StorageBuilder,
     config: ScanConfig,
 }
 
-impl SimdScanner {
+impl CopyScanner {
     /// Create a new scanner with the given configuration.
     pub fn new(config: ScanConfig) -> Self {
-        SimdScanner {
+        CopyScanner {
             builder: StorageBuilder::new(config.keep_raw),
             config,
         }
@@ -121,7 +121,7 @@ impl SimdScanner {
         if self.config.validate_utf8 {
             std::str::from_utf8(buf).map_err(|e| {
                 ArrowError::InvalidArgumentError(format!(
-                    "SimdScanner: input is not valid UTF-8: {e}"
+                    "CopyScanner: input is not valid UTF-8: {e}"
                 ))
             })?;
         }
@@ -132,7 +132,7 @@ impl SimdScanner {
 }
 
 // ---------------------------------------------------------------------------
-// StreamingSimdScanner — StreamingBuilder (zero-copy hot path)
+// ZeroCopyScanner — StreamingBuilder (zero-copy hot path)
 // ---------------------------------------------------------------------------
 
 /// SIMD scanner producing zero-copy `RecordBatch` via `StreamingBuilder`.
@@ -140,15 +140,15 @@ impl SimdScanner {
 /// String values are `StringViewArray` views into the reference-counted input
 /// buffer (`bytes::Bytes`). The input buffer must stay alive while the
 /// `RecordBatch` is in use.
-pub struct StreamingSimdScanner {
+pub struct ZeroCopyScanner {
     builder: StreamingBuilder,
     config: ScanConfig,
 }
 
-impl StreamingSimdScanner {
+impl ZeroCopyScanner {
     /// Create a new streaming scanner with the given configuration.
     pub fn new(config: ScanConfig) -> Self {
-        StreamingSimdScanner {
+        ZeroCopyScanner {
             builder: StreamingBuilder::new(config.keep_raw),
             config,
         }
@@ -162,7 +162,7 @@ impl StreamingSimdScanner {
         if self.config.validate_utf8 {
             std::str::from_utf8(&buf).map_err(|e| {
                 ArrowError::InvalidArgumentError(format!(
-                    "StreamingSimdScanner: input is not valid UTF-8: {e}"
+                    "ZeroCopyScanner: input is not valid UTF-8: {e}"
                 ))
             })?;
         }
@@ -183,7 +183,7 @@ impl StreamingSimdScanner {
         if self.config.validate_utf8 {
             std::str::from_utf8(&buf).map_err(|e| {
                 ArrowError::InvalidArgumentError(format!(
-                    "StreamingSimdScanner: input is not valid UTF-8: {e}"
+                    "ZeroCopyScanner: input is not valid UTF-8: {e}"
                 ))
             })?;
         }
@@ -195,12 +195,12 @@ impl StreamingSimdScanner {
 
 #[cfg(test)]
 mod tests {
-    use crate::scanner::{SimdScanner, StreamingSimdScanner};
+    use crate::scanner::{CopyScanner, ZeroCopyScanner};
     use arrow::array::{Array, Int64Array, StringArray};
     use logfwd_core::scan_config::{FieldSpec, ScanConfig};
 
-    fn default_scanner(_rows: usize) -> SimdScanner {
-        SimdScanner::new(ScanConfig::default())
+    fn default_scanner(_rows: usize) -> CopyScanner {
+        CopyScanner::new(ScanConfig::default())
     }
 
     #[test]
@@ -310,7 +310,7 @@ mod tests {
             keep_raw: false,
             validate_utf8: false,
         };
-        let batch = SimdScanner::new(config)
+        let batch = CopyScanner::new(config)
             .scan(
                 br#"{"a":"1","b":"2","c":"3"}
 "#,
@@ -328,7 +328,7 @@ mod tests {
             keep_raw: true,
             validate_utf8: false,
         };
-        let batch = SimdScanner::new(config)
+        let batch = CopyScanner::new(config)
             .scan(b"{\"msg\":\"hi\"}\n")
             .unwrap();
         assert!(batch.column_by_name("_raw").is_some());
@@ -463,10 +463,10 @@ mod tests {
         assert_eq!(default_scanner(1024).scan(&input).unwrap().num_rows(), 1000);
     }
 
-    // --- StreamingSimdScanner ---
+    // --- ZeroCopyScanner ---
     #[test]
     fn test_streaming_simple() {
-        let mut s = StreamingSimdScanner::new(ScanConfig::default());
+        let mut s = ZeroCopyScanner::new(ScanConfig::default());
         let batch = s
             .scan(bytes::Bytes::from_static(
                 b"{\"host\":\"web1\",\"status\":200}\n{\"host\":\"web2\"}\n",
@@ -478,7 +478,7 @@ mod tests {
     }
     #[test]
     fn test_streaming_reuse() {
-        let mut s = StreamingSimdScanner::new(ScanConfig::default());
+        let mut s = ZeroCopyScanner::new(ScanConfig::default());
         let _ = s
             .scan(bytes::Bytes::from_static(b"{\"x\":\"a\"}\n"))
             .unwrap();
@@ -496,7 +496,7 @@ mod tests {
             keep_raw: true,
             validate_utf8: false,
         };
-        let batch = StreamingSimdScanner::new(config)
+        let batch = ZeroCopyScanner::new(config)
             .scan(bytes::Bytes::from_static(b"{\"msg\":\"hi\"}\n"))
             .unwrap();
         assert!(
@@ -507,7 +507,7 @@ mod tests {
         let raw_arr = raw_col
             .as_any()
             .downcast_ref::<arrow::array::StringViewArray>()
-            .expect("_raw must be StringViewArray in StreamingSimdScanner");
+            .expect("_raw must be StringViewArray in ZeroCopyScanner");
         assert_eq!(raw_arr.value(0), "{\"msg\":\"hi\"}");
     }
 
@@ -518,7 +518,7 @@ mod tests {
             validate_utf8: true,
             ..ScanConfig::default()
         };
-        let batch = SimdScanner::new(config)
+        let batch = CopyScanner::new(config)
             .scan(b"{\"msg\":\"hello\"}\n")
             .unwrap();
         assert_eq!(batch.num_rows(), 1);
@@ -531,7 +531,7 @@ mod tests {
             ..ScanConfig::default()
         };
         // 0xFF is not valid UTF-8
-        let result = SimdScanner::new(config).scan(b"{\"msg\":\"\xFF\"}\n");
+        let result = CopyScanner::new(config).scan(b"{\"msg\":\"\xFF\"}\n");
         assert!(result.is_err());
     }
 
@@ -541,7 +541,7 @@ mod tests {
             validate_utf8: true,
             ..ScanConfig::default()
         };
-        let batch = StreamingSimdScanner::new(config)
+        let batch = ZeroCopyScanner::new(config)
             .scan(bytes::Bytes::from_static(b"{\"msg\":\"hello\"}\n"))
             .unwrap();
         assert_eq!(batch.num_rows(), 1);
@@ -553,8 +553,8 @@ mod tests {
             validate_utf8: true,
             ..ScanConfig::default()
         };
-        let result = StreamingSimdScanner::new(config)
-            .scan(bytes::Bytes::from_static(b"{\"msg\":\"\xFF\"}\n"));
+        let result =
+            ZeroCopyScanner::new(config).scan(bytes::Bytes::from_static(b"{\"msg\":\"\xFF\"}\n"));
         assert!(result.is_err());
     }
 }

--- a/crates/logfwd-arrow/tests/allocation_regression.rs
+++ b/crates/logfwd-arrow/tests/allocation_regression.rs
@@ -11,7 +11,7 @@ use std::alloc::System;
 #[global_allocator]
 static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
 
-use logfwd_arrow::scanner::{SimdScanner, StreamingSimdScanner};
+use logfwd_arrow::scanner::{CopyScanner, ZeroCopyScanner};
 use logfwd_core::scan_config::ScanConfig;
 
 fn make_ndjson(n: usize) -> Vec<u8> {
@@ -46,7 +46,7 @@ fn assert_stable_windows(label: &str, alloc1: usize, alloc2: usize) {
 #[test]
 #[serial]
 fn storage_scanner_no_leak_across_batches() {
-    let mut scanner = SimdScanner::new(ScanConfig::default());
+    let mut scanner = CopyScanner::new(ScanConfig::default());
     let data = make_ndjson(500);
 
     for _ in 0..5 {
@@ -76,7 +76,7 @@ fn storage_scanner_no_leak_across_batches() {
 #[test]
 #[serial]
 fn streaming_scanner_no_leak_across_batches() {
-    let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+    let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
     let input: bytes::Bytes = make_ndjson(500).into();
 
     for _ in 0..5 {
@@ -107,7 +107,7 @@ fn streaming_scanner_no_leak_across_batches() {
 #[test]
 #[serial]
 fn scanner_allocs_scale_linearly() {
-    let mut scanner = SimdScanner::new(ScanConfig::default());
+    let mut scanner = CopyScanner::new(ScanConfig::default());
     let _ = scanner.scan(&make_ndjson(1000)).unwrap();
 
     let data_500 = make_ndjson(500);
@@ -130,7 +130,7 @@ fn scanner_allocs_scale_linearly() {
     );
 
     // StreamingBuilder should be sub-linear (zero-copy path).
-    let mut streaming = StreamingSimdScanner::new(ScanConfig::default());
+    let mut streaming = ZeroCopyScanner::new(ScanConfig::default());
     let _ = streaming
         .scan(bytes::Bytes::from(make_ndjson(1000)))
         .unwrap();

--- a/crates/logfwd-bench/benches/builder_compare.rs
+++ b/crates/logfwd-bench/benches/builder_compare.rs
@@ -14,7 +14,7 @@ use bytes::Bytes;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use logfwd_arrow::materialize::detach_if_attached;
-use logfwd_arrow::scanner::StreamingSimdScanner;
+use logfwd_arrow::scanner::ZeroCopyScanner;
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_transform::SqlTransform;
 
@@ -200,12 +200,12 @@ fn bench_scan(c: &mut Criterion) {
         group.throughput(Throughput::Bytes(data.len() as u64));
 
         group.bench_function(BenchmarkId::new("streaming", name), |b| {
-            let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+            let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
             b.iter(|| scanner.scan(buf.clone()).unwrap());
         });
 
         group.bench_function(BenchmarkId::new("scan_owned", name), |b| {
-            let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+            let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
             b.iter(|| scanner.scan_owned(buf.clone()).unwrap());
         });
     }
@@ -235,7 +235,7 @@ fn bench_persist(c: &mut Criterion) {
 
         // streaming scan → detach → IPC zstd
         group.bench_function(BenchmarkId::new("streaming", name), |b| {
-            let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+            let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
             b.iter(|| {
                 let batch = scanner.scan(buf.clone()).unwrap();
                 let owned = logfwd_arrow::materialize::detach(&batch);
@@ -246,7 +246,7 @@ fn bench_persist(c: &mut Criterion) {
 
         // scan_owned → IPC zstd (no intermediate StringViewArray)
         group.bench_function(BenchmarkId::new("scan_owned", name), |b| {
-            let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+            let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
             b.iter(|| {
                 let batch = scanner.scan_owned(buf.clone()).unwrap();
                 let compressed = write_ipc_zstd(&batch);
@@ -274,7 +274,7 @@ fn bench_pipeline(c: &mut Criterion) {
     // --- Passthrough (SELECT *) ---
 
     group.bench_function(BenchmarkId::new("passthrough", "streaming"), |b| {
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         b.iter(|| {
             let batch = scanner.scan(buf.clone()).unwrap();
@@ -286,7 +286,7 @@ fn bench_pipeline(c: &mut Criterion) {
     });
 
     group.bench_function(BenchmarkId::new("passthrough", "scan_owned"), |b| {
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         b.iter(|| {
             let batch = scanner.scan_owned(buf.clone()).unwrap();
@@ -299,7 +299,7 @@ fn bench_pipeline(c: &mut Criterion) {
     // --- WHERE filter (25% selectivity) ---
 
     group.bench_function(BenchmarkId::new("where_filter", "streaming"), |b| {
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs WHERE level = 'ERROR'").unwrap();
         b.iter(|| {
             let batch = scanner.scan(buf.clone()).unwrap();
@@ -311,7 +311,7 @@ fn bench_pipeline(c: &mut Criterion) {
     });
 
     group.bench_function(BenchmarkId::new("where_filter", "scan_owned"), |b| {
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs WHERE level = 'ERROR'").unwrap();
         b.iter(|| {
             let batch = scanner.scan_owned(buf.clone()).unwrap();
@@ -324,7 +324,7 @@ fn bench_pipeline(c: &mut Criterion) {
     // --- Projection + filter ---
 
     group.bench_function(BenchmarkId::new("proj_filter", "streaming"), |b| {
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new(
             "SELECT level, message, status, duration_ms FROM logs WHERE status >= 400",
         )
@@ -339,7 +339,7 @@ fn bench_pipeline(c: &mut Criterion) {
     });
 
     group.bench_function(BenchmarkId::new("proj_filter", "scan_owned"), |b| {
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new(
             "SELECT level, message, status, duration_ms FROM logs WHERE status >= 400",
         )
@@ -370,7 +370,7 @@ fn bench_decompress(c: &mut Criterion) {
 
     for (name, data) in &datasets {
         let buf = Bytes::from(data.clone());
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let batch = scanner.scan_owned(buf).unwrap();
         let compressed = write_ipc_zstd(&batch);
 
@@ -413,12 +413,12 @@ fn bench_sizes(c: &mut Criterion) {
         let buf = Bytes::from(data.clone());
         let raw_size = data.len();
 
-        let mut s1 = StreamingSimdScanner::new(ScanConfig::default());
+        let mut s1 = ZeroCopyScanner::new(ScanConfig::default());
         let streaming_batch = s1.scan(buf.clone()).unwrap();
         let streaming_mem = streaming_batch.get_array_memory_size();
         let streaming_ipc = write_ipc_zstd(&logfwd_arrow::materialize::detach(&streaming_batch));
 
-        let mut s2 = StreamingSimdScanner::new(ScanConfig::default());
+        let mut s2 = ZeroCopyScanner::new(ScanConfig::default());
         let owned_batch = s2.scan_owned(buf).unwrap();
         let owned_mem = owned_batch.get_array_memory_size();
         let owned_ipc = write_ipc_zstd(&owned_batch);

--- a/crates/logfwd-bench/benches/pipeline.rs
+++ b/crates/logfwd-bench/benches/pipeline.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 use logfwd_core::cri::{CriReassembler, ReassembleResult, parse_cri_line};
 use logfwd_core::scan_config::{FieldSpec, ScanConfig};
 use logfwd_io::compress::ChunkCompressor;
@@ -112,7 +112,7 @@ fn bench_scanner(c: &mut Criterion) {
 
         group.throughput(Throughput::Bytes(bytes));
         group.bench_with_input(BenchmarkId::new("scan_all_fields", n), &data, |b, data| {
-            let mut scanner = SimdScanner::new(ScanConfig::default());
+            let mut scanner = CopyScanner::new(ScanConfig::default());
             b.iter(|| scanner.scan(data).expect("bench: scan should not fail"));
         });
 
@@ -137,7 +137,7 @@ fn bench_scanner(c: &mut Criterion) {
                 keep_raw: false,
                 validate_utf8: false,
             };
-            let mut scanner = SimdScanner::new(config);
+            let mut scanner = CopyScanner::new(config);
             b.iter(|| scanner.scan(data).expect("bench: scan should not fail"));
         });
     }
@@ -214,7 +214,7 @@ fn bench_transform(c: &mut Criterion) {
 
     let n = 10_000;
     let data = gen_json_lines(n);
-    let mut scanner = SimdScanner::new(ScanConfig::default());
+    let mut scanner = CopyScanner::new(ScanConfig::default());
     let batch = scanner.scan(&data).expect("bench: scan should not fail");
     group.throughput(Throughput::Elements(n as u64));
     group.bench_function("select_star", |b| {
@@ -292,7 +292,7 @@ fn bench_output(c: &mut Criterion) {
 
     let n = 10_000;
     let data = gen_json_lines(n);
-    let mut scanner = SimdScanner::new(ScanConfig::default());
+    let mut scanner = CopyScanner::new(ScanConfig::default());
     let batch = scanner.scan(&data).expect("bench: scan should not fail");
     let meta = make_metadata();
 
@@ -335,7 +335,7 @@ fn bench_end_to_end(c: &mut Criterion) {
     // Full pipeline: scan → SELECT * → capture sink
     group.throughput(Throughput::Elements(n as u64));
     group.bench_function("scan_passthrough_capture", |b| {
-        let mut scanner = SimdScanner::new(ScanConfig::default());
+        let mut scanner = CopyScanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         let mut sink = NullSink;
         b.iter(|| {
@@ -347,7 +347,7 @@ fn bench_end_to_end(c: &mut Criterion) {
 
     // Full pipeline: scan → filter → capture sink
     group.bench_function("scan_filter_capture", |b| {
-        let mut scanner = SimdScanner::new(ScanConfig::default());
+        let mut scanner = CopyScanner::new(ScanConfig::default());
         let mut transform =
             SqlTransform::new("SELECT * FROM logs WHERE level_str = 'ERROR'").unwrap();
         let mut sink = NullSink;
@@ -360,7 +360,7 @@ fn bench_end_to_end(c: &mut Criterion) {
 
     // Full pipeline: scan → grok + filter → capture sink
     group.bench_function("scan_grok_filter_capture", |b| {
-        let mut scanner = SimdScanner::new(ScanConfig::default());
+        let mut scanner = CopyScanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new(
             "SELECT grok(message_str, '%{WORD:method} %{URIPATH:path} %{WORD:proto}') AS parsed \
              FROM logs WHERE level_str != 'DEBUG'",
@@ -381,7 +381,7 @@ fn bench_end_to_end(c: &mut Criterion) {
 // Elasticsearch bulk serialization benchmark
 // ---------------------------------------------------------------------------
 
-/// Measures the throughput of `ElasticsearchAsyncSink::serialize_batch` —
+/// Measures the throughput of `ElasticsearchSink::serialize_batch` —
 /// the hot path that converts Arrow RecordBatches into NDJSON bulk payloads
 /// ready to POST to `/_bulk`.
 ///
@@ -404,7 +404,7 @@ fn bench_elasticsearch_serialize(c: &mut Criterion) {
 
     for &n in &[1_000usize, 10_000, 100_000] {
         let data = gen_json_lines(n);
-        let mut scanner = SimdScanner::new(ScanConfig::default());
+        let mut scanner = CopyScanner::new(ScanConfig::default());
         let batch = scanner.scan(&data).expect("bench: scan should not fail");
         let meta = make_metadata();
 

--- a/crates/logfwd-bench/src/e2e_profile.rs
+++ b/crates/logfwd-bench/src/e2e_profile.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_core::scanner::StreamingSimdScanner;
+use logfwd_core::scanner::ZeroCopyScanner;
 use logfwd_io::compress::ChunkCompressor;
 use logfwd_transform::SqlTransform;
 use logfwd_output::BatchMetadata;
@@ -20,7 +20,7 @@ fn main() {
 
     // Stage 1: Scan
     let t0 = Instant::now();
-    let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+    let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
     let batch = scanner.scan(bytes::Bytes::from(data)).unwrap();
     let scan_ms = t0.elapsed().as_millis();
 
@@ -92,7 +92,7 @@ fn main() {
         let data = generate_simple(n);
         
         let t = Instant::now();
-        let mut s = StreamingSimdScanner::new(ScanConfig::default());
+        let mut s = ZeroCopyScanner::new(ScanConfig::default());
         let batch = s.scan(bytes::Bytes::from(data)).unwrap();
         let scan = t.elapsed().as_millis();
         

--- a/crates/logfwd-bench/src/es_throughput.rs
+++ b/crates/logfwd-bench/src/es_throughput.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_io::diagnostics::ComponentStats;
 use logfwd_output::sink::SinkFactory;
@@ -116,7 +116,7 @@ fn run_worker(
     .expect("failed to create sink factory");
     let mut sink = factory.create().expect("failed to create sink");
 
-    let mut scanner = SimdScanner::new(ScanConfig::default());
+    let mut scanner = CopyScanner::new(ScanConfig::default());
     let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
     let meta = BatchMetadata {
         resource_attrs: Arc::new(vec![("service.name".into(), "es-bench".into())]),

--- a/crates/logfwd-bench/src/explore.rs
+++ b/crates/logfwd-bench/src/explore.rs
@@ -5,7 +5,7 @@ use std::io::Write;
 use std::time::Instant;
 
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_core::scanner::StreamingSimdScanner;
+use logfwd_core::scanner::ZeroCopyScanner;
 use logfwd_transform::SqlTransform;
 
 fn main() {
@@ -138,7 +138,7 @@ fn fmt_count(n: usize) -> String {
 fn bench(dataset: &str, lines: usize, fields: usize, sql: &str, data: &[u8]) {
     let mut transform = SqlTransform::new(sql).expect("bad SQL");
     let config = transform.scan_config();
-    let mut scanner = StreamingSimdScanner::new(config);
+    let mut scanner = ZeroCopyScanner::new(config);
 
     let t0 = Instant::now();
     let batch = scanner.scan(bytes::Bytes::from(data.to_vec()))
@@ -163,7 +163,7 @@ fn bench(dataset: &str, lines: usize, fields: usize, sql: &str, data: &[u8]) {
 
 fn bench_scan_only(dataset: &str, lines: usize, fields: usize, data: &[u8]) {
     let config = ScanConfig::default();
-    let mut scanner = StreamingSimdScanner::new(config);
+    let mut scanner = ZeroCopyScanner::new(config);
 
     let t0 = Instant::now();
     let batch = scanner.scan(bytes::Bytes::from(data.to_vec()))

--- a/crates/logfwd-bench/src/rss.rs
+++ b/crates/logfwd-bench/src/rss.rs
@@ -4,7 +4,7 @@
 use std::io::Write;
 
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_core::scanner::StreamingSimdScanner;
+use logfwd_core::scanner::ZeroCopyScanner;
 use logfwd_transform::SqlTransform;
 
 fn rss_mb() -> f64 {
@@ -59,7 +59,7 @@ fn main() {
             data.len() as f64 / 1_048_576.0, after_gen, after_gen - baseline);
 
         // Scan
-        let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
         let batch = scanner.scan(bytes::Bytes::from(data.clone())).unwrap();
         let after_scan = rss_mb();
         println!("  After scan ({} rows):    {:.1} MB  (+{:.1} MB)",
@@ -99,7 +99,7 @@ fn main() {
         let raw_mb = data.len() as f64 / 1_048_576.0;
 
         let before = rss_mb();
-        let mut storage_scanner = logfwd_core::scanner::SimdScanner::new(ScanConfig::default());
+        let mut storage_scanner = logfwd_core::scanner::CopyScanner::new(ScanConfig::default());
         let batch = storage_scanner.scan(&data).unwrap();
         let after_storage = rss_mb();
         let storage_cols = batch.num_columns();
@@ -108,7 +108,7 @@ fn main() {
         drop(storage_scanner);
 
         let mid = rss_mb();
-        let mut streaming_scanner = StreamingSimdScanner::new(ScanConfig::default());
+        let mut streaming_scanner = ZeroCopyScanner::new(ScanConfig::default());
         let batch = streaming_scanner.scan(bytes::Bytes::from(data)).unwrap();
         let after_streaming = rss_mb();
         let streaming_cols = batch.num_columns();
@@ -140,7 +140,7 @@ fn main() {
     {
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         let config = transform.scan_config();
-        let mut scanner = StreamingSimdScanner::new(config);
+        let mut scanner = ZeroCopyScanner::new(config);
         let batch = scanner.scan(bytes::Bytes::from(data.clone())).unwrap();
         let after = rss_mb();
         println!("  SELECT * (20 fields):    {:.1} MB  (delta {:.1} MB)", after, after - baseline);
@@ -153,7 +153,7 @@ fn main() {
     {
         let mut transform = SqlTransform::new("SELECT timestamp_str, level_str FROM logs").unwrap();
         let config = transform.scan_config();
-        let mut scanner = StreamingSimdScanner::new(config);
+        let mut scanner = ZeroCopyScanner::new(config);
         let batch = scanner.scan(bytes::Bytes::from(data.clone())).unwrap();
         let after = rss_mb();
         println!("  SELECT 2 fields:         {:.1} MB  (delta {:.1} MB)", after, after - mid);

--- a/crates/logfwd-bench/src/sizes.rs
+++ b/crates/logfwd-bench/src/sizes.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use arrow::ipc::writer::{FileWriter, IpcWriteOptions};
 use arrow::record_batch::RecordBatch;
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_core::scanner::StreamingSimdScanner;
+use logfwd_core::scanner::ZeroCopyScanner;
 use logfwd_transform::SqlTransform;
 
 fn main() {
@@ -157,12 +157,12 @@ fn memory_analysis(data: &[u8], lines: usize) {
 fn scan(data: &[u8], sql: &str) -> RecordBatch {
     let mut transform = SqlTransform::new(sql).expect("bad SQL");
     let config = transform.scan_config();
-    let mut scanner = StreamingSimdScanner::new(config);
+    let mut scanner = ZeroCopyScanner::new(config);
     let batch = scanner.scan(bytes::Bytes::from(data.to_vec())).expect("scan failed");
     // Run through transform for accurate schema
     transform.execute_blocking(batch).unwrap_or_else(|_| {
         // If transform fails, return the raw scan
-        let mut scanner2 = StreamingSimdScanner::new(ScanConfig::default());
+        let mut scanner2 = ZeroCopyScanner::new(ScanConfig::default());
         scanner2.scan(bytes::Bytes::from(data.to_vec())).unwrap()
     })
 }
@@ -307,7 +307,7 @@ fn deep_memory_analysis() {
     println!("\n=== Deep Memory Analysis (100K simple lines) ===\n");
     println!("  Raw JSON: {} ({} bytes/line)", fmt_bytes(raw_size), raw_size / 100_000);
 
-    let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+    let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
     let batch = scanner.scan(bytes::Bytes::from(data.to_vec())).unwrap();
 
     println!("  Reported total: {}", fmt_bytes(batch.get_array_memory_size()));
@@ -387,7 +387,7 @@ fn deep_memory_analysis_v2() {
     let raw_size = data.len();
     println!("\n=== Deep Memory V2 (10K lines, {} raw) ===\n", fmt_bytes(raw_size));
 
-    let mut scanner = StreamingSimdScanner::new(ScanConfig::default());
+    let mut scanner = ZeroCopyScanner::new(ScanConfig::default());
     let batch = scanner.scan(bytes::Bytes::from(data.to_vec())).unwrap();
 
     for (i, field) in batch.schema().fields().iter().enumerate() {

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -112,14 +112,14 @@ pub enum OutputType {
     Elasticsearch,
     Loki,
     Stdout,
-    FileOut,
+    File,
     Parquet,
     /// Discard all data. Used for benchmarking and blackhole receivers.
     Null,
     /// Send newline-delimited data over TCP.
-    TcpOut,
+    Tcp,
     /// Send datagrams over UDP.
-    UdpOut,
+    Udp,
     /// Arrow IPC stream over HTTP (native Arrow transport).
     ArrowIpc,
 }
@@ -132,11 +132,11 @@ impl fmt::Display for OutputType {
             OutputType::Elasticsearch => f.write_str("elasticsearch"),
             OutputType::Loki => f.write_str("loki"),
             OutputType::Stdout => f.write_str("stdout"),
-            OutputType::FileOut => f.write_str("file_out"),
+            OutputType::File => f.write_str("file"),
             OutputType::Parquet => f.write_str("parquet"),
             OutputType::Null => f.write_str("null"),
-            OutputType::TcpOut => f.write_str("tcp_out"),
-            OutputType::UdpOut => f.write_str("udp_out"),
+            OutputType::Tcp => f.write_str("tcp"),
+            OutputType::Udp => f.write_str("udp"),
             OutputType::ArrowIpc => f.write_str("arrow_ipc"),
         }
     }
@@ -157,11 +157,11 @@ impl<'de> Deserialize<'de> for OutputType {
                     "elasticsearch" => Ok(OutputType::Elasticsearch),
                     "loki" => Ok(OutputType::Loki),
                     "stdout" => Ok(OutputType::Stdout),
-                    "file_out" => Ok(OutputType::FileOut),
+                    "file" | "file_out" => Ok(OutputType::File),
                     "parquet" => Ok(OutputType::Parquet),
                     "null" => Ok(OutputType::Null),
-                    "tcp_out" => Ok(OutputType::TcpOut),
-                    "udp_out" => Ok(OutputType::UdpOut),
+                    "tcp" | "tcp_out" => Ok(OutputType::Tcp),
+                    "udp" | "udp_out" => Ok(OutputType::Udp),
                     "arrow_ipc" => Ok(OutputType::ArrowIpc),
                     other => Err(E::unknown_variant(
                         other,
@@ -171,11 +171,11 @@ impl<'de> Deserialize<'de> for OutputType {
                             "elasticsearch",
                             "loki",
                             "stdout",
-                            "file_out",
+                            "file",
                             "parquet",
                             "null",
-                            "tcp_out",
-                            "udp_out",
+                            "tcp",
+                            "udp",
                             "arrow_ipc",
                         ],
                     )),
@@ -681,7 +681,7 @@ impl Config {
 
                 // Reject placeholder output types that are not yet implemented.
                 match output.output_type {
-                    OutputType::FileOut | OutputType::Parquet => {
+                    OutputType::File | OutputType::Parquet => {
                         return Err(ConfigError::Validation(format!(
                             "pipeline '{name}' output '{label}': {} output type is not yet implemented",
                             output.output_type,
@@ -737,7 +737,7 @@ impl Config {
                             )));
                         }
                     }
-                    OutputType::FileOut => {
+                    OutputType::File => {
                         if output.path.is_none() {
                             return Err(ConfigError::Validation(format!(
                                 "pipeline '{name}' output '{label}': {} output requires 'path'",
@@ -746,7 +746,7 @@ impl Config {
                         }
                     }
                     OutputType::Stdout | OutputType::Null => {}
-                    OutputType::TcpOut | OutputType::UdpOut => {
+                    OutputType::Tcp | OutputType::Udp => {
                         if output.endpoint.is_none() {
                             return Err(ConfigError::Validation(format!(
                                 "pipeline '{name}' output '{label}': {} output requires 'endpoint'",
@@ -1157,13 +1157,13 @@ server:
     }
 
     #[test]
-    fn file_out_rejected_as_unimplemented() {
+    fn file_rejected_as_unimplemented() {
         let yaml = r"
 input:
   type: file
   path: /var/log/test.log
 output:
-  type: file_out
+  type: file
 ";
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
@@ -1177,7 +1177,7 @@ output:
     fn validation_unimplemented_output_type() {
         // Each placeholder type should be caught by Config::validate() before
         // pipeline construction, not silently accepted.
-        for otype in ["file_out", "parquet"] {
+        for otype in ["file", "parquet"] {
             let yaml = format!(
                 "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: {otype}\n  endpoint: http://x\n  path: /tmp/x\n"
             );
@@ -1248,7 +1248,7 @@ output:
         }
 
         // Placeholder output types must be rejected at validation time.
-        for otype in ["file_out", "parquet"] {
+        for otype in ["file", "parquet"] {
             let yaml = format!(
                 "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: {otype}\n  endpoint: http://x\n  path: /tmp/x\n"
             );

--- a/crates/logfwd-core/README.md
+++ b/crates/logfwd-core/README.md
@@ -19,7 +19,7 @@ Proven pure-logic kernel. Scanner, parsers, pipeline state machine, OTLP encodin
 - `structural.rs` — SIMD structural character detection (quote, backslash, bitmasks)
 - `cri.rs` — CRI log format parser + reassembler
 - `framer.rs` — NewlineFramer (Kani-proven, fixed-size, no heap)
-- `aggregator.rs` — CriAggregator (zero-copy F path, Kani-proven)
+- `aggregator.rs` — CriReassembler (zero-copy F path, Kani-proven)
 - `pipeline/` — BatchTicket, PipelineMachine (typestate, Kani-proven)
 - `otlp.rs` — OTLP protobuf encoding
 

--- a/crates/logfwd-core/benches/scanner.rs
+++ b/crates/logfwd-core/benches/scanner.rs
@@ -1,5 +1,5 @@
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 use logfwd_core::scan_config::{FieldSpec, ScanConfig};
 use std::hint::black_box;
 
@@ -287,7 +287,7 @@ macro_rules! bench_scenario {
             group.throughput(Throughput::Bytes(data.len() as u64));
 
             group.bench_function("SIMD scanner", |b| {
-                let mut scanner = SimdScanner::new($config());
+                let mut scanner = CopyScanner::new($config());
                 b.iter(|| {
                     black_box(
                         scanner

--- a/crates/logfwd-core/fuzz/fuzz_targets/scanner.rs
+++ b/crates/logfwd-core/fuzz/fuzz_targets/scanner.rs
@@ -3,7 +3,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 
 fn validate_batch(batch: &arrow::record_batch::RecordBatch, label: &str) {
     let num_rows = batch.num_rows();
@@ -27,7 +27,7 @@ fuzz_target!(|data: &[u8]| {
         keep_raw: true,
         validate_utf8: false,
     };
-    let mut scanner = SimdScanner::new(config);
+    let mut scanner = CopyScanner::new(config);
     let Ok(batch) = scanner.scan(data) else {
         return;
     };
@@ -49,7 +49,7 @@ fuzz_target!(|data: &[u8]| {
         keep_raw: false,
         validate_utf8: false,
     };
-    let mut scanner2 = SimdScanner::new(config2);
+    let mut scanner2 = CopyScanner::new(config2);
     let Ok(batch2) = scanner2.scan(data) else {
         return;
     };

--- a/crates/logfwd-core/fuzz/fuzz_targets/scanner_consistency.rs
+++ b/crates/logfwd-core/fuzz/fuzz_targets/scanner_consistency.rs
@@ -1,7 +1,7 @@
 //! Cross-builder consistency fuzz target.
 //!
-//! Runs the same input through both `SimdScanner` (StorageBuilder) and
-//! `StreamingSimdScanner` (StreamingBuilder) and asserts that:
+//! Runs the same input through both `CopyScanner` (StorageBuilder) and
+//! `ZeroCopyScanner` (StreamingBuilder) and asserts that:
 //! - Row counts match.
 //! - The same set of column names is produced.
 //! - For every column, the null pattern matches.
@@ -12,17 +12,17 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_arrow::scanner::{SimdScanner, StreamingSimdScanner};
+use logfwd_arrow::scanner::{CopyScanner, ZeroCopyScanner};
 
 use arrow::array::{Array, AsArray};
 use arrow::datatypes::DataType;
 use std::collections::BTreeSet;
 
 fuzz_target!(|data: &[u8]| {
-    let mut storage_scanner = SimdScanner::new(ScanConfig::default());
+    let mut storage_scanner = CopyScanner::new(ScanConfig::default());
     let Ok(storage_batch) = storage_scanner.scan(data) else { return; };
 
-    let mut streaming_scanner = StreamingSimdScanner::new(ScanConfig::default());
+    let mut streaming_scanner = ZeroCopyScanner::new(ScanConfig::default());
     let Ok(streaming_batch) = streaming_scanner.scan(bytes::Bytes::copy_from_slice(data)) else { return; };
 
     // Row counts must match.

--- a/crates/logfwd-core/fuzz/fuzz_targets/scanner_sink.rs
+++ b/crates/logfwd-core/fuzz/fuzz_targets/scanner_sink.rs
@@ -1,6 +1,6 @@
 //! Fuzz the scanner-to-output-sink pipeline.
 //!
-//! Feeds arbitrary bytes through `SimdScanner` and then serializes the
+//! Feeds arbitrary bytes through `CopyScanner` and then serializes the
 //! resulting `RecordBatch` with both `JsonLinesSink` and `OtlpSink`.
 //!
 //! Verifies that:
@@ -12,13 +12,13 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 use logfwd_io::diagnostics::ComponentStats;
 use logfwd_output::{BatchMetadata, Compression, JsonLinesSink, OtlpProtocol, OtlpSink};
 use std::sync::Arc;
 
 fuzz_target!(|data: &[u8]| {
-    let mut scanner = SimdScanner::new(ScanConfig {
+    let mut scanner = CopyScanner::new(ScanConfig {
         wanted_fields: vec![],
         extract_all: true,
         keep_raw: false,

--- a/crates/logfwd-core/fuzz/fuzz_targets/scanner_transform.rs
+++ b/crates/logfwd-core/fuzz/fuzz_targets/scanner_transform.rs
@@ -1,6 +1,6 @@
 //! Fuzz the scanner → DataFusion `SqlTransform` integration.
 //!
-//! Feeds arbitrary bytes through `SimdScanner` and then executes a SQL query
+//! Feeds arbitrary bytes through `CopyScanner` and then executes a SQL query
 //! on the resulting `RecordBatch` via `SqlTransform`.
 //!
 //! The goal is to verify that no combination of scanner output can cause a
@@ -18,11 +18,11 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 use logfwd_transform::SqlTransform;
 
 fuzz_target!(|data: &[u8]| {
-    let mut scanner = SimdScanner::new(ScanConfig {
+    let mut scanner = CopyScanner::new(ScanConfig {
         wanted_fields: vec![],
         extract_all: true,
         keep_raw: false,

--- a/crates/logfwd-core/fuzz/fuzz_targets/streaming_scanner.rs
+++ b/crates/logfwd-core/fuzz/fuzz_targets/streaming_scanner.rs
@@ -1,4 +1,4 @@
-//! Fuzz the StreamingSimdScanner (StreamingBuilder / zero-copy path) with
+//! Fuzz the ZeroCopyScanner (StreamingBuilder / zero-copy path) with
 //! arbitrary bytes.
 //!
 //! Covers:
@@ -11,7 +11,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_arrow::scanner::StreamingSimdScanner;
+use logfwd_arrow::scanner::ZeroCopyScanner;
 
 fn validate_batch(batch: &arrow::record_batch::RecordBatch, label: &str) {
     let num_rows = batch.num_rows();
@@ -35,7 +35,7 @@ fuzz_target!(|data: &[u8]| {
         keep_raw: false,
         validate_utf8: false,
     };
-    let mut scanner = StreamingSimdScanner::new(config);
+    let mut scanner = ZeroCopyScanner::new(config);
     let Ok(batch) = scanner.scan(bytes::Bytes::copy_from_slice(data)) else { return; };
     validate_batch(&batch, "streaming_extract_all");
 
@@ -55,7 +55,7 @@ fuzz_target!(|data: &[u8]| {
         keep_raw: false,
         validate_utf8: false,
     };
-    let mut scanner2 = StreamingSimdScanner::new(config2);
+    let mut scanner2 = ZeroCopyScanner::new(config2);
     let Ok(batch2) = scanner2.scan(bytes::Bytes::copy_from_slice(data)) else { return; };
     validate_batch(&batch2, "streaming_pushdown");
 });

--- a/crates/logfwd-core/fuzz/fuzz_targets/structural_index.rs
+++ b/crates/logfwd-core/fuzz/fuzz_targets/structural_index.rs
@@ -10,7 +10,7 @@
 //! 2. Exercises all public query methods (`is_in_string`, `next_quote`,
 //!    `scan_string`, `skip_nested`) at every byte position to ensure no
 //!    out-of-bounds access or panic.
-//! 3. Passes the same bytes through `SimdScanner` to exercise the full
+//! 3. Passes the same bytes through `CopyScanner` to exercise the full
 //!    scanner pipeline built on top of `StructuralIndex`.
 //!
 //! The corpus should include inputs with dense backslash runs near multiples
@@ -21,7 +21,7 @@
 use libfuzzer_sys::fuzz_target;
 use logfwd_core::structural::StructuralIndex;
 use logfwd_core::scan_config::ScanConfig;
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 
 fuzz_target!(|data: &[u8]| {
     // --- Direct StructuralIndex API exercise ---
@@ -56,7 +56,7 @@ fuzz_target!(|data: &[u8]| {
     }
 
     // --- Full scanner pipeline (uses StructuralIndex internally) ---
-    let mut scanner = SimdScanner::new(ScanConfig::default());
+    let mut scanner = CopyScanner::new(ScanConfig::default());
     let Ok(batch) = scanner.scan(data) else { return; };
     let num_rows = batch.num_rows();
     let schema = batch.schema();

--- a/crates/logfwd-core/src/aggregator.rs
+++ b/crates/logfwd-core/src/aggregator.rs
@@ -31,7 +31,7 @@
 /// ```
 use alloc::vec::Vec;
 /// CRI partial line aggregator. Merges P/F lines into complete messages.
-pub struct CriAggregator {
+pub struct CriReassembler {
     pending: Vec<u8>,
     max_message_size: usize,
     /// Set to `true` when any chunk in the current P/F sequence was truncated
@@ -53,14 +53,14 @@ pub enum AggregateResult<'a> {
     Pending,
 }
 
-impl CriAggregator {
+impl CriReassembler {
     /// Create a new aggregator with the given maximum message size.
     ///
     /// Messages exceeding this size are truncated. Set to a generous
     /// default (e.g., 256KB) to handle Java stack traces and large
     /// structured log lines.
     pub fn new(max_message_size: usize) -> Self {
-        CriAggregator {
+        CriReassembler {
             pending: Vec::new(),
             max_message_size,
             truncated: false,
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn f_only_zero_copy() {
-        let mut agg = CriAggregator::new(1024);
+        let mut agg = CriReassembler::new(1024);
         let msg = b"hello world";
         match agg.feed(msg, true) {
             AggregateResult::Complete(out) => {
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn p_then_f() {
-        let mut agg = CriAggregator::new(1024);
+        let mut agg = CriReassembler::new(1024);
 
         assert!(matches!(
             agg.feed(b"hello ", false),
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn max_size_truncation() {
-        let mut agg = CriAggregator::new(10);
+        let mut agg = CriReassembler::new(10);
 
         // P line with 8 bytes
         agg.feed(b"12345678", false);
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn max_size_f_only() {
-        let mut agg = CriAggregator::new(5);
+        let mut agg = CriReassembler::new(5);
         match agg.feed(b"truncated", true) {
             AggregateResult::Truncated(out) => {
                 assert_eq!(out, b"trunc");
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn reset_preserves_capacity() {
-        let mut agg = CriAggregator::new(1024);
+        let mut agg = CriReassembler::new(1024);
         agg.feed(b"some data", false);
         let cap_before = agg.pending.capacity();
         agg.reset();
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn multiple_sequences() {
-        let mut agg = CriAggregator::new(1024);
+        let mut agg = CriReassembler::new(1024);
 
         // Sequence 1: P + F
         agg.feed(b"a", false);
@@ -280,7 +280,7 @@ mod proptests {
                 1..20usize,
             )
         ) {
-            let mut agg = CriAggregator::new(max_size);
+            let mut agg = CriReassembler::new(max_size);
             for (msg, is_full) in sequence {
                 match agg.feed(&msg, is_full) {
                     AggregateResult::Complete(out) | AggregateResult::Truncated(out) => {
@@ -310,7 +310,7 @@ mod proptests {
                 1..20usize,
             )
         ) {
-            let mut agg = CriAggregator::new(max_size);
+            let mut agg = CriReassembler::new(max_size);
             for chunk in p_chunks {
                 match agg.feed(&chunk, false) {
                     AggregateResult::Pending => {}
@@ -331,7 +331,7 @@ mod proptests {
             p_chunk in proptest::collection::vec(proptest::num::u8::ANY, 0..32usize),
             f_chunk in proptest::collection::vec(proptest::num::u8::ANY, 0..32usize),
         ) {
-            let mut agg = CriAggregator::new(max_size);
+            let mut agg = CriReassembler::new(max_size);
 
             // Accumulate some P data, then reset
             let _ = agg.feed(&p_chunk, false);
@@ -358,13 +358,13 @@ mod proptests {
 mod verification {
     use super::*;
 
-    /// Prove CriAggregator::feed respects max_message_size for F-only lines.
+    /// Prove CriReassembler::feed respects max_message_size for F-only lines.
     #[kani::proof]
     fn verify_aggregator_f_only_max_size() {
         let max_size: usize = kani::any();
         kani::assume(max_size >= 1 && max_size <= 32);
 
-        let mut agg = CriAggregator::new(max_size);
+        let mut agg = CriReassembler::new(max_size);
         let msg: [u8; 16] = kani::any();
 
         match agg.feed(&msg, true) {
@@ -380,13 +380,13 @@ mod verification {
         }
     }
 
-    /// Prove CriAggregator::feed respects max_message_size for P+F sequences.
+    /// Prove CriReassembler::feed respects max_message_size for P+F sequences.
     #[kani::proof]
     fn verify_aggregator_pf_max_size() {
         let max_size: usize = kani::any();
         kani::assume(max_size >= 1 && max_size <= 32);
 
-        let mut agg = CriAggregator::new(max_size);
+        let mut agg = CriReassembler::new(max_size);
 
         let msg1: [u8; 8] = kani::any();
         let _ = agg.feed(&msg1, false);
@@ -410,7 +410,7 @@ mod verification {
     /// Prove P lines never produce output.
     #[kani::proof]
     fn verify_aggregator_p_returns_pending() {
-        let mut agg = CriAggregator::new(1024);
+        let mut agg = CriReassembler::new(1024);
         let msg: [u8; 8] = kani::any();
         match agg.feed(&msg, false) {
             AggregateResult::Pending => {} // expected
@@ -426,7 +426,7 @@ mod verification {
         let max_size: usize = kani::any();
         kani::assume(max_size >= 1 && max_size <= 32);
 
-        let mut agg = CriAggregator::new(max_size);
+        let mut agg = CriReassembler::new(max_size);
 
         let msg1: [u8; 8] = kani::any();
         let _ = agg.feed(&msg1, false);
@@ -453,7 +453,7 @@ mod verification {
     /// Prove reset after Complete allows a clean new sequence.
     #[kani::proof]
     fn verify_aggregator_reset_clears_state() {
-        let mut agg = CriAggregator::new(64);
+        let mut agg = CriReassembler::new(64);
 
         let msg1: [u8; 4] = kani::any();
         let _ = agg.feed(&msg1, false);
@@ -479,7 +479,7 @@ mod verification {
     /// F lines return Truncated(&[]) without slicing panics.
     #[kani::proof]
     fn verify_aggregator_max_size_zero() {
-        let mut agg = CriAggregator::new(0);
+        let mut agg = CriReassembler::new(0);
         let msg: [u8; 8] = kani::any();
 
         // P line: no output, no panic
@@ -505,7 +505,7 @@ mod verification {
     fn verify_aggregator_f_only_is_input_prefix() {
         let max_size: usize = kani::any();
         kani::assume(max_size >= 1 && max_size <= 32); // consistent with other aggregator proofs
-        let mut agg = CriAggregator::new(max_size);
+        let mut agg = CriReassembler::new(max_size);
         assert!(!agg.has_pending()); // fast path requires no pending
 
         let msg: [u8; 8] = kani::any();
@@ -533,7 +533,7 @@ mod verification {
     #[kani::proof]
     fn verify_aggregator_pf_content_correct() {
         let max_size: usize = kani::any_where(|&s: &usize| s >= 1 && s <= 16);
-        let mut agg = CriAggregator::new(max_size);
+        let mut agg = CriReassembler::new(max_size);
 
         let p_msg: [u8; 4] = kani::any();
         let _ = agg.feed(&p_msg, false); // P chunk

--- a/crates/logfwd-core/src/pipeline/lifecycle.rs
+++ b/crates/logfwd-core/src/pipeline/lifecycle.rs
@@ -53,7 +53,7 @@ pub struct PipelineMachine<S, C> {
 
 /// Result of applying an AckReceipt to the pipeline.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CommitAdvance<C> {
+pub struct CheckpointAdvance<C> {
     /// The source whose checkpoint may have advanced.
     pub source: SourceId,
     /// Whether the committed checkpoint actually changed.
@@ -141,7 +141,7 @@ impl<C: Clone> PipelineMachine<Running, C> {
     /// Ordered ACK: the checkpoint advances only when all batches with
     /// lower IDs for this source have also been acked. Out-of-order acks
     /// are buffered in `pending_acks`.
-    pub fn apply_ack(&mut self, receipt: AckReceipt<C>) -> CommitAdvance<C> {
+    pub fn apply_ack(&mut self, receipt: AckReceipt<C>) -> CheckpointAdvance<C> {
         record_ack_and_advance(
             &mut self.committed,
             &mut self.in_flight,
@@ -189,7 +189,7 @@ fn record_ack_and_advance<C: Clone>(
     in_flight: &mut BTreeMap<SourceId, BTreeMap<BatchId, C>>,
     pending_acks: &mut BTreeMap<SourceId, BTreeMap<BatchId, C>>,
     receipt: AckReceipt<C>,
-) -> CommitAdvance<C> {
+) -> CheckpointAdvance<C> {
     let source = receipt.source;
     let batch_id = receipt.batch_id;
 
@@ -210,7 +210,7 @@ fn record_ack_and_advance<C: Clone>(
     };
 
     if !removed {
-        return CommitAdvance {
+        return CheckpointAdvance {
             source,
             advanced: false,
             checkpoint: committed.get(&source).cloned(),
@@ -245,7 +245,7 @@ fn record_ack_and_advance<C: Clone>(
         pending_acks.remove(&source);
     }
 
-    CommitAdvance {
+    CheckpointAdvance {
         source,
         advanced,
         checkpoint: committed.get(&source).cloned(),
@@ -258,7 +258,7 @@ fn record_ack_and_advance<C: Clone>(
 
 impl<C: Clone> PipelineMachine<Draining, C> {
     /// Apply an AckReceipt during drain (same logic as Running).
-    pub fn apply_ack(&mut self, receipt: AckReceipt<C>) -> CommitAdvance<C> {
+    pub fn apply_ack(&mut self, receipt: AckReceipt<C>) -> CheckpointAdvance<C> {
         record_ack_and_advance(
             &mut self.committed,
             &mut self.in_flight,

--- a/crates/logfwd-core/src/pipeline/mod.rs
+++ b/crates/logfwd-core/src/pipeline/mod.rs
@@ -31,7 +31,7 @@ mod registry;
 pub use batch::{AckReceipt, BatchId, BatchTicket, Queued, Sending, SourceId};
 
 // Pipeline lifecycle types
-pub use lifecycle::{CommitAdvance, Draining, PipelineMachine, Running, Starting, Stopped};
+pub use lifecycle::{CheckpointAdvance, Draining, PipelineMachine, Running, Starting, Stopped};
 
 // Source registry types
 pub use registry::{SourceEntry, SourceRegistry, SourceState};

--- a/crates/logfwd-core/src/scan_config.rs
+++ b/crates/logfwd-core/src/scan_config.rs
@@ -1,7 +1,7 @@
 // scanner.rs — Scan configuration types for JSON field extraction.
 //
 // Defines ScanConfig and FieldSpec, used by all scanner implementations
-// (SimdScanner, StreamingSimdScanner) and the SQL transform layer.
+// (CopyScanner, ZeroCopyScanner) and the SQL transform layer.
 
 use alloc::{string::String, vec, vec::Vec};
 /// Specification for a single field to extract.

--- a/crates/logfwd-core/src/scanner.rs
+++ b/crates/logfwd-core/src/scanner.rs
@@ -1,7 +1,7 @@
 // scanner.rs — Generic JSON-to-columnar scan loop.
 //
 // Provides the ScanBuilder trait and the scan_into/scan_line functions.
-// Arrow-specific scanner types (SimdScanner, StreamingSimdScanner) live
+// Arrow-specific scanner types (CopyScanner, ZeroCopyScanner) live
 // in the logfwd-arrow crate.
 
 use crate::scan_config::ScanConfig;

--- a/crates/logfwd-core/tests/it/compliance_data.rs
+++ b/crates/logfwd-core/tests/it/compliance_data.rs
@@ -10,8 +10,8 @@ use arrow::array::{Array, Float64Array, Int64Array, StringArray, StructArray};
 use arrow::compute;
 use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
-use logfwd_arrow::scanner::{SimdScanner, StreamingSimdScanner};
-use logfwd_core::aggregator::{AggregateResult, CriAggregator};
+use logfwd_arrow::scanner::{CopyScanner, ZeroCopyScanner};
+use logfwd_core::aggregator::{AggregateResult, CriReassembler};
 use logfwd_core::cri::parse_cri_line;
 use logfwd_core::scan_config::ScanConfig;
 
@@ -19,26 +19,26 @@ use logfwd_core::scan_config::ScanConfig;
 // Helpers
 // ===========================================================================
 
-/// Scan with SimdScanner (StorageBuilder) using default config.
+/// Scan with CopyScanner (StorageBuilder) using default config.
 fn scan_storage(input: &[u8]) -> RecordBatch {
-    let mut s = SimdScanner::new(ScanConfig::default());
+    let mut s = CopyScanner::new(ScanConfig::default());
     s.scan(input).expect("StorageBuilder scan failed")
 }
 
-/// Scan with StreamingSimdScanner (StreamingBuilder) using default config.
+/// Scan with ZeroCopyScanner (StreamingBuilder) using default config.
 fn scan_streaming(input: &[u8]) -> RecordBatch {
-    let mut s = StreamingSimdScanner::new(ScanConfig::default());
+    let mut s = ZeroCopyScanner::new(ScanConfig::default());
     s.scan(bytes::Bytes::from(input.to_vec()))
         .expect("StreamingBuilder scan failed")
 }
 
-/// Scan with SimdScanner using keep_raw=true.
+/// Scan with CopyScanner using keep_raw=true.
 fn scan_storage_raw(input: &[u8]) -> RecordBatch {
     let config = ScanConfig {
         keep_raw: true,
         ..ScanConfig::default()
     };
-    let mut s = SimdScanner::new(config);
+    let mut s = CopyScanner::new(config);
     s.scan(input)
         .expect("StorageBuilder scan (keep_raw) failed")
 }
@@ -159,7 +159,7 @@ fn assert_struct_child_null(batch: &RecordBatch, field: &str, child: &str, row: 
     // Column not existing is also acceptable.
 }
 
-/// Run a test function against both SimdScanner and StreamingSimdScanner,
+/// Run a test function against both CopyScanner and ZeroCopyScanner,
 /// verifying they produce the same row count and column names.
 fn assert_both_scanners<F>(input: &[u8], check: F)
 where
@@ -533,8 +533,8 @@ fn compliance_cri_format() {
 
 #[test]
 fn compliance_cri_partial_lines() {
-    // CRI partial (P) + full (F) — CriAggregator handles reassembly.
-    let mut agg = CriAggregator::new(2 * 1024 * 1024);
+    // CRI partial (P) + full (F) — CriReassembler handles reassembly.
+    let mut agg = CriReassembler::new(2 * 1024 * 1024);
 
     let p_line = b"2024-01-15T10:30:00.000000000Z stdout P {\"msg\":\"hel";
     let f_line = b"2024-01-15T10:30:00.000000000Z stdout F lo\"}";
@@ -572,7 +572,7 @@ fn compliance_raw_format() {
         keep_raw: true,
         validate_utf8: false,
     };
-    let mut scanner = SimdScanner::new(config);
+    let mut scanner = CopyScanner::new(config);
     let batch = scanner.scan(raw_input).unwrap();
     assert_eq!(batch.num_rows(), 1);
     assert!(
@@ -707,7 +707,7 @@ fn compliance_negative_zero_integer() {
 fn compliance_batch_reuse_isolation() {
     // Scanning two different inputs with the same scanner should not leak
     // data between batches.
-    let mut s = SimdScanner::new(ScanConfig::default());
+    let mut s = CopyScanner::new(ScanConfig::default());
     let b1 = s.scan(b"{\"a\":\"first\"}\n").unwrap();
     let b2 = s.scan(b"{\"b\":\"second\"}\n").unwrap();
 
@@ -725,7 +725,7 @@ fn compliance_batch_reuse_isolation() {
 
 #[test]
 fn compliance_streaming_batch_reuse_isolation() {
-    let mut s = StreamingSimdScanner::new(ScanConfig::default());
+    let mut s = ZeroCopyScanner::new(ScanConfig::default());
     let b1 = s
         .scan(bytes::Bytes::from_static(b"{\"a\":\"first\"}\n"))
         .unwrap();

--- a/crates/logfwd-core/tests/it/scanner_conformance.rs
+++ b/crates/logfwd-core/tests/it/scanner_conformance.rs
@@ -14,7 +14,7 @@
 //!   cargo test --features simd-scanner -p logfwd-core --test scanner_conformance -- --nocapture
 
 use arrow::array::{Array, Float64Array, Int64Array, StringArray, StructArray};
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_test_utils::json::{arb_flat_object, arb_json_string, arb_ndjson_buffer};
 use proptest::prelude::*;
@@ -41,7 +41,7 @@ fn get_struct_child<'a>(
 fn assert_values_correct(input: &[u8]) {
     use sonic_rs::{JsonContainerTrait, JsonValueTrait};
 
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let batch = simd.scan(input).expect("scan should succeed");
 
     // Parse each line with sonic-rs and verify the Arrow output matches
@@ -308,16 +308,16 @@ proptest! {
 }
 
 // ===========================================================================
-// Cross-builder consistency: SimdScanner vs StreamingSimdScanner
+// Cross-builder consistency: CopyScanner vs ZeroCopyScanner
 // ===========================================================================
 
 /// Verify both scanners produce the same row count and the same non-null
 /// values for the same input. Accounts for StringArray vs StringViewArray.
 fn assert_builders_consistent(input: &[u8]) {
-    use logfwd_arrow::scanner::StreamingSimdScanner;
+    use logfwd_arrow::scanner::ZeroCopyScanner;
 
-    let mut storage = SimdScanner::new(ScanConfig::default());
-    let mut streaming = StreamingSimdScanner::new(ScanConfig::default());
+    let mut storage = CopyScanner::new(ScanConfig::default());
+    let mut streaming = ZeroCopyScanner::new(ScanConfig::default());
 
     let sb = storage.scan(input).expect("scan should succeed");
     let stb = streaming
@@ -595,7 +595,7 @@ fn edge_duplicate_keys() {
     let input = br#"{"a":1,"a":2}
 "#;
     // Both scanners handle duplicates via first-writer-wins in the builder
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let batch = simd.scan(input).expect("scan should succeed");
     assert_eq!(batch.num_rows(), 1);
     // First-writer-wins
@@ -612,7 +612,7 @@ fn edge_duplicate_keys() {
 fn edge_duplicate_keys_different_types() {
     let input = br#"{"a":1,"a":"hello"}
 "#;
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let batch = simd.scan(input).expect("scan should succeed");
     assert_eq!(batch.num_rows(), 1);
 }
@@ -622,7 +622,7 @@ fn edge_duplicate_keys_different_types() {
 #[test]
 fn no_panic_truncated_string() {
     let input = b"{\"a\":\"unterminated\n";
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let _batch = simd
         .scan(input)
         .expect("scan should not fail on malformed JSON");
@@ -631,7 +631,7 @@ fn no_panic_truncated_string() {
 #[test]
 fn no_panic_truncated_object() {
     let input = b"{\"a\":1,\"b\"\n";
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let _batch = simd
         .scan(input)
         .expect("scan should not fail on malformed JSON");
@@ -640,7 +640,7 @@ fn no_panic_truncated_object() {
 #[test]
 fn no_panic_garbage() {
     let input = b"not json at all\n";
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let _batch = simd
         .scan(input)
         .expect("scan should not fail on malformed JSON");
@@ -654,7 +654,7 @@ fn no_panic_random_bytes() {
     let input = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789{}\n\u{00e9}\u{4e2d}\u{1f600}\n"
         .as_bytes()
         .to_vec();
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let _batch = simd
         .scan(&input)
         .expect("scan should not fail on valid UTF-8");
@@ -663,7 +663,7 @@ fn no_panic_random_bytes() {
 #[test]
 fn no_panic_only_quotes() {
     let input = b"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"\"";
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let _batch = simd
         .scan(input)
         .expect("scan should not fail on malformed JSON");
@@ -672,7 +672,7 @@ fn no_panic_only_quotes() {
 #[test]
 fn no_panic_only_backslashes() {
     let input = b"\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\";
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let _batch = simd
         .scan(input)
         .expect("scan should not fail on malformed JSON");
@@ -690,7 +690,7 @@ fn no_panic_deeply_nested() {
         input.push('}');
     }
     input.push_str("}\n");
-    let mut simd = SimdScanner::new(ScanConfig::default());
+    let mut simd = CopyScanner::new(ScanConfig::default());
     let _batch = simd
         .scan(input.as_bytes())
         .expect("scan should not fail on valid UTF-8");

--- a/crates/logfwd-io/src/format.rs
+++ b/crates/logfwd-io/src/format.rs
@@ -1,12 +1,12 @@
 //! Format processing for input data.
 //!
-//! A `FormatProcessor` transforms framed lines (complete, newline-delimited)
+//! A `FormatDecoder` transforms framed lines (complete, newline-delimited)
 //! into scanner-ready output. This separates format concerns from transport
 //! and framing, allowing any transport (file, TCP, UDP) to use any format
 //! (JSON, CRI, Raw) via composition.
 
 use crate::diagnostics::ComponentStats;
-use logfwd_core::aggregator::{AggregateResult, CriAggregator};
+use logfwd_core::aggregator::{AggregateResult, CriReassembler};
 use logfwd_core::cri::{json_escape_bytes, parse_cri_line};
 use std::sync::Arc;
 
@@ -18,7 +18,7 @@ use std::sync::Arc;
 /// - `Cri`: parse CRI container log format, extract message body
 /// - `Auto`: try CRI, fall through to passthrough on parse failure
 #[non_exhaustive]
-pub enum FormatProcessor {
+pub enum FormatDecoder {
     Passthrough {
         stats: Arc<ComponentStats>,
     },
@@ -26,16 +26,16 @@ pub enum FormatProcessor {
         stats: Arc<ComponentStats>,
     },
     Cri {
-        aggregator: CriAggregator,
+        aggregator: CriReassembler,
         stats: Arc<ComponentStats>,
     },
     Auto {
-        aggregator: CriAggregator,
+        aggregator: CriReassembler,
         stats: Arc<ComponentStats>,
     },
 }
 
-impl FormatProcessor {
+impl FormatDecoder {
     /// Create a passthrough processor for raw (non-JSON) input.
     ///
     /// Lines are forwarded verbatim. Non-JSON-object lines are **not** counted
@@ -56,7 +56,7 @@ impl FormatProcessor {
     /// Create a CRI format processor with the given max message size.
     pub fn cri(max_message_size: usize, stats: Arc<ComponentStats>) -> Self {
         Self::Cri {
-            aggregator: CriAggregator::new(max_message_size),
+            aggregator: CriReassembler::new(max_message_size),
             stats,
         }
     }
@@ -64,7 +64,7 @@ impl FormatProcessor {
     /// Create an Auto format processor (tries CRI, falls through to passthrough).
     pub fn auto(max_message_size: usize, stats: Arc<ComponentStats>) -> Self {
         Self::Auto {
-            aggregator: CriAggregator::new(max_message_size),
+            aggregator: CriReassembler::new(max_message_size),
             stats,
         }
     }
@@ -82,11 +82,11 @@ impl FormatProcessor {
                 stats: Arc::clone(stats),
             },
             Self::Cri { aggregator, stats } => Self::Cri {
-                aggregator: CriAggregator::new(aggregator.max_message_size()),
+                aggregator: CriReassembler::new(aggregator.max_message_size()),
                 stats: Arc::clone(stats),
             },
             Self::Auto { aggregator, stats } => Self::Auto {
-                aggregator: CriAggregator::new(aggregator.max_message_size()),
+                aggregator: CriReassembler::new(aggregator.max_message_size()),
                 stats: Arc::clone(stats),
             },
         }
@@ -159,7 +159,7 @@ fn count_json_parse_errors(chunk: &[u8], stats: &ComponentStats) {
 fn extract_cri_messages(
     input: &[u8],
     out: &mut Vec<u8>,
-    aggregator: &mut CriAggregator,
+    aggregator: &mut CriReassembler,
     stats: &ComponentStats,
     passthrough_on_fail: bool,
 ) {
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn passthrough_copies_verbatim() {
         let stats = make_stats();
-        let mut proc = FormatProcessor::passthrough(stats);
+        let mut proc = FormatDecoder::passthrough(stats);
         let input = b"line1\nline2\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn cri_full_lines_extracted() {
         let stats = make_stats();
-        let mut proc = FormatProcessor::cri(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::cri(2 * 1024 * 1024, stats);
         let input = b"2024-01-15T10:30:00Z stdout F {\"msg\":\"hello\"}\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -285,7 +285,7 @@ mod tests {
     #[test]
     fn cri_partial_then_full_merged() {
         let stats = make_stats();
-        let mut proc = FormatProcessor::cri(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::cri(2 * 1024 * 1024, stats);
         let mut out = Vec::new();
 
         // Partial line
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn cri_malformed_lines_count_errors() {
         let stats = make_stats();
-        let mut proc = FormatProcessor::cri(2 * 1024 * 1024, Arc::clone(&stats));
+        let mut proc = FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats));
         let input = b"not a cri line\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn auto_passthrough_for_non_cri() {
         let stats = make_stats();
-        let mut proc = FormatProcessor::auto(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::auto(2 * 1024 * 1024, stats);
         let input = b"{\"msg\":\"plain json\"}\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -329,7 +329,7 @@ mod tests {
     #[test]
     fn auto_handles_cri_when_valid() {
         let stats = make_stats();
-        let mut proc = FormatProcessor::auto(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::auto(2 * 1024 * 1024, stats);
         let input = b"2024-01-15T10:30:00Z stdout F {\"msg\":\"cri\"}\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn auto_malformed_line_resets_pending_state() {
         let stats = make_stats();
-        let mut proc = FormatProcessor::auto(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::auto(2 * 1024 * 1024, stats);
         let mut out = Vec::new();
 
         proc.process_lines(b"2024-01-15T10:30:00Z stdout P hello \n", &mut out);
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn reset_clears_aggregator_state() {
         let stats = make_stats();
-        let mut proc = FormatProcessor::cri(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::cri(2 * 1024 * 1024, stats);
         let mut out = Vec::new();
 
         // Feed a partial
@@ -383,7 +383,7 @@ mod tests {
     fn cri_injects_timestamp_and_stream() {
         // Verify that _timestamp and _stream are injected for both stdout and stderr.
         let stats = make_stats();
-        let mut proc = FormatProcessor::cri(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::cri(2 * 1024 * 1024, stats);
         let mut out = Vec::new();
 
         proc.process_lines(
@@ -410,7 +410,7 @@ mod tests {
         // For a P+F sequence the timestamp/stream from the closing F line are used.
         // P message: `{"msg":`, F message: `"hello"}`, concatenated: `{"msg":"hello"}`
         let stats = make_stats();
-        let mut proc = FormatProcessor::cri(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::cri(2 * 1024 * 1024, stats);
         let mut out = Vec::new();
 
         proc.process_lines(b"2024-01-15T10:30:00Z stdout P {\"msg\":\n", &mut out);
@@ -429,7 +429,7 @@ mod tests {
         // {"_timestamp":"...","_stream":"...","_raw":"<text>"} so that message
         // content is not silently lost when the scanner sees a non-JSON line.
         let stats = make_stats();
-        let mut proc = FormatProcessor::cri(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::cri(2 * 1024 * 1024, stats);
         let input = b"2024-01-15T10:30:00Z stdout F plain text message\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -443,7 +443,7 @@ mod tests {
     fn cri_non_json_message_escapes_special_chars() {
         // Plain text containing JSON-special characters must be properly escaped.
         let stats = make_stats();
-        let mut proc = FormatProcessor::cri(2 * 1024 * 1024, stats);
+        let mut proc = FormatDecoder::cri(2 * 1024 * 1024, stats);
         let input = b"2024-01-15T10:30:00Z stdout F say \"hello\"\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -457,7 +457,7 @@ mod tests {
     fn passthrough_json_valid_line_no_error() {
         // A valid JSON-object line must NOT increment parse_errors.
         let stats = make_stats();
-        let mut proc = FormatProcessor::passthrough_json(Arc::clone(&stats));
+        let mut proc = FormatDecoder::passthrough_json(Arc::clone(&stats));
         let input = b"{\"msg\":\"hello\"}\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -475,7 +475,7 @@ mod tests {
     fn passthrough_json_non_json_line_counts_error() {
         // A non-JSON line must be forwarded AND increment parse_errors.
         let stats = make_stats();
-        let mut proc = FormatProcessor::passthrough_json(Arc::clone(&stats));
+        let mut proc = FormatDecoder::passthrough_json(Arc::clone(&stats));
         let input = b"not json at all\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -493,7 +493,7 @@ mod tests {
     fn passthrough_json_empty_line_no_error() {
         // Empty lines must not increment parse_errors.
         let stats = make_stats();
-        let mut proc = FormatProcessor::passthrough_json(Arc::clone(&stats));
+        let mut proc = FormatDecoder::passthrough_json(Arc::clone(&stats));
         let input = b"\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -510,7 +510,7 @@ mod tests {
     fn passthrough_json_counts_multiple_invalid_lines() {
         // Each invalid line in a batch increments parse_errors independently.
         let stats = make_stats();
-        let mut proc = FormatProcessor::passthrough_json(Arc::clone(&stats));
+        let mut proc = FormatDecoder::passthrough_json(Arc::clone(&stats));
         let input = b"bad line\n{\"ok\":1}\nanother bad\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -528,7 +528,7 @@ mod tests {
     fn passthrough_raw_never_counts_errors() {
         // Raw passthrough must never increment parse_errors regardless of content.
         let stats = make_stats();
-        let mut proc = FormatProcessor::passthrough(Arc::clone(&stats));
+        let mut proc = FormatDecoder::passthrough(Arc::clone(&stats));
         let input = b"not json at all\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
@@ -549,7 +549,7 @@ mod tests {
     fn cri_truncated_message_emitted_and_counted_as_error() {
         let stats = make_stats();
         // max_message_size = 5 bytes — much smaller than the actual message.
-        let mut proc = FormatProcessor::cri(5, Arc::clone(&stats));
+        let mut proc = FormatDecoder::cri(5, Arc::clone(&stats));
         let input = b"2024-01-15T10:30:00Z stdout F {\"msg\":\"hello world\"}\n";
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -11,7 +11,7 @@
 
 use crate::diagnostics::ComponentStats;
 use crate::filter_hints::FilterHints;
-use crate::format::FormatProcessor;
+use crate::format::FormatDecoder;
 use crate::input::{InputEvent, InputSource};
 use crate::tail::ByteOffset;
 use logfwd_core::checkpoint_tracker::CheckpointTracker;
@@ -34,7 +34,7 @@ struct SourceState {
     /// Partial-line bytes after the last newline.
     remainder: Vec<u8>,
     /// Per-source format processor (CRI aggregator state is source-scoped).
-    format: FormatProcessor,
+    format: FormatDecoder,
     /// Kani-proven checkpoint offset tracker. Tracks the relationship
     /// between file read position and the last complete newline boundary.
     tracker: CheckpointTracker,
@@ -54,7 +54,7 @@ struct SourceState {
 pub struct FramedInput {
     inner: Box<dyn InputSource>,
     /// Template format processor — cloned per-source on first data arrival.
-    format_template: FormatProcessor,
+    format_template: FormatDecoder,
     /// Per-source state: remainder, format processor, checkpoint tracker.
     sources: HashMap<Option<SourceId>, SourceState>,
     out_buf: Vec<u8>,
@@ -67,7 +67,7 @@ pub struct FramedInput {
 impl FramedInput {
     pub fn new(
         inner: Box<dyn InputSource>,
-        format: FormatProcessor,
+        format: FormatDecoder,
         stats: Arc<ComponentStats>,
     ) -> Self {
         Self {
@@ -407,7 +407,7 @@ mod tests {
         let source = MockSource::from_chunks(vec![b"line1\nline2\n"]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             stats,
         );
 
@@ -421,7 +421,7 @@ mod tests {
         let source = MockSource::from_chunks(vec![b"hello\nwor", b"ld\n"]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             stats,
         );
 
@@ -440,7 +440,7 @@ mod tests {
         let source = MockSource::from_chunks(vec![b"partial", b"more\n"]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             Arc::clone(&stats),
         );
 
@@ -461,7 +461,7 @@ mod tests {
         let source = MockSource::from_chunks(vec![&big, b"\n"]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             Arc::clone(&stats),
         );
 
@@ -499,7 +499,7 @@ mod tests {
         let source = MockSource::from_chunks(vec![&chunk, b"\n"]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             Arc::clone(&stats),
         );
 
@@ -547,7 +547,7 @@ mod tests {
         ]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             stats,
         );
 
@@ -574,7 +574,7 @@ mod tests {
         let source = MockSource::from_chunks(vec![input.as_slice()]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
             stats,
         );
 
@@ -594,7 +594,7 @@ mod tests {
         let source_full = MockSource::from_chunks(vec![full_input.as_slice()]);
         let mut framed_full = FramedInput::new(
             Box::new(source_full),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             Arc::clone(&stats),
         );
         let reference = collect_data(framed_full.poll().unwrap());
@@ -607,7 +607,7 @@ mod tests {
             let source = MockSource::from_chunks(vec![chunk1, chunk2]);
             let mut framed = FramedInput::new(
                 Box::new(source),
-                FormatProcessor::passthrough(Arc::clone(&stats2)),
+                FormatDecoder::passthrough(Arc::clone(&stats2)),
                 stats2,
             );
 
@@ -636,7 +636,7 @@ mod tests {
         ]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(stats.clone()),
+            FormatDecoder::passthrough(stats.clone()),
             stats,
         );
 
@@ -663,7 +663,7 @@ mod tests {
         ]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(stats.clone()),
+            FormatDecoder::passthrough(stats.clone()),
             stats,
         );
 
@@ -689,7 +689,7 @@ mod tests {
         ]);
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(stats.clone()),
+            FormatDecoder::passthrough(stats.clone()),
             stats,
         );
 
@@ -738,7 +738,7 @@ mod tests {
 
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             stats,
         );
 
@@ -793,7 +793,7 @@ mod tests {
 
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             stats,
         );
 
@@ -823,7 +823,7 @@ mod tests {
 
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             stats,
         );
 
@@ -851,7 +851,7 @@ mod tests {
 
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             stats,
         );
 
@@ -897,7 +897,7 @@ mod tests {
 
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
             stats,
         );
 
@@ -948,7 +948,7 @@ mod tests {
 
         let mut framed = FramedInput::new(
             Box::new(source),
-            FormatProcessor::passthrough(Arc::clone(&stats)),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
             stats,
         );
 

--- a/crates/logfwd-io/tests/allocation_churn.rs
+++ b/crates/logfwd-io/tests/allocation_churn.rs
@@ -9,7 +9,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 use serial_test::serial;
 
 use logfwd_io::diagnostics::ComponentStats;
-use logfwd_io::format::FormatProcessor;
+use logfwd_io::format::FormatDecoder;
 use logfwd_io::framed::FramedInput;
 use logfwd_io::input::{InputEvent, InputSource};
 use std::collections::VecDeque;
@@ -62,7 +62,7 @@ fn framed_input_no_buffer_churn() {
     let source = MockSource::repeating(&chunk, TOTAL_POLLS);
     let mut framed = FramedInput::new(
         Box::new(source),
-        FormatProcessor::passthrough(Arc::clone(&stats)),
+        FormatDecoder::passthrough(Arc::clone(&stats)),
         Arc::clone(&stats),
     );
 
@@ -103,7 +103,7 @@ fn framed_input_no_leak_across_polls() {
     let source = MockSource::repeating(&chunk, 100);
     let mut framed = FramedInput::new(
         Box::new(source),
-        FormatProcessor::passthrough(Arc::clone(&stats)),
+        FormatDecoder::passthrough(Arc::clone(&stats)),
         Arc::clone(&stats),
     );
 

--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -12,10 +12,10 @@ use tokio_stream::wrappers::ReceiverStream;
 use super::{BatchMetadata, build_col_infos, write_row_json};
 
 // ---------------------------------------------------------------------------
-// ElasticsearchAsyncSink — reqwest-based async implementation of Sink
+// ElasticsearchSink — reqwest-based async implementation of Sink
 // ---------------------------------------------------------------------------
 
-/// Configuration shared across all `ElasticsearchAsyncSink` instances from
+/// Configuration shared across all `ElasticsearchSink` instances from
 /// the same factory.
 pub(crate) struct ElasticsearchConfig {
     endpoint: String,
@@ -46,7 +46,7 @@ pub enum ElasticsearchRequestMode {
 /// Implements the [`super::sink::Sink`] trait for use with `OutputWorkerPool`.
 /// All workers share the same `reqwest::Client` (cloned from the factory) to
 /// reuse connection pools, TLS sessions, and DNS caches.
-pub struct ElasticsearchAsyncSink {
+pub struct ElasticsearchSink {
     config: Arc<ElasticsearchConfig>,
     client: reqwest::Client,
     name: String,
@@ -54,14 +54,14 @@ pub struct ElasticsearchAsyncSink {
     stats: Arc<ComponentStats>,
 }
 
-impl ElasticsearchAsyncSink {
+impl ElasticsearchSink {
     pub(crate) fn new(
         name: String,
         config: Arc<ElasticsearchConfig>,
         client: reqwest::Client,
         stats: Arc<ComponentStats>,
     ) -> Self {
-        ElasticsearchAsyncSink {
+        ElasticsearchSink {
             name,
             config,
             client,
@@ -598,7 +598,7 @@ impl ElasticsearchAsyncSink {
     }
 }
 
-impl super::sink::Sink for ElasticsearchAsyncSink {
+impl super::sink::Sink for ElasticsearchSink {
     fn send_batch<'a>(
         &'a mut self,
         batch: &'a RecordBatch,
@@ -625,7 +625,7 @@ impl super::sink::Sink for ElasticsearchAsyncSink {
 // ElasticsearchSinkFactory
 // ---------------------------------------------------------------------------
 
-/// Creates `ElasticsearchAsyncSink` instances for the output worker pool.
+/// Creates `ElasticsearchSink` instances for the output worker pool.
 ///
 /// All workers share a single `reqwest::Client` (which is internally
 /// `Arc`-wrapped) so they reuse the same connection pool, TLS sessions,
@@ -712,7 +712,7 @@ impl ElasticsearchSinkFactory {
 
 impl super::sink::SinkFactory for ElasticsearchSinkFactory {
     fn create(&self) -> io::Result<Box<dyn super::sink::Sink>> {
-        Ok(Box::new(ElasticsearchAsyncSink::new(
+        Ok(Box::new(ElasticsearchSink::new(
             self.name.clone(),
             Arc::clone(&self.config),
             self.client.clone(), // reqwest::Client is Arc-wrapped, clone is cheap
@@ -726,12 +726,12 @@ impl super::sink::SinkFactory for ElasticsearchSinkFactory {
 }
 
 impl ElasticsearchSinkFactory {
-    /// Create a concrete `ElasticsearchAsyncSink` without boxing it.
+    /// Create a concrete `ElasticsearchSink` without boxing it.
     ///
     /// Intended for benchmarks and tests that need access to
     /// `serialize_batch` or `serialized_len` directly.
-    pub fn create_sink(&self) -> ElasticsearchAsyncSink {
-        ElasticsearchAsyncSink::new(
+    pub fn create_sink(&self) -> ElasticsearchSink {
+        ElasticsearchSink::new(
             self.name.clone(),
             Arc::clone(&self.config),
             self.client.clone(),
@@ -873,7 +873,7 @@ mod tests {
         }
     }
 
-    fn make_test_sink(index: &str) -> ElasticsearchAsyncSink {
+    fn make_test_sink(index: &str) -> ElasticsearchSink {
         let factory = ElasticsearchSinkFactory::new(
             "test".to_string(),
             "http://localhost:9200".to_string(),
@@ -885,7 +885,7 @@ mod tests {
         )
         .expect("factory creation failed");
         let client = reqwest::Client::new();
-        ElasticsearchAsyncSink::new(
+        ElasticsearchSink::new(
             "test".to_string(),
             Arc::clone(&factory.config),
             client,
@@ -929,7 +929,7 @@ mod tests {
     #[test]
     fn parse_bulk_response_success() {
         let response = br#"{"took":5,"errors":false,"items":[{"index":{"_id":"1","status":201}}]}"#;
-        ElasticsearchAsyncSink::parse_bulk_response(response).expect("should not error on success");
+        ElasticsearchSink::parse_bulk_response(response).expect("should not error on success");
     }
 
     #[test]
@@ -942,7 +942,7 @@ mod tests {
                 {"index":{"error":{"type":"mapper_parsing_exception","reason":"failed to parse"},"status":400}}
             ]
         }"#;
-        let err = ElasticsearchAsyncSink::parse_bulk_response(response)
+        let err = ElasticsearchSink::parse_bulk_response(response)
             .expect_err("should error on bulk failure");
         assert!(err.to_string().contains("mapper_parsing_exception"));
     }
@@ -1051,21 +1051,21 @@ mod tests {
     #[test]
     fn parse_bulk_response_empty_items_array() {
         let response = br#"{"took":0,"errors":false,"items":[]}"#;
-        ElasticsearchAsyncSink::parse_bulk_response(response).expect("empty items should succeed");
+        ElasticsearchSink::parse_bulk_response(response).expect("empty items should succeed");
     }
 
     #[test]
     fn parse_bulk_response_malformed_json_without_errors_true_is_ok() {
         // The implementation uses fast-path memchr for "errors":true.
         // Malformed JSON that doesn't contain that string is treated as success.
-        ElasticsearchAsyncSink::parse_bulk_response(b"not valid json")
+        ElasticsearchSink::parse_bulk_response(b"not valid json")
             .expect("no errors:true → treated as ok");
     }
 
     #[test]
     fn parse_bulk_response_malformed_json_after_errors_true_returns_err() {
         // If "errors":true is present but the full JSON parse fails, return an error.
-        ElasticsearchAsyncSink::parse_bulk_response(b"\"errors\":true {{{malformed")
+        ElasticsearchSink::parse_bulk_response(b"\"errors\":true {{{malformed")
             .expect_err("malformed JSON after errors:true should error");
     }
 
@@ -1073,7 +1073,7 @@ mod tests {
     fn parse_bulk_response_errors_false_does_not_error() {
         // errors:false means success even if items have non-200 status
         let response = br#"{"took":1,"errors":false,"items":[{"index":{"_id":"1","status":200}}]}"#;
-        ElasticsearchAsyncSink::parse_bulk_response(response).expect("errors:false must succeed");
+        ElasticsearchSink::parse_bulk_response(response).expect("errors:false must succeed");
     }
 }
 
@@ -1101,7 +1101,7 @@ mod snapshot_tests {
         }
     }
 
-    fn make_test_sink() -> ElasticsearchAsyncSink {
+    fn make_test_sink() -> ElasticsearchSink {
         let factory = ElasticsearchSinkFactory::new(
             "test".to_string(),
             "http://localhost:9200".to_string(),
@@ -1113,7 +1113,7 @@ mod snapshot_tests {
         )
         .expect("factory creation failed");
         let client = reqwest::Client::new();
-        ElasticsearchAsyncSink::new(
+        ElasticsearchSink::new(
             "test".to_string(),
             Arc::clone(&factory.config),
             client,

--- a/crates/logfwd-output/src/fanout.rs
+++ b/crates/logfwd-output/src/fanout.rs
@@ -6,22 +6,22 @@ use arrow::record_batch::RecordBatch;
 use super::{BatchMetadata, OutputSink};
 
 // ---------------------------------------------------------------------------
-// FanOut
+// FanoutSink
 // ---------------------------------------------------------------------------
 
 /// Multiplexes output to multiple sinks.
 #[allow(deprecated)]
-pub struct FanOut {
+pub struct FanoutSink {
     sinks: Vec<Box<dyn OutputSink>>,
 }
 
 #[derive(Debug)]
-pub struct FanOutError {
+pub struct FanoutSinkError {
     failed_sinks: Vec<String>,
     first_error: io::Error,
 }
 
-impl FanOutError {
+impl FanoutSinkError {
     fn new(failed_sinks: Vec<String>, first_error: io::Error) -> Self {
         Self {
             failed_sinks,
@@ -34,7 +34,7 @@ impl FanOutError {
     }
 }
 
-impl std::fmt::Display for FanOutError {
+impl std::fmt::Display for FanoutSinkError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -44,21 +44,21 @@ impl std::fmt::Display for FanOutError {
     }
 }
 
-impl std::error::Error for FanOutError {
+impl std::error::Error for FanoutSinkError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         Some(&self.first_error)
     }
 }
 
 #[allow(deprecated)]
-impl FanOut {
+impl FanoutSink {
     pub fn new(sinks: Vec<Box<dyn OutputSink>>) -> Self {
-        FanOut { sinks }
+        FanoutSink { sinks }
     }
 }
 
 #[allow(deprecated)]
-impl OutputSink for FanOut {
+impl OutputSink for FanoutSink {
     fn send_batch(&mut self, batch: &RecordBatch, meta: &BatchMetadata) -> io::Result<()> {
         // Try ALL sinks before returning an error. Don't short-circuit.
         let mut failed_sinks = Vec::new();
@@ -73,7 +73,7 @@ impl OutputSink for FanOut {
             }
         }
         match first_err {
-            Some(e) => Err(io::Error::other(FanOutError::new(failed_sinks, e))),
+            Some(e) => Err(io::Error::other(FanoutSinkError::new(failed_sinks, e))),
             None => Ok(()),
         }
     }
@@ -91,7 +91,7 @@ impl OutputSink for FanOut {
             }
         }
         match first_err {
-            Some(e) => Err(io::Error::other(FanOutError::new(failed_sinks, e))),
+            Some(e) => Err(io::Error::other(FanoutSinkError::new(failed_sinks, e))),
             None => Ok(()),
         }
     }
@@ -187,7 +187,7 @@ mod tests {
     fn all_sinks_succeed_returns_ok() {
         let (a, a_calls, _) = MockSink::new("a", false);
         let (b, b_calls, _) = MockSink::new("b", false);
-        let mut fanout = FanOut::new(vec![Box::new(a), Box::new(b)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(a), Box::new(b)]);
         fanout.send_batch(&empty_batch(), &meta()).unwrap();
         assert_eq!(a_calls.load(Ordering::Relaxed), 1);
         assert_eq!(b_calls.load(Ordering::Relaxed), 1);
@@ -195,10 +195,10 @@ mod tests {
 
     #[test]
     fn first_sink_fails_all_still_called() {
-        // FanOut must NOT short-circuit — all sinks must be called even if the first fails.
+        // FanoutSink must NOT short-circuit — all sinks must be called even if the first fails.
         let (a, a_calls, _) = MockSink::new("a", true); // fails
         let (b, b_calls, _) = MockSink::new("b", false);
-        let mut fanout = FanOut::new(vec![Box::new(a), Box::new(b)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(a), Box::new(b)]);
         let err = fanout.send_batch(&empty_batch(), &meta()).unwrap_err();
         assert_eq!(
             a_calls.load(Ordering::Relaxed),
@@ -210,7 +210,7 @@ mod tests {
             1,
             "subsequent sink must still be called"
         );
-        // err.to_string() uses FanOutError::Display which lists the failed sink names.
+        // err.to_string() uses FanoutSinkError::Display which lists the failed sink names.
         let msg = err.to_string();
         assert!(
             msg.contains('a'),
@@ -223,14 +223,14 @@ mod tests {
         let (a, _, _) = MockSink::new("alpha", false);
         let (b, _, _) = MockSink::new("beta", true); // fails
         let (c, c_calls, _) = MockSink::new("gamma", false);
-        let mut fanout = FanOut::new(vec![Box::new(a), Box::new(b), Box::new(c)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(a), Box::new(b), Box::new(c)]);
         let err = fanout.send_batch(&empty_batch(), &meta()).unwrap_err();
         assert_eq!(
             c_calls.load(Ordering::Relaxed),
             1,
             "third sink must be called after middle failure"
         );
-        // err.to_string() uses FanOutError::Display which lists the failed sink names.
+        // err.to_string() uses FanoutSinkError::Display which lists the failed sink names.
         let msg = err.to_string();
         assert!(
             msg.contains("beta"),
@@ -242,9 +242,9 @@ mod tests {
     fn all_sinks_fail_first_error_returned() {
         let (a, _, _) = MockSink::new("x", true);
         let (b, _, _) = MockSink::new("y", true);
-        let mut fanout = FanOut::new(vec![Box::new(a), Box::new(b)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(a), Box::new(b)]);
         let err = fanout.send_batch(&empty_batch(), &meta()).unwrap_err();
-        // err.to_string() uses FanOutError::Display which lists all failed sink names.
+        // err.to_string() uses FanoutSinkError::Display which lists all failed sink names.
         let msg = err.to_string();
         assert!(
             msg.contains('x') && msg.contains('y'),
@@ -256,7 +256,7 @@ mod tests {
     fn flush_all_succeed_returns_ok() {
         let (a, _, a_flush) = MockSink::new("a", false);
         let (b, _, b_flush) = MockSink::new("b", false);
-        let mut fanout = FanOut::new(vec![Box::new(a), Box::new(b)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(a), Box::new(b)]);
         fanout.flush().unwrap();
         assert_eq!(a_flush.load(Ordering::Relaxed), 1);
         assert_eq!(b_flush.load(Ordering::Relaxed), 1);
@@ -267,7 +267,7 @@ mod tests {
         let (a, _, _) = MockSink::new("a", false);
         let (b_base, _, _) = MockSink::new("b", false);
         let b = b_base.with_fail_flush();
-        let mut fanout = FanOut::new(vec![Box::new(a), Box::new(b)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(a), Box::new(b)]);
         assert!(fanout.flush().is_err());
     }
 
@@ -278,7 +278,7 @@ mod tests {
         let (b_base, _, _) = MockSink::new("bob", false);
         let a = a_base.with_fail_flush();
         let b = b_base.with_fail_flush();
-        let mut fanout = FanOut::new(vec![Box::new(a), Box::new(b)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(a), Box::new(b)]);
         let err = fanout.flush().unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -289,12 +289,12 @@ mod tests {
 
     #[test]
     fn flush_first_fails_second_still_called() {
-        // FanOut flush must NOT short-circuit — both sinks must be called even if the first fails.
+        // FanoutSink flush must NOT short-circuit — both sinks must be called even if the first fails.
         let (a_base, _, a_flush) = MockSink::new("a", false);
         let (b_base, _, b_flush) = MockSink::new("b", false);
         let a = a_base.with_fail_flush();
         let b = b_base.with_fail_flush();
-        let mut fanout = FanOut::new(vec![Box::new(a), Box::new(b)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(a), Box::new(b)]);
         fanout.flush().unwrap_err();
         assert_eq!(
             a_flush.load(Ordering::Relaxed),
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn empty_sinks_list_returns_ok() {
-        let mut fanout = FanOut::new(vec![]);
+        let mut fanout = FanoutSink::new(vec![]);
         fanout.send_batch(&empty_batch(), &meta()).unwrap();
         fanout.flush().unwrap();
     }

--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -19,12 +19,10 @@ mod loki;
 mod parquet;
 
 pub use arrow_ipc_sink::{ArrowIpcSinkFactory, deserialize_ipc, serialize_ipc};
-pub use elasticsearch::{
-    ElasticsearchAsyncSink, ElasticsearchRequestMode, ElasticsearchSinkFactory,
-};
-pub use fanout::{FanOut, FanOutError};
+pub use elasticsearch::{ElasticsearchRequestMode, ElasticsearchSink, ElasticsearchSinkFactory};
+pub use fanout::{FanoutSink, FanoutSinkError};
 pub use json_lines::JsonLinesSink;
-pub use loki::{LokiAsyncSink, LokiSinkFactory};
+pub use loki::{LokiSink, LokiSinkFactory};
 pub use null::NullSink;
 pub use otap_sink::{
     ArrowPayloadType, BatchStatus, DecodedPayload, OtapSinkFactory, StatusCode,
@@ -598,25 +596,25 @@ pub fn build_output_sink(
             )))
         }
         OutputType::Null => Ok(Box::new(NullSink::new(name.to_string(), stats))),
-        OutputType::TcpOut => {
+        OutputType::Tcp => {
             let endpoint = cfg
                 .endpoint
                 .as_ref()
-                .ok_or_else(|| format!("output '{name}': tcp_out requires 'endpoint'"))?;
+                .ok_or_else(|| format!("output '{name}': tcp requires 'endpoint'"))?;
             Ok(Box::new(TcpSink::new(
                 name.to_string(),
                 endpoint.clone(),
                 stats,
             )))
         }
-        OutputType::UdpOut => {
+        OutputType::Udp => {
             let endpoint = cfg
                 .endpoint
                 .as_ref()
-                .ok_or_else(|| format!("output '{name}': udp_out requires 'endpoint'"))?;
+                .ok_or_else(|| format!("output '{name}': udp requires 'endpoint'"))?;
             UdpSink::new(name.to_string(), endpoint.clone(), stats)
                 .map(|s| Box::new(s) as Box<dyn OutputSink>)
-                .map_err(|e| format!("output '{name}': udp_out bind failed: {e}"))
+                .map_err(|e| format!("output '{name}': udp bind failed: {e}"))
         }
         OutputType::Elasticsearch => Err(format!(
             "output '{name}': elasticsearch requires the async pipeline — use build_sink_factory() instead"
@@ -878,7 +876,7 @@ mod tests {
 
     #[test]
     fn test_fanout() {
-        // FanOut to two sinks that write to Vec<u8>.
+        // FanoutSink to two sinks that write to Vec<u8>.
         // We use StdoutSink with write_batch_to to capture output.
         let batch = make_test_batch();
         let meta = make_metadata();
@@ -904,7 +902,7 @@ mod tests {
         assert_eq!(out1, out2);
         assert!(!out1.is_empty());
 
-        // Also test FanOut trait dispatch works.
+        // Also test FanoutSink trait dispatch works.
         let fanout_s1 = StdoutSink::new(
             "f1".to_string(),
             StdoutFormat::Json,
@@ -915,7 +913,7 @@ mod tests {
             StdoutFormat::Json,
             Arc::new(ComponentStats::new()),
         );
-        let mut fanout = FanOut::new(vec![Box::new(fanout_s1), Box::new(fanout_s2)]);
+        let mut fanout = FanoutSink::new(vec![Box::new(fanout_s1), Box::new(fanout_s2)]);
         // send_batch writes to real stdout, but should not error.
         let result = fanout.send_batch(&batch, &meta);
         assert!(result.is_ok());
@@ -948,7 +946,7 @@ mod tests {
     fn test_fanout_error_reports_failed_sink_names() {
         let batch = make_test_batch();
         let meta = make_metadata();
-        let mut fanout = FanOut::new(vec![
+        let mut fanout = FanoutSink::new(vec![
             Box::new(AlwaysFailSink { name: "sink-a" }),
             Box::new(AlwaysFailSink { name: "sink-b" }),
         ]);
@@ -958,8 +956,8 @@ mod tests {
             .expect_err("fanout should fail");
         let fanout_err = err
             .get_ref()
-            .and_then(|inner| inner.downcast_ref::<FanOutError>())
-            .expect("fanout should wrap failures in FanOutError");
+            .and_then(|inner| inner.downcast_ref::<FanoutSinkError>())
+            .expect("fanout should wrap failures in FanoutSinkError");
 
         assert_eq!(fanout_err.failed_sinks(), ["sink-a", "sink-b"]);
     }

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -103,7 +103,7 @@ pub fn sort_and_dedup_timestamps(entries: &mut Vec<LokiEntry>) -> usize {
 }
 
 // ---------------------------------------------------------------------------
-// LokiAsyncSink
+// LokiSink — reqwest-based async implementation of Sink
 // ---------------------------------------------------------------------------
 
 struct LokiConfig {
@@ -115,21 +115,21 @@ struct LokiConfig {
 }
 
 /// Async Loki sink using reqwest.
-pub struct LokiAsyncSink {
+pub struct LokiSink {
     config: Arc<LokiConfig>,
     client: Arc<reqwest::Client>,
     name: String,
     stats: Arc<ComponentStats>,
 }
 
-impl LokiAsyncSink {
+impl LokiSink {
     fn new(
         name: String,
         config: Arc<LokiConfig>,
         client: Arc<reqwest::Client>,
         stats: Arc<ComponentStats>,
     ) -> Self {
-        LokiAsyncSink {
+        LokiSink {
             config,
             client,
             name,
@@ -331,7 +331,7 @@ impl LokiAsyncSink {
     }
 }
 
-impl super::sink::Sink for LokiAsyncSink {
+impl super::sink::Sink for LokiSink {
     fn send_batch<'a>(
         &'a mut self,
         batch: &'a RecordBatch,
@@ -366,7 +366,7 @@ impl super::sink::Sink for LokiAsyncSink {
 // LokiSinkFactory
 // ---------------------------------------------------------------------------
 
-/// Creates `LokiAsyncSink` instances for the output worker pool.
+/// Creates `LokiSink` instances for the output worker pool.
 pub struct LokiSinkFactory {
     name: String,
     config: Arc<LokiConfig>,
@@ -424,46 +424,12 @@ impl LokiSinkFactory {
 
 impl super::sink::SinkFactory for LokiSinkFactory {
     fn create(&self) -> io::Result<Box<dyn super::sink::Sink>> {
-        Ok(Box::new(LokiAsyncSink::new(
+        Ok(Box::new(LokiSink::new(
             self.name.clone(),
             Arc::clone(&self.config),
             Arc::clone(&self.client),
             Arc::clone(&self.stats),
         )))
-    }
-
-    fn name(&self) -> &str {
-        &self.name
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Old placeholder (kept for backward compat with lib.rs exports if any)
-// ---------------------------------------------------------------------------
-
-/// Synchronous placeholder Loki sink.
-///
-/// Deprecated: use `LokiSinkFactory` with the async worker pool instead.
-#[allow(dead_code)]
-pub struct LokiSink {
-    name: String,
-}
-
-#[allow(dead_code)]
-impl LokiSink {
-    pub fn new(name: String, _endpoint: String) -> Self {
-        LokiSink { name }
-    }
-}
-
-#[allow(deprecated)]
-impl super::OutputSink for LokiSink {
-    fn send_batch(&mut self, _batch: &RecordBatch, _metadata: &BatchMetadata) -> io::Result<()> {
-        Ok(())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
     }
 
     fn name(&self) -> &str {

--- a/crates/logfwd-transform/src/udf/json_extract.rs
+++ b/crates/logfwd-transform/src/udf/json_extract.rs
@@ -21,7 +21,7 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
 };
 
-use logfwd_arrow::StreamingSimdScanner;
+use logfwd_arrow::ZeroCopyScanner;
 use logfwd_core::scan_config::{FieldSpec, ScanConfig};
 
 // ---------------------------------------------------------------------------
@@ -105,7 +105,7 @@ fn parse_raw(raw_array: &StringArray, field_name: &str) -> Result<RecordBatch, D
         validate_utf8: false,
     };
 
-    let mut scanner = StreamingSimdScanner::new(config);
+    let mut scanner = ZeroCopyScanner::new(config);
     let batch = scanner
         .scan(bytes::Bytes::from(buf))
         .map_err(|e| DataFusionError::Execution(format!("scanner error: {e}")))?;

--- a/crates/logfwd-transform/tests/it/raw_first_bench.rs
+++ b/crates/logfwd-transform/tests/it/raw_first_bench.rs
@@ -53,7 +53,7 @@ async fn path_a_extraction(json_data: &[u8], num_fields: usize) -> RecordBatch {
         keep_raw: false,
         validate_utf8: false,
     };
-    let mut scanner = logfwd_arrow::StreamingSimdScanner::new(config);
+    let mut scanner = logfwd_arrow::ZeroCopyScanner::new(config);
     let batch = scanner
         .scan(bytes::Bytes::copy_from_slice(json_data))
         .unwrap();
@@ -82,7 +82,7 @@ async fn path_a_passthrough(json_data: &[u8]) -> RecordBatch {
         keep_raw: false,
         validate_utf8: false,
     };
-    let mut scanner = logfwd_arrow::StreamingSimdScanner::new(config);
+    let mut scanner = logfwd_arrow::ZeroCopyScanner::new(config);
     let batch = scanner
         .scan(bytes::Bytes::copy_from_slice(json_data))
         .unwrap();

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -396,9 +396,9 @@ fn output_label(o: &logfwd_config::OutputConfig) -> String {
             format!("elasticsearch  {}", o.endpoint.as_deref().unwrap_or(""))
         }
         OutputType::Loki => format!("loki  {}", o.endpoint.as_deref().unwrap_or("")),
-        OutputType::TcpOut => format!("tcp   {}", o.endpoint.as_deref().unwrap_or("")),
-        OutputType::UdpOut => format!("udp   {}", o.endpoint.as_deref().unwrap_or("")),
-        OutputType::FileOut => format!("file  {}", o.path.as_deref().unwrap_or("")),
+        OutputType::Tcp => format!("tcp   {}", o.endpoint.as_deref().unwrap_or("")),
+        OutputType::Udp => format!("udp   {}", o.endpoint.as_deref().unwrap_or("")),
+        OutputType::File => format!("file  {}", o.path.as_deref().unwrap_or("")),
         OutputType::Parquet => format!("parquet  {}", o.path.as_deref().unwrap_or("")),
         OutputType::Stdout => "stdout".to_string(),
         OutputType::Null => "null".to_string(),

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -13,7 +13,7 @@ use opentelemetry::metrics::Meter;
 use tracing::Instrument;
 
 use crate::worker_pool::{AckItem, OutputWorkerPool, WorkItem};
-use logfwd_arrow::scanner::StreamingSimdScanner as Scanner;
+use logfwd_arrow::scanner::ZeroCopyScanner as Scanner;
 use logfwd_config::{
     EnrichmentConfig, Format, GeoDatabaseFormat, InputConfig, InputType, PipelineConfig,
 };
@@ -22,13 +22,13 @@ use logfwd_io::checkpoint::{
     CheckpointStore, FileCheckpointStore, SourceCheckpoint, default_data_dir,
 };
 use logfwd_io::diagnostics::{ComponentStats, PipelineMetrics};
-use logfwd_io::format::FormatProcessor;
+use logfwd_io::format::FormatDecoder;
 use logfwd_io::framed::FramedInput;
 use logfwd_io::input::{FileInput, InputEvent, InputSource};
 use logfwd_io::tail::{ByteOffset, TailConfig};
 #[allow(deprecated)]
 use logfwd_output::{
-    BatchMetadata, FanOut, OnceAsyncFactory, OnceFactory, OutputSink, SinkFactory,
+    BatchMetadata, FanoutSink, OnceAsyncFactory, OnceFactory, OutputSink, SinkFactory,
     build_output_sink, build_sink_factory,
 };
 use logfwd_transform::SqlTransform;
@@ -283,8 +283,8 @@ impl Pipeline {
         }
 
         // Build output sink factory → pool.
-        // For multiple outputs, we build a FanOut wrapped in a OnceFactory
-        // (single-worker pool) until async FanOut is available.
+        // For multiple outputs, we build a FanoutSink wrapped in a OnceFactory
+        // (single-worker pool) until async FanoutSink is available.
         let factory: Arc<dyn SinkFactory> = if config.outputs.len() == 1 {
             let output_cfg = &config.outputs[0];
             let output_name = output_cfg
@@ -295,7 +295,7 @@ impl Pipeline {
             let output_stats = metrics.add_output(&output_name, &output_type_str);
             build_sink_factory(&output_name, output_cfg, output_stats)?
         } else {
-            // Multiple outputs: build a FanOut of sync sinks wrapped in OnceFactory.
+            // Multiple outputs: build a FanoutSink of sync sinks wrapped in OnceFactory.
             #[allow(deprecated)]
             {
                 let mut sinks: Vec<Box<dyn OutputSink>> = Vec::new();
@@ -309,7 +309,10 @@ impl Pipeline {
                     sinks.push(build_output_sink(&output_name, output_cfg, output_stats)?);
                 }
                 let fanout_name = name.to_string();
-                Arc::new(OnceFactory::new(fanout_name, Box::new(FanOut::new(sinks))))
+                Arc::new(OnceFactory::new(
+                    fanout_name,
+                    Box::new(FanoutSink::new(sinks)),
+                ))
             }
         };
 
@@ -1010,13 +1013,13 @@ fn make_format(
     input_type: InputType,
     format: &Format,
     stats: &Arc<ComponentStats>,
-) -> Result<FormatProcessor, String> {
+) -> Result<FormatDecoder, String> {
     const CRI_MAX_MESSAGE: usize = 2 * 1024 * 1024;
     let proc = match format {
-        Format::Cri => FormatProcessor::cri(CRI_MAX_MESSAGE, Arc::clone(stats)),
-        Format::Auto => FormatProcessor::auto(CRI_MAX_MESSAGE, Arc::clone(stats)),
-        Format::Json => FormatProcessor::passthrough_json(Arc::clone(stats)),
-        Format::Raw => FormatProcessor::passthrough(Arc::clone(stats)),
+        Format::Cri => FormatDecoder::cri(CRI_MAX_MESSAGE, Arc::clone(stats)),
+        Format::Auto => FormatDecoder::auto(CRI_MAX_MESSAGE, Arc::clone(stats)),
+        Format::Json => FormatDecoder::passthrough_json(Arc::clone(stats)),
+        Format::Raw => FormatDecoder::passthrough(Arc::clone(stats)),
         unsupported => {
             return Err(format!(
                 "input '{name}': format {:?} is not supported for {:?} inputs",
@@ -1997,14 +2000,14 @@ output:
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_async_fanout_output_errors_only_increment_failing_output() {
-        // This test verifies that a persistently-failing output in a FanOut
+        // This test verifies that a persistently-failing output in a FanoutSink
         // does not crash the pipeline and is recorded as a dropped batch.
         //
         // With the async worker pool, retries are built into the pool. An
         // always-failing sink causes the pool to exhaust retries and return
         // AckItem { success: false }, which increments dropped_batches_total.
         //
-        // Per-sink error tracking within FanOut is not currently supported
+        // Per-sink error tracking within FanoutSink is not currently supported
         // by the pool's AckItem protocol (tracked in issue #702).
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("fanout_output_err.log");
@@ -2829,7 +2832,7 @@ output:
 #[cfg(test)]
 mod format_integration_tests {
     use super::*;
-    use logfwd_arrow::scanner::SimdScanner;
+    use logfwd_arrow::scanner::CopyScanner;
     use logfwd_core::scan_config::ScanConfig;
 
     /// JSON format: raw bytes pass directly through to scanner.
@@ -2843,7 +2846,7 @@ mod format_integration_tests {
             keep_raw: false,
             validate_utf8: false,
         };
-        let mut scanner = SimdScanner::new(config);
+        let mut scanner = CopyScanner::new(config);
         let batch = scanner.scan(input).unwrap();
         assert_eq!(batch.num_rows(), 2);
         // Single-type string fields: bare names
@@ -2861,7 +2864,7 @@ mod format_integration_tests {
             keep_raw: true,
             validate_utf8: false,
         };
-        let mut scanner = SimdScanner::new(config);
+        let mut scanner = CopyScanner::new(config);
         let batch = scanner.scan(input).unwrap();
         assert_eq!(batch.num_rows(), 2);
         assert!(batch.schema().field_with_name("_raw").is_ok());
@@ -2873,7 +2876,7 @@ mod format_integration_tests {
         let cri_input = b"2024-01-15T10:30:00Z stdout F {\"level\":\"INFO\",\"msg\":\"hello\"}\n";
         let mut out = Vec::new();
         let stats = Arc::new(ComponentStats::new());
-        let mut fmt = FormatProcessor::cri(1024, Arc::clone(&stats));
+        let mut fmt = FormatDecoder::cri(1024, Arc::clone(&stats));
         fmt.process_lines(cri_input, &mut out);
 
         let config = ScanConfig {
@@ -2882,7 +2885,7 @@ mod format_integration_tests {
             keep_raw: false,
             validate_utf8: false,
         };
-        let mut scanner = SimdScanner::new(config);
+        let mut scanner = CopyScanner::new(config);
         let batch = scanner.scan(&out).unwrap();
         assert_eq!(batch.num_rows(), 1);
         // Single-type string field: bare name
@@ -2895,7 +2898,7 @@ mod format_integration_tests {
         let input = b"2024-01-15T10:30:00Z stdout P {\"level\":\"ER\n2024-01-15T10:30:00Z stdout F ROR\",\"msg\":\"boom\"}\n";
         let mut out = Vec::new();
         let stats = Arc::new(ComponentStats::new());
-        let mut fmt = FormatProcessor::cri(1024, Arc::clone(&stats));
+        let mut fmt = FormatDecoder::cri(1024, Arc::clone(&stats));
         fmt.process_lines(input, &mut out);
 
         let config = ScanConfig {
@@ -2904,7 +2907,7 @@ mod format_integration_tests {
             keep_raw: false,
             validate_utf8: false,
         };
-        let mut scanner = SimdScanner::new(config);
+        let mut scanner = CopyScanner::new(config);
         let batch = scanner.scan(&out).unwrap();
         assert_eq!(batch.num_rows(), 1);
     }
@@ -2913,7 +2916,7 @@ mod format_integration_tests {
 #[cfg(test)]
 mod proptest_pipeline {
     use super::*;
-    use logfwd_arrow::scanner::SimdScanner;
+    use logfwd_arrow::scanner::CopyScanner;
     use logfwd_core::scan_config::ScanConfig;
     use proptest::prelude::*;
 
@@ -2954,7 +2957,7 @@ mod proptest_pipeline {
                 keep_raw: false,
                 validate_utf8: false,
             };
-            let mut scanner_whole = SimdScanner::new(ScanConfig { wanted_fields: vec![], extract_all: true, keep_raw: false, validate_utf8: false });
+            let mut scanner_whole = CopyScanner::new(ScanConfig { wanted_fields: vec![], extract_all: true, keep_raw: false, validate_utf8: false });
             let batch_whole = scanner_whole.scan(&ndjson).unwrap();
 
             // Split into two chunks with remainder handling
@@ -2989,7 +2992,7 @@ mod proptest_pipeline {
                 buf.extend_from_slice(&combined);
             }
 
-            let config2 = ScanConfig { wanted_fields: vec![], extract_all: true, keep_raw: false, validate_utf8: false }; let mut scanner_split = SimdScanner::new(config2);
+            let config2 = ScanConfig { wanted_fields: vec![], extract_all: true, keep_raw: false, validate_utf8: false }; let mut scanner_split = CopyScanner::new(config2);
             let batch_split = scanner_split.scan(&buf).unwrap();
 
             prop_assert_eq!(
@@ -3045,7 +3048,7 @@ mod proptest_pipeline {
 
             let mut out = Vec::new();
             let stats = Arc::new(ComponentStats::new());
-            let mut fmt = FormatProcessor::cri(1024 * 1024, Arc::clone(&stats));
+            let mut fmt = FormatDecoder::cri(1024 * 1024, Arc::clone(&stats));
             fmt.process_lines(&input, &mut out);
 
             let line_count = out.iter().filter(|&&b| b == b'\n').count();

--- a/crates/logfwd/tests/it/integration.rs
+++ b/crates/logfwd/tests/it/integration.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use logfwd::pipeline::Pipeline;
-use logfwd_arrow::scanner::SimdScanner;
+use logfwd_arrow::scanner::CopyScanner;
 use logfwd_config::Config;
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_io::enrichment::CsvFileTable;
@@ -471,7 +471,7 @@ fn test_enrichment_join() {
         r#"{"service":"auth","message":"login failed"}"#,
         "\n",
     );
-    let mut scanner = SimdScanner::new(ScanConfig::default());
+    let mut scanner = CopyScanner::new(ScanConfig::default());
     let batch = scanner.scan(json_lines.as_bytes()).expect("scan failed");
     assert_eq!(batch.num_rows(), 3);
 

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -71,7 +71,7 @@ with per-source remainder tracking. It handles three formats:
 output (4096 lines, 64KB stack), no heap, Kani-proven. It returns byte
 ranges into the input buffer — zero-copy.
 
-**CriAggregator** (`logfwd-core/src/aggregator.rs`):
+**CriReassembler** (`logfwd-core/src/aggregator.rs`):
 zero-copy for F-only lines (99% of traffic), copies only for P+F
 reassembly. Kani-proven.
 
@@ -80,7 +80,7 @@ reassembly. Kani-proven.
 ```
 Bytes → StructuralIndex::new(buf)     [ONE SIMD pass, all characters]
       → NewlineFramer                  [consumes \n bitmask → line ranges]
-      → CriAggregator (if CRI format) [merges P/F partials]
+      → CriReassembler (if CRI format) [merges P/F partials]
       → Scanner                        [consumes remaining bitmasks]
 ```
 
@@ -170,8 +170,8 @@ Both produce `RecordBatch` via `finish_batch()`.
 **Scanner wrappers** in logfwd-arrow combine classification + scanning
 + building into one call:
 
-- `SimdScanner::scan(&[u8]) → RecordBatch` (StorageBuilder, copies)
-- `StreamingSimdScanner::scan(Bytes) → RecordBatch` (StreamingBuilder,
+- `CopyScanner::scan(&[u8]) → RecordBatch` (StorageBuilder, copies)
+- `ZeroCopyScanner::scan(Bytes) → RecordBatch` (StreamingBuilder,
   zero-copy)
 
 ### 6. Transform: RecordBatch → RecordBatch
@@ -201,12 +201,12 @@ RecordBatch → OutputSink::send_batch() → HTTP/stdout/file
 
 - **OtlpSink**: Encodes RecordBatch → OTLP protobuf, sends via HTTP.
   Handles resource attributes, observed timestamps, DataType-based dispatch.
-- **ElasticsearchAsyncSink**: Bulk API with retry, compression, async reqwest.
-- **LokiAsyncSink**: Loki push API with label grouping, dedup, async reqwest.
+- **ElasticsearchSink**: Bulk API with retry, compression, async reqwest.
+- **LokiSink**: Loki push API with label grouping, dedup, async reqwest.
 - **JsonLinesSink**: Converts RecordBatch → newline-delimited JSON,
   sends via HTTP with zstd compression.
 - **StdoutSink**: Renders to terminal (JSON, console, or text format).
-- **FanOut**: Sends to multiple sinks.
+- **FanoutSink**: Sends to multiple sinks.
 
 ## Crate boundaries
 
@@ -226,8 +226,8 @@ InputSource trait              FileInput, TcpInput, UdpInput,
 
 logfwd-output defines + implements
 ──────────────────────────────────────────
-OutputSink / Sink traits       OtlpSink, ElasticsearchAsyncSink,
-                               LokiAsyncSink, JsonLinesSink, StdoutSink
+OutputSink / Sink traits       OtlpSink, ElasticsearchSink,
+                               LokiSink, JsonLinesSink, StdoutSink
 ```
 
 The binary crate (`logfwd`) wires these together in `pipeline.rs`.
@@ -274,7 +274,7 @@ Understanding who owns what and when copies happen:
 Current (after #939 — 3 copies remain, down from 5):
   tailer reads → BytesMut → freeze() → Bytes           (no copy)
   FramedInput: remainder + extend_from_slice(bytes)     [COPY 1: framing]
-  FormatProcessor: chunk → out_buf                      [COPY 2: format processing]
+  FormatDecoder: chunk → out_buf                      [COPY 2: format processing]
   pipeline: scan_buf.extend_from_slice(&bytes)          [COPY 3: SIMD contiguity — required]
   scanner classifies → ChunkIndex (bitmasks, no copy)
   StreamingBuilder stores views → RecordBatch (zero-copy)

--- a/dev-docs/DESIGN.md
+++ b/dev-docs/DESIGN.md
@@ -130,7 +130,7 @@ partition offset (gaps from compaction), Journald is an opaque cursor string, pu
 work for file inputs.
 
 **Cost:** `C: Clone` bound on methods; generic propagates to `AckReceipt<C>`,
-`CommitAdvance<C>`.  
+`CheckpointAdvance<C>`.  
 **Research:** `dev-docs/research/offset-checkpoint-research.md`. **Related:** #270.
 
 ### Rejected batches advance the checkpoint

--- a/dev-docs/PR_PROCESS.md
+++ b/dev-docs/PR_PROCESS.md
@@ -110,7 +110,7 @@ Every PR gets reviewed for:
 ### Common Copilot issues to watch for
 - **Lint failures** — Copilot doesn't run `cargo fmt` or `cargo clippy`. Every PR needs lint fixes.
 - **Approx constant test values** — using `3.14` (too close to PI) triggers `clippy::approx_constant`
-- **API drift** — Copilot branches from old commits, uses removed methods (e.g., `Scanner::new` → `SimdScanner::new`, `execute` → `execute_blocking`)
+- **API drift** — Copilot branches from old commits, uses removed methods (e.g., `Scanner::new` → `CopyScanner::new`, `execute` → `execute_blocking`)
 - **Dead config** — adding config fields that are parsed but never used at runtime
 - **Formatting noise** — 50%+ of diff is `rustfmt` changes to unrelated files
 

--- a/dev-docs/SCANNER_CONTRACT.md
+++ b/dev-docs/SCANNER_CONTRACT.md
@@ -1,7 +1,7 @@
 # Scanner Contract
 
 This document formalises the contract between callers and the scanner layer
-(`SimdScanner` / `StreamingSimdScanner`).  It covers input requirements,
+(`CopyScanner` / `ZeroCopyScanner`).  It covers input requirements,
 output guarantees, and known limitations.
 
 ---
@@ -127,7 +127,7 @@ fields.
 
 ### Batch reuse
 
-Both `SimdScanner` and `StreamingSimdScanner` can be reused across batches.
+Both `CopyScanner` and `ZeroCopyScanner` can be reused across batches.
 Each call to `scan()` resets builder state internally and produces an
 independent `RecordBatch`; schema and data from previous batches are not
 carried over.
@@ -147,6 +147,6 @@ carried over.
 - **No escape decoding of string values** — string values are stored as
   raw bytes (including any JSON escape sequences such as `\n`, `\uXXXX`).
   Callers that need decoded strings must unescape them.
-- **`_raw` column not supported by `StreamingSimdScanner`** — setting
-  `keep_raw = true` with the streaming variant is a no-op; use `SimdScanner`
+- **`_raw` column not supported by `ZeroCopyScanner`** — setting
+  `keep_raw = true` with the streaming variant is a no-op; use `CopyScanner`
   if a `_raw` column is needed.

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -244,7 +244,7 @@ u64 bitmask operations, integer parsing, varint roundtrip, pipeline state machin
 
 **Tier 2 — Bounded (Kani proves for inputs up to size N):**
 `parse_cri_line` (≤32 bytes), `NewlineFramer` (all 32-byte inputs), `skip_nested`
-(all 16-byte inputs), `CriAggregator` P+P+F (8-byte messages, max_size ≤32).
+(all 16-byte inputs), `CriReassembler` P+P+F (8-byte messages, max_size ≤32).
 
 **Tier 3 — Statistical (proptest, high confidence):**
 SIMD ≡ scalar structural detection, scanner oracle vs sonic-rs, pipeline event sequences,

--- a/dev-docs/research/checkpoint-snapshot-design.md
+++ b/dev-docs/research/checkpoint-snapshot-design.md
@@ -486,9 +486,9 @@ an entry, also remove it from the checkpoint store. Prevents unbounded growth.
 
 ## Remaining Design Gaps
 
-### FanOut Partial Success
+### FanoutSink Partial Success
 
-If a batch is sent to multiple outputs via FanOut and only some succeed,
+If a batch is sent to multiple outputs via FanoutSink and only some succeed,
 the current pipeline code (line 378-391) treats this as a full batch failure:
 no checkpoint advance. Successful sinks already received the data. On restart,
 ALL sinks re-receive from the old checkpoint — successful sinks get duplicates.

--- a/examples/elasticsearch/ARROW_IPC.md
+++ b/examples/elasticsearch/ARROW_IPC.md
@@ -80,7 +80,7 @@ let factory = ElasticsearchSinkFactory::new(
 let sink = factory.create()?;
 
 // Query with ES|QL uses the async sink's query_arrow method.
-// See ElasticsearchAsyncSink::query_arrow for the Arrow IPC query API.
+// See ElasticsearchSink::query_arrow for the Arrow IPC query API.
 ```
 
 ### ES|QL Query Examples
@@ -171,7 +171,7 @@ Arrow IPC format provides significant performance improvements over JSON:
 
 ## API Reference
 
-### `ElasticsearchAsyncSink::query_arrow(query: &str) -> io::Result<Vec<RecordBatch>>`
+### `ElasticsearchSink::query_arrow(query: &str) -> io::Result<Vec<RecordBatch>>`
 
 Query Elasticsearch using ES|QL and receive Arrow IPC response.
 
@@ -216,7 +216,7 @@ The implementation automatically sets this header in `query_arrow()`.
 
 For large queries, increase the HTTP timeout:
 - Default: 30 seconds
-- Adjust in `ElasticsearchAsyncSink::new()` configuration
+- Adjust in `ElasticsearchSink::new()` configuration
 
 ## References
 


### PR DESCRIPTION
## Summary
Mechanical renames across the codebase for clarity and consistency:

- `CommitAdvance` → `CheckpointAdvance` (#925)
- `ElasticsearchAsyncSink` → `ElasticsearchSink`, `LokiAsyncSink` → `LokiSink`, `FanOut` → `FanoutSink` (#926)
- `OutputType::FileOut/TcpOut/UdpOut` → `OutputType::File/Tcp/Udp` with backward-compat serde aliases (#927)
- `FormatProcessor` → `FormatDecoder`, `CriAggregator` → `CriReassembler` (#928)
- `SimdScanner` → `CopyScanner`, `StreamingSimdScanner` → `ZeroCopyScanner` (#929)

Closes #925, #926, #927, #928, #929

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --no-run` compiles
- [x] `cargo fmt` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename scanner, sink, format, and config types across the codebase
> - Renames `SimdScanner`→`CopyScanner` and `StreamingSimdScanner`→`ZeroCopyScanner` in [logfwd-arrow/src/scanner.rs](https://github.com/strawgate/memagent/pull/952/files#diff-d020b04e9264ef05f7929c3b3811b914e981603e23a31190efd83e14e4590eae) and all call sites.
> - Renames `ElasticsearchAsyncSink`→`ElasticsearchSink`, `LokiAsyncSink`→`LokiSink`, `FanOut`/`FanOutError`→`FanoutSink`/`FanoutSinkError`, and `FormatProcessor`→`FormatDecoder` in their respective modules.
> - Renames `CriAggregator`→`CriReassembler` in [logfwd-core/src/aggregator.rs](https://github.com/strawgate/memagent/pull/952/files#diff-e90c5576f1467d0760bced0d55da5d03559363bede15d41411b5b05a0461e5f5) and `CommitAdvance`→`CheckpointAdvance` in [logfwd-core/src/pipeline/lifecycle.rs](https://github.com/strawgate/memagent/pull/952/files#diff-f6c0036fc06079043b282b61d3783c86cf517aa4fdd888cbbe4bbcf36c6879f5).
> - Renames `OutputType` variants `FileOut`/`TcpOut`/`UdpOut`→`File`/`Tcp`/`Udp` in [logfwd-config/src/lib.rs](https://github.com/strawgate/memagent/pull/952/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150); the deserializer accepts both old and new names as aliases.
> - Behavioral Change: `OutputType::Display` now emits `"file"`, `"tcp"`, `"udp"` instead of `"file_out"`, `"tcp_out"`, `"udp_out"`, and error messages from `build_output_sink` now reference the shorter names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 99260b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->