### PR TITLE
bench(batch_formation): increase sample_size from 20 to 50 for reliable measurements

### DIFF
--- a/crates/logfwd-bench/benches/batch_formation.rs
+++ b/crates/logfwd-bench/benches/batch_formation.rs
@@ -21,7 +21,7 @@ use logfwd_transform::SqlTransform;
 
 fn bench_batch_scan(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_scan");
-    group.sample_size(20);
+    group.sample_size(50);
 
     let batch_sizes: &[usize] = &[100, 500, 1_000, 5_000, 10_000, 50_000, 100_000];
 
@@ -49,7 +49,7 @@ fn bench_batch_scan(c: &mut Criterion) {
 
 fn bench_batch_transform(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_transform");
-    group.sample_size(20);
+    group.sample_size(50);
 
     let meta = generators::make_metadata();
     let batch_sizes: &[usize] = &[100, 500, 1_000, 5_000, 10_000, 50_000];
@@ -100,7 +100,7 @@ fn bench_batch_transform(c: &mut Criterion) {
 
 fn bench_batch_pipeline(c: &mut Criterion) {
     let mut group = c.benchmark_group("batch_pipeline");
-    group.sample_size(20);
+    group.sample_size(50);
 
     let meta = generators::make_metadata();
     let batch_sizes: &[usize] = &[100, 500, 1_000, 5_000, 10_000, 50_000];


### PR DESCRIPTION
## Summary

- All three benchmark groups in `batch_formation.rs` (`batch_scan`, `batch_transform`, `batch_pipeline`) used `group.sample_size(20)`, below Criterion's recommended minimum of 30.
- Fast 100-row batches completing in microseconds are especially susceptible to measurement noise at low sample counts.
- Increased to 50 samples, providing good statistical confidence without significantly increasing wall-clock bench time.

Closes #1192

## Test plan

- [x] `cargo check -p logfwd-bench --bench batch_formation` — passes clean
- [x] `cargo fmt -p logfwd-bench` — no formatting changes
- [x] Pre-existing clippy warnings in `memory_profile.rs` (unresolved `libc` crate) are unrelated to this change and present on the base branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase batch_formation benchmark sample size from 20 to 50 for reliable measurements
> Updates the Criterion sample size for all three benchmark groups (`batch_scan`, `batch_transform`, `batch_pipeline`) in [batch_formation.rs](https://github.com/strawgate/memagent/pull/1282/files#diff-2d3588e4c47b7a203c007a918333bfd32c65fa2602cefeb49e752af397b4362c) from 20 to 50. This increases the number of collected samples per run, reducing measurement variance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1374144.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->