### PR TITLE
fix(config): allow listen field for generator inputs (#1222)

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -715,11 +715,6 @@ impl Config {
                                 "pipeline '{name}' input '{label}': 'max_open_files' is not supported for generator inputs"
                             )));
                         }
-                        if input.listen.is_some() {
-                            return Err(ConfigError::Validation(format!(
-                                "pipeline '{name}' input '{label}': 'listen' is not supported for generator inputs"
-                            )));
-                        }
                     }
                     InputType::ArrowIpc => {
                         return Err(ConfigError::Validation(format!(
@@ -2359,20 +2354,22 @@ pipelines:
     }
 
     #[test]
-    fn generator_input_rejects_listen() {
+    fn generator_input_accepts_listen_as_rate_limit() {
+        // `listen` is reused as events/sec for generators (pipeline.rs reads
+        // cfg.listen at runtime). The validation guard must not reject it.
         let yaml = r#"
 pipelines:
   test:
     inputs:
       - type: generator
-        listen: 0.0.0.0:514
+        listen: "1000"
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("listen"),
-            "expected listen rejection: {err}"
+        let cfg = Config::load_str(yaml).expect("generator with listen should be valid");
+        assert_eq!(
+            cfg.pipelines["test"].inputs[0].listen.as_deref(),
+            Some("1000")
         );
     }
 


### PR DESCRIPTION
## Summary

PR #1123 added a validation guard that rejects `listen` for `InputType::Generator`. However, `pipeline.rs` reads `cfg.listen` at runtime (line 1331) to configure the generator's events/sec rate limit. Valid production configs using `listen` to throttle a generator were broken by this check.

**Fix:** remove the `Generator` arm from the `listen` rejection block in config validation (`crates/logfwd-config/src/lib.rs`, lines 718–722 pre-patch).

The existing `generator_input_rejects_listen` test was also updated to instead assert that a generator config with `listen` is accepted and the value is preserved.

## Test plan
- [x] `cargo fmt -p logfwd-config` — no changes
- [x] `cargo clippy -p logfwd-config --no-deps` — clean
- [x] `cargo test -p logfwd-config` — 74 tests pass (including the updated `generator_input_accepts_listen_as_rate_limit`)
- [ ] CI green

Closes #1222

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `listen` field on generator inputs in config loading
> Removes a validation check in `Config.from_raw` that rejected generator inputs with a `listen` field set. The `listen` value (used as a rate limit) is now accepted and retained in the parsed config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09dedd0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->