### PR TITLE
ci: add turmoil to CI, create nightly extended testing, standardize proptest config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,27 @@ jobs:
           RUSTC_WRAPPER: ""
 
   # -------------------------------------------------------------------------
+  # Turmoil deterministic simulation
+  # -------------------------------------------------------------------------
+  turmoil:
+    name: Turmoil simulation
+    needs: [changes]
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      (github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Turmoil simulation tests
+        run: cargo test -p logfwd --features turmoil --test turmoil_sim
+
+  # -------------------------------------------------------------------------
   # TLC: TLA+ model checking for all specs
   # -------------------------------------------------------------------------
   tlc:

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -1,0 +1,61 @@
+name: Nightly extended testing
+on:
+  schedule:
+    - cron: '0 4 * * *'  # 4am UTC daily
+  workflow_dispatch: {}
+
+jobs:
+  proptest-extended:
+    name: Proptest (10,000 cases)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run proptests with 10K cases
+        run: |
+          PROPTEST_CASES=10000 cargo test -p logfwd-core --test it -- proptest
+          PROPTEST_CASES=10000 cargo test -p logfwd-io --test it -- proptest
+          PROPTEST_CASES=10000 cargo test -p logfwd-types -- proptest
+          PROPTEST_CASES=10000 cargo test -p logfwd-output -- proptest
+        env:
+          PROPTEST_CASES: "10000"
+
+  turmoil-seed-sweep:
+    name: Turmoil seed sweep (100 seeds)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run turmoil tests with 100 different seeds
+        run: |
+          FAILED=0
+          for SEED in $(seq 1 100); do
+            echo "=== Seed $SEED ==="
+            if ! TURMOIL_SEED=$SEED cargo test -p logfwd --features turmoil --test turmoil_sim 2>&1 | tail -3; then
+              echo "FAILED on seed $SEED"
+              FAILED=$((FAILED + 1))
+            fi
+          done
+          echo "=== Results: $FAILED failures out of 100 seeds ==="
+          if [ $FAILED -gt 0 ]; then exit 1; fi
+
+  fuzz-short:
+    name: Fuzz (5 minutes per target)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+      - name: Run fuzz targets
+        run: |
+          cd crates/logfwd-core
+          for target in $(cargo fuzz list 2>/dev/null); do
+            echo "=== Fuzzing $target for 5 minutes ==="
+            timeout 300 cargo fuzz run "$target" -- -max_total_time=300 || true
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,6 +2381,7 @@ dependencies = [
  "libc",
  "logfwd-arrow",
  "logfwd-core",
+ "logfwd-test-utils",
  "logfwd-types",
  "memchr",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tokio = { version = "1" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-opentelemetry = "0.32"
+turmoil = "0.7"
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/crates/logfwd-core/tests/it/scanner_conformance.rs
+++ b/crates/logfwd-core/tests/it/scanner_conformance.rs
@@ -241,7 +241,7 @@ fn assert_values_correct(input: &[u8]) {
 // ===========================================================================
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(256))]
+    #![proptest_config(ProptestConfig::with_cases(logfwd_test_utils::proptest_cases()))]
 
     #[test]
     fn oracle_single_line(obj in arb_flat_object(1..20)) {
@@ -416,7 +416,7 @@ fn assert_builders_consistent(input: &[u8]) {
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(256))]
+    #![proptest_config(ProptestConfig::with_cases(logfwd_test_utils::proptest_cases()))]
 
     #[test]
     fn consistency_single_line(obj in arb_flat_object(1..15)) {
@@ -523,7 +523,7 @@ fn assert_accumulation_consistent(chunks: &[&[u8]]) {
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(256))]
+    #![proptest_config(ProptestConfig::with_cases(logfwd_test_utils::proptest_cases()))]
 
     /// Split NDJSON at a proptest-chosen newline boundary and accumulate via BytesMut.
     #[test]

--- a/crates/logfwd-io/Cargo.toml
+++ b/crates/logfwd-io/Cargo.toml
@@ -32,6 +32,7 @@ xxhash-rust = { version = "0.8.15", features = ["xxh32", "xxh64"] }
 
 [dev-dependencies]
 dhat = "0.3"
+logfwd-test-utils = { version = "0.1.0", path = "../logfwd-test-utils" }
 proptest = "1"
 proptest-state-machine = "0.8"
 serial_test = "3"

--- a/crates/logfwd-io/tests/it/checkpoint_state_machine.rs
+++ b/crates/logfwd-io/tests/it/checkpoint_state_machine.rs
@@ -426,7 +426,7 @@ impl StateMachineTest for TailCheckpointTest {
 
 prop_state_machine! {
     #![proptest_config(ProptestConfig {
-        cases: 128,
+        cases: logfwd_test_utils::proptest_cases(),
         max_shrink_iters: 5_000,
         failure_persistence: None,
         .. ProptestConfig::default()

--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -772,14 +772,22 @@ pub fn build_sink_factory(
                 Some(Format::Console) => StdoutFormat::Console,
                 _ => StdoutFormat::Text,
             };
-            Ok(Arc::new(StdoutSinkFactory::new(name.to_string(), fmt, stats)))
+            Ok(Arc::new(StdoutSinkFactory::new(
+                name.to_string(),
+                fmt,
+                stats,
+            )))
         }
         OutputType::Tcp => {
             let endpoint = cfg
                 .endpoint
                 .as_ref()
                 .ok_or_else(|| format!("output '{name}': tcp requires 'endpoint'"))?;
-            Ok(Arc::new(TcpSinkFactory::new(name.to_string(), endpoint.clone(), stats)))
+            Ok(Arc::new(TcpSinkFactory::new(
+                name.to_string(),
+                endpoint.clone(),
+                stats,
+            )))
         }
         _ => {
             // Sync sink — build it once, wrap in OnceFactory (max_workers=1).

--- a/crates/logfwd-test-utils/src/lib.rs
+++ b/crates/logfwd-test-utils/src/lib.rs
@@ -11,6 +11,18 @@ pub use sinks::CountingSink;
 use std::io::Write as _;
 use std::path::Path;
 
+/// Return the number of proptest cases to run.
+///
+/// Reads from `PROPTEST_CASES` env var (for CI scaling).
+/// Default: 256 (fast enough for per-PR CI, thorough enough to catch most bugs).
+/// Nightly CI sets 10,000 for deeper exploration.
+pub fn proptest_cases() -> u32 {
+    std::env::var("PROPTEST_CASES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(256)
+}
+
 /// Return a no-op OpenTelemetry Meter for tests.
 pub fn test_meter() -> opentelemetry::metrics::Meter {
     opentelemetry::global::meter("test")

--- a/crates/logfwd/Cargo.toml
+++ b/crates/logfwd/Cargo.toml
@@ -34,7 +34,7 @@ arrow = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "time", "sync"] }
 tokio-util = { version = "0.7" }
 logfwd-io = { version = "0.1.0", path = "../logfwd-io" }
-turmoil = { version = "0.7", optional = true }
+turmoil = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["stats"] }
@@ -48,7 +48,7 @@ proptest = "1.11.0"
 stats_alloc = "0.1"
 tempfile = "3"
 tiny_http = "0.12"
-turmoil = "0.7"
+turmoil = { workspace = true }
 
 [lints]
 workspace = true

--- a/justfile
+++ b/justfile
@@ -56,6 +56,11 @@ dashboard:
 
 
 
+# Extended testing: 10K proptest cases + turmoil simulation
+test-extended:
+    PROPTEST_CASES=10000 cargo nextest run --profile ci
+    cargo test -p logfwd --features turmoil --test turmoil_sim
+
 # Build release binary
 build:
     cargo build --release


### PR DESCRIPTION
## Summary

- **Turmoil in CI**: Added a new `turmoil` job to `ci.yml` that runs all 16 deterministic network simulation tests on every PR and push to master (<2s runtime)
- **Nightly extended testing**: Created `nightly-testing.yml` with three jobs: proptest with 10K cases, turmoil seed sweep across 100 seeds, and 5-minute fuzz runs per target
- **Workspace turmoil dep**: Moved `turmoil` to `[workspace.dependencies]` per project convention (CodeRabbit feedback)
- **Configurable proptest cases**: Added `proptest_cases()` helper to `logfwd-test-utils` that reads `PROPTEST_CASES` env var (default 256). Updated `scanner_conformance` and `checkpoint_state_machine` to use it
- **`test-extended` recipe**: Added to justfile for local extended testing (10K proptest + turmoil)
- **Formatting fix**: Fixed pre-existing `rustfmt` issue in `logfwd-output`

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p logfwd-test-utils` passes (8/8)
- [x] `cargo test -p logfwd --features turmoil --test turmoil_sim` passes (16/16)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] CI turmoil job runs successfully on this PR
- [ ] Nightly workflow syntax validates (manual dispatch after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Turmoil simulation tests to CI and create nightly extended testing workflow
> - Adds a `turmoil` job to [ci.yml](.github/workflows/ci.yml) that runs deterministic simulation tests on pushes to master and non-draft PRs.
> - Adds a [nightly-testing.yml](.github/workflows/nightly-testing.yml) workflow (daily at 4am UTC) with three jobs: extended proptests (`PROPTEST_CASES=10000`), a 100-seed Turmoil sweep, and 5-minute fuzz sessions per target in `logfwd-core`.
> - Adds `proptest_cases()` in [logfwd-test-utils](crates/logfwd-test-utils/src/lib.rs) to read `PROPTEST_CASES` from the environment, defaulting to 256; all proptest call sites in `logfwd-core` and `logfwd-io` now use this helper.
> - Adds a `test-extended` recipe to the [justfile](justfile) for running extended tests and Turmoil simulations locally.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 96fa62c. 10 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->