### PR TITLE
fix(otlp): enable reqwest http2 feature for gRPC support

### DIFF
--- a/crates/logfwd-output/Cargo.toml
+++ b/crates/logfwd-output/Cargo.toml
@@ -24,7 +24,7 @@ memchr = "2"
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "time", "io-std", "io-util"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip", "json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "http2", "gzip", "json", "stream"] }
 flate2 = "1"
 tokio-stream = "0.1.18"
 

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -280,7 +280,14 @@ impl OtlpSink {
         }
         req = req.header("Content-Type", content_type);
         if payload_is_compressed {
-            req = req.header("Content-Encoding", "zstd");
+            // gRPC compression is signaled via the wire-frame compressed flag byte
+            // and the `grpc-encoding` header (per the gRPC-over-HTTP/2 spec).
+            // Plain HTTP/protobuf uses `Content-Encoding` instead.
+            if self.protocol == OtlpProtocol::Grpc {
+                req = req.header("grpc-encoding", "zstd");
+            } else {
+                req = req.header("Content-Encoding", "zstd");
+            }
         }
 
         match req.body(payload.to_vec()).send().await {


### PR DESCRIPTION
Fixes #1228

## What was broken

Two bugs made gRPC-mode OTLP non-functional:

### Bug 1 — reqwest built without HTTP/2 (`Cargo.toml`)

`reqwest` was declared with `default-features = false` and the feature list `["rustls-tls", "gzip", "json", "stream"]`. The `http2` feature was absent, so reqwest's HTTP/2 support (required by gRPC) was compiled out. Any attempt to send a gRPC request would fail at the transport layer.

**Fix:** Add `"http2"` to the reqwest feature list.

### Bug 2 — Wrong compression header for gRPC (`otlp_sink.rs`)

When using gRPC + zstd compression the code added `Content-Encoding: zstd` as an HTTP header. This is incorrect: `Content-Encoding` is a plain HTTP mechanism. The gRPC-over-HTTP/2 spec signals message-level compression via the `grpc-encoding` header (while the compressed flag byte in the 5-byte length-prefixed frame tells the receiver whether the payload is compressed). Sending `Content-Encoding` to a gRPC endpoint causes receivers to reject or misparse the message.

**Fix:** Emit `grpc-encoding: zstd` for gRPC and `Content-Encoding: zstd` for plain HTTP/protobuf.

## Verification

- `cargo build -p logfwd-output` — clean
- `cargo test -p logfwd-output --lib` — 158 tests pass
- `cargo clippy -p logfwd-output -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gRPC compression header in `OtlpSink.send_payload` to use `grpc-encoding`
> - Fixes incorrect use of `Content-Encoding: zstd` for gRPC payloads in [otlp_sink.rs](https://github.com/strawgate/memagent/pull/1250/files#diff-56ca7e19db98793b4ef621c0d28a618a4c8af2bd492bc89cc8a21e845f25a43c); gRPC now sends `grpc-encoding: zstd` while non-gRPC protocols continue to use `Content-Encoding: zstd`.
> - Enables the `http2` feature on the `reqwest` 0.12 dependency in [Cargo.toml](https://github.com/strawgate/memagent/pull/1250/files#diff-38ee22c36dedec0020da943c2ac0eecd733961ae65e2c6b2c10cdc72d7a5f5ab), which is required for gRPC transport.
> - Behavioral Change: compressed gRPC requests will now send a different header than before; receivers that relied on `Content-Encoding` for gRPC decompression will no longer see that header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24118d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->