### PR TITLE
devcontainer: add Rust/Node/Docker setup with startup automations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "memagent",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/rust": {
+      "profile": "default"
+    },
+    "ghcr.io/devcontainers/features/node": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker": {}
+  },
+  "forwardPorts": [9090],
+  "portsAttributes": {
+    "9090": {
+      "label": "Diagnostics",
+      "onAutoForward": "silent"
+    }
+  }
+}

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -1,0 +1,30 @@
+tasks:
+  install-tools:
+    name: Install dev tools
+    description: Install just, taplo, cargo-deny, cargo-nextest, and sccache.
+    command: |
+      cargo install just taplo-cli cargo-deny cargo-nextest sccache --locked
+    triggeredBy:
+      - postDevcontainerStart
+
+  build-dashboard:
+    name: Build dashboard
+    description: |
+      Compile the Preact/TypeScript diagnostics dashboard into
+      crates/logfwd-io/src/dashboard.html. Must run before cargo build/test/clippy.
+    command: |
+      cd dashboard && npm install --prefer-offline && npm run build
+    triggeredBy:
+      - postDevcontainerStart
+    dependsOn:
+      - install-tools
+
+  cargo-check:
+    name: Cargo check
+    description: Verify the workspace compiles and warm the sccache build cache.
+    command: |
+      cargo check --all-targets
+    triggeredBy:
+      - postDevcontainerStart
+    dependsOn:
+      - build-dashboard


### PR DESCRIPTION
## What

Replaces the placeholder Dockerfile-based devcontainer with a fully functional setup using official devcontainer features, and adds `.ona/automations.yaml` to automate the startup sequence.

## Changes

**`.devcontainer/devcontainer.json`**
- Base image: `mcr.microsoft.com/devcontainers/base:ubuntu-24.04`
- Features: `rust` (stable + clippy + rustfmt), `node:lts` (dashboard build), `docker-in-docker` (ES benchmarks)
- Forwards port 9090 (diagnostics HTTP API)

**`.ona/automations.yaml`**
Three `postDevcontainerStart` tasks in dependency order:
1. `install-tools` — installs `just`, `taplo-cli`, `cargo-deny`, `cargo-nextest`, `sccache`
2. `build-dashboard` — compiles the Preact/Vite dashboard into `crates/logfwd-io/src/dashboard.html` (required before any `cargo build/test/clippy`)
3. `cargo-check` — runs `cargo check --all-targets` to warm the sccache build cache

## Verification

- `devcontainer.json` passes schema validation
- Dashboard builds successfully (`npm run build` → `dashboard.html` 111K)
- `cargo check -p logfwd-core` resolves and compiles cleanly


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add devcontainer setup with Rust, Node, and Docker with post-start build automations
> - Adds [devcontainer.json](.devcontainer/devcontainer.json) configuring an Ubuntu 24.04 environment with Rust (default profile), Node LTS, and docker-in-docker; port 9090 is forwarded silently.
> - Adds [automations.yaml](.ona/automations.yaml) with three `postDevcontainerStart` tasks: install dev tools (`just`, `taplo-cli`, `cargo-deny`, `cargo-nextest`, `sccache`), build the dashboard via `npm run build`, and run `cargo check --all-targets` to verify compilation and warm sccache.
> - Tasks run in dependency order: tool install → dashboard build → cargo check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc3e0d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->