### PR TITLE
fix: star_schema timestamp parsing and type handling

### DIFF
--- a/crates/logfwd-arrow/Cargo.toml
+++ b/crates/logfwd-arrow/Cargo.toml
@@ -17,9 +17,5 @@ bytes = "1"
 serial_test = "3"
 stats_alloc = "0.1"
 
-[[test]]
-name = "timestamp_parsing"
-path = "tests/timestamp_parsing.rs"
-
 [lints]
 workspace = true

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayRef, BinaryArray, BooleanArray, Float64Array, Int64Array, StringArray, UInt8Array,
-    UInt32Array,
+    Array, ArrayRef, BinaryArray, BooleanArray, Float64Array, Int64Array, LargeBinaryArray,
+    StringArray, UInt8Array, UInt32Array,
 };
 use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::error::ArrowError;
@@ -679,9 +679,22 @@ fn build_log_attrs(
                     bytes_vals.push(None);
                 }
                 ATTR_TYPE_BYTES => {
-                    let a = arr.as_any().downcast_ref::<BinaryArray>().ok_or_else(|| {
+                    // attr_type_for() maps both DataType::Binary and DataType::LargeBinary to
+                    // ATTR_TYPE_BYTES, so we must handle both array types here.
+                    let bytes = match arr.data_type() {
+                        DataType::Binary => arr
+                            .as_any()
+                            .downcast_ref::<BinaryArray>()
+                            .map(|a| a.value(row).to_vec()),
+                        DataType::LargeBinary => arr
+                            .as_any()
+                            .downcast_ref::<LargeBinaryArray>()
+                            .map(|a| a.value(row).to_vec()),
+                        _ => None,
+                    }
+                    .ok_or_else(|| {
                         ArrowError::ComputeError(format!(
-                            "Expected BinaryArray for column {}, got {}",
+                            "Expected BinaryArray or LargeBinaryArray for column {}, got {}",
                             key,
                             arr.data_type()
                         ))
@@ -690,7 +703,7 @@ fn build_log_attrs(
                     int_vals.push(None);
                     double_vals.push(None);
                     bool_vals.push(None);
-                    bytes_vals.push(Some(a.value(row).to_vec()));
+                    bytes_vals.push(Some(bytes));
                 }
                 _ => {
                     // String (default).
@@ -932,18 +945,21 @@ pub(crate) fn parse_timestamp_to_nanos(s: &str) -> Option<i64> {
     }
     // Try bare integer nanoseconds first.
     if let Ok(ns) = s.parse::<i64>() {
-        // Heuristic for epoch timestamps:
+        // Heuristic for epoch timestamps based on magnitude. We use unsigned_abs() so that
+        // pre-1970 (negative) timestamps are classified correctly — for negative values the
+        // comparisons against positive thresholds would otherwise always be false.
         // > 1e17: nanoseconds  (1e17 ns = ~3.17 years from 1970)
         // > 1e14: microseconds (1e14 us = ~3.17 years)
         // > 1e11: milliseconds (1e11 ms = ~3.17 years)
         // else: seconds
-        if ns > 100_000_000_000_000_000 {
+        let abs = ns.unsigned_abs();
+        if abs > 100_000_000_000_000_000 {
             return Some(ns);
         }
-        if ns > 100_000_000_000_000 {
+        if abs > 100_000_000_000_000 {
             return ns.checked_mul(1_000);
         }
-        if ns > 100_000_000_000 {
+        if abs > 100_000_000_000 {
             return ns.checked_mul(1_000_000);
         }
         return ns.checked_mul(1_000_000_000);
@@ -991,8 +1007,13 @@ pub(crate) fn parse_rfc3339_nanos(s: &str) -> Option<i64> {
     };
 
     let tz_str = &rest[tz_start..];
-    let tz_offset_secs: i64 = if tz_str.is_empty() || tz_str == "Z" || tz_str == "z" {
+    // RFC 3339 requires an explicit timezone designator. Strings without one (e.g.
+    // "2024-01-15T10:30:00") are not valid RFC 3339 and we return None rather than
+    // silently assuming UTC, which could misinterpret local-time values.
+    let tz_offset_secs: i64 = if tz_str == "Z" || tz_str == "z" {
         0
+    } else if tz_str.is_empty() {
+        return None;
     } else if tz_str.len() >= 6 && (tz_str.starts_with('+') || tz_str.starts_with('-')) {
         let sign: i64 = if tz_str.starts_with('-') { -1 } else { 1 };
         let tz_h: i64 = tz_str[1..3].parse().ok()?;

--- a/crates/logfwd-arrow/tests/timestamp_parsing.rs
+++ b/crates/logfwd-arrow/tests/timestamp_parsing.rs
@@ -116,8 +116,7 @@ fn test_unexpected_column_types() {
 
     let batch = RecordBatch::try_new(schema, columns).unwrap();
 
-    // This should NOT panic. It might return Error or handle it.
-    // If it currently panics, this test will fail until fixed.
-    let result = flat_to_star(&batch);
-    assert!(result.is_err() || result.is_ok()); // Just want it to not panic.
+    // This should NOT panic. Reaching this line without panicking is the assertion.
+    // flat_to_star handles unexpected column types gracefully (returns Ok, skipping the column).
+    let _result = flat_to_star(&batch);
 }


### PR DESCRIPTION
I have fixed five bugs in `crates/logfwd-arrow/src/star_schema.rs` related to timestamp parsing and robust column type handling.

Specifically, I:
- Updated `parse_timestamp_to_nanos` to disambiguate epoch timestamps (seconds, milliseconds, microseconds, nanoseconds) based on their magnitude.
- Enhanced `parse_rfc3339_nanos` and `days_from_civil` to strictly validate date and time components (e.g., rejecting 99:99:99 or February 30th).
- Switched to checked arithmetic for all timestamp-to-nanosecond conversions to handle potential `i64` overflows (returning `None` instead of wrapping).
- Replaced several `.expect()` calls with safe downcasting and error propagation to prevent panics when encountering unexpected Arrow types in input data.
- Added a new integration test file `crates/logfwd-arrow/tests/timestamp_parsing.rs` covering these edge cases and regressions.

All tests passed successfully.

Fixes #1131

---
*PR created automatically by Jules for task [8002861273338031358](https://jules.google.com/task/8002861273338031358) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix timestamp parsing and type handling in `star_schema`
> - Replaces panics with recoverable errors across `str_value_at`, `str_from_array`, and `build_log_attrs` in [star_schema.rs](https://github.com/strawgate/memagent/pull/1136/files#diff-fb28eb9d8306708fff07b41c8d2b450df493a129ad9ffa16eceed5676b3a0f62): downcast mismatches now return empty strings or `ArrowError::ComputeError` instead of panicking.
> - Adds support for `LargeBinaryArray` alongside `BinaryArray` in `build_log_attrs` byte attribute handling.
> - Reworks `parse_timestamp_to_nanos` to classify integer timestamps as seconds, milliseconds, microseconds, or nanoseconds by magnitude (including negative values), using `checked_mul` to avoid overflow.
> - Fixes `parse_rfc3339_nanos` to validate time fields and timezone offsets, reject strings without a timezone designator, and return `None` on arithmetic overflow.
> - Fixes `days_from_civil` to reject invalid dates such as Feb 30 or Feb 29 on non-leap years.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 014d032.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->