### PR TITLE
perf(scanner): replace SipHash with AHash for field resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
 name = "logfwd-arrow"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "arrow",
  "bytes",
  "logfwd-core",

--- a/crates/logfwd-arrow/Cargo.toml
+++ b/crates/logfwd-arrow/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 logfwd-core = { version = "0.1.0", path = "../logfwd-core" }
+ahash = "0.8"
 arrow = { workspace = true }
 bytes = "1"
 

--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -7,7 +7,7 @@
 //
 // For the hot pipeline path: scan -> query -> output -> discard.
 
-use std::collections::HashMap;
+use ahash::AHashMap;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Float64Array, Int64Array, StringViewBuilder, StructArray};
@@ -92,7 +92,7 @@ impl FieldColumns {
 /// ```
 pub struct StreamingBuilder {
     fields: Vec<FieldColumns>,
-    field_index: HashMap<Vec<u8>, usize>,
+    field_index: AHashMap<Vec<u8>, usize>,
     /// Number of fields active in the current batch. Slots `0..num_active` in
     /// `fields` are in use; slots beyond that are pre-allocated but dormant.
     /// Resetting this to zero on `begin_batch` — together with clearing
@@ -132,7 +132,7 @@ impl StreamingBuilder {
     pub fn new(keep_raw: bool) -> Self {
         StreamingBuilder {
             fields: Vec::with_capacity(32),
-            field_index: HashMap::with_capacity(32),
+            field_index: AHashMap::with_capacity(32),
             num_active: 0,
             row_count: 0,
             written_bits: 0,


### PR DESCRIPTION
## Summary

Replace `std::collections::HashMap` with `ahash::AHashMap` in `StreamingBuilder::resolve_field` — the #1 hot spot in the scanner path (20.1% of total CPU).

## Change

- **3 lines changed** in `streaming_builder.rs`: swap `HashMap` → `AHashMap`, `use std::collections::HashMap` → `use ahash::AHashMap`
- Add `ahash = "0.8"` to `logfwd-arrow/Cargo.toml` (already a transitive dep via hashbrown/arrow)

## Why

CPU profiling (macOS `sample`, generator passthrough, single-core) shows `resolve_field` consuming 292/1449 samples (20.1%) — dominated by SipHash computation and key comparison. SipHash provides HashDoS resistance, which is unnecessary for trusted internal field-name lookups. AHash uses AES-NI/NEON hardware intrinsics, ideal for short keys.

## Criterion Results (vs saved baseline)

| Benchmark | Time Δ | Throughput Δ |
|-----------|--------|-------------|
| Narrow 5f pushdown | **−16.6%** | **+19.9%** (464→556 MiB/s) |
| Narrow 5f SELECT * | **−17.3%** | **+21.0%** (354→437 MiB/s) |
| Wide 55f SELECT * | **−23.1%** | **+30.0%** (690→897 MiB/s) |
| CRI K8s 8f pushdown | −7.0% | +7.4% (879→950 MiB/s) |
| Escape-heavy SELECT * | −20.4% | +25.7% (102→128 MiB/s) |

Wide schemas benefit most (more fields = more HashMap lookups per row).

## Test Plan

- `cargo test -p logfwd-arrow` — all 33 tests pass (unit + allocation regression)
- `cargo clippy -p logfwd-arrow --lib` — zero warnings
- Criterion scanner benchmarks show consistent improvement across all schema shapes
- `cargo deny check` — passes (ahash already in dep tree)

Closes #1252
Relates to #1173

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace SipHash with AHash for `StreamingBuilder` field index lookups
> Swaps `std::collections::HashMap` for `ahash::AHashMap` in [streaming_builder.rs](https://github.com/strawgate/memagent/pull/1253/files#diff-05a83edf355d162945f5713b5186fd14c583cb463359f1d3252e5efac352170d) to use a faster, non-cryptographic hash for the `field_index` map. AHash is significantly faster than the default SipHash for short byte-key lookups in hot paths like field resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9df353.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->