### PR TITLE
fix(receivers): restore .expect() on rx Option — reverted by bot in #1246

### DIFF
--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -238,7 +238,7 @@ impl ArrowIpcReceiver {
     /// Try to receive all available RecordBatches (non-blocking).
     pub fn try_recv_all(&self) -> Vec<RecordBatch> {
         let mut batches = Vec::new();
-        while let Ok(batch) = self.rx.as_ref().unwrap().try_recv() {
+        while let Ok(batch) = self.rx.as_ref().expect("rx is Some until drop").try_recv() {
             batches.push(batch);
         }
         batches
@@ -248,7 +248,7 @@ impl ArrowIpcReceiver {
     pub fn recv(&self) -> io::Result<RecordBatch> {
         self.rx
             .as_ref()
-            .unwrap()
+            .expect("rx is Some until drop")
             .recv()
             .map_err(|_| io::Error::other("Arrow IPC receiver: channel disconnected"))
     }
@@ -257,7 +257,7 @@ impl ArrowIpcReceiver {
     pub fn recv_timeout(&self, timeout: std::time::Duration) -> io::Result<RecordBatch> {
         self.rx
             .as_ref()
-            .unwrap()
+            .expect("rx is Some until drop")
             .recv_timeout(timeout)
             .map_err(|e| match e {
                 mpsc::RecvTimeoutError::Timeout => {

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -259,7 +259,7 @@ impl OtapReceiver {
     /// Try to receive all available RecordBatches (non-blocking).
     pub fn try_recv_all(&self) -> Vec<RecordBatch> {
         let mut batches = Vec::new();
-        while let Ok(batch) = self.rx.as_ref().unwrap().try_recv() {
+        while let Ok(batch) = self.rx.as_ref().expect("rx is Some until drop").try_recv() {
             batches.push(batch);
         }
         batches
@@ -269,7 +269,7 @@ impl OtapReceiver {
     pub fn recv(&self) -> io::Result<RecordBatch> {
         self.rx
             .as_ref()
-            .unwrap()
+            .expect("rx is Some until drop")
             .recv()
             .map_err(|_| io::Error::other("OTAP receiver: channel disconnected"))
     }
@@ -278,7 +278,7 @@ impl OtapReceiver {
     pub fn recv_timeout(&self, timeout: std::time::Duration) -> io::Result<RecordBatch> {
         self.rx
             .as_ref()
-            .unwrap()
+            .expect("rx is Some until drop")
             .recv_timeout(timeout)
             .map_err(|e| match e {
                 mpsc::RecvTimeoutError::Timeout => {

--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -278,7 +278,7 @@ impl InputSource for OtlpReceiverInput {
         let mut all = Vec::new();
 
         // Drain all available decoded batches.
-        while let Ok(data) = self.rx.as_ref().unwrap().try_recv() {
+        while let Ok(data) = self.rx.as_ref().expect("rx is Some until drop").try_recv() {
             all.extend_from_slice(&data);
         }
 


### PR DESCRIPTION
## Summary

- Jules bot commit `7200ffd` in PR #1246 explicitly reverted our `.unwrap()` → `.expect("rx is Some until drop")` fix that was originally applied in commit `57761d6`
- The merged PR therefore still has bare `.unwrap()` on `rx.as_ref()` in all three HTTP receivers, which was the subject of CodeRabbit's CHANGES_REQUESTED on #1246
- This PR restores the 7 `.expect()` calls (2 in `otlp_receiver.rs`, 3 in `otap_receiver.rs`, 3 in `arrow_ipc_receiver.rs`)

The `.unwrap()` calls are technically safe (ownership guarantees `rx` is `Some` while the struct lives), but violate the project's no-bare-unwrap coding guideline.

## Test plan

- [x] `cargo fmt -p logfwd-io` — no changes
- [x] `cargo clippy -p logfwd-io` — no new warnings
- [ ] CI green

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore `.expect()` on `rx` Option in `ArrowIpcReceiver`, `OtapReceiver`, and `OtlpReceiverInput`
> Replaces `.unwrap()` with `.expect("rx is Some until drop")` across receiver `recv`, `recv_timeout`, and `try_recv_all` methods, reverting a bot change from #1246. This adds a descriptive panic message when `rx` is `None` but does not change any other behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b022ea3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->