### PR TITLE
fix: resolve config validation regressions (ArrowIPC, Hostnames, Generators)

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -1025,11 +1025,15 @@ pub fn validate_host_port(addr: &str) -> Result<(), String> {
         let close_bracket = addr
             .find(']')
             .ok_or_else(|| format!("'{addr}' has mismatched brackets"))?;
-        if addr[1..close_bracket].is_empty() {
+        let inner = &addr[1..close_bracket];
+        if inner.is_empty() {
             return Err(format!(
                 "'{addr}' has an empty IPv6 address inside brackets"
             ));
         }
+        inner
+            .parse::<std::net::Ipv6Addr>()
+            .map_err(|_| format!("'{addr}' contains a non-IPv6 value inside brackets"))?;
         if !addr[close_bracket..].starts_with("]:") {
             return Err(format!("'{addr}' is missing a port after IPv6 brackets"));
         }

--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -663,7 +663,9 @@ pub fn build_sink_factory(
             let fmt = match cfg.format.as_ref() {
                 Some(Format::Json) => StdoutFormat::Json,
                 Some(Format::Console) => StdoutFormat::Console,
-                Some(Format::Text) | None => StdoutFormat::Text,
+                Some(Format::Text) => StdoutFormat::Text,
+                // Default to console output when no format is specified.
+                None => StdoutFormat::Console,
                 Some(other) => {
                     return Err(OutputError::Construction(format!(
                         "output '{name}': stdout does not support '{other:?}' format (use json, console, or text)"

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -372,8 +372,11 @@ async fn cmd_blackhole(args: &[String]) -> Result<(), CliError> {
         .map_err(|e| CliError::Config(format!("invalid bind address: {e}")))?;
 
     // Use port 0 for diagnostics so it never collides with an in-use port.
+    // Quote addr as a YAML string so bracketed IPv6 (e.g. [::1]:4318) does not
+    // break YAML parsing. Single-quote with '' escaping for any embedded quotes.
+    let yaml_addr = addr.replace('\'', "''");
     let yaml = format!(
-        "input:\n  type: otlp\n  listen: {addr}\noutput:\n  type: null\nserver:\n  diagnostics: 127.0.0.1:0\n"
+        "input:\n  type: otlp\n  listen: '{yaml_addr}'\noutput:\n  type: null\nserver:\n  diagnostics: 127.0.0.1:0\n"
     );
     let config = logfwd_config::Config::load_str(&yaml)
         .map_err(|e| CliError::Config(format!("internal config error: {e}")))?;


### PR DESCRIPTION
This PR fixes three config validation regressions related to GitHub Issue #1353:
1. #1331: Reordered ArrowIPC config validation so the "not yet supported" check occurs before `listen` field validation, preventing misleading error messages.
2. #1335: Fixed `validate_bind_addr` and `validate_host_port` to allow hostnames instead of strictly numeric IPs, handle IPv6 bracket addresses, and reject missing hosts and URLs.
3. #1336: Allowed the `listen` field for Generator inputs, which is used for rate limiting. Also fixed `Format::Text` to output plain text instead of colored console text, and enforced that Loki output rejects the `compression` field since it was silently accepted but unused.

---
*PR created automatically by Jules for task [1068403247151767570](https://jules.google.com/task/1068403247151767570) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix config validation regressions for ArrowIPC inputs, hostnames, and generators
> - Explicitly rejects `ArrowIpc` input configs early with a clear error message; OTLP validation errors now include the concrete input type.
> - Introduces `validate_host_port` in [logfwd-config](https://github.com/strawgate/memagent/pull/1381/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150) to accept hostnames and IPv6 addresses, replacing direct `SocketAddr` parsing in `validate_bind_addr`.
> - Loki outputs now reject configurations that set `compression`; stdout outputs default to `Console` format and reject unsupported formats with an error.
> - The `cmd_blackhole` CLI command uses `validate_host_port` and quotes addresses in generated YAML to handle IPv6 brackets safely.
> - Behavioral Change: `validate_bind_addr` now accepts hostnames (e.g. `localhost:4318`) and rejects URLs/malformed IPv6; stdout no longer silently falls back to text for unsupported formats.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d49b84.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->