### PR TITLE
fix(ci): add sccache to nightly proptest and turmoil jobs

### DIFF
--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -11,6 +11,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run proptests with 10K cases
@@ -28,6 +29,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+      - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run turmoil tests with 100 different seeds


### PR DESCRIPTION
The nightly proptest job fails because `.cargo/config.toml` sets `rustc-wrapper = sccache` but the sccache binary isn't installed. Adds `mozilla-actions/sccache-action@v0.0.9` to proptest and turmoil jobs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sccache to nightly proptest and turmoil CI jobs
> Adds `mozilla-actions/sccache-action@v0.0.9` to the 'Proptest (10,000 cases)' and 'Turmoil seed sweep (100 seeds)' jobs in [nightly-testing.yml](https://github.com/strawgate/memagent/pull/1112/files#diff-f9941ccca923bf4b7a47243d258bc06d456585fd74b6b26a0594a29463b56657). The step runs after checkout and before the Rust toolchain and cache steps, consistent with other CI jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized f7a0e7d. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->