### PR TITLE
fix: u32 overflow in streaming_builder + checkpoint flush retry

### DIFF
--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -140,9 +140,9 @@ impl StreamingBuilder {
     /// Start a new batch. Takes ownership of the input buffer via Bytes
     /// (zero-copy if converted from Vec via `Bytes::from(vec)`).
     ///
-    /// # Panics (debug builds)
-    /// Debug-asserts that `buf.len()` fits in a u32, because string-view
-    /// offsets are stored as u32.  Buffers larger than 4 GiB would produce
+    /// # Panics
+    /// Asserts that `buf.len()` fits in a u32, because string-view
+    /// offsets are stored as u32. Buffers larger than 4 GiB would produce
     /// silently truncated offsets without this guard.
     pub fn begin_batch(&mut self, buf: bytes::Bytes) {
         debug_assert_ne!(
@@ -290,7 +290,8 @@ impl StreamingBuilder {
         if std::str::from_utf8(value).is_err() {
             return;
         }
-        let decoded_offset = self.decoded_buf.len() as u32;
+        let decoded_offset = u32::try_from(self.decoded_buf.len())
+            .expect("StreamingBuilder decoded_buf exceeds u32::MAX");
         self.decoded_buf.extend_from_slice(value);
         // Offset into the combined buffer: original buf bytes come first,
         // decoded bytes follow at buf.len() + decoded_offset.

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -1121,6 +1121,10 @@ fn input_poll_loop(
 /// The final shutdown flush is the last chance to persist checkpoint progress.
 /// A single failure here loses all checkpoint advancement from the run.
 /// Retry with brief sleeps to handle transient I/O errors (disk busy, NFS glitch).
+///
+/// Uses `std::thread::sleep` (not `tokio::time::sleep`) because this runs
+/// during shutdown after all async work is drained, and `CheckpointStore::flush`
+/// is itself synchronous I/O — there is no benefit to yielding.
 fn flush_checkpoint_with_retry(store: &mut dyn CheckpointStore) {
     const MAX_ATTEMPTS: u32 = 3;
     const RETRY_DELAY: Duration = Duration::from_millis(100);


### PR DESCRIPTION
## Summary

Two production bug fixes:

### #1076 — streaming_builder u32 overflow (silent data corruption)
- `combined_offset = self.buf.len() as u32 + decoded_offset` wraps silently when combined buffer exceeds 4 GiB
- **Fix**: `checked_add().expect()` — panics with clear message instead of silent corruption
- Also promotes `debug_assert` to hard `assert` for `buf.len() > u32::MAX` (#659)

### #985 — shutdown checkpoint flush has no retry (data re-read on restart)
- Final `store.flush()` was fire-and-forget — a single I/O error loses all checkpoint progress
- **Fix**: `flush_checkpoint_with_retry()` — 3 attempts, 100ms between, applied to both normal and force-stop paths
- Logs warn on retry, error on final failure

## Test plan
- [x] `cargo test -p logfwd --lib` — 60 tests pass
- [x] `cargo test -p logfwd-arrow --lib` — 89 tests pass
- [x] `cargo clippy -p logfwd -p logfwd-arrow -- -D warnings` — clean

Closes #1076. Closes #985.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix u32 overflow in `StreamingBuilder` and add checkpoint flush retry on shutdown
> - Replaces `debug_assert` with a hard `assert` in `StreamingBuilder.begin_batch` so release builds panic if the input buffer length exceeds `u32::MAX`, preventing silent offset truncation.
> - Replaces unchecked `as u32` casts in `StreamingBuilder.append_decoded_str_by_idx` with checked conversions using `u32::try_from` and `checked_add`, panicking on overflow instead of wrapping silently.
> - Adds `flush_checkpoint_with_retry` in [pipeline.rs](https://github.com/strawgate/memagent/pull/1099/files#diff-871beaad2d14990b89072990f0a821dd4266ab3e624d58590ec24abc1047056d) that retries checkpoint flush up to 3 times with 100ms sleeps, replacing single-attempt calls in both normal and force-stop shutdown paths.
> - Risk: the new panics in `StreamingBuilder` are now reachable in release builds; previously these would silently corrupt offset data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 253c06c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->