### PR TITLE
fix(pipeline): import std::time::Instant in test module for turmoil builds

### DIFF
--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -1424,6 +1424,9 @@ fn now_nanos() -> u64 {
 mod tests {
     use super::*;
     use std::sync::atomic::Ordering;
+    // std::time::Instant is cfg-gated in the parent module for turmoil compatibility,
+    // but tests need it for timeout deadlines regardless of the turmoil feature flag.
+    use std::time::Instant;
 
     use logfwd_config::{Format, OutputConfig, OutputType};
     use logfwd_io::diagnostics::ComponentStats;


### PR DESCRIPTION
## Summary

- The outer module gates `use std::time::Instant` with `#[cfg(not(feature = \"turmoil\"))]` to keep production code compatible with turmoil's simulated clock
- `use super::*` in `mod tests` doesn't bring `Instant` into scope when `--features turmoil` is active
- Multiple test functions use `Instant::now()` for timeout deadlines, failing to compile under turmoil

Fix: add `use std::time::Instant;` directly inside `mod tests`. Test timeout logic doesn't interact with turmoil's simulated clock, so using `std::time::Instant` unconditionally in tests is correct.

Fixes #1279.

## Test plan

- [ ] `cargo check -p logfwd --features turmoil` passes (previously failed to compile)
- [ ] `cargo test -p logfwd` still passes without turmoil feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `std::time::Instant` import in test module for turmoil builds in pipeline
> In [pipeline.rs](https://github.com/strawgate/memagent/pull/1287/files#diff-871beaad2d14990b89072990f0a821dd4266ab3e624d58590ec24abc1047056d), `Instant` is cfg-gated in the parent module but needed directly in the tests module for timeout deadlines. Adds an explicit `use std::time::Instant` import inside the tests module to fix compilation under turmoil builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0308178.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->