### PR TITLE
fix(config): ArrowIpc input always emits 'not yet supported', not 'listen required'

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -661,14 +661,9 @@ impl Config {
                             )));
                         }
                     }
-                    InputType::ArrowIpc => {
-                        if input.listen.is_none() {
-                            return Err(ConfigError::Validation(format!(
-                                "pipeline '{name}' input '{label}': 'listen' is required for arrow_ipc inputs"
-                            )));
-                        }
-                    }
-                    InputType::Generator => {}
+                    // ArrowIpc is always rejected below as "not yet supported";
+                    // skip listen validation to avoid a misleading error message.
+                    InputType::ArrowIpc | InputType::Generator => {}
                 }
 
                 // Reject fields that don't apply to this input type.
@@ -1277,7 +1272,10 @@ output:
     }
 
     #[test]
-    fn validation_arrow_ipc_requires_listen() {
+    fn validation_arrow_ipc_not_supported() {
+        // arrow_ipc is always rejected as "not yet supported" regardless of
+        // whether 'listen' is specified — the 'listen' check must not fire
+        // first and give a misleading error.
         let yaml = r"
 input:
   type: arrow_ipc
@@ -1286,7 +1284,10 @@ output:
 ";
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("listen"), "expected 'listen' in error: {msg}");
+        assert!(
+            msg.contains("not yet supported"),
+            "expected 'not yet supported' in error: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The `listen`-required validation for `ArrowIpc` inputs fired before the \"not yet supported\" check
- A config with `type: arrow_ipc` and no `listen` field produced: `'listen' is required for arrow_ipc inputs`
- The correct error is always: `arrow_ipc input type is not yet supported`

Fix: merge the `ArrowIpc` arm with the `Generator` no-op arm in the listen-required check, so `ArrowIpc` skips that validation and falls through to the unsupported-type rejection.

Also updates the existing test to assert the correct error message.

Fixes #1280.

## Test plan

- [ ] `cargo test -p logfwd-config` passes (75 tests, including updated `validation_arrow_ipc_not_supported`)
- [ ] Config with `type: arrow_ipc` and no `listen` field now produces "not yet supported" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `ArrowIpc` input validation to emit 'not yet supported' instead of 'listen required'
> Previously, `Config::from_raw` in [lib.rs](https://github.com/strawgate/memagent/pull/1288/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150) ran a 'listen is required' check for `InputType::ArrowIpc` before reaching the 'not yet supported' rejection, causing a misleading error. `ArrowIpc` is now grouped with `Generator` to skip the listen check, so the correct error is always returned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dae4c6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->