### PR TITLE
fix(config): reject glob_rescan_interval_ms for non-file inputs (#1229)

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -691,6 +691,11 @@ impl Config {
                                 "pipeline '{name}' input '{label}': 'max_open_files' is not supported for tcp/udp inputs"
                             )));
                         }
+                        if input.glob_rescan_interval_ms.is_some() {
+                            return Err(ConfigError::Validation(format!(
+                                "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for tcp/udp inputs"
+                            )));
+                        }
                     }
                     InputType::Otlp => {
                         if input.path.is_some() {
@@ -703,6 +708,11 @@ impl Config {
                                 "pipeline '{name}' input '{label}': 'max_open_files' is not supported for otlp inputs"
                             )));
                         }
+                        if input.glob_rescan_interval_ms.is_some() {
+                            return Err(ConfigError::Validation(format!(
+                                "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for otlp inputs"
+                            )));
+                        }
                     }
                     InputType::Generator => {
                         if input.path.is_some() {
@@ -713,6 +723,11 @@ impl Config {
                         if input.max_open_files.is_some() {
                             return Err(ConfigError::Validation(format!(
                                 "pipeline '{name}' input '{label}': 'max_open_files' is not supported for generator inputs"
+                            )));
+                        }
+                        if input.glob_rescan_interval_ms.is_some() {
+                            return Err(ConfigError::Validation(format!(
+                                "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for generator inputs"
                             )));
                         }
                     }
@@ -2332,6 +2347,25 @@ pipelines:
         assert!(
             err.to_string().contains("max_open_files"),
             "expected max_open_files rejection: {err}"
+        );
+    }
+
+    #[test]
+    fn tcp_input_rejects_glob_rescan_interval_ms() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: tcp
+        listen: 0.0.0.0:514
+        glob_rescan_interval_ms: 5000
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("glob_rescan_interval_ms"),
+            "expected glob_rescan_interval_ms rejection: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

`glob_rescan_interval_ms` is only meaningful for glob file inputs. Setting it on a TCP, UDP, or generator input was silently ignored with no validation error — inconsistent with how `max_open_files` is handled.

**Fix:** Added a validation check that rejects `glob_rescan_interval_ms` for non-file input types, mirroring the existing `max_open_files` validation pattern.

## Test plan
- [x] `cargo test -p logfwd-config` passes (75/75 tests, including new `tcp_input_rejects_glob_rescan_interval_ms`)
- [x] `cargo clippy -p logfwd-config` clean
- [ ] CI green

Closes #1229

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject `glob_rescan_interval_ms` for non-file inputs in config validation
> Config loading now returns a `ConfigError::Validation` error if `glob_rescan_interval_ms` is set on tcp, udp, otlp, or generator inputs, since this option only applies to file-based inputs. Previously, the field was silently ignored for these input types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08de1c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->