### PR TITLE
fix: address CodeRabbit pre-merge feedback on #963

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 arrow = { version = "55", default-features = false, features = ["ipc_compression"] }
+bytes = "1"
 arrow-json = "55"
 datafusion = { version = "48", default-features = false, features = [
     "string_expressions",

--- a/crates/logfwd-core/tests/it/scanner_conformance.rs
+++ b/crates/logfwd-core/tests/it/scanner_conformance.rs
@@ -440,14 +440,14 @@ proptest! {
 ///   multiple Bytes → extend_from_slice into BytesMut → split().freeze() → ZeroCopyScanner
 fn assert_accumulation_consistent(chunks: &[&[u8]]) {
     use bytes::BytesMut;
-    use logfwd_arrow::scanner::ZeroCopyScanner;
+    use logfwd_arrow::scanner::Scanner;
 
     // Path A: concatenate then scan (baseline)
     let mut full = Vec::new();
     for chunk in chunks {
         full.extend_from_slice(chunk);
     }
-    let mut scanner_a = ZeroCopyScanner::new(ScanConfig::default());
+    let mut scanner_a = Scanner::new(ScanConfig::default());
     let batch_a = scanner_a
         .scan(bytes::Bytes::from(full.clone()))
         .expect("baseline scan should succeed");
@@ -458,7 +458,7 @@ fn assert_accumulation_consistent(chunks: &[&[u8]]) {
         buf.extend_from_slice(chunk);
     }
     let frozen = buf.split().freeze();
-    let mut scanner_b = ZeroCopyScanner::new(ScanConfig::default());
+    let mut scanner_b = Scanner::new(ScanConfig::default());
     let batch_b = scanner_b
         .scan(frozen)
         .expect("accumulated scan should succeed");
@@ -471,31 +471,66 @@ fn assert_accumulation_consistent(chunks: &[&[u8]]) {
         batch_b.num_rows()
     );
 
-    // Compare all column values
+    // Schema must match (name + type + nullability)
+    let mut fields_a: Vec<_> = batch_a
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| (f.name().clone(), f.data_type().clone(), f.is_nullable()))
+        .collect();
+    let mut fields_b: Vec<_> = batch_b
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| (f.name().clone(), f.data_type().clone(), f.is_nullable()))
+        .collect();
+    fields_a.sort_by(|l, r| l.0.cmp(&r.0));
+    fields_b.sort_by(|l, r| l.0.cmp(&r.0));
+    assert_eq!(
+        fields_a, fields_b,
+        "Schema fields differ between direct and accumulated"
+    );
+
+    // Compare every column's values — catches corrupted StringView offsets
     for (i, field) in batch_a.schema().fields().iter().enumerate() {
         let col_a = batch_a.column(i);
-        let col_b = batch_b.column_by_name(field.name());
-        assert!(
-            col_b.is_some(),
-            "Column '{}' missing in accumulated batch",
-            field.name()
-        );
-        let col_b = col_b.unwrap();
+        let col_b = batch_b.column_by_name(field.name()).unwrap_or_else(|| {
+            panic!("Column '{}' missing in accumulated batch", field.name());
+        });
         assert_eq!(
             col_a.len(),
             col_b.len(),
             "Column '{}' length differs",
             field.name()
         );
+        for row in 0..col_a.len() {
+            assert_eq!(
+                col_a.is_null(row),
+                col_b.is_null(row),
+                "Null mismatch at {}[{row}]",
+                field.name(),
+            );
+            if !col_a.is_null(row) {
+                assert_eq!(
+                    format!("{:?}", col_a.as_ref().slice(row, 1)),
+                    format!("{:?}", col_b.as_ref().slice(row, 1)),
+                    "Value mismatch at {}[{row}]",
+                    field.name(),
+                );
+            }
+        }
     }
 }
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(256))]
 
-    /// Split NDJSON at random newline boundaries and accumulate via BytesMut.
+    /// Split NDJSON at a proptest-chosen newline boundary and accumulate via BytesMut.
     #[test]
-    fn accumulation_matches_direct(buf in arb_ndjson_buffer()) {
+    fn accumulation_matches_direct(
+        buf in arb_ndjson_buffer(),
+        split_pct in 0usize..100,
+    ) {
         // Find all newline positions
         let newlines: Vec<usize> = buf.iter()
             .enumerate()
@@ -507,8 +542,9 @@ proptest! {
             return Ok(());
         }
 
-        // Split at a random newline position
-        let mid = newlines[newlines.len() / 2];
+        // Pick a newline index based on proptest-generated percentage
+        let idx = split_pct % newlines.len();
+        let mid = newlines[idx];
         let chunk1 = &buf[..mid];
         let chunk2 = &buf[mid..];
 

--- a/crates/logfwd/Cargo.toml
+++ b/crates/logfwd/Cargo.toml
@@ -13,7 +13,7 @@ dhat-heap = ["dhat"]
 cpu-profiling = ["pprof"]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 logfwd-config = { version = "0.1.0", path = "../logfwd-config" }
 logfwd-core = { version = "0.1.0", path = "../logfwd-core" }
 logfwd-arrow = { version = "0.1.0", path = "../logfwd-arrow" }
@@ -40,7 +40,7 @@ tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 
 [dev-dependencies]
 arrow = { workspace = true }
-bytes = "1"
+bytes = { workspace = true }
 logfwd-test-utils = { version = "0.1.0", path = "../logfwd-test-utils" }
 proptest = "1.11.0"
 stats_alloc = "0.1"

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -392,7 +392,7 @@ impl Pipeline {
     pub fn with_input(mut self, _name: &str, source: Box<dyn InputSource>) -> Self {
         self.inputs.push(InputState {
             source,
-            buf: BytesMut::new(),
+            buf: BytesMut::with_capacity(self.batch_target_bytes),
             stats: Arc::new(ComponentStats::new()),
         });
         self

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -37,14 +37,17 @@ The binary crate wires everything together.
 ### 1. Reading: bytes enter the system
 
 ```
-Disk → FileReader (BytesMut) → freeze() → InputEvent::Data { bytes: Bytes }
+Disk → FileReader (Vec<u8>) → InputEvent::Data { bytes: Vec<u8> }
 ```
 
 **FileTailer** (`logfwd-io/src/tail.rs`) is composed of two internal layers:
 - **FileDiscovery**: path watching via notify (kqueue/inotify), glob evaluation,
   rotation detection, deleted-file cleanup, LRU eviction.
-- **FileReader**: open file descriptors, `BytesMut` read buffer, byte reading.
-  Reads into `BytesMut`, then `freeze()` produces refcounted `Bytes`.
+- **FileReader**: open file descriptors, `Vec<u8>` read buffer, byte reading.
+
+> **Note:** logfwd-io (tailer, InputEvent, FramedInput) still uses `Vec<u8>`.
+> Only `pipeline.rs` uses `BytesMut`/`Bytes`. The Bytes boundary is at the
+> `input_poll_loop` → `ChannelMsg` transition.
 
 Each input source runs on its own OS thread. Reads feed a bounded
 `tokio::sync::mpsc` channel to the async pipeline loop. The channel
@@ -54,7 +57,7 @@ across the thread boundary.
 ### 2. Framing: raw bytes → complete lines
 
 ```
-Bytes → FramedInput::poll() → newline-delimited JSON as Bytes
+Vec<u8> → FramedInput::poll() → newline-delimited JSON as Vec<u8>
 ```
 
 **FramedInput** (`logfwd-io/src/framed.rs`) combines format detection
@@ -262,20 +265,20 @@ operations.
 Understanding who owns what and when copies happen:
 
 ```
-Current (after #939 + #963 — 4 copies):
-  tailer reads → Vec<u8>                                [COPY 1: kernel → Vec]
-  FramedInput: remainder + extend_from_slice             [COPY 2: framing]
-  FormatDecoder: chunk → out_buf → Bytes::from(Vec)      [COPY 3: format processing]
-  pipeline: input.buf (BytesMut) .extend_from_slice      [COPY 4: thread accumulation]
-  channel: split().freeze() → Bytes                      (no copy — refcount)
-  scan_buf (BytesMut) .extend_from_slice(&bytes)         (copy — SIMD contiguity)
-  flush: split().freeze() → Bytes                        (no copy — refcount)
-  ZeroCopyScanner receives Bytes directly                (no copy)
+Current (after #939 + #963 — 5 heap copies, 2 zero-copy transitions):
+  tailer reads → Vec<u8>                                [COPY 1: kernel → userspace]
+  FramedInput: remainder + extend_from_slice             [COPY 2: Vec prepend]
+  FormatDecoder: chunk → out_buf                         [COPY 3: format processing]
+  pipeline input.buf: extend_from_slice → BytesMut       [COPY 4: thread accumulation]
+  channel: split().freeze() → Bytes                      (zero-copy — refcount only)
+  scan_buf: extend_from_slice → BytesMut                 [COPY 5: async accumulation]
+  flush: split().freeze() → Bytes                        (zero-copy — refcount only)
+  Scanner receives Bytes directly                (zero-copy)
   StreamingBuilder stores views → RecordBatch            (zero-copy)
   Bytes dropped when RecordBatch is consumed
 
-  Note: tailer, InputEvent, FramedInput still use Vec<u8>.
-  Only pipeline.rs (ChannelMsg, InputState.buf, scan_buf) uses BytesMut/Bytes.
+  logfwd-io boundary: Vec<u8> (tailer, InputEvent, FramedInput)
+  pipeline.rs boundary: BytesMut/Bytes (ChannelMsg, scan_buf, scanner)
 
 Target (zero-copy for 99% passthrough path — #608):
   tailer reads → BytesMut → freeze() → Bytes             (no copy)
@@ -283,7 +286,7 @@ Target (zero-copy for 99% passthrough path — #608):
   Passthrough format: emit Bytes slice directly           (no copy)
   CRI format: metadata injection requires rewrite         [COPY 1: unavoidable]
   pipeline: scan_buf.extend_from_slice(&bytes)            [COPY 2: SIMD contiguity]
-  ZeroCopyScanner receives Bytes directly                 (no copy)
+  Scanner receives Bytes directly                 (no copy)
   StreamingBuilder stores views → RecordBatch             (zero-copy)
   Bytes dropped when RecordBatch is consumed
 ```

--- a/dev-docs/CRATE_RULES.md
+++ b/dev-docs/CRATE_RULES.md
@@ -52,7 +52,8 @@ Rules and constraints for each crate. Enforced by CI, not just convention.
 |------|-------------|
 | Async orchestration only — no business logic | Code review |
 | Pipeline decisions go through core state machine | Architecture |
-| Deps: everything + tokio | Cargo.toml |
+| Deps: everything + tokio + bytes | Cargo.toml |
+| BytesMut/Bytes used for pipeline buffer accumulation | Architecture |
 
 ## Adding a new crate
 

--- a/dev-docs/DESIGN.md
+++ b/dev-docs/DESIGN.md
@@ -183,6 +183,27 @@ attributes. Directly queryable by DuckDB, Polars, DataFusion with zero schema kn
 OTAP's star schema (4+ tables with foreign keys) is optimized for wire efficiency, not
 queryability. Convert at the boundary when needed.
 
+### bytes::Bytes for pipeline buffer ownership
+
+Pipeline accumulation buffers use `BytesMut` (mutable, single-owner) in each
+stage, converting to `Bytes` (immutable, refcounted) at stage boundaries via
+`split().freeze()`. This is the standard Rust pattern for I/O pipelines where
+buffers cross thread/async boundaries.
+
+Why `Bytes` instead of `Vec<u8>`: The Arrow `StreamingBuilder` needs the input
+buffer to outlive the scan phase — `StringViewArray` stores `(offset, len)` views
+into the buffer, and the `RecordBatch` carries these through SQL transform and
+output serialization. `Bytes` provides this lifetime extension via refcounting.
+`Vec<u8>` cannot be shared without cloning.
+
+Why not `Arc<Vec<u8>>`: `Bytes` supports zero-copy `slice()` and `split()` that
+`Arc<Vec<u8>>` does not. Future FramedInput work (#608) will use `Bytes::slice()`
+for zero-copy newline framing.
+
+Current boundary: logfwd-io produces `Vec<u8>` (tailer, FramedInput). The Bytes
+transition happens at `input_poll_loop` in pipeline.rs. logfwd-core is untouched
+(scanner takes `&[u8]` via `Bytes::Deref`).
+
 ### Verification strategy
 
 Three tools, each at a different layer. See `dev-docs/VERIFICATION.md` for mechanics.

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -232,6 +232,7 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 | `logfwd-io/tail.rs` | File tailer EOF emission state machine (eof_emitted flag) | Kani (4 proofs: at-most-once emission per streak, data-reset invariant, two-poll sequence, reset-cycle) |
 | `logfwd-arrow/storage_builder.rs` | StructArray conflict column assembly | Kani (2 proofs: duplicate name guard, row count invariant) + unit tests |
 | `logfwd-arrow/streaming_builder.rs` | StructArray conflict column assembly (StringView) | Kani (2 proofs: duplicate name guard, row count invariant) + unit tests |
+| `scanner_conformance.rs` (accumulation) | BytesMut accumulation → Bytes → Scanner equivalence | proptest (3 tests × 256 cases: random split, single chunk, per-line split; full value comparison) |
 
 ### Verification tiers
 


### PR DESCRIPTION
## Summary

Fixes all CodeRabbit pre-merge check failures from the Bytes pipeline PR (#963):

- **Crate Boundary** (error): Move `bytes` to `[workspace.dependencies]`, use `workspace = true` in crate manifests
- **Formal Verification** (error): Proptest now compares full cell values (not just lengths), randomizes split index via proptest strategy
- **Documentation** (warning): ARCHITECTURE.md corrected — tailer/framing says `Vec<u8>` not `BytesMut`, copy count fixed from "4" to "5 heap copies + 2 zero-copy transitions"
- **Test helper**: `with_input` pre-sizes `BytesMut` to `batch_target_bytes`
- **Import fix**: `ZeroCopyScanner` renamed to `Scanner` on latest master

## Test plan

- [x] `cargo test -p logfwd --lib` — 53 pass
- [x] `cargo test -p logfwd-core --test it -- accumulation` — 3 proptests pass (768 cases)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pre-merge feedback on scanner conformance tests and pipeline buffer allocation
> - Strengthens `assert_accumulation_consistent` in [scanner_conformance.rs](https://github.com/strawgate/memagent/pull/965/files#diff-b1399ad48dd1cc848beafae32de9374bcd7e7a1dc4d9e787e15b50e17142477a) to validate schema equality (field names, types, nullability) and per-row values in addition to row counts, switching from `ZeroCopyScanner` to `Scanner`.
> - Updates the `accumulation_matches_direct` proptest to use a generated `split_pct` to explore varied split positions across newline boundaries instead of always splitting at the midpoint.
> - Changes `Pipeline.with_input` in [pipeline.rs](https://github.com/strawgate/memagent/pull/965/files#diff-871beaad2d14990b89072990f0a821dd4266ab3e624d58590ec24abc1047056d) to initialize `BytesMut` with `with_capacity(batch_target_bytes)` instead of `BytesMut::new()`.
> - Moves `bytes` dependency to workspace-level in [Cargo.toml](https://github.com/strawgate/memagent/pull/965/files#diff-6001f9e7e56bdc3d814d284508d70471bb696f23381a85b6aa415694a96a47d8) and updates dev-docs to reflect current architecture.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3230b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->