### PR TITLE
Fix Loki sink null timestamp and JSON escape correctness

### DIFF
--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -889,7 +889,8 @@ mod tests {
         let mut entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
         entries.sort_by_key(|(ts, _)| *ts);
 
-        // After sorting, the valid timestamp (100) comes first, then the fallback observed_time_ns (12345).
+        // Sorted by timestamp: the non-null row (100) comes before the
+        // null row's fallback value (observed_time_ns = 12345).
         assert_eq!(entries[0].0, 100, "Valid timestamp should be preserved");
         assert_eq!(
             entries[1].0, metadata.observed_time_ns,


### PR DESCRIPTION
This PR fixes two bugs in the Loki output sink:
1. `bug #1339`: Null Int64 timestamps were being read without a null check, sending garbage nanosecond values to Loki. A check `col.is_null(row)` has been added before getting the value, and we now fall back to `metadata.observed_time_ns` if the timestamp is null. Includes a regression test.
2. `bug #1048`: `escape_json_raw` needed to ensure that the passed string actually successfully parses as valid JSON. We now use `serde_json::from_str::<serde_json::Value>` to make the validation robust, and include tests for unterminated quotes.

---
*PR created automatically by Jules for task [4490293877340363110](https://jules.google.com/task/4490293877340363110) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix null timestamp handling and JSON escape correctness in Loki sink
> - Fixes a bug in `LokiSink.build_stream_map` where rows with a null timestamp column would fail to read a valid value; null timestamps now fall back to `metadata.observed_time_ns`.
> - Fixes `escape_json_raw` to parse quote-prefixed input as `serde_json::Value` (rather than specifically as a JSON string), so any valid JSON is passed through as-is and only invalid JSON is escaped and wrapped.
> - Adds tests for null timestamp fallback behavior and additional malformed/unterminated string cases in [loki.rs](https://github.com/strawgate/memagent/pull/1380/files#diff-1bc2e0eadd25a290f776d0bb22aa248a0dfefee5e49c32d486e2d963e8f08bce).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ee9909.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->