### PR TITLE
fix(es_sink): avoid full JSON parse on successful bulk response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,7 @@ dependencies = [
  "prost",
  "reqwest",
  "ryu",
+ "serde",
  "serde_json",
  "serial_test",
  "stats_alloc",

--- a/crates/logfwd-output/Cargo.toml
+++ b/crates/logfwd-output/Cargo.toml
@@ -28,6 +28,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 httpdate = "1"
 flate2 = "1"
 tokio-stream = "0.1.18"
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -187,17 +187,22 @@ impl ElasticsearchSink {
     /// - `InvalidData`: item-level document errors (mapper_parsing_exception, etc.) — permanent,
     ///   retrying the same document is futile, so these map to `Rejected` in the caller
     fn parse_bulk_response(body: &[u8]) -> io::Result<()> {
-        let v: serde_json::Value = serde_json::from_slice(body)
-            .map_err(|e| io::Error::other(format!("failed to parse ES bulk response: {e}")))?;
+        #[derive(serde::Deserialize)]
+        struct BulkHeader {
+            errors: bool,
+        }
 
-        let has_errors = v
-            .get("errors")
-            .and_then(serde_json::Value::as_bool)
-            .ok_or_else(|| io::Error::other("ES bulk response missing 'errors' boolean field"))?;
+        let header: BulkHeader = serde_json::from_slice(body).map_err(|e| {
+            io::Error::other(format!("failed to parse ES bulk response header: {e}"))
+        })?;
 
-        if !has_errors {
+        if !header.errors {
             return Ok(());
         }
+
+        // Only do full parse on the error path to avoid hot-path allocations.
+        let v: serde_json::Value = serde_json::from_slice(body)
+            .map_err(|e| io::Error::other(format!("failed to parse ES bulk response: {e}")))?;
 
         let items = v
             .get("items")


### PR DESCRIPTION
This PR addresses a performance regression in the Elasticsearch sink's hot path (#1340).

Previously, `parse_bulk_response` would do a full `serde_json::Value` allocation for the entire bulk response payload, even when `errors: false`. For large batch sizes, this would unnecessarily allocate huge JSON trees proportional to the batch size, leading to significant memory churn and regression in output throughput.

This PR introduces a small `BulkHeader` struct that only derives `Deserialize` for the `errors` boolean. It parses this header first, and returns immediately if no errors occurred. The full `serde_json::Value` parsing is now only performed on the error path to extract detailed rejection reasons.

---
*PR created automatically by Jules for task [7123014716953248043](https://jules.google.com/task/7123014716953248043) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid full JSON parse on successful bulk response in `ElasticsearchSink`
> In `parse_bulk_response`, deserializes only the top-level `errors` boolean first using a minimal `BulkHeader` struct, and defers full `serde_json::Value` parsing to the error path only. This reduces deserialization overhead on the common success case. Behavioral Change: parse failure error messages have changed from "missing 'errors' boolean field" to "failed to parse ES bulk response header: ..." (with serde's field error appended).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84d8de0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->