### PR TITLE
fix(turmoil): use tokio::time::Instant so simulation advances correctly

### DIFF
--- a/crates/logfwd/src/batch_accumulator.rs
+++ b/crates/logfwd/src/batch_accumulator.rs
@@ -5,7 +5,6 @@
 //! based on size threshold or timeout.
 
 use std::collections::HashMap;
-use std::time::Instant;
 
 use bytes::{Bytes, BytesMut};
 use logfwd_core::pipeline::SourceId;
@@ -17,7 +16,8 @@ pub enum AccumulatorAction {
     Flush {
         data: Bytes,
         checkpoints: HashMap<SourceId, ByteOffset>,
-        queued_at: Option<Instant>,
+        /// Uses tokio::time::Instant so elapsed() measures simulated time under Turmoil.
+        queued_at: Option<tokio::time::Instant>,
         reason: &'static str,
     },
     /// Not enough data yet.
@@ -27,7 +27,8 @@ pub enum AccumulatorAction {
 pub struct BatchAccumulator {
     buf: BytesMut,
     checkpoints: HashMap<SourceId, ByteOffset>,
-    queued_at: Option<Instant>,
+    /// Uses tokio::time::Instant so elapsed() measures simulated time under Turmoil.
+    queued_at: Option<tokio::time::Instant>,
     batch_target_bytes: usize,
 }
 
@@ -46,7 +47,7 @@ impl BatchAccumulator {
         &mut self,
         bytes: Bytes,
         input_checkpoints: Vec<(SourceId, ByteOffset)>,
-        queued_at: Instant,
+        queued_at: tokio::time::Instant,
     ) -> AccumulatorAction {
         if self.queued_at.is_none() {
             self.queued_at = Some(queued_at);
@@ -73,7 +74,13 @@ impl BatchAccumulator {
     }
 
     /// Force-drain remaining data (shutdown path).
-    pub fn drain(&mut self) -> Option<(Bytes, HashMap<SourceId, ByteOffset>, Option<Instant>)> {
+    pub fn drain(
+        &mut self,
+    ) -> Option<(
+        Bytes,
+        HashMap<SourceId, ByteOffset>,
+        Option<tokio::time::Instant>,
+    )> {
         if self.buf.is_empty() {
             return None;
         }
@@ -118,7 +125,7 @@ mod tests {
         let result = acc.ingest(
             Bytes::from_static(b"hello\n"),
             vec![(sid(1), ByteOffset(6))],
-            Instant::now(),
+            tokio::time::Instant::now(),
         );
         assert!(matches!(result, AccumulatorAction::Continue));
         assert_eq!(acc.len(), 6);
@@ -130,7 +137,7 @@ mod tests {
         let result = acc.ingest(
             Bytes::from(vec![b'x'; 15]),
             vec![(sid(1), ByteOffset(15))],
-            Instant::now(),
+            tokio::time::Instant::now(),
         );
         assert!(matches!(
             result,
@@ -148,7 +155,11 @@ mod tests {
     #[test]
     fn check_timeout_nonempty_returns_flush() {
         let mut acc = BatchAccumulator::new(100);
-        acc.ingest(Bytes::from_static(b"data\n"), vec![], Instant::now());
+        acc.ingest(
+            Bytes::from_static(b"data\n"),
+            vec![],
+            tokio::time::Instant::now(),
+        );
         let result = acc.check_timeout();
         assert!(matches!(
             result,
@@ -166,7 +177,7 @@ mod tests {
         acc.ingest(
             Bytes::from_static(b"drain me\n"),
             vec![(sid(1), ByteOffset(9))],
-            Instant::now(),
+            tokio::time::Instant::now(),
         );
         let result = acc.drain();
         assert!(result.is_some());
@@ -188,12 +199,12 @@ mod tests {
         acc.ingest(
             Bytes::from_static(b"a\n"),
             vec![(sid(1), ByteOffset(2))],
-            Instant::now(),
+            tokio::time::Instant::now(),
         );
         acc.ingest(
             Bytes::from_static(b"b\n"),
             vec![(sid(1), ByteOffset(4))],
-            Instant::now(),
+            tokio::time::Instant::now(),
         );
         let (_, checkpoints, _) = acc.drain().unwrap();
         assert_eq!(checkpoints[&sid(1)], ByteOffset(4));

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -7,7 +7,11 @@ use std::collections::HashMap;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+// std::time::Instant is used in the non-turmoil input_poll_loop (buffered_since).
+// Under turmoil that function is excluded, so the import would be unused.
+#[cfg(not(feature = "turmoil"))]
+use std::time::Instant;
 
 use bytes::{Bytes, BytesMut};
 
@@ -72,7 +76,9 @@ enum ChannelMsg {
         checkpoints: Vec<(SourceId, ByteOffset)>,
         /// When the input thread enqueued this message. Used to measure
         /// queue wait time (time data sat in channel before processing).
-        queued_at: Instant,
+        /// Uses tokio::time::Instant so elapsed() measures simulated time
+        /// under Turmoil, not wall-clock time.
+        queued_at: tokio::time::Instant,
     },
 }
 
@@ -761,7 +767,7 @@ impl Pipeline {
         data: Bytes,
         checkpoints: HashMap<SourceId, ByteOffset>,
         flush_reason: &'static str,
-        queued_at: Option<Instant>,
+        queued_at: Option<tokio::time::Instant>,
     ) {
         if data.is_empty() {
             return;
@@ -794,7 +800,8 @@ impl Pipeline {
 
         // Scan (CPU-bound, ~1-5ms per 4MB batch). scan_maybe_blocking
         // uses block_in_place in production, direct call under turmoil.
-        let t0 = Instant::now();
+        // Use tokio::time::Instant so elapsed() measures simulated time under Turmoil.
+        let t0 = tokio::time::Instant::now();
         let batch = {
             let scan_span =
                 tracing::info_span!("scan", pipeline = %self.name, rows = tracing::field::Empty);
@@ -850,7 +857,8 @@ impl Pipeline {
         tracing::Span::current().record("input_rows", num_rows);
 
         // Transform (already async).
-        let t1 = Instant::now();
+        // Use tokio::time::Instant so elapsed() measures simulated time under Turmoil.
+        let t1 = tokio::time::Instant::now();
         let result = match self
             .transform
             .execute(batch)
@@ -906,7 +914,9 @@ impl Pipeline {
             resource_attrs: Arc::clone(&self.resource_attrs),
             observed_time_ns: now_nanos(),
         };
-        let submitted_at = Instant::now();
+        // Use tokio::time::Instant so queue-wait and batch-latency metrics
+        // measure simulated time under Turmoil, not wall-clock time.
+        let submitted_at = tokio::time::Instant::now();
         self.pool
             .submit(WorkItem {
                 num_rows: result.num_rows() as u64,
@@ -1069,7 +1079,7 @@ fn input_poll_loop(
             let msg = ChannelMsg::Data {
                 bytes: data,
                 checkpoints,
-                queued_at: Instant::now(),
+                queued_at: tokio::time::Instant::now(),
             };
             if blocking_send_channel_msg(input.source.name(), &tx, &metrics, msg).is_err() {
                 break;
@@ -1085,7 +1095,7 @@ fn input_poll_loop(
         let msg = ChannelMsg::Data {
             bytes: data,
             checkpoints,
-            queued_at: Instant::now(),
+            queued_at: tokio::time::Instant::now(),
         };
         let _ = blocking_send_channel_msg(input.source.name(), &tx, &metrics, msg);
     }
@@ -1215,7 +1225,7 @@ async fn async_input_poll_loop(
             let msg = ChannelMsg::Data {
                 bytes: data,
                 checkpoints,
-                queued_at: Instant::now(), // std::time OK here — metrics only
+                queued_at: tokio::time::Instant::now(),
             };
             if tx.send(msg).await.is_err() {
                 break;
@@ -1231,7 +1241,7 @@ async fn async_input_poll_loop(
         let msg = ChannelMsg::Data {
             bytes: data,
             checkpoints,
-            queued_at: Instant::now(), // std::time OK here — metrics only
+            queued_at: tokio::time::Instant::now(),
         };
         let _ = tx.send(msg).await;
     }
@@ -1905,7 +1915,7 @@ output:
         tx.try_send(ChannelMsg::Data {
             bytes: Bytes::from_static(&[1]),
             checkpoints: vec![],
-            queued_at: Instant::now(),
+            queued_at: tokio::time::Instant::now(),
         })
         .unwrap();
 
@@ -1919,7 +1929,7 @@ output:
                 ChannelMsg::Data {
                     bytes: Bytes::from_static(&[2]),
                     checkpoints: vec![],
-                    queued_at: Instant::now(),
+                    queued_at: tokio::time::Instant::now(),
                 },
             )
         });
@@ -2809,7 +2819,7 @@ output:
         tx.try_send(ChannelMsg::Data {
             bytes: Bytes::from_static(b"test\n"),
             checkpoints: vec![(SourceId(42), ByteOffset(1000))],
-            queued_at: Instant::now(),
+            queued_at: tokio::time::Instant::now(),
         })
         .unwrap();
 

--- a/crates/logfwd/src/worker_pool.rs
+++ b/crates/logfwd/src/worker_pool.rs
@@ -65,7 +65,8 @@ pub struct WorkItem {
     /// Number of rows in the batch (for metrics recording at ack time).
     pub num_rows: u64,
     /// When this item was submitted to the pool (set by the caller, not submit()).
-    pub submitted_at: std::time::Instant,
+    /// Uses tokio::time::Instant so elapsed() measures simulated time under Turmoil.
+    pub submitted_at: tokio::time::Instant,
     /// Nanoseconds spent in the scan stage (passed through for metrics at ack time).
     pub scan_ns: u64,
     /// Nanoseconds spent in the transform stage (passed through for metrics at ack time).
@@ -86,7 +87,8 @@ pub struct AckItem {
     /// Passed through from WorkItem for metrics recording.
     pub num_rows: u64,
     /// When the corresponding WorkItem was submitted.
-    pub submitted_at: std::time::Instant,
+    /// Uses tokio::time::Instant so elapsed() measures simulated time under Turmoil.
+    pub submitted_at: tokio::time::Instant,
     /// Nanoseconds spent in the scan stage (passed through from WorkItem).
     pub scan_ns: u64,
     /// Nanoseconds spent in the transform stage (passed through from WorkItem).
@@ -1065,7 +1067,7 @@ mod tests {
             metadata: make_metadata(),
             tickets: vec![],
             num_rows: 0,
-            submitted_at: std::time::Instant::now(),
+            submitted_at: tokio::time::Instant::now(),
             scan_ns: 0,
             transform_ns: 0,
             batch_id: 0,


### PR DESCRIPTION
Fixes #1227

Replaces std::time::Instant with tokio::time::Instant in async pipeline paths. Under Turmoil, only tokio::time advances simulated time — std::time::Instant always returns wall-clock time, making time-dependent tests non-deterministic.

## Changes

- `crates/logfwd/src/batch_accumulator.rs`: `queued_at` field and `ingest()` parameter changed to `tokio::time::Instant`
- `crates/logfwd/src/pipeline.rs`:
  - `ChannelMsg::Data.queued_at` field changed to `tokio::time::Instant`
  - `flush_batch_from` parameter changed to `Option<tokio::time::Instant>`
  - `t0`, `t1`, `submitted_at` locals in `flush_batch_from` (async fn) changed to `tokio::time::Instant`
  - Both `input_poll_loop` (non-turmoil) and `async_input_poll_loop` (turmoil) updated to use `tokio::time::Instant::now()` when constructing `ChannelMsg`
  - `std::time::Instant` import conditionally compiled with `#[cfg(not(feature = "turmoil"))]` since it is only needed by `input_poll_loop` which is excluded under that feature
- `crates/logfwd/src/worker_pool.rs`: `WorkItem.submitted_at` and `AckItem.submitted_at` changed to `tokio::time::Instant`; test helper updated

## Verification

- `cargo test -p logfwd --lib`: 60/60 pass
- `cargo test -p logfwd --features turmoil --test turmoil_sim`: 16/16 pass
- `cargo clippy -p logfwd -- -D warnings`: clean
- `cargo clippy -p logfwd --features turmoil -- -D warnings`: clean
- `cargo fmt --check`: clean

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Turmoil simulation time by replacing `std::time::Instant` with `tokio::time::Instant` in log pipeline
> Turmoil intercepts `tokio::time` to advance simulated time, but the log forwarding pipeline was using `std::time::Instant` for queue timestamps and metrics, causing elapsed durations to not reflect simulated time.
>
> - Updates `queued_at` fields in `ChannelMsg`, `BatchAccumulator`, `WorkItem`, and `AckItem` to use `tokio::time::Instant`
> - Updates timing measurements in `Pipeline::flush_batch_from` (`t0`, `t1`, `submitted_at`) to use `tokio::time::Instant::now()`
> - `std::time::Instant` import in [pipeline.rs](https://github.com/strawgate/memagent/pull/1254/files#diff-871beaad2d14990b89072990f0a821dd4266ab3e624d58590ec24abc1047056d) is now gated behind `cfg(not(feature = "turmoil"))` to preserve wall-clock behavior in non-simulated builds
> - Behavioral Change: all elapsed duration calculations in the pipeline now use tokio time, so metrics will reflect simulated time under Turmoil rather than wall-clock time
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f95dcba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->