### PR TITLE
fix(loki+otlp): protect static labels from dynamic overwrite; skip empty label values; fix skip_field overflow

### DIFF
--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -240,7 +240,9 @@ pub fn skip_field(buf: &[u8], wire_type: u8, pos: usize) -> Result<usize, &'stat
         2 => {
             // Length-delimited.
             let (len, new_pos) = decode_varint(buf, pos)?;
-            let end = new_pos + len as usize;
+            let end = new_pos
+                .checked_add(len as usize)
+                .ok_or("skip: length-delimited overflow")?;
             if end > buf.len() {
                 return Err("skip: length-delimited overflow");
             }
@@ -499,6 +501,22 @@ fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn skip_field_length_overflow_rejected() {
+        // wire_type 2 (length-delimited) with a varint that encodes a length
+        // large enough that new_pos + len wraps usize — must return Err, not Ok.
+        use alloc::vec;
+        let mut buf = vec![0u8; 16];
+        // Encode varint for usize::MAX - 1 at position 0.
+        let big: u64 = (usize::MAX as u64) - 1;
+        let mut tmp = Vec::new();
+        encode_varint(&mut tmp, big);
+        buf[..tmp.len()].copy_from_slice(&tmp);
+        // new_pos = tmp.len() (~10); len = usize::MAX-1 → overflows
+        let result = skip_field(&buf, 2, 0);
+        assert!(result.is_err(), "expected overflow error, got {:?}", result);
+    }
 
     #[test]
     fn test_parse_timestamp() {

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -205,7 +205,10 @@ impl LokiSink {
             let mut labels: Vec<(String, String)> = self.config.static_labels.clone();
             for (label_name, col_info) in &label_col_infos {
                 if let Some(val) = coalesce_as_str(batch, row, col_info) {
-                    labels.push((label_name.clone(), val));
+                    // Skip empty label values — Loki API rejects them with HTTP 400.
+                    if !val.is_empty() {
+                        labels.push((label_name.clone(), val));
+                    }
                 }
             }
             labels.sort_unstable_by(|a, b| a.0.cmp(&b.0));
@@ -252,10 +255,12 @@ impl LokiSink {
             retained += sort_and_dedup_timestamps(entries) as u64;
 
             // Parse stream_key (JSON array of [key, value] pairs) back into label map.
+            // Static labels are seeded first as immutable identifiers; dynamic labels
+            // from the stream_key fill in any remaining keys but cannot override statics.
             let mut labels_map: HashMap<String, String> = static_labels.iter().cloned().collect();
             if let Ok(pairs) = serde_json::from_str::<Vec<[String; 2]>>(stream_key.as_str()) {
                 for [k, v] in pairs {
-                    labels_map.insert(k, v);
+                    labels_map.entry(k).or_insert(v);
                 }
             }
 
@@ -742,6 +747,90 @@ mod tests {
         assert_eq!(
             entries[1].0, metadata.observed_time_ns,
             "Negative timestamp should fall back to observed_time_ns"
+        );
+    }
+
+    #[test]
+    fn static_label_not_overwritten_by_dynamic() {
+        // Bug #1385: static labels were seeded into labels_map first; dynamic
+        // labels from stream_key were inserted on top, silently overwriting them.
+        use arrow::array::StringArray;
+        use arrow::datatypes::{Field, Schema};
+
+        let config = Arc::new(LokiConfig {
+            endpoint: "http://localhost".to_string(),
+            tenant_id: None,
+            static_labels: vec![("env".to_string(), "prod".to_string())],
+            label_columns: vec!["env".to_string()],
+            headers: vec![],
+        });
+        let sink = LokiSink::new(
+            "test".to_string(),
+            config,
+            Arc::new(reqwest::Client::new()),
+            Arc::new(ComponentStats::new()),
+        );
+
+        // The log record has env="staging" — static label "env"="prod" must survive.
+        let schema = Arc::new(Schema::new(vec![Field::new("env", DataType::Utf8, true)]));
+        let env_arr = StringArray::from(vec![Some("staging")]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(env_arr)]).unwrap();
+        let metadata = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 1_000,
+        };
+
+        let mut stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
+        let (payload, _) = LokiSink::serialize_loki_json(
+            &mut stream_map,
+            &[("env".to_string(), "prod".to_string())],
+        );
+        // The static label "prod" must not be overwritten by the dynamic "staging".
+        assert!(
+            payload.contains("\"env\":\"prod\""),
+            "static label must not be overwritten; payload: {payload}"
+        );
+    }
+
+    #[test]
+    fn empty_label_value_skipped() {
+        // Bug #1385: empty label values were forwarded to Loki, causing HTTP 400.
+        use arrow::array::StringArray;
+        use arrow::datatypes::{Field, Schema};
+
+        let config = Arc::new(LokiConfig {
+            endpoint: "http://localhost".to_string(),
+            tenant_id: None,
+            static_labels: vec![],
+            label_columns: vec!["namespace".to_string()],
+            headers: vec![],
+        });
+        let sink = LokiSink::new(
+            "test".to_string(),
+            config,
+            Arc::new(reqwest::Client::new()),
+            Arc::new(ComponentStats::new()),
+        );
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "namespace",
+            DataType::Utf8,
+            true,
+        )]));
+        let ns_arr = StringArray::from(vec![Some("")]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ns_arr)]).unwrap();
+        let metadata = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 1_000,
+        };
+
+        let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
+        // There must be exactly one stream; its key must not include "namespace".
+        assert_eq!(stream_map.len(), 1);
+        let key = stream_map.keys().next().unwrap();
+        assert!(
+            !key.contains("namespace"),
+            "empty label value must be excluded from stream key; key: {key}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Three correctness fixes for the Loki sink and OTLP parser. Closes #1385.

- **Static Loki labels overwritten by dynamic labels with same key**: `serialize_loki_json` seeded `labels_map` from `static_labels` then overwrote them with dynamic labels from the stream_key. Static labels are now immutable — dynamic labels fill in keys not already covered by statics.

- **Empty label values cause HTTP 400 from Loki API**: `build_stream_map` included labels with empty string values in the stream key, causing Loki to reject the push with HTTP 400. Empty values are now skipped before adding to the label set.

- **`skip_field` integer overflow in release builds**: `new_pos + len as usize` in the wire_type=2 branch wraps without panic in release mode when `len` is near `usize::MAX`. Changed to `checked_add` to return `Err` on overflow. (See also #1338 for the same pattern in `otap_receiver.rs`.)

## Test plan

- `static_label_not_overwritten_by_dynamic` — static `env=prod` survives when dynamic `env=staging` is present
- `empty_label_value_skipped` — batch with `namespace=""` produces a stream key without `namespace`
- `skip_field_length_overflow_rejected` — varint encoding `usize::MAX-1` returns `Err` instead of a wrapped `Ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix static label precedence, empty label filtering, and `skip_field` overflow in Loki/OTLP output
> - In [`loki.rs`](https://github.com/strawgate/memagent/pull/1388/files#diff-1bc2e0eadd25a290f776d0bb22aa248a0dfefee5e49c32d486e2d963e8f08bce), static labels are now seeded before dynamic labels during stream key reconstruction, using `entry(...).or_insert(...)` so dynamic labels cannot overwrite static ones.
> - Empty-string dynamic label values are now skipped when building the stream map, preventing empty labels from being sent to Loki.
> - In [`otlp.rs`](https://github.com/strawgate/memagent/pull/1388/files#diff-c45bc29b4d59fee2317cecce3b4061a1c4017aad89e68047a1dbbb09a8ad87fe), `skip_field` now uses `checked_add` when computing the end offset for length-delimited fields, returning an error on overflow instead of wrapping.
> - Unit tests are added for all three fixes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 953cf18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->