### PR TITLE
fix(config): validate workers >= 1 and batch_target_bytes > 0; respect start_from_end for glob-discovered files

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -630,12 +630,12 @@ impl Config {
             }
             if pipe.workers == Some(0) {
                 return Err(ConfigError::Validation(format!(
-                    "pipeline '{name}': workers must be >= 1"
+                    "pipeline '{name}': workers must be greater than 0"
                 )));
             }
             if pipe.batch_target_bytes == Some(0) {
                 return Err(ConfigError::Validation(format!(
-                    "pipeline '{name}': batch_target_bytes must be > 0"
+                    "pipeline '{name}': batch_target_bytes must be greater than 0"
                 )));
             }
             if let Some(sql) = &pipe.transform {
@@ -2707,8 +2707,8 @@ pipelines:
             "expected 'workers' in error: {msg}"
         );
         assert!(
-            msg.contains("must be >= 1"),
-            "expected '>= 1' in error: {msg}"
+            msg.contains("must be greater than 0"),
+            "expected 'must be greater than 0' in error: {msg}"
         );
     }
 

--- a/crates/logfwd-io/src/tail.rs
+++ b/crates/logfwd-io/src/tail.rs
@@ -405,8 +405,8 @@ impl FileDiscovery {
     /// Check for new or rotated files among the watched paths.
     ///
     /// For rotated files, drains remaining data from the old fd before
-    /// switching to the new file. For newly-appeared files, opens them
-    /// from the beginning.
+    /// switching to the new file (always read from the beginning).
+    /// For newly-appeared files, respects `config.start_from_end`.
     fn detect_changes(&self, reader: &mut FileReader, events: &mut Vec<TailEvent>) {
         let watch_paths = self.watch_paths.clone();
         for path in &watch_paths {
@@ -2394,7 +2394,7 @@ mod tests {
         );
     }
 
-    /// #730: Non-existent file paths should not prevent construction.
+    /// Glob-discovered files must respect start_from_end config.
     #[test]
     fn glob_rescan_respects_start_from_end() {
         // Verify that files discovered during glob rescan (new pods, new log files)
@@ -2484,6 +2484,7 @@ mod tests {
         );
     }
 
+    /// #730: Non-existent file paths should not prevent construction.
     #[test]
     fn test_nonexistent_path_does_not_panic() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Fixes two config/runtime parity bugs in the file tailer. Closes #1384.

- **`workers: 0` and `batch_target_bytes: 0` pass `--validate` but fail at runtime**: Both values are rejected at runtime in `pipeline.rs:142–146` but the `--validate` path didn't check them. Added checks mirroring the existing `batch_timeout_ms == 0` guard.

- **`start_from_end: true` ignored for files discovered after startup**: Files opened via glob rescan or rotation-creation detection were always opened with `seek_to_end: false`, meaning the full history of new pod log files was re-read even with `start_from_end: true`. Fixed in `rescan_globs` and the new-file branch of `detect_changes`. (Rotation replacement intentionally keeps `false` — we want to read from the beginning of a rotated-in file.)

## Test plan

- `workers_zero_is_rejected` — `--validate` now returns error for `workers: 0`
- `batch_target_bytes_zero_is_rejected` — `--validate` now returns error for `batch_target_bytes: 0`
- `glob_rescan_respects_start_from_end` — files discovered by glob rescan with `start_from_end: true` are opened at EOF

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix config validation for `workers` and `batch_target_bytes`, and respect `start_from_end` for glob-discovered files
> - Adds validation in `Config.from_raw` to reject pipelines where `workers: 0` or `batch_target_bytes: 0`, matching the existing check for `batch_timeout_ms: 0`.
> - Changes `FileDiscovery.rescan_globs` and `FileDiscovery.detect_changes` in [tail.rs](https://github.com/strawgate/memagent/pull/1387/files#diff-eb28129757c059684e16401c616b90f230c604b673f2aaf1f985be40db02079f) to open newly discovered files using `reader.config.start_from_end` instead of always starting from the beginning; rotated files still reopen from the beginning.
> - Behavioral Change: glob-discovered files on rescan will now skip existing content when `start_from_end: true` is set, where previously they always read from offset 0.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 686af93. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->