### PR TITLE
fix(devcontainer): wire RUSTC_WRAPPER=sccache and use npm ci

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,9 @@
     },
     "ghcr.io/devcontainers/features/docker-in-docker": {}
   },
+  "remoteEnv": {
+    "RUSTC_WRAPPER": "sccache"
+  },
   "forwardPorts": [9090],
   "portsAttributes": {
     "9090": {

--- a/.ona/automations.yaml
+++ b/.ona/automations.yaml
@@ -13,7 +13,7 @@ tasks:
       Compile the Preact/TypeScript diagnostics dashboard into
       crates/logfwd-io/src/dashboard.html. Must run before cargo build/test/clippy.
     command: |
-      cd dashboard && npm install --prefer-offline && npm run build
+      cd dashboard && npm ci && npm run build
     triggeredBy:
       - postDevcontainerStart
     dependsOn:


### PR DESCRIPTION
Fixes #1223

- Add remoteEnv RUSTC_WRAPPER=sccache so cargo actually uses the installed sccache
- Use npm ci instead of npm install for reproducible lockfile installs

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire `RUSTC_WRAPPER=sccache` in devcontainer and use `npm ci` in build-dashboard task
> - Sets `RUSTC_WRAPPER=sccache` via `remoteEnv` in [devcontainer.json](https://github.com/strawgate/memagent/pull/1241/files#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686) so Cargo builds use sccache for caching.
> - Replaces `npm install --prefer-offline` with `npm ci` in the `build-dashboard` task in [automations.yaml](https://github.com/strawgate/memagent/pull/1241/files#diff-423a6c09d40a8b5a932204ad8968095a9ef4b8b84d4cbc6c293065fa79a3bbba) for deterministic, lockfile-based installs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21f3b63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->