### PR TITLE
fix(tail): normalize empty glob root, fix depth for relative patterns, remove unsafe

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -442,15 +442,15 @@ fn json_any_value_to_string(v: &sonic_rs::Value) -> String {
         if let Some(n) = i.as_i64() {
             let mut buf = Vec::new();
             write_i64_to_buf(&mut buf, n);
-            // SAFETY: write_i64_to_buf only writes ASCII digits and '-'
-            return unsafe { String::from_utf8_unchecked(buf) };
+            // write_i64_to_buf only produces ASCII digits and '-', so from_utf8 always succeeds.
+            return String::from_utf8(buf).unwrap_or_default();
         }
     }
     if let Some(d) = v.get("doubleValue").and_then(JsonValueTrait::as_f64) {
         let mut buf = Vec::new();
         write_f64_to_buf(&mut buf, d);
-        // SAFETY: write_f64_to_buf only writes ASCII characters
-        return unsafe { String::from_utf8_unchecked(buf) };
+        // write_f64_to_buf only produces ASCII characters, so from_utf8 always succeeds.
+        return String::from_utf8(buf).unwrap_or_default();
     }
     if let Some(b) = v.get("boolValue").and_then(JsonValueTrait::as_bool) {
         return if b { "true" } else { "false" }.to_string();

--- a/crates/logfwd-io/src/tail.rs
+++ b/crates/logfwd-io/src/tail.rs
@@ -217,9 +217,12 @@ fn glob_root(pattern: &str) -> PathBuf {
             PathBuf::from(trimmed)
         }
     } else {
-        Path::new(prefix)
-            .parent()
-            .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
+        let parent = Path::new(prefix).parent().unwrap_or(Path::new(""));
+        if parent.as_os_str().is_empty() {
+            PathBuf::from(".")
+        } else {
+            parent.to_path_buf()
+        }
     }
 }
 
@@ -231,7 +234,13 @@ fn glob_max_depth(pattern: &str) -> Option<usize> {
         return None;
     }
     let root = glob_root(pattern);
-    let root_depth = root.components().count();
+    // Exclude the CurDir (`.`) component so relative roots don't
+    // inflate the depth count — Path::new(".").components().count() == 1
+    // but logically the root has 0 "meaningful" segments.
+    let root_depth = root
+        .components()
+        .filter(|c| *c != std::path::Component::CurDir)
+        .count();
     let total_depth = Path::new(pattern).components().count();
     // Ensure at least depth 1 — a file is always at depth ≥1 from its directory.
     Some(total_depth.saturating_sub(root_depth).max(1))
@@ -1150,6 +1159,19 @@ mod tests {
     }
 
     #[test]
+    fn glob_root_relative_no_wildcard() {
+        // Bare filename with no path separator or wildcard — parent is current dir.
+        assert_eq!(glob_root("test.log"), PathBuf::from("."));
+        assert_eq!(glob_root("app.log"), PathBuf::from("."));
+    }
+
+    #[test]
+    fn glob_root_relative_mid_filename_wildcard() {
+        // `app*.log` — wildcard mid-filename, root is current dir (parent of "app" is "").
+        assert_eq!(glob_root("app*.log"), PathBuf::from("."));
+    }
+
+    #[test]
     fn glob_max_depth_single_level() {
         // /var/log/*.log → root=/var/log, pattern has 3 components, root has 2 → depth 1
         assert_eq!(glob_max_depth("/var/log/*.log"), Some(1));
@@ -1164,6 +1186,13 @@ mod tests {
     fn glob_max_depth_relative_is_at_least_1() {
         // *.log → root=., 1 component each, but max(0,1) = 1
         assert_eq!(glob_max_depth("*.log"), Some(1));
+    }
+
+    #[test]
+    fn glob_max_depth_relative_subdir() {
+        // */*.log → root=. (0 effective components), pattern has 2 → depth 2.
+        // WalkDir must search at depth 2 to find files in subdirectories.
+        assert_eq!(glob_max_depth("*/*.log"), Some(2));
     }
 
     // ---- end glob helper tests ----


### PR DESCRIPTION
## Summary

Three correctness bugs in the I/O refactor (merged in #1334) identified by CodeRabbit:

- **`glob_root` empty parent bug**: `Path::new("test.log").parent()` returns `Some("")` not `None`. The previous `map_or_else` converted the empty path to `PathBuf::from("")`, causing `WalkDir::new("")` to find nothing. Bare filenames and mid-filename wildcards (e.g. `app*.log`) now correctly return `.` as the walk root.

- **`glob_max_depth` CurDir inflation**: `Path::new(".").components().count()` returns 1 (CurDir component), inflating the root depth by 1 for relative patterns. A pattern like `*/*.log` was computing depth 1 instead of 2, causing `WalkDir::max_depth(1)` to miss files in subdirectories. CurDir component is now excluded from the root depth count.

- **`unsafe String::from_utf8_unchecked`**: Replaced with safe `String::from_utf8(...).unwrap_or_default()` — `write_i64_to_buf` and `write_f64_to_buf` only produce ASCII, so `from_utf8` always succeeds. Removes hand-written `unsafe` per project guidelines.

## Test plan

- [ ] Existing glob unit tests pass
- [ ] New tests: `glob_root_relative_no_wildcard`, `glob_root_relative_mid_filename_wildcard`, `glob_max_depth_relative_subdir`
- [ ] `cargo test -p logfwd-io --lib -- glob` passes (15 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix glob root normalization and depth calculation for relative patterns in tail
> - `glob_root` in [tail.rs](https://github.com/strawgate/memagent/pull/1350/files#diff-eb28129757c059684e16401c616b90f230c604b673f2aaf1f985be40db02079f) now returns `"."` when the computed parent path is empty, fixing cases where a mid-filename wildcard or relative pattern produced an empty path buffer.
> - `glob_max_depth` no longer counts `Component::CurDir` (`"."`), so relative patterns like `*/*.log` now correctly yield a depth of 2 instead of 1.
> - Replaces `String::from_utf8_unchecked` with `String::from_utf8(...).unwrap_or_default()` in [otlp_receiver.rs](https://github.com/strawgate/memagent/pull/1350/files#diff-839a5b8c237a52e782ebba56a56e0053ec71e6e918888b20043904fabcd7b99e), returning an empty string on invalid UTF-8 instead of unsafe construction.
> - Behavioral Change: `glob_max_depth` returns higher depths for relative-rooted patterns, which may cause the file watcher to recurse deeper than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0a7776b. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->