### PR TITLE
fix(elasticsearch): structural bulk response failures must be retriable

### DIFF
--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -179,23 +179,19 @@ impl ElasticsearchSink {
     ///
     /// Returns `Ok(())` if all documents succeeded (`errors: false`), or
     /// an `Err` with the first failure's type and reason.
+    ///
+    /// Error kinds are chosen deliberately:
+    /// - `Other`: structural/transient failures (malformed JSON, missing fields) — retriable
+    /// - `InvalidData`: item-level document errors (mapper_parsing_exception, etc.) — permanent,
+    ///   retrying the same document is futile, so these map to `Rejected` in the caller
     fn parse_bulk_response(body: &[u8]) -> io::Result<()> {
-        let v: serde_json::Value = serde_json::from_slice(body).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("failed to parse ES bulk response: {e}"),
-            )
-        })?;
+        let v: serde_json::Value = serde_json::from_slice(body)
+            .map_err(|e| io::Error::other(format!("failed to parse ES bulk response: {e}")))?;
 
         let has_errors = v
             .get("errors")
             .and_then(serde_json::Value::as_bool)
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "ES bulk response missing 'errors' boolean field",
-                )
-            })?;
+            .ok_or_else(|| io::Error::other("ES bulk response missing 'errors' boolean field"))?;
 
         if !has_errors {
             return Ok(());
@@ -204,16 +200,10 @@ impl ElasticsearchSink {
         let items = v
             .get("items")
             .and_then(serde_json::Value::as_array)
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "ES bulk response missing 'items' array",
-                )
-            })?;
+            .ok_or_else(|| io::Error::other("ES bulk response missing 'items' array"))?;
 
         if items.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
+            return Err(io::Error::other(
                 "ES bulk response indicated errors but 'items' array is empty",
             ));
         }
@@ -233,6 +223,7 @@ impl ElasticsearchSink {
                         .get("reason")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("no reason provided");
+                    // InvalidData: document-level rejection — permanent, do not retry.
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("ES bulk error: {error_type}: {reason}"),


### PR DESCRIPTION
## Summary

- `parse_bulk_response` used `InvalidData` for both structural failures (malformed JSON, missing `errors`/`items` fields) and item-level document errors
- PR #1267 mapped `InvalidData` → `Rejected`, so transient structural failures were silently dropped instead of retried
- Fix: change structural failure cases to `io::Error::other()` (kind=`Other`), which falls through to the `IoError` branch and triggers retry
- Only item-level document errors (`mapper_parsing_exception`, etc.) remain `InvalidData` → `Rejected`, where retrying is futile

Fixes #1277.

## Test plan

- [ ] Existing `cargo test -p logfwd-output` passes — no behavior change for item-level errors
- [ ] Structural failures (malformed JSON response, missing `errors`/`items` fields) now return `IoError` and are retried

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parse_bulk_response` to retry structural bulk response failures in Elasticsearch
> Structural failures in the Elasticsearch bulk response (malformed JSON, missing `errors` field, missing `items` array, or `errors: true` with empty `items`) were previously classified as `io::ErrorKind::InvalidData`, which is non-retriable. These are now reclassified as `io::ErrorKind::Other` so they trigger retries. Item-level document rejections found in `items[*].<action>.error` retain `InvalidData` since they represent permanent failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd8e4eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->