### PR TITLE
fix(ci): repair master CI — typos false positive and OutputConfig struct fields

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -5,6 +5,8 @@ hel = "hel"
 leve = "leve"
 # CSS class prefix for pipeline nodes in the dashboard.
 pn = "pn"
+# Intentional "ue" string slice in streaming_builder tests (tail of "value").
+ue = "ue"
 
 [files]
 extend-exclude = [

--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -1210,6 +1210,9 @@ mod tests {
                 path: None,
                 index: None,
                 auth: None,
+                tenant_id: None,
+                static_labels: None,
+                label_columns: None,
             };
             let result = build_sink_factory("test", &cfg, Arc::new(ComponentStats::new()));
             assert!(result.is_err(), "Expected error for format {:?}", format);
@@ -1234,6 +1237,9 @@ mod tests {
             path: None,
             index: None,
             auth: None,
+            tenant_id: None,
+            static_labels: None,
+            label_columns: None,
         };
         let factory = build_sink_factory("test", &cfg, Arc::new(ComponentStats::new())).unwrap();
         assert_eq!(factory.name(), "test");


### PR DESCRIPTION
## Summary

Two CI regressions on master after recent merges:

1. **Typos false positive** (`Lint`): `streaming_builder.rs:1337` has `// "ue"` in a comment (showing the literal string slice `"ue"` from `"value"`). The typos checker incorrectly flags it. Added `ue = "ue"` to `_typos.toml`.

2. **Missing `OutputConfig` fields** (`Test`): Two test structs in `logfwd-output/src/lib.rs` were missing `tenant_id`, `static_labels`, and `label_columns` fields added in the Loki PR (#1148). Added the fields as `None` to both structs.

## Test plan
- [ ] Lint: Typos check passes
- [ ] Test (Linux): logfwd-output tests compile and pass
- [ ] Test (macOS): logfwd-output tests compile and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI failures from typos false positive and missing `OutputConfig` struct fields
> - Adds `ue = "ue"` to [_typos.toml](https://github.com/strawgate/memagent/pull/1158/files#diff-e936c0fb5ab3dfb5a78d7e9b66fba7bada4187148866402e8cb2b585b5fc5799) to suppress a false positive triggered by an intentional string slice in streaming_builder tests.
> - Adds missing `tenant_id`, `static_labels`, and `label_columns` fields (set to `None`) to `OutputConfig` struct literals in [logfwd-output/src/lib.rs](https://github.com/strawgate/memagent/pull/1158/files#diff-00ddb9f7cbde401078d0410c694ec7302918c0a95336aabc22305c3084e799c9) tests, fixing compile errors after the struct was extended.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00074d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->