### PR TITLE
fix(ci): add checks:write permission for rustsec security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read  # needed by dorny/paths-filter to list changed files on bot PRs
+  checks: write        # needed by rustsec/audit-check@v2 to create check run annotations
 
 # Tool versions — bump these to upgrade across all jobs.
 env:


### PR DESCRIPTION
## Summary

The `rustsec/audit-check@v2` security audit step was failing with `Resource not accessible by integration` after recent CI fixes unblocked the fail-fast behavior.

The action requires `checks: write` permission to create GitHub Check Run annotations. The workflow only had `contents: read` and `pull-requests: read`. Adding `checks: write` fixes this.

**Note**: The audit itself shows no vulnerabilities — there's only an informational "unmaintained" warning for the `paste` transitive dependency (RUSTSEC-2024-0436), which is handled by the `deny.toml` `unmaintained = "workspace"` setting.

## Test plan
- [ ] Security audit passes in CI
- [ ] No other lint steps regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `checks: write` permission to CI workflow for rustsec audit annotations
> The `rustsec/audit-check@v2` action requires write access to GitHub Checks to create annotation runs. Adds `checks: write` to the permissions block in [ci.yml](.github/workflows/ci.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adbe519.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->