### PR TITLE
fix(streaming_builder): checked u32 cast for decoded_buf; tokio sleep (#1217)

### DIFF
--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -311,11 +311,12 @@ impl StreamingBuilder {
         if std::str::from_utf8(value).is_err() {
             return;
         }
+        // Compute both offsets before mutating decoded_buf so that a bail-out
+        // on overflow does not leave unreferenced bytes in decoded_buf.
         let Ok(decoded_offset) = u32::try_from(self.decoded_buf.len()) else {
             // decoded_buf has grown past 4 GiB; drop this field rather than panic.
             return;
         };
-        self.decoded_buf.extend_from_slice(value);
         // Offset into the combined buffer: original buf bytes come first,
         // decoded bytes follow at buf.len() + decoded_offset.
         let Some(combined_offset) = u32::try_from(self.buf.len())
@@ -325,6 +326,8 @@ impl StreamingBuilder {
             // Combined offset would overflow u32; drop this field rather than panic.
             return;
         };
+        // All checks passed — safe to extend decoded_buf.
+        self.decoded_buf.extend_from_slice(value);
         let fc = &mut self.fields[idx];
         fc.has_str = true;
         fc.str_views

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -1111,8 +1111,9 @@ fn input_poll_loop(
 /// A single failure here loses all checkpoint advancement from the run.
 /// Retry with brief sleeps to handle transient I/O errors (disk busy, NFS glitch).
 ///
-/// Uses `tokio::time::sleep` so that this function is non-blocking and
-/// compatible with Turmoil's single-threaded deterministic simulation.
+/// Uses `tokio::time::sleep` for the retry delay so the async task yields
+/// between attempts (Turmoil-compatible). Note: `store.flush()` itself is
+/// synchronous I/O; only the inter-retry sleep is non-blocking.
 async fn flush_checkpoint_with_retry(store: &mut dyn CheckpointStore) {
     const MAX_ATTEMPTS: u32 = 3;
     const RETRY_DELAY: Duration = Duration::from_millis(100);


### PR DESCRIPTION
## Summary

Two fixes from issue #1217:

1. **`decoded_buf.len() as u32` and `buf.len() as u32` overflow:** The code had a `u32::try_from(...).expect()` (panic) for `decoded_offset` and a silent-truncating `as u32` cast for `buf.len()`. Both are replaced with checked casts that return early (silently drop the field), consistent with how UTF-8 errors are already handled in the same function.

2. **`std::thread::sleep` in async context:** `flush_checkpoint_with_retry` was blocking the Tokio runtime thread. The comment in the code claimed this was intentional (synchronous shutdown path), but it breaks Turmoil's single-threaded deterministic simulation. Converted to `async fn` using `tokio::time::sleep(...).await`.

## Test plan
- [x] `cargo test -p logfwd-arrow` passes (95 + 3 + 4 tests)
- [x] `cargo test -p logfwd` passes (17 tests)
- [x] `cargo clippy -p logfwd-arrow --no-deps -- -D warnings` clean
- [x] `cargo clippy -p logfwd --no-deps -- -D warnings` clean
- [ ] CI green

Closes #1217

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix u32 overflow panic in `StreamingBuilder.append_str_by_idx` and use async sleep in checkpoint retry
> - In [`streaming_builder.rs`](https://github.com/strawgate/memagent/pull/1266/files#diff-05a83edf355d162945f5713b5186fd14c583cb463359f1d3252e5efac352170d), replaces unconditional `u32` casts (which could panic) with checked conversions that early-return and drop the field if `decoded_buf.len()` or the combined offset exceeds `u32::MAX`; `decoded_buf` is not mutated on bail-out.
> - In [`pipeline.rs`](https://github.com/strawgate/memagent/pull/1266/files#diff-871beaad2d14990b89072990f0a821dd4266ab3e624d58590ec24abc1047056d), converts `flush_checkpoint_with_retry` to `async` and replaces `std::thread::sleep` with `tokio::time::sleep`, so retry backoff yields to the async runtime instead of blocking the thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d750e80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->