### PR TITLE
fix(checkpoint): harden segment storage — validation, replay caps, and overflow safety

### DIFF
--- a/crates/logfwd-io/src/segment.rs
+++ b/crates/logfwd-io/src/segment.rs
@@ -408,15 +408,15 @@ impl SegmentFile {
         })
     }
 
-    /// Read all RecordBatches from a validated segment.
-    ///
-    /// Each `append()` wrote an independent IPC stream (schema + batch + EOS),
-    /// so we create a new `StreamReader` for each sub-stream using a shared
-    /// cursor that tracks the read position across streams.
     /// Maximum data_size we'll allocate for reading (1 GiB).
     /// Defense-in-depth against corrupt footer claiming enormous size.
     const MAX_READ_DATA_SIZE: u64 = 1024 * 1024 * 1024;
 
+    /// Read all `RecordBatch` values from a validated segment.
+    ///
+    /// Each `append()` wrote an independent IPC stream (schema + batch + EOS),
+    /// so this replays the segment by opening a fresh `StreamReader` for each
+    /// sub-stream while a shared cursor tracks the byte position.
     pub fn read_batches(&self) -> io::Result<Vec<RecordBatch>> {
         if self.footer.data_size > Self::MAX_READ_DATA_SIZE {
             return Err(io::Error::new(
@@ -588,7 +588,10 @@ impl SegmentWriter {
             .map_err(|e| io::Error::other(e.to_string()))?;
 
         // Enforce the read-time limit so every written segment can be replayed.
-        let new_data_size = self.data_size + self.ipc_buf.len() as u64;
+        let new_data_size = self
+            .data_size
+            .checked_add(self.ipc_buf.len() as u64)
+            .ok_or_else(|| io::Error::other("segment data_size overflow"))?;
         if new_data_size > SegmentFile::MAX_READ_DATA_SIZE {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -602,8 +605,14 @@ impl SegmentWriter {
         self.writer.write_all(&self.ipc_buf)?;
         self.hasher.update(&self.ipc_buf);
 
-        self.record_count += batch.num_rows() as u64;
-        self.batch_count += 1;
+        self.record_count = self
+            .record_count
+            .checked_add(batch.num_rows() as u64)
+            .ok_or_else(|| io::Error::other("segment record_count overflow"))?;
+        self.batch_count = self
+            .batch_count
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("segment batch_count overflow"))?;
         self.data_size = new_data_size;
 
         Ok(())
@@ -758,7 +767,6 @@ impl SegmentManager {
             .next_segment_id
             .checked_add(1)
             .ok_or_else(|| io::Error::other("segment ID overflow: u64::MAX reached"))?;
-
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -1319,10 +1327,9 @@ mod tests {
     }
 
     #[test]
-    fn open_new_segment_overflow_safety() {
+    fn open_new_segment_overflow_has_no_side_effects() {
         let dir = tempfile::tempdir().unwrap();
         let seg_dir = dir.path().join("segments");
-
         let policy = RotationPolicy::default();
         // Start with next_segment_id at u64::MAX — open_new_segment must fail
         // before creating a file or mutating manager state.
@@ -1338,5 +1345,19 @@ mod tests {
             !seg_dir.exists() || fs::read_dir(&seg_dir).unwrap().next().is_none(),
             "overflow must not leave a partially opened segment on disk"
         );
+    }
+
+    #[test]
+    fn open_new_segment_private_overflow_has_no_side_effects() {
+        let dir = tempfile::tempdir().unwrap();
+        let seg_dir = dir.path().join("segments");
+        let policy = RotationPolicy::default();
+        let mut mgr = SegmentManager::new(seg_dir.clone(), policy, 0, 1).unwrap();
+        mgr.next_segment_id = u64::MAX;
+
+        let err = mgr.open_new_segment().unwrap_err();
+        assert!(err.to_string().contains("segment ID overflow"));
+        assert!(mgr.current.is_none());
+        assert_eq!(fs::read_dir(&seg_dir).unwrap().count(), 0);
     }
 }


### PR DESCRIPTION
Fixes #1211

## Summary

This PR hardens segment storage so corrupt on-disk metadata and impossible segment ID states fail closed instead of creating unreadable files, exhausting memory, or leaving partial state behind.

## What this branch fixes

1. Caps `read_batches()` preallocation so a corrupt footer cannot request an enormous `Vec` allocation.
2. Validates segment headers before `SegmentWriter::create()` writes a file, preventing unreadable segments from being created.
3. Enforces the replayability cap in `append()` so we do not write segments that `read_batches()` must later reject.
4. Distinguishes unsupported-but-valid headers and non-`NotFound` I/O failures from `NotASegment`, improving recovery diagnostics.
5. Avoids truncating `bytes_to_hash` on 32-bit platforms.
6. Checks `next_segment_id` overflow before file creation or manager mutation, so overflow leaves no orphaned file or half-open segment.
7. Preserves the underlying seek error details during checksum verification.
8. Replaces the remaining writer-side unchecked size/counter increments with `checked_add` guard rails.

## Additional polish in this pass

- Puts the `read_batches()` docs on the public API instead of on the internal size cap constant.
- Adds focused regression tests for:
  - invalid header version rejection
  - unknown flag rejection
  - append size-cap enforcement
  - no-ZSTD writer path
  - overflow with no side effects through both the public append path and the internal open path

## Verification

- `cargo fmt --all`
- `cargo test -p logfwd-io --lib segment -- --nocapture`
- `cargo clippy -p logfwd-io --lib -- -D warnings`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden segment storage with validation, replay caps, and overflow safety
> - Expands segment filename zero-padding from 10 to 20 digits in [`segment.rs`](https://github.com/strawgate/memagent/pull/1251/files#diff-1aab6b5347baf9761af45286454562e02fbc2212a96b37641264b86487e8eff4) to cover the full u64 range and maintain lexicographic sort order
> - `SegmentFile::open` now returns `Corrupt` with detailed diagnostics for most IO/parse failures, and `Incomplete` on `UnexpectedEof`, rather than generic errors
> - `SegmentWriter::create` rejects unsupported versions and unknown flag bits with `InvalidInput`; `append` now respects the `FLAG_ZSTD` header flag for conditional compression and enforces `MAX_READ_DATA_SIZE`
> - `SegmentFile::read_batches` caps pre-allocated batch vector capacity at 65536 to avoid trusting unbounded on-disk counts
> - All u64/usize arithmetic in segment ID generation, size tracking, and checksum computation uses `checked_add` to return errors instead of wrapping on overflow
> - Behavioral Change: segment filenames change from 10-digit to 20-digit padding; existing filenames with 10-digit padding will no longer sort correctly relative to new ones
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8eaee6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->