### PR TITLE
bench: Fix black_box usage and justfile race condition

### DIFF
--- a/crates/logfwd-bench/benches/batch_formation.rs
+++ b/crates/logfwd-bench/benches/batch_formation.rs
@@ -33,9 +33,11 @@ fn bench_batch_scan(c: &mut Criterion) {
             let data_bytes = bytes::Bytes::from(data.clone());
             let mut scanner = Scanner::new(ScanConfig::default());
             b.iter(|| {
-                scanner
-                    .scan_detached(data_bytes.clone())
-                    .expect("scan should not fail")
+                std::hint::black_box(
+                    scanner
+                        .scan_detached(data_bytes.clone())
+                        .expect("scan should not fail"),
+                )
             });
         });
     }
@@ -70,7 +72,7 @@ fn bench_batch_transform(c: &mut Criterion) {
                     .scan_detached(data_bytes.clone())
                     .expect("scan should not fail");
                 let result = transform.execute_blocking(batch).unwrap();
-                sink.send_batch(&result, &meta).unwrap();
+                std::hint::black_box(sink.send_batch(&result, &meta).unwrap());
             });
         });
 
@@ -86,7 +88,7 @@ fn bench_batch_transform(c: &mut Criterion) {
                     .scan_detached(data_bytes.clone())
                     .expect("scan should not fail");
                 let result = transform.execute_blocking(batch).unwrap();
-                sink.send_batch(&result, &meta).unwrap();
+                std::hint::black_box(sink.send_batch(&result, &meta).unwrap());
             });
         });
     }

--- a/crates/logfwd-bench/benches/builder_compare.rs
+++ b/crates/logfwd-bench/benches/builder_compare.rs
@@ -201,12 +201,12 @@ fn bench_scan(c: &mut Criterion) {
 
         group.bench_function(BenchmarkId::new("streaming", name), |b| {
             let mut scanner = Scanner::new(ScanConfig::default());
-            b.iter(|| scanner.scan(buf.clone()).unwrap());
+            b.iter(|| std::hint::black_box(scanner.scan(buf.clone()).unwrap()));
         });
 
         group.bench_function(BenchmarkId::new("scan_detached", name), |b| {
             let mut scanner = Scanner::new(ScanConfig::default());
-            b.iter(|| scanner.scan_detached(buf.clone()).unwrap());
+            b.iter(|| std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap()));
         });
     }
 
@@ -237,7 +237,7 @@ fn bench_persist(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("streaming", name), |b| {
             let mut scanner = Scanner::new(ScanConfig::default());
             b.iter(|| {
-                let batch = scanner.scan(buf.clone()).unwrap();
+                let batch = std::hint::black_box(scanner.scan(buf.clone()).unwrap());
                 let owned = logfwd_arrow::materialize::detach(&batch);
                 let compressed = write_ipc_zstd(&owned);
                 std::hint::black_box(compressed.len());
@@ -248,7 +248,7 @@ fn bench_persist(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("scan_detached", name), |b| {
             let mut scanner = Scanner::new(ScanConfig::default());
             b.iter(|| {
-                let batch = scanner.scan_detached(buf.clone()).unwrap();
+                let batch = std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap());
                 let compressed = write_ipc_zstd(&batch);
                 std::hint::black_box(compressed.len());
             });
@@ -277,7 +277,7 @@ fn bench_pipeline(c: &mut Criterion) {
         let mut scanner = Scanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         b.iter(|| {
-            let batch = scanner.scan(buf.clone()).unwrap();
+            let batch = std::hint::black_box(scanner.scan(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let owned = detach_if_attached(&transformed, &buf);
             let compressed = write_ipc_zstd(&owned);
@@ -289,7 +289,7 @@ fn bench_pipeline(c: &mut Criterion) {
         let mut scanner = Scanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         b.iter(|| {
-            let batch = scanner.scan_detached(buf.clone()).unwrap();
+            let batch = std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let compressed = write_ipc_zstd(&transformed);
             std::hint::black_box(compressed.len());
@@ -302,7 +302,7 @@ fn bench_pipeline(c: &mut Criterion) {
         let mut scanner = Scanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs WHERE level = 'ERROR'").unwrap();
         b.iter(|| {
-            let batch = scanner.scan(buf.clone()).unwrap();
+            let batch = std::hint::black_box(scanner.scan(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let owned = detach_if_attached(&transformed, &buf);
             let compressed = write_ipc_zstd(&owned);
@@ -314,7 +314,7 @@ fn bench_pipeline(c: &mut Criterion) {
         let mut scanner = Scanner::new(ScanConfig::default());
         let mut transform = SqlTransform::new("SELECT * FROM logs WHERE level = 'ERROR'").unwrap();
         b.iter(|| {
-            let batch = scanner.scan_detached(buf.clone()).unwrap();
+            let batch = std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let compressed = write_ipc_zstd(&transformed);
             std::hint::black_box(compressed.len());
@@ -330,7 +330,7 @@ fn bench_pipeline(c: &mut Criterion) {
         )
         .unwrap();
         b.iter(|| {
-            let batch = scanner.scan(buf.clone()).unwrap();
+            let batch = std::hint::black_box(scanner.scan(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let owned = detach_if_attached(&transformed, &buf);
             let compressed = write_ipc_zstd(&owned);
@@ -345,7 +345,7 @@ fn bench_pipeline(c: &mut Criterion) {
         )
         .unwrap();
         b.iter(|| {
-            let batch = scanner.scan_detached(buf.clone()).unwrap();
+            let batch = std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let compressed = write_ipc_zstd(&transformed);
             std::hint::black_box(compressed.len());

--- a/crates/logfwd-bench/benches/full_chain.rs
+++ b/crates/logfwd-bench/benches/full_chain.rs
@@ -70,7 +70,7 @@ fn bench_json_chain(c: &mut Criterion) {
                     .scan_detached(data_bytes.clone())
                     .expect("scan should not fail");
                 let result = transform.execute_blocking(batch).unwrap();
-                sink.encode_batch(&result, &meta);
+                std::hint::black_box(sink.encode_batch(&result, &meta));
             });
         });
 
@@ -81,9 +81,11 @@ fn bench_json_chain(c: &mut Criterion) {
             let data_bytes = bytes::Bytes::from(data.clone());
             let mut scanner = Scanner::new(ScanConfig::default());
             b.iter(|| {
-                scanner
-                    .scan_detached(data_bytes.clone())
-                    .expect("scan should not fail")
+                std::hint::black_box(
+                    scanner
+                        .scan_detached(data_bytes.clone())
+                        .expect("scan should not fail"),
+                )
             });
         });
 
@@ -105,7 +107,7 @@ fn bench_json_chain(c: &mut Criterion) {
             &transformed,
             |b, batch| {
                 let mut sink = make_otlp_sink(Compression::None);
-                b.iter(|| sink.encode_batch(batch, &meta));
+                b.iter(|| std::hint::black_box(sink.encode_batch(batch, &meta)));
             },
         );
     }
@@ -140,7 +142,7 @@ fn bench_cri_chain(c: &mut Criterion) {
                     .scan_detached(bytes::Bytes::from(json))
                     .expect("scan should not fail");
                 let result = transform.execute_blocking(batch).unwrap();
-                sink.encode_batch(&result, &meta);
+                std::hint::black_box(sink.encode_batch(&result, &meta));
             });
         });
 
@@ -184,7 +186,7 @@ fn bench_grok_chain(c: &mut Criterion) {
                     .scan_detached(data_bytes.clone())
                     .expect("scan should not fail");
                 let result = transform.execute_blocking(batch).unwrap();
-                sink.send_batch(&result, &meta).unwrap();
+                std::hint::black_box(sink.send_batch(&result, &meta).unwrap());
                 // Also serialize to JSON to measure the full output path
                 let cols = logfwd_output::build_col_infos(&result);
                 buf.clear();

--- a/crates/logfwd-bench/benches/output_encode.rs
+++ b/crates/logfwd-bench/benches/output_encode.rs
@@ -78,7 +78,7 @@ fn bench_output_encode(c: &mut Criterion) {
                 |b, batch| {
                     let mut sink = make_otlp_sink(Compression::None);
                     b.iter(|| {
-                        sink.encode_batch(batch, &meta);
+                        std::hint::black_box(sink.encode_batch(batch, &meta));
                     });
                 },
             );

--- a/crates/logfwd-bench/benches/pipeline.rs
+++ b/crates/logfwd-bench/benches/pipeline.rs
@@ -97,7 +97,7 @@ fn bench_cri(c: &mut Criterion) {
                     }
                     start = end + 1;
                 }
-                count
+                std::hint::black_box(count);
             });
         });
 
@@ -151,20 +151,20 @@ fn bench_transform(c: &mut Criterion) {
     group.throughput(Throughput::Elements(n as u64));
     group.bench_function("select_star", |b| {
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
-        b.iter(|| transform.execute_blocking(batch.clone()).unwrap());
+        b.iter(|| std::hint::black_box(transform.execute_blocking(batch.clone()).unwrap()));
     });
 
     // Filter
     group.bench_function("where_filter", |b| {
         let mut transform = SqlTransform::new("SELECT * FROM logs WHERE level = 'ERROR'").unwrap();
-        b.iter(|| transform.execute_blocking(batch.clone()).unwrap());
+        b.iter(|| std::hint::black_box(transform.execute_blocking(batch.clone()).unwrap()));
     });
 
     // Projection + computed column
     group.bench_function("projection_computed", |b| {
         let mut transform =
             SqlTransform::new("SELECT level, message, status, duration_ms FROM logs").unwrap();
-        b.iter(|| transform.execute_blocking(batch.clone()).unwrap());
+        b.iter(|| std::hint::black_box(transform.execute_blocking(batch.clone()).unwrap()));
     });
 
     // regexp_extract
@@ -174,7 +174,7 @@ fn bench_transform(c: &mut Criterion) {
              regexp_extract(message, '(GET|POST) (\\S+)', 2) AS path FROM logs",
         )
         .unwrap();
-        b.iter(|| transform.execute_blocking(batch.clone()).unwrap());
+        b.iter(|| std::hint::black_box(transform.execute_blocking(batch.clone()).unwrap()));
     });
 
     // grok
@@ -183,7 +183,7 @@ fn bench_transform(c: &mut Criterion) {
             "SELECT grok(message, '%{WORD:method} %{URIPATH:path} %{WORD:proto}') AS parsed FROM logs",
         )
         .unwrap();
-        b.iter(|| transform.execute_blocking(batch.clone()).unwrap());
+        b.iter(|| std::hint::black_box(transform.execute_blocking(batch.clone()).unwrap()));
     });
 
     group.finish();
@@ -231,7 +231,7 @@ fn bench_output(c: &mut Criterion) {
     group.throughput(Throughput::Elements(n as u64));
     group.bench_function("null_sink", |b| {
         let mut sink = NullSink;
-        b.iter(|| sink.send_batch(&batch, &meta).unwrap());
+        b.iter(|| std::hint::black_box(sink.send_batch(&batch, &meta).unwrap()));
     });
 
     // JSON serialization via write_row_json (measures build_col_infos + per-row dispatch)
@@ -241,7 +241,7 @@ fn bench_output(c: &mut Criterion) {
         b.iter(|| {
             buf.clear();
             for row in 0..batch.num_rows() {
-                let _ = logfwd_output::write_row_json(&batch, row, &cols, &mut buf);
+                logfwd_output::write_row_json(&batch, row, &cols, &mut buf).unwrap();
                 buf.push(b'\n');
             }
             std::hint::black_box(buf.len());

--- a/crates/logfwd-bench/benches/throughput_ceiling.rs
+++ b/crates/logfwd-bench/benches/throughput_ceiling.rs
@@ -88,7 +88,7 @@ fn bench_ceiling_by_schema(c: &mut Criterion) {
                 let batch = scanner
                     .scan_detached(buf.clone())
                     .expect("scan should not fail");
-                sink.send_batch(&batch, &meta).unwrap();
+                std::hint::black_box(sink.send_batch(&batch, &meta).unwrap());
             });
         });
 
@@ -101,7 +101,7 @@ fn bench_ceiling_by_schema(c: &mut Criterion) {
                 let batch = scanner
                     .scan_detached(buf.clone())
                     .expect("scan should not fail");
-                sink.send_batch(&batch, &meta).unwrap();
+                std::hint::black_box(sink.send_batch(&batch, &meta).unwrap());
             });
         });
     }
@@ -132,7 +132,7 @@ fn bench_ceiling_by_batch_size(c: &mut Criterion) {
                 let batch = scanner
                     .scan_detached(buf.clone())
                     .expect("scan should not fail");
-                sink.send_batch(&batch, &meta).unwrap();
+                std::hint::black_box(sink.send_batch(&batch, &meta).unwrap());
             });
         });
     }
@@ -162,7 +162,7 @@ fn bench_ceiling_by_scan_config(c: &mut Criterion) {
             let batch = scanner
                 .scan_detached(buf.clone())
                 .expect("scan should not fail");
-            sink.send_batch(&batch, &meta).unwrap();
+            std::hint::black_box(sink.send_batch(&batch, &meta).unwrap());
         });
     });
 
@@ -175,7 +175,7 @@ fn bench_ceiling_by_scan_config(c: &mut Criterion) {
             let batch = scanner
                 .scan_detached(buf.clone())
                 .expect("scan should not fail");
-            sink.send_batch(&batch, &meta).unwrap();
+            std::hint::black_box(sink.send_batch(&batch, &meta).unwrap());
         });
     });
 
@@ -188,7 +188,7 @@ fn bench_ceiling_by_scan_config(c: &mut Criterion) {
             let batch = scanner
                 .scan_detached(buf.clone())
                 .expect("scan should not fail");
-            sink.send_batch(&batch, &meta).unwrap();
+            std::hint::black_box(sink.send_batch(&batch, &meta).unwrap());
         });
     });
 
@@ -215,7 +215,7 @@ fn bench_ceiling_by_scan_mode(c: &mut Criterion) {
         let mut sink = NullSink;
         b.iter(|| {
             let batch = scanner.scan(buf.clone()).expect("scan should not fail");
-            sink.send_batch(&batch, &meta).unwrap();
+            std::hint::black_box(sink.send_batch(&batch, &meta).unwrap());
         });
     });
 
@@ -226,7 +226,7 @@ fn bench_ceiling_by_scan_mode(c: &mut Criterion) {
             let batch = scanner
                 .scan_detached(buf.clone())
                 .expect("scan should not fail");
-            sink.send_batch(&batch, &meta).unwrap();
+            std::hint::black_box(sink.send_batch(&batch, &meta).unwrap());
         });
     });
 
@@ -274,7 +274,7 @@ fn bench_bottleneck_isolation(c: &mut Criterion) {
 
     group.bench_function(BenchmarkId::new("null_sink_only", n), |b| {
         let mut sink = NullSink;
-        b.iter(|| sink.send_batch(&batch, &meta).unwrap());
+        b.iter(|| std::hint::black_box(sink.send_batch(&batch, &meta).unwrap()));
     });
 
     group.finish();

--- a/crates/logfwd-bench/benches/transform_overhead.rs
+++ b/crates/logfwd-bench/benches/transform_overhead.rs
@@ -228,7 +228,7 @@ fn bench_context_reuse(c: &mut Criterion) {
             transform.execute_blocking(batch.clone()).expect("warmup");
 
             b.iter(|| {
-                transform.execute_blocking(batch.clone()).expect("execute");
+                std::hint::black_box(transform.execute_blocking(batch.clone()).expect("execute"));
             });
         });
 
@@ -236,7 +236,7 @@ fn bench_context_reuse(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("cold_start", name), |b| {
             b.iter(|| {
                 let mut transform = SqlTransform::new(sql).expect("sql");
-                transform.execute_blocking(batch.clone()).expect("execute");
+                std::hint::black_box(transform.execute_blocking(batch.clone()).expect("execute"));
             });
         });
     }
@@ -257,7 +257,7 @@ fn bench_batch_size_scaling(c: &mut Criterion) {
             let mut transform = SqlTransform::new("SELECT * FROM logs").expect("sql");
             transform.execute_blocking(batch.clone()).expect("warmup");
             b.iter(|| {
-                transform.execute_blocking(batch.clone()).expect("execute");
+                std::hint::black_box(transform.execute_blocking(batch.clone()).expect("execute"));
             });
         });
 
@@ -266,7 +266,7 @@ fn bench_batch_size_scaling(c: &mut Criterion) {
                 SqlTransform::new("SELECT * FROM logs WHERE level = 'ERROR'").expect("sql");
             transform.execute_blocking(batch.clone()).expect("warmup");
             b.iter(|| {
-                transform.execute_blocking(batch.clone()).expect("execute");
+                std::hint::black_box(transform.execute_blocking(batch.clone()).expect("execute"));
             });
         });
 
@@ -276,7 +276,7 @@ fn bench_batch_size_scaling(c: &mut Criterion) {
                     .expect("sql");
             transform.execute_blocking(batch.clone()).expect("warmup");
             b.iter(|| {
-                transform.execute_blocking(batch.clone()).expect("execute");
+                std::hint::black_box(transform.execute_blocking(batch.clone()).expect("execute"));
             });
         });
     }
@@ -338,7 +338,7 @@ fn bench_query_complexity(c: &mut Criterion) {
             let mut transform = SqlTransform::new(sql).expect("sql");
             transform.execute_blocking(batch.clone()).expect("warmup");
             b.iter(|| {
-                transform.execute_blocking(batch.clone()).expect("execute");
+                std::hint::black_box(transform.execute_blocking(batch.clone()).expect("execute"));
             });
         });
     }

--- a/crates/logfwd-bench/src/es_throughput.rs
+++ b/crates/logfwd-bench/src/es_throughput.rs
@@ -127,11 +127,11 @@ fn run_worker(
         observed_time_ns: 0,
     };
 
-    let line_buf = gen_json_lines(batch_lines);
+    let line_bytes = bytes::Bytes::from(gen_json_lines(batch_lines));
     let deadline = Instant::now() + duration;
 
     while Instant::now() < deadline {
-        let batch = match scanner.scan_detached(bytes::Bytes::from(line_buf.clone())) {
+        let batch = match scanner.scan_detached(line_bytes.clone()) {
             Ok(b) => b,
             Err(e) => {
                 eprintln!("[worker {worker_id}] scan error: {e}");

--- a/justfile
+++ b/justfile
@@ -96,7 +96,13 @@ _bench-pair name rx_config tx_config seconds="10":
     set -euo pipefail
     LOGFWD=./target/release/logfwd
     $LOGFWD --config {{rx_config}} &
-    RX=$!; sleep 1
+    RX=$!; sleep 5
+    for i in $(seq 1 10); do
+        if curl -sf http://127.0.0.1:9091/api/stats > /dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
     $LOGFWD --config {{tx_config}} &
     TX=$!; sleep {{seconds}}
     STATS=$(curl -s http://127.0.0.1:9091/api/stats 2>/dev/null || echo '{}')


### PR DESCRIPTION
Fixes GitHub issue #1238.

This PR addresses all items in Phase 1e:
- Wraps measured results in `black_box()` across the criterion benchmark suite to ensure computations are preserved and accurately measured.
- Refactors the `es_throughput` benchmark to avoid a costly hot-loop clone of a 1.3 MB buffer.
- Updates `justfile`'s `_bench-pair` command to robustly wait for server startup (using a `curl` readiness probe loop) instead of an inadequate static wait.

Tested via `cargo test`, `cargo clippy`, and `cargo fmt`.

---
*PR created automatically by Jules for task [5140843062619348243](https://jules.google.com/task/5140843062619348243) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `black_box` usage in benchmarks and justfile race condition in `_bench-pair`
> - Wraps benchmark return values in `std::hint::black_box` across all benchmark files to prevent the compiler from optimizing away measured work.
> - Updates the `_bench-pair` justfile recipe to poll the RX stats endpoint (up to 10 times) before starting TX, replacing a fixed 1-second sleep with a 5-second initial wait plus readiness loop.
> - Behavioral Change: the `json_serialize` benchmark in [pipeline.rs](https://github.com/strawgate/memagent/pull/1249/files#diff-103c452bc3ac55ac40f7effa04ebf390d97be0cbd29c0e6d1d35ad37d6c14a28) now panics on JSON serialization errors instead of silently ignoring them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4ed656.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->