### PR TITLE
fix(ci): add fuzz-short nightly job with sccache setup (#1219)

### DIFF
--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -63,6 +63,26 @@ jobs:
           echo "=== Results: $FAILED failures out of 500 seeds ==="
           if [ $FAILED -gt 0 ]; then exit 1; fi
 
+  fuzz-short:
+    name: Fuzz (5 minutes per target)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+        env:
+          RUSTC_WRAPPER: ""
+      - name: Run fuzz targets
+        run: |
+          cd crates/logfwd-core
+          for target in $(cargo fuzz list 2>/dev/null); do
+            echo "=== Fuzzing $target for 5 minutes ==="
+            cargo fuzz run "$target" -- -max_total_time=300
+          done
+
   fuzz-extended:
     name: Fuzz (30 minutes per target)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `.cargo/config.toml` sets `rustc-wrapper = "sccache"` workspace-wide. The `fuzz-short` nightly job was missing from `nightly-testing.yml`, causing every nightly fuzz run to fail with `sccache: not found`.
- Added a new `fuzz-short` job (5-minute per-target fuzz run) with `mozilla-actions/sccache-action@v0.0.9`, matching the pattern used by `proptest-extended`, `turmoil-seed-sweep`, and `fuzz-extended`.
- The `cargo install cargo-fuzz` step overrides `RUSTC_WRAPPER: ""` (consistent with `fuzz-extended`) to avoid sccache interference during tool install itself.

## Test plan
- [ ] CI green on this PR (nightly jobs won't fire on PRs, but the YAML is syntactically valid)
- [ ] Confirm `fuzz-short` job appears in Actions tab on next nightly run

Closes #1219

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fuzz-short nightly CI job for `logfwd-core` fuzz targets
> Adds a new `fuzz-short` job to [nightly-testing.yml](.github/workflows/nightly-testing.yml) that runs all `cargo fuzz` targets under `crates/logfwd-core` for up to 300 seconds each. The job installs the nightly Rust toolchain and `cargo-fuzz`, using sccache for build caching, with a 60-minute total timeout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fa7f56.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->