### PR TITLE
fix(diagnostics): reject NaN at MetricBuffer push time; cap consistency retry loop

### DIFF
--- a/crates/logfwd-io/src/diagnostics.rs
+++ b/crates/logfwd-io/src/diagnostics.rs
@@ -986,14 +986,14 @@ impl DiagnosticsServer {
 
             // Compute batch latency using a consistent snapshot since they are
             // updated at different times. We retry until batches remains the same,
-            // capping at 3 attempts to avoid spinning indefinitely under contention.
+            // capping at 64 attempts to avoid spinning indefinitely under contention.
             let mut latency_batches = pm.batches_total.load(Ordering::Acquire);
             let mut batch_latency_total;
             let mut attempts = 0;
             loop {
                 batch_latency_total = pm.batch_latency_nanos_total.load(Ordering::Acquire);
                 let current_batches = pm.batches_total.load(Ordering::Acquire);
-                if current_batches == latency_batches || attempts >= 3 {
+                if current_batches == latency_batches || attempts >= 64 {
                     latency_batches = current_batches;
                     break;
                 }

--- a/crates/logfwd-io/src/metric_history.rs
+++ b/crates/logfwd-io/src/metric_history.rs
@@ -79,6 +79,12 @@ impl MetricBuffer {
 
     /// Push a new high-resolution point. Automatically downsamples to lower tiers.
     fn push(&mut self, t: f64, v: f64) {
+        if t.is_nan() {
+            return; // reject NaN timestamps — they break tier trimming
+        }
+        if v.is_nan() {
+            return; // reject NaN values — they are meaningless and pollute history
+        }
         let p = Point { t, v };
 
         // Always push to tier 0 (highest resolution).


### PR DESCRIPTION
Fixes #1216

- Reject NaN timestamps at push() time to prevent unbounded tier growth in `Tier::trim()` (NaN < cutoff is always false, so entries never get trimmed)
- Also reject NaN values at push() time as additional defense
- Update consistency retry loop cap from 3 to 64 iterations in diagnostics.rs
- Retain existing NaN filter in `points()` as defense-in-depth (belt-and-suspenders)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject NaN values in `MetricBuffer.push` and cap consistency retry loop at 64 attempts
> - Adds early returns in [`MetricBuffer.push`](https://github.com/strawgate/memagent/pull/1245/files#diff-c7d6a60df05d8928cf0ac5235774ab21f44def54bb5d5640cfc0266794119eb3) to discard any sample where the timestamp or value is NaN, preventing NaN propagation into downsampling tiers.
> - Increases the consistency retry cap in the batch latency computation in [`DiagnosticsServer`](https://github.com/strawgate/memagent/pull/1245/files#diff-6bb180a311d04982be05f9e192221a4f2c0d9b4f6733fa3f46f63229ef488cdb) from 3 to 64 attempts, reducing the chance of returning an inconsistent snapshot under contention.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9249ef1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->