### PR TITLE
docs(book): align user docs with current runtime (UDP, HTTP, MSRV, CLI)

### DIFF
--- a/book/src/config/inputs.md
+++ b/book/src/config/inputs.md
@@ -30,7 +30,7 @@ input:
   listen: "50000"   # ~50,000 events/sec; omit for unlimited
 ```
 
-Use `--generate-json <n> <file>` on the CLI to write a fixed number of lines to a file instead.
+Use `--generate-json <num_lines> <output_file>` on the CLI to write a fixed number of lines to a file instead.
 
 ## UDP
 
@@ -40,7 +40,7 @@ Receive log lines on a UDP socket.
 input:
   type: udp
   listen: 0.0.0.0:514
-  format: syslog
+  format: json
 ```
 
 ## TCP

--- a/book/src/config/reference.md
+++ b/book/src/config/reference.md
@@ -107,7 +107,7 @@ Listen for log lines on a UDP socket.
 input:
   type: udp
   listen: 0.0.0.0:514
-  format: syslog
+  format: json
 ```
 
 ### `tcp` input *(not yet implemented)*
@@ -196,13 +196,12 @@ POST log records as newline-delimited JSON to an HTTP endpoint.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `endpoint` | string | Yes | Full URL, e.g. `http://ingest.example.com/logs`. |
-| `compression` | string | No | `zstd` to compress the request body. |
+| `compression` | string | No | Reserved for future use. HTTP output is not yet implemented. |
 
 ```yaml
 output:
   type: http
   endpoint: http://ingest.example.com/logs
-  compression: zstd
 ```
 
 ### `stdout` output
@@ -258,7 +257,7 @@ Write records to Parquet files. Not yet functional.
 | Value | Status | Description |
 |-------|--------|-------------|
 | `otlp` | Implemented | OTLP protobuf over HTTP or gRPC. |
-| `http` | Implemented | JSON lines over HTTP POST. |
+| `http` | Planned | JSON lines over HTTP POST (not yet implemented). |
 | `stdout` | Implemented | Print to stdout (JSON or coloured text). |
 | `elasticsearch` | Stub | Elasticsearch bulk API. |
 | `loki` | Stub | Grafana Loki push API. |

--- a/book/src/getting-started/quickstart.md
+++ b/book/src/getting-started/quickstart.md
@@ -11,7 +11,7 @@ You need the `logfwd` binary. See [Installation](./installation.md) for all opti
 curl -fsSL https://github.com/strawgate/memagent/releases/latest/download/logfwd-darwin-arm64 -o logfwd
 chmod +x logfwd
 
-# Or build from source (Rust 1.86+)
+# Or build from source (Rust 1.85+)
 cargo build --release -p logfwd && cp target/release/logfwd .
 ```
 


### PR DESCRIPTION
### Motivation

- User-facing docs in `book/src` advertised features or examples that no longer match runtime validation and behavior (syslog/UDP, HTTP `zstd` compression, Rust MSRV, and CLI placeholders).
- This change is docs-only to remove misleading examples and mark unimplemented functionality as planned so users are not led to configure unsupported behavior.

### Description

- Updated generator CLI placeholder in `book/src/config/inputs.md` from `--generate-json <n> <file>` to `--generate-json <num_lines> <output_file>` to match runtime argument names.  
- Replaced `format: syslog` in UDP examples with `format: json` in `book/src/config/inputs.md` and `book/src/config/reference.md` to avoid implying syslog parsing is implemented.  
- Adjusted HTTP output docs in `book/src/config/reference.md` to remove the `compression: zstd` example, mark the HTTP output as `Planned` (not implemented), and change the `compression` field description to reserved for future use.  
- Bumped quickstart MSRV text in `book/src/getting-started/quickstart.md` from `Rust 1.86+` to `Rust 1.85+` to match `Cargo.toml`.

### Testing

- Ran ripgrep checks to assert no remaining stale patterns: `rg -n 'format:\s*syslog|Rust 1\.86\+|--generate-json' book/src/...` which returned no unexpected matches (passed).  
- Verified no remaining HTTP `zstd` examples with `rg -n 'type:\s*http[\s\S]{0,120}compression:\s*zstd' book/src/config/reference.md -U` which returned none (passed).  
- Changes were committed (`docs: align book docs with current runtime behavior`) and a follow-up PR was created; this is a docs-only change and no runtime tests were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2dfc6de48832eb3a1e6cc1808f1de)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align user docs with current runtime behavior for UDP, HTTP, and MSRV
> - Changes the UDP input `format` field from `syslog` to `json` in both [inputs.md](https://github.com/strawgate/memagent/pull/1295/files#diff-564d5636713f92e3956eb26bc730a948a2ad6dd4f76d50106f8d684bb04c07d2) and [reference.md](https://github.com/strawgate/memagent/pull/1295/files#diff-9e62f3792ee78f759c5c8d316df6c512da935054f0d6112f4181f26e4793823b).
> - Marks HTTP output as `Planned` (not yet implemented) in the output types table and notes the `compression` field is reserved in [reference.md](https://github.com/strawgate/memagent/pull/1295/files#diff-9e62f3792ee78f759c5c8d316df6c512da935054f0d6112f4181f26e4793823b).
> - Lowers the stated minimum Rust toolchain version from 1.86+ to 1.85+ in [quickstart.md](https://github.com/strawgate/memagent/pull/1295/files#diff-84e743ca6da287e62514148633370c3a6b253818611813b75679b11c79fb5b3d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 002cfe1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->