### PR TITLE
Fix work-unit: logfwd — worker_pool and sink lifecycle bugs

### DIFF
--- a/crates/logfwd-output/src/udp_sink.rs
+++ b/crates/logfwd-output/src/udp_sink.rs
@@ -157,8 +157,6 @@ impl Sink for UdpSink {
 /// Factory for creating [`UdpSink`] instances.
 ///
 /// Each call to `create()` binds a fresh UDP socket on an ephemeral port.
-/// The factory is `is_single_use() = true` because each `UdpSink` holds
-/// mutable scratch buffers — sharing across workers would require locking.
 pub struct UdpSinkFactory {
     name: String,
     target: String,
@@ -191,7 +189,7 @@ impl SinkFactory for UdpSinkFactory {
     }
 
     fn is_single_use(&self) -> bool {
-        true
+        false
     }
 }
 
@@ -286,9 +284,11 @@ mod tests {
             Arc::new(ComponentStats::new()),
         );
         assert_eq!(factory.name(), "test-udp");
-        assert!(factory.is_single_use());
+        assert!(!factory.is_single_use());
 
         let sink = factory.create().expect("create should succeed");
         assert_eq!(sink.name(), "test-udp");
+
+        let _sink2 = factory.create().expect("second create should succeed");
     }
 }

--- a/crates/logfwd/src/worker_pool.rs
+++ b/crates/logfwd/src/worker_pool.rs
@@ -537,7 +537,10 @@ async fn worker_task(
         }
     }
     // Graceful sink shutdown (flush, close connection).
-    let _ = sink.shutdown().await;
+    if let Err(e) = sink.shutdown().await {
+        tracing::error!(worker_id = id, error = %e, "worker_pool: sink shutdown failed");
+        metrics.output_error(sink.name());
+    }
 }
 
 /// Receive with idle timeout — returns `None` on timeout or channel close.
@@ -978,6 +981,7 @@ mod tests {
         name: String,
         calls: Arc<AtomicU32>,
         fail: bool,
+        fail_shutdown: bool,
     }
 
     impl Sink for CountingSink {
@@ -1007,13 +1011,21 @@ mod tests {
         }
 
         fn shutdown(&mut self) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + '_>> {
-            Box::pin(async { Ok(()) })
+            let fail_shutdown = self.fail_shutdown;
+            Box::pin(async move {
+                if fail_shutdown {
+                    Err(io::Error::other("shutdown failed"))
+                } else {
+                    Ok(())
+                }
+            })
         }
     }
 
     struct CountingSinkFactory {
         calls: Arc<AtomicU32>,
         fail: bool,
+        fail_shutdown: bool,
     }
 
     impl SinkFactory for CountingSinkFactory {
@@ -1022,6 +1034,7 @@ mod tests {
                 name: "counting".into(),
                 calls: Arc::clone(&self.calls),
                 fail: self.fail,
+                fail_shutdown: self.fail_shutdown,
             }))
         }
 
@@ -1073,6 +1086,7 @@ mod tests {
         let factory = Arc::new(CountingSinkFactory {
             calls: Arc::clone(&calls),
             fail: false,
+            fail_shutdown: false,
         });
         let mut pool = OutputWorkerPool::new(factory, 4, Duration::from_secs(60), test_metrics());
         assert_eq!(pool.worker_count(), 0);
@@ -1095,6 +1109,7 @@ mod tests {
         let factory = Arc::new(CountingSinkFactory {
             calls: Arc::clone(&calls),
             fail: false,
+            fail_shutdown: false,
         });
         // max_workers=4, but all items should go to the same worker (MRU).
         let mut pool = OutputWorkerPool::new(factory, 4, Duration::from_secs(60), test_metrics());
@@ -1118,6 +1133,7 @@ mod tests {
         let factory = Arc::new(CountingSinkFactory {
             calls: Arc::clone(&calls),
             fail: false,
+            fail_shutdown: false,
         });
         let mut pool = OutputWorkerPool::new(factory, 2, Duration::from_secs(60), test_metrics());
 
@@ -1137,6 +1153,7 @@ mod tests {
         let factory = Arc::new(CountingSinkFactory {
             calls: Arc::clone(&calls),
             fail: true,
+            fail_shutdown: false,
         });
         let mut pool = OutputWorkerPool::new(factory, 1, Duration::from_secs(60), test_metrics());
 
@@ -1157,6 +1174,7 @@ mod tests {
         let factory = Arc::new(CountingSinkFactory {
             calls: Arc::clone(&calls),
             fail: false,
+            fail_shutdown: false,
         });
         // max 2 workers
         let mut pool = OutputWorkerPool::new(factory, 2, Duration::from_secs(60), test_metrics());
@@ -1175,11 +1193,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pool_drain_propagates_shutdown_error() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let factory = Arc::new(CountingSinkFactory {
+            calls: Arc::clone(&calls),
+            fail: false,
+            fail_shutdown: true,
+        });
+
+        let meter = logfwd_test_utils::test_meter();
+        let mut pm = PipelineMetrics::new("test", "", &meter);
+        let out_stats = pm.add_output("counting", "counting");
+        let metrics = Arc::new(pm);
+
+        let mut pool = OutputWorkerPool::new(factory, 1, Duration::from_secs(60), metrics);
+
+        pool.submit(empty_work_item()).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        pool.drain(Duration::from_secs(5)).await;
+
+        assert_eq!(
+            out_stats.errors(),
+            1,
+            "expected output_error to increment stats when shutdown fails"
+        );
+    }
+
+    #[tokio::test]
     async fn pool_drain_waits_for_in_flight() {
         let calls = Arc::new(AtomicU32::new(0));
         let factory = Arc::new(CountingSinkFactory {
             calls: Arc::clone(&calls),
             fail: false,
+            fail_shutdown: false,
         });
         let mut pool = OutputWorkerPool::new(factory, 2, Duration::from_secs(60), test_metrics());
 


### PR DESCRIPTION
Fix 2 bugs in sink lifecycle management — one where shutdown errors are silently swallowed (losing buffered data) and one where a factory contract is violated.

- `worker_pool` propagates shutdown errors (log + metric)
- `UdpSinkFactory` enforces single-use contract or `is_single_use` returns `false`

---
*PR created automatically by Jules for task [6101789907915798794](https://jules.google.com/task/6101789907915798794) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `worker_pool` sink shutdown error handling and `UdpSinkFactory` reuse flag
> - Fixes `worker_task` in [worker_pool.rs](https://github.com/strawgate/memagent/pull/1161/files#diff-7aaeb25da3bfad836d812c3bfdc7af0d310b9d60b8920d9e9f07b97ab201533b) to log and record an output error metric when `sink.shutdown()` fails, rather than silently ignoring the error.
> - Fixes `UdpSinkFactory::is_single_use()` in [udp_sink.rs](https://github.com/strawgate/memagent/pull/1161/files#diff-9e3b3ad35ddc18d4aa752faef209856a84b98d4b63cdfe8f7a6f5fe7da528c80) to return `false` instead of `true`, allowing the factory to create multiple sinks.
> - Adds a `pool_drain_propagates_shutdown_error` test to verify the output error metric increments on shutdown failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a176e6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->