### PR TITLE
fix: tighten --validate for configs that fail at runtime

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -623,6 +623,18 @@ impl Config {
         }
 
         for (name, pipe) in &self.pipelines {
+            if pipe.batch_timeout_ms == Some(0) {
+                return Err(ConfigError::Validation(format!(
+                    "pipeline '{name}': batch_timeout_ms must be greater than 0"
+                )));
+            }
+            if let Some(sql) = &pipe.transform {
+                if sql.trim().is_empty() {
+                    return Err(ConfigError::Validation(format!(
+                        "pipeline '{name}': transform SQL cannot be empty"
+                    )));
+                }
+            }
             if pipe.inputs.is_empty() {
                 return Err(ConfigError::Validation(format!(
                     "pipeline '{name}' has no inputs"
@@ -653,12 +665,26 @@ impl Config {
                                 "pipeline '{name}' input '{label}': udp/tcp input requires 'listen'"
                             )));
                         }
+                        if let Some(addr) = &input.listen {
+                            if let Err(msg) = validate_bind_addr(addr) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': {msg}"
+                                )));
+                            }
+                        }
                     }
                     InputType::Otlp => {
                         if input.listen.is_none() {
                             return Err(ConfigError::Validation(format!(
                                 "pipeline '{name}' input '{label}': 'listen' is required for otlp inputs"
                             )));
+                        }
+                        if let Some(addr) = &input.listen {
+                            if let Err(msg) = validate_bind_addr(addr) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': {msg}"
+                                )));
+                            }
                         }
                     }
                     // ArrowIpc is always rejected below as "not yet supported";
@@ -828,6 +854,13 @@ impl Config {
                                 output.output_type,
                             )));
                         }
+                        if let Some(ep) = &output.endpoint {
+                            if let Err(msg) = validate_host_port(ep) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' output '{label}': {msg}",
+                                )));
+                            }
+                        }
                     }
                     OutputType::Parquet => {
                         // Parquet output not yet implemented
@@ -952,6 +985,18 @@ fn validate_bind_addr(addr: &str) -> Result<(), String> {
     addr.parse::<std::net::SocketAddr>()
         .map(|_| ())
         .map_err(|e| format!("'{addr}' is not a valid host:port address: {e}"))
+}
+
+/// Validate that a string has a valid `host:port` format where port is a u16.
+/// This allows hostnames as well as IP addresses.
+fn validate_host_port(addr: &str) -> Result<(), String> {
+    let (_, port_str) = addr
+        .rsplit_once(':')
+        .ok_or_else(|| format!("'{addr}' is missing a port (expected format host:port)"))?;
+    port_str
+        .parse::<u16>()
+        .map_err(|_| format!("'{addr}' has an invalid port '{port_str}'"))?;
+    Ok(())
 }
 
 /// Validate that a log level string is a recognised tracing level.

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -334,19 +334,17 @@ fn validate_pipelines(
     for (name, pipe_cfg) in &config.pipelines {
         match Pipeline::from_config(name, pipe_cfg, &meter, base_path) {
             Ok(mut pipeline) => {
-                // --dry-run: also execute a probe batch through the SQL plan
-                // to catch planning errors (duplicate aliases, bad window specs)
-                // that only surface on the first real batch at runtime.
-                if dry_run {
-                    if let Err(e) = pipeline.validate_sql_plan() {
-                        eprintln!(
-                            "  {}error{}: pipeline '{name}' SQL plan: {e}",
-                            red(),
-                            reset()
-                        );
-                        errors += 1;
-                        continue;
-                    }
+                // Execute a probe batch through the SQL plan to catch planning
+                // errors (duplicate aliases, bad window specs) that only
+                // surface on the first real batch at runtime.
+                if let Err(e) = pipeline.validate_sql_plan() {
+                    eprintln!(
+                        "  {}error{}: pipeline '{name}' SQL plan: {e}",
+                        red(),
+                        reset()
+                    );
+                    errors += 1;
+                    continue;
                 }
                 // Success output goes to stdout so scripts can capture it.
                 println!("  {}ready{}: {}{name}{}", green(), reset(), bold(), reset());


### PR DESCRIPTION
Tighten `--validate` so configs that would fail immediately at runtime are rejected up front. This batch stays in the existing config-validation seam and focuses on low-discretion validation fixes, not schema redesign.

Resolves #1143.
Resolves #1036 (zero batch timeout is a validation-time bounds check).
Resolves #1045 (same config validation surface for TCP/UDP outputs).
Resolves #1054 (same validate() path for transform SQL).
Resolves #1170 (same validate() path for OTLP input listen handling).

---
*PR created automatically by Jules for task [654578838478549728](https://jules.google.com/task/654578838478549728) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten `--validate` to catch configs that fail at runtime
> - Adds validation in [`Config.from_raw`](https://github.com/strawgate/memagent/pull/1323/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150) to reject `batch_timeout_ms == 0`, empty transform SQL, and invalid `listen`/`endpoint` host:port values for UDP, TCP, and OTLP inputs and outputs.
> - Introduces a `validate_host_port` helper that accepts hostnames or IPs but rejects missing or non-u16 ports, used for TCP/UDP output endpoint validation.
> - SQL plan validation in [`validate_pipelines`](https://github.com/strawgate/memagent/pull/1323/files#diff-48e7b38d2f38857cdef3f17a929b768683b2c5ee185fe3c4fb45ae95d4bcdbe4) now always runs, not only during `--dry-run`.
> - Behavioral Change: invalid SQL plans now surface during `--validate` as well as `--dry-run`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6850d0f. 2 files reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->