### PR TITLE
fix(bench): separate last/peak RSS atomics; guard iterations=0 panic (#1220)

### DIFF
--- a/crates/logfwd-bench/src/bin/framed_input_profile.rs
+++ b/crates/logfwd-bench/src/bin/framed_input_profile.rs
@@ -346,6 +346,7 @@ fn measure_pipeline_scenario(scenario: &Scenario, iterations: usize) -> StageSum
         samples.push(run_pipeline_once(scenario));
     }
     samples.sort_by_key(|s| s.total_ns);
+    assert!(!samples.is_empty(), "--iterations must be at least 1");
     let median = &samples[samples.len() / 2];
     StageSummary {
         name: scenario.name,
@@ -467,6 +468,9 @@ fn median_time_ns(iterations: usize, mut f: impl FnMut()) -> u64 {
         samples.push(start.elapsed().as_nanos() as u64);
     }
     samples.sort_unstable();
+    if samples.is_empty() {
+        return 0;
+    }
     samples[samples.len() / 2]
 }
 
@@ -516,8 +520,9 @@ struct RssSampler {
 impl RssSampler {
     fn start() -> Self {
         let stop = Arc::new(AtomicBool::new(false));
-        let peak_rss_kb = Arc::new(AtomicU64::new(current_rss_kb()));
-        let last_rss_kb = Arc::clone(&peak_rss_kb);
+        let initial_rss = current_rss_kb();
+        let peak_rss_kb = Arc::new(AtomicU64::new(initial_rss));
+        let last_rss_kb = Arc::new(AtomicU64::new(initial_rss));
         let thread_stop = Arc::clone(&stop);
         let thread_peak = Arc::clone(&peak_rss_kb);
         let thread_last = Arc::clone(&last_rss_kb);


### PR DESCRIPTION
## Summary

Two bugs in `framed_input_profile.rs`:

1. **Peak RSS never tracked correctly:** `Arc::clone(&peak_rss_kb)` made `last_rss_kb` an alias of `peak_rss_kb` — the same `AtomicU64`. The peak check `rss > current_peak` read back the value just written, so it was always false. Fixed by creating a separate `Arc<AtomicU64>` for `last_rss_kb`.

2. **`--iterations 0` panic:** `samples[samples.len() / 2]` panicked with zero iterations. Added a guard via `assert!`.

## Test plan
- [x] `cargo build -p logfwd-bench` passes
- [x] `cargo clippy -p logfwd-bench --bin framed_input_profile` clean
- [ ] CI green

Closes #1220

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix separate last/peak RSS atomics and guard against iterations=0 panic in bench
> - Fixes `RssSampler.start` in [framed_input_profile.rs](https://github.com/strawgate/memagent/pull/1265/files#diff-cba7aff1a5fddfd5abfa06c66fe752ee02efd643683d1e3bc85ae7ef34b53f0e) so `last_rss_kb` and `peak_rss_kb` are independent atomics; previously `last_rss_kb` mirrored `peak_rss_kb` instead of tracking the most recent sample.
> - Fixes `median_time_ns` to return 0 instead of panicking when the samples vector is empty (i.e. `--iterations=0`).
> - Adds an assertion in `measure_pipeline_scenario` that panics with a clear message (`--iterations must be at least 1`) when iterations is 0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6431bcf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->