### PR TITLE
fix(logfwd-arrow): replace ahash with std HashMap to restore HashDoS resistance

### DIFF
--- a/crates/logfwd-arrow/Cargo.toml
+++ b/crates/logfwd-arrow/Cargo.toml
@@ -10,7 +10,6 @@ doctest = false
 
 [dependencies]
 logfwd-core = { version = "0.1.0", path = "../logfwd-core" }
-ahash = "0.8"
 arrow = { workspace = true }
 bytes = "1"
 

--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -7,7 +7,7 @@
 //
 // For the hot pipeline path: scan -> query -> output -> discard.
 
-use ahash::AHashMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{ArrayRef, Float64Array, Int64Array, StringViewBuilder, StructArray};
@@ -92,7 +92,7 @@ impl FieldColumns {
 /// ```
 pub struct StreamingBuilder {
     fields: Vec<FieldColumns>,
-    field_index: AHashMap<Vec<u8>, usize>,
+    field_index: HashMap<Vec<u8>, usize>,
     /// Number of fields active in the current batch. Slots `0..num_active` in
     /// `fields` are in use; slots beyond that are pre-allocated but dormant.
     /// Resetting this to zero on `begin_batch` — together with clearing
@@ -132,7 +132,7 @@ impl StreamingBuilder {
     pub fn new(keep_raw: bool) -> Self {
         StreamingBuilder {
             fields: Vec::with_capacity(32),
-            field_index: AHashMap::with_capacity(32),
+            field_index: HashMap::with_capacity(32),
             num_active: 0,
             row_count: 0,
             written_bits: 0,


### PR DESCRIPTION
## Summary

- `ahash::AHashMap` was added to `logfwd-arrow` in PR #1253, keyed by field names from untrusted JSON log input
- AHash uses a fixed compile-time seed — an attacker can craft field names that maximize hash collisions, causing O(n²) behavior (HashDoS)
- The dep also violates `logfwd-arrow`'s documented rule: `Deps: core + arrow + bytes`

Fix: replace `AHashMap` with `std::collections::HashMap` (SipHash-1-3 with a per-process random seed = HashDoS resistant). Remove `ahash = "0.8"` from `logfwd-arrow/Cargo.toml`.

The `field_index` map is cleared per-batch via `begin_batch()`, limiting the blast radius, but the fixed seed still makes targeted collision attacks practical.

Fixes #1281.

## Test plan

- [ ] `cargo test -p logfwd-arrow` passes (102 tests)
- [ ] `cargo deny check` passes (ahash no longer a dep of this crate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `ahash::AHashMap` with `std::collections::HashMap` in `StreamingBuilder` to restore HashDoS resistance
> `ahash` does not provide HashDoS resistance by default, making the `field_index` map in `StreamingBuilder` a potential attack surface. Switching to the standard library `HashMap` restores randomized SipHash-based key hashing. The `ahash` dependency is also removed from [Cargo.toml](https://github.com/strawgate/memagent/pull/1291/files#diff-38bac25879d913a3e8caf2c30cb2b1e552a4fd4b41e1ff7b362a8832a20396e1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b5eca1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->