### PR TITLE
fix(security): checked arithmetic for untrusted OTAP length fields (#1215)

### DIFF
--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -346,7 +346,12 @@ fn decode_batch_arrow_records(buf: &[u8]) -> Result<BatchArrowRecords, InputErro
             (2, WIRE_TYPE_LENGTH_DELIMITED) => {
                 let (len, new_pos) =
                     decode_varint(buf, pos).map_err(|e| InputError::Receiver(e.to_string()))?;
-                let end = new_pos + len as usize;
+                let len_usize = usize::try_from(len).map_err(|_| {
+                    InputError::Receiver("ArrowPayload: length too large".to_string())
+                })?;
+                let end = new_pos.checked_add(len_usize).ok_or_else(|| {
+                    InputError::Receiver("ArrowPayload: length overflow".to_string())
+                })?;
                 if end > buf.len() {
                     return Err(InputError::Receiver(
                         "ArrowPayload: length overflow".to_string(),
@@ -391,7 +396,12 @@ fn decode_arrow_payload(buf: &[u8]) -> Result<ArrowPayload, InputError> {
             (1, WIRE_TYPE_LENGTH_DELIMITED) => {
                 let (len, new_pos) =
                     decode_varint(buf, pos).map_err(|e| InputError::Receiver(e.to_string()))?;
-                pos = new_pos + len as usize;
+                let len_usize = usize::try_from(len).map_err(|_| {
+                    InputError::Receiver("ArrowPayload.schema_id: length too large".to_string())
+                })?;
+                pos = new_pos.checked_add(len_usize).ok_or_else(|| {
+                    InputError::Receiver("ArrowPayload.schema_id: length overflow".to_string())
+                })?;
                 if pos > buf.len() {
                     return Err(InputError::Receiver(
                         "ArrowPayload.schema_id: length overflow".to_string(),
@@ -409,7 +419,12 @@ fn decode_arrow_payload(buf: &[u8]) -> Result<ArrowPayload, InputError> {
             (3, WIRE_TYPE_LENGTH_DELIMITED) => {
                 let (len, new_pos) =
                     decode_varint(buf, pos).map_err(|e| InputError::Receiver(e.to_string()))?;
-                let end = new_pos + len as usize;
+                let len_usize = usize::try_from(len).map_err(|_| {
+                    InputError::Receiver("ArrowPayload.record: length too large".to_string())
+                })?;
+                let end = new_pos.checked_add(len_usize).ok_or_else(|| {
+                    InputError::Receiver("ArrowPayload.record: length overflow".to_string())
+                })?;
                 if end > buf.len() {
                     return Err(InputError::Receiver(
                         "ArrowPayload.record: length overflow".to_string(),


### PR DESCRIPTION
## Summary

Three places in `otap_receiver.rs` decoded untrusted `u64` varint lengths with `len as usize`, which truncates silently on 64-bit when `len > usize::MAX`. Combined with unchecked addition for `pos`/`end`, a malformed payload could pass bounds checks with a wrapped value.

**Fix:** `usize::try_from(len)` returning a parse error on overflow, plus `checked_add` for all position arithmetic.

## Test plan
- [x] `cargo test -p logfwd-io` passes (175 unit + 17 integration tests)
- [x] `cargo clippy -p logfwd-io` clean
- [ ] CI green

Closes #1215

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix integer overflow in OTAP length field parsing in `otap_receiver`
> Replaces unchecked arithmetic (`pos + len as usize`) with safe conversions and overflow-checked addition in [`otap_receiver.rs`](https://github.com/strawgate/memagent/pull/1263/files#diff-d857a8f6754a55babf2b290bc90d4dc983d53420419d6c33740dd7bab066964a). Affected fields are `ArrowPayload` length in `decode_batch_arrow_records`, and `schema_id` and `record` lengths in `decode_arrow_payload`. Each now returns `InputError::Receiver` with a descriptive message on overflow or out-of-range length instead of proceeding with potentially invalid buffer slices.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a98ca59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->