### PR TITLE
fix(streaming_builder): update last_row only after UTF-8 validation succeeds

### DIFF
--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -267,17 +267,17 @@ impl StreamingBuilder {
         if check_dup_bits(&mut self.written_bits, idx) {
             return;
         }
-        if idx >= 64 {
-            if self.fields[idx].last_row == self.row_count {
-                return;
-            }
-            self.fields[idx].last_row = self.row_count;
+        if idx >= u64::BITS as usize && self.fields[idx].last_row == self.row_count {
+            return;
         }
         // StringViewArray requires valid UTF-8.  JSON is always UTF-8 in
         // production; for fuzz / corrupted input we skip non-UTF-8 bytes so
         // that append_view_unchecked is never called on invalid bytes.
         if std::str::from_utf8(value).is_err() {
             return;
+        }
+        if idx >= u64::BITS as usize {
+            self.fields[idx].last_row = self.row_count;
         }
         let offset = self.offset_of(value);
         let fc = &mut self.fields[idx];
@@ -302,11 +302,8 @@ impl StreamingBuilder {
         if check_dup_bits(&mut self.written_bits, idx) {
             return;
         }
-        if idx >= 64 {
-            if self.fields[idx].last_row == self.row_count {
-                return;
-            }
-            self.fields[idx].last_row = self.row_count;
+        if idx >= u64::BITS as usize && self.fields[idx].last_row == self.row_count {
+            return;
         }
         if std::str::from_utf8(value).is_err() {
             return;
@@ -326,7 +323,10 @@ impl StreamingBuilder {
             // Combined offset would overflow u32; drop this field rather than panic.
             return;
         };
-        // All checks passed — safe to extend decoded_buf.
+        // All validation passed — safe to update dedup guard and extend decoded_buf.
+        if idx >= u64::BITS as usize {
+            self.fields[idx].last_row = self.row_count;
+        }
         self.decoded_buf.extend_from_slice(value);
         let fc = &mut self.fields[idx];
         fc.has_str = true;


### PR DESCRIPTION
## Summary

- Fixes #1226
- In `append_str_by_idx` and `append_decoded_str_by_idx`, the dedup guard `last_row = row_count` was set **before** the UTF-8 validation check. If the UTF-8 check returned early (or the overflow check in the decoded variant), `last_row` was already poisoned — permanently blocking any future valid write to that field in the same row.
- Fix: move the `last_row` assignment to after all validation passes in both functions. Also replace the magic number `64` with `u64::BITS as usize` in all four guard comparisons for clarity.

## Test plan

- [ ] `cargo test -p logfwd-arrow` passes (102 tests, all green)
- [ ] `cargo clippy -p logfwd-arrow -- -D warnings` passes with no warnings
- [ ] `cargo fmt -p logfwd-arrow` produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `last_row` update in `StreamingBuilder` to only set after UTF-8 validation succeeds
> In [streaming_builder.rs](https://github.com/strawgate/memagent/pull/1269/files#diff-05a83edf355d162945f5713b5186fd14c583cb463359f1d3252e5efac352170d), `last_row` was being set before UTF-8 validation in `append_str_by_idx` and `append_decoded_str_by_idx`, causing subsequent valid writes for the same field in the same row to be silently skipped for indices >= 64.
>
> - Moves `last_row` update to after UTF-8 validation (and offset calculations) pass in both methods
> - Replaces hardcoded `idx >= 64` with `idx >= u64::BITS as usize` for the dedup-guard path
> - Consolidates the duplicate early-return check into a single condition per method
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c809fbc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->