### PR TITLE
fix(output): add missing OutputConfig fields to test struct literals

### DIFF
--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -1210,6 +1210,9 @@ mod tests {
                 path: None,
                 index: None,
                 auth: None,
+                tenant_id: None,
+                static_labels: None,
+                label_columns: None,
             };
             let result = build_sink_factory("test", &cfg, Arc::new(ComponentStats::new()));
             assert!(result.is_err(), "Expected error for format {:?}", format);
@@ -1234,6 +1237,9 @@ mod tests {
             path: None,
             index: None,
             auth: None,
+            tenant_id: None,
+            static_labels: None,
+            label_columns: None,
         };
         let factory = build_sink_factory("test", &cfg, Arc::new(ComponentStats::new())).unwrap();
         assert_eq!(factory.name(), "test");


### PR DESCRIPTION
## Summary
- Two test functions (`test_build_sink_factory_stdout_input_only_formats` and `test_build_sink_factory_stdout_default_format`) in `crates/logfwd-output/src/lib.rs` were added without the three new `OutputConfig` fields (`tenant_id`, `static_labels`, `label_columns`) that were introduced in the Loki sink commit
- This caused CI compilation failures: `error[E0063]: missing fields label_columns, static_labels and tenant_id in initializer of logfwd_config::OutputConfig`

## Test plan
- [x] `cargo clippy -p logfwd-output -- -D warnings` passes
- [x] `cargo test -p logfwd-output` passes (167 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add missing `OutputConfig` fields to test struct literals in `logfwd-output`
> Two `OutputConfig` struct literals in the tests module of [lib.rs](https://github.com/strawgate/memagent/pull/1159/files#diff-00ddb9f7cbde401078d0410c694ec7302918c0a95336aabc22305c3084e799c9) were missing `tenant_id`, `static_labels`, and `label_columns` fields, likely causing compile errors after those fields were added to the struct. Sets all three to `None` in both test cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 222ca5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->