### PR TITLE
fix(star_schema): use Euclidean div/rem for pre-1970 timestamp nanos

### DIFF
--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -352,9 +352,12 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
                     .downcast_ref::<arrow::array::TimestampNanosecondArray>()
                 {
                     let ns = prim.value(row);
-                    // Format as RFC3339 nanoseconds.
-                    let secs = ns / 1_000_000_000;
-                    let nanos = (ns % 1_000_000_000) as u32;
+                    // Format as RFC3339 nanoseconds. Use Euclidean div/rem so
+                    // that negative timestamps (pre-1970) yield nanos in
+                    // [0, 999_999_999] rather than a negative value that wraps
+                    // on the `as u32` cast, which would corrupt the output.
+                    let secs = ns.div_euclid(1_000_000_000);
+                    let nanos = ns.rem_euclid(1_000_000_000) as u32;
                     if let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1 {
                         v[row] = Some(chrono_timestamp(secs, nanos));
                     }


### PR DESCRIPTION
## Summary

Fixes a data corruption bug when formatting negative nanosecond timestamps (pre-1970 dates) in `star_to_flat`.

**Root cause:** `ns % 1_000_000_000` uses truncating remainder in Rust. For negative `ns` values, this yields a negative result. Casting a negative `i64` to `u32` wraps around, producing a nonsensical nanoseconds value in the RFC3339 output.

**Example (ns = -1, one nanosecond before Unix epoch):**
```
Before: secs = 0, nanos = u32::MAX (4294967295) → corrupt timestamp
After:  secs = -1, nanos = 999_999_999 → "1969-12-31T23:59:59.999999999Z"
```

The `chrono_timestamp` helper already uses `div_euclid`/`rem_euclid` correctly for its own internal arithmetic (days→hours, etc). This PR applies the same pattern at the call site.

Flagged as **MAJOR** by CodeRabbit and Copilot on PR #1255. The fix is independent of #1255's behavioral timestamp threshold changes.

## Test plan
- [x] `cargo fmt -p logfwd-arrow` — no changes
- [x] `cargo clippy -p logfwd-arrow` — no new warnings
- [ ] CI green

Closes part of the concern from #1255 review.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nanosecond computation for pre-1970 timestamps in `star_to_flat`
> Integer division and modulo on negative `i64` values produce negative remainders, causing an invalid nanosecond component when casting to `u32` for timestamps before the Unix epoch. Replaces `/` and `%` with Euclidean division and remainder in [star_schema.rs](https://github.com/strawgate/memagent/pull/1259/files#diff-fb28eb9d8306708fff07b41c8d2b450df493a129ad9ffa16eceed5676b3a0f62) so the nanosecond component always falls in `[0, 999_999_999]` regardless of sign.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d44f8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->