### PR TITLE
Fix benchmark correctness issues

### DIFF
--- a/crates/logfwd-bench/benches/batch_formation.rs
+++ b/crates/logfwd-bench/benches/batch_formation.rs
@@ -28,7 +28,7 @@ fn bench_batch_scan(c: &mut Criterion) {
     for &n in batch_sizes {
         let data = generators::gen_production_mixed(n, 42);
 
-        group.throughput(Throughput::Elements(n as u64));
+        group.throughput(Throughput::Bytes(data.len() as u64));
         group.bench_with_input(BenchmarkId::new("scan", n), &data, |b, data| {
             let data_bytes = bytes::Bytes::from(data.clone());
             let mut scanner = Scanner::new(ScanConfig::default());
@@ -59,7 +59,7 @@ fn bench_batch_transform(c: &mut Criterion) {
     for &n in batch_sizes {
         let data = generators::gen_production_mixed(n, 42);
 
-        group.throughput(Throughput::Elements(n as u64));
+        group.throughput(Throughput::Bytes(data.len() as u64));
 
         // Scan + SELECT * (passthrough)
         group.bench_with_input(BenchmarkId::new("scan_passthrough", n), &data, |b, data| {
@@ -110,7 +110,7 @@ fn bench_batch_pipeline(c: &mut Criterion) {
     for &n in batch_sizes {
         let data = generators::gen_production_mixed(n, 42);
 
-        group.throughput(Throughput::Elements(n as u64));
+        group.throughput(Throughput::Bytes(data.len() as u64));
 
         // Full pipeline: scan → SELECT * → OTLP encode
         group.bench_with_input(
@@ -152,7 +152,7 @@ fn bench_batch_pipeline(c: &mut Criterion) {
                             .expect("JSON serialization should not fail");
                         buf.push(b'\n');
                     }
-                    std::hint::black_box(buf.len());
+                    std::hint::black_box(&buf);
                 });
             },
         );

--- a/crates/logfwd-bench/benches/builder_compare.rs
+++ b/crates/logfwd-bench/benches/builder_compare.rs
@@ -240,7 +240,7 @@ fn bench_persist(c: &mut Criterion) {
                 let batch = std::hint::black_box(scanner.scan(buf.clone()).unwrap());
                 let owned = logfwd_arrow::materialize::detach(&batch);
                 let compressed = write_ipc_zstd(&owned);
-                std::hint::black_box(compressed.len());
+                std::hint::black_box(&compressed);
             });
         });
 
@@ -250,7 +250,7 @@ fn bench_persist(c: &mut Criterion) {
             b.iter(|| {
                 let batch = std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap());
                 let compressed = write_ipc_zstd(&batch);
-                std::hint::black_box(compressed.len());
+                std::hint::black_box(&compressed);
             });
         });
     }
@@ -281,7 +281,7 @@ fn bench_pipeline(c: &mut Criterion) {
             let transformed = transform.execute_blocking(batch).unwrap();
             let owned = detach_if_attached(&transformed, &buf);
             let compressed = write_ipc_zstd(&owned);
-            std::hint::black_box(compressed.len());
+            std::hint::black_box(&compressed);
         });
     });
 
@@ -292,7 +292,7 @@ fn bench_pipeline(c: &mut Criterion) {
             let batch = std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let compressed = write_ipc_zstd(&transformed);
-            std::hint::black_box(compressed.len());
+            std::hint::black_box(&compressed);
         });
     });
 
@@ -306,7 +306,7 @@ fn bench_pipeline(c: &mut Criterion) {
             let transformed = transform.execute_blocking(batch).unwrap();
             let owned = detach_if_attached(&transformed, &buf);
             let compressed = write_ipc_zstd(&owned);
-            std::hint::black_box(compressed.len());
+            std::hint::black_box(&compressed);
         });
     });
 
@@ -317,7 +317,7 @@ fn bench_pipeline(c: &mut Criterion) {
             let batch = std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let compressed = write_ipc_zstd(&transformed);
-            std::hint::black_box(compressed.len());
+            std::hint::black_box(&compressed);
         });
     });
 
@@ -334,7 +334,7 @@ fn bench_pipeline(c: &mut Criterion) {
             let transformed = transform.execute_blocking(batch).unwrap();
             let owned = detach_if_attached(&transformed, &buf);
             let compressed = write_ipc_zstd(&owned);
-            std::hint::black_box(compressed.len());
+            std::hint::black_box(&compressed);
         });
     });
 
@@ -348,7 +348,7 @@ fn bench_pipeline(c: &mut Criterion) {
             let batch = std::hint::black_box(scanner.scan_detached(buf.clone()).unwrap());
             let transformed = transform.execute_blocking(batch).unwrap();
             let compressed = write_ipc_zstd(&transformed);
-            std::hint::black_box(compressed.len());
+            std::hint::black_box(&compressed);
         });
     });
 

--- a/crates/logfwd-bench/benches/file_io.rs
+++ b/crates/logfwd-bench/benches/file_io.rs
@@ -134,10 +134,12 @@ fn bench_cri_framing(c: &mut Criterion) {
             BenchmarkId::new("read_parse_reassemble", label),
             &file_path.to_path_buf(),
             |b, path| {
+                let mut reassembler = CriReassembler::new(1024 * 1024);
+                let mut json_buf = Vec::with_capacity(data.len());
                 b.iter(|| {
                     let buf = std::fs::read(path).expect("read file");
-                    let mut reassembler = CriReassembler::new(1024 * 1024);
-                    let mut json_buf = Vec::with_capacity(buf.len());
+                    reassembler.reset();
+                    json_buf.clear();
                     let mut count = 0usize;
                     let mut start = 0;
                     while start < buf.len() {

--- a/crates/logfwd-bench/benches/full_chain.rs
+++ b/crates/logfwd-bench/benches/full_chain.rs
@@ -23,9 +23,9 @@ use logfwd_transform::SqlTransform;
 // ---------------------------------------------------------------------------
 
 /// Parse CRI data and reassemble into JSON lines buffer.
-fn cri_to_json(data: &[u8]) -> Vec<u8> {
-    let mut reassembler = CriReassembler::new(1024 * 1024);
-    let mut json_buf = Vec::with_capacity(data.len());
+fn cri_to_json(data: &[u8], reassembler: &mut CriReassembler, json_buf: &mut Vec<u8>) {
+    reassembler.reset();
+    json_buf.clear();
     let mut start = 0;
     while start < data.len() {
         let end = memchr::memchr(b'\n', &data[start..]).map_or(data.len(), |p| start + p);
@@ -41,7 +41,6 @@ fn cri_to_json(data: &[u8]) -> Vec<u8> {
         }
         start = end + 1;
     }
-    json_buf
 }
 
 // ---------------------------------------------------------------------------
@@ -57,7 +56,7 @@ fn bench_json_chain(c: &mut Criterion) {
     for &n in &[1_000usize, 10_000, 100_000] {
         let data = generators::gen_production_mixed(n, 42);
 
-        group.throughput(Throughput::Elements(n as u64));
+        group.throughput(Throughput::Bytes(data.len() as u64));
 
         // Composed: scan → SELECT * → OTLP encode
         group.bench_with_input(BenchmarkId::new("composed", n), &data, |b, data| {
@@ -128,7 +127,7 @@ fn bench_cri_chain(c: &mut Criterion) {
     for &n in &[1_000usize, 10_000] {
         let data = generators::gen_cri_k8s(n, 42);
 
-        group.throughput(Throughput::Elements(n as u64));
+        group.throughput(Throughput::Bytes(data.len() as u64));
 
         // Composed: CRI parse → scan → WHERE filter → OTLP encode
         group.bench_with_input(BenchmarkId::new("composed", n), &data, |b, data| {
@@ -136,10 +135,12 @@ fn bench_cri_chain(c: &mut Criterion) {
             let mut transform =
                 SqlTransform::new("SELECT * FROM logs WHERE level = 'ERROR'").unwrap();
             let mut sink = make_otlp_sink(Compression::None);
+            let mut reassembler = CriReassembler::new(1024 * 1024);
+            let mut json_buf = Vec::with_capacity(data.len());
             b.iter(|| {
-                let json = cri_to_json(data);
+                cri_to_json(data, &mut reassembler, &mut json_buf);
                 let batch = scanner
-                    .scan_detached(bytes::Bytes::from(json))
+                    .scan_detached(bytes::Bytes::copy_from_slice(&json_buf))
                     .expect("scan should not fail");
                 let result = transform.execute_blocking(batch).unwrap();
                 std::hint::black_box(sink.encode_batch(&result, &meta));
@@ -148,7 +149,12 @@ fn bench_cri_chain(c: &mut Criterion) {
 
         // Stage 1: CRI parse + reassemble only
         group.bench_with_input(BenchmarkId::new("cri_parse_only", n), &data, |b, data| {
-            b.iter(|| std::hint::black_box(cri_to_json(data)));
+            let mut reassembler = CriReassembler::new(1024 * 1024);
+            let mut json_buf = Vec::with_capacity(data.len());
+            b.iter(|| {
+                cri_to_json(data, &mut reassembler, &mut json_buf);
+                std::hint::black_box(&json_buf);
+            });
         });
     }
 
@@ -168,7 +174,7 @@ fn bench_grok_chain(c: &mut Criterion) {
     for &n in &[1_000usize, 10_000] {
         let data = generators::gen_production_mixed(n, 42);
 
-        group.throughput(Throughput::Elements(n as u64));
+        group.throughput(Throughput::Bytes(data.len() as u64));
 
         // Composed: scan → grok+filter → JSON serialize
         group.bench_with_input(BenchmarkId::new("composed", n), &data, |b, data| {
@@ -195,7 +201,7 @@ fn bench_grok_chain(c: &mut Criterion) {
                         .expect("JSON serialization should not fail");
                     buf.push(b'\n');
                 }
-                std::hint::black_box(buf.len());
+                std::hint::black_box(&buf);
             });
         });
     }

--- a/crates/logfwd-bench/benches/output_encode.rs
+++ b/crates/logfwd-bench/benches/output_encode.rs
@@ -63,7 +63,7 @@ fn bench_output_encode(c: &mut Criterion) {
             let batch = scan_to_batch(data);
             let label = format!("{schema_name}/{n}");
 
-            group.throughput(Throughput::Elements(*n as u64));
+            group.throughput(Throughput::Bytes(data.len() as u64));
 
             // NullSink — baseline
             group.bench_with_input(BenchmarkId::new("null_sink", &label), &batch, |b, batch| {
@@ -103,7 +103,7 @@ fn bench_output_encode(c: &mut Criterion) {
                         let compressed = compressor
                             .compress(&json_buf)
                             .expect("compression should not fail");
-                        std::hint::black_box(compressed.compressed_size);
+                        std::hint::black_box(&compressed);
                     });
                 },
             );
@@ -122,7 +122,7 @@ fn bench_output_encode(c: &mut Criterion) {
                                 .expect("JSON serialization should not fail");
                             buf.push(b'\n');
                         }
-                        std::hint::black_box(buf.len());
+                        std::hint::black_box(&buf);
                     });
                 },
             );

--- a/crates/logfwd-bench/benches/pipeline.rs
+++ b/crates/logfwd-bench/benches/pipeline.rs
@@ -32,9 +32,11 @@ fn bench_scanner(c: &mut Criterion) {
             let data_bytes = bytes::Bytes::from(data.clone());
             let mut scanner = Scanner::new(ScanConfig::default());
             b.iter(|| {
-                scanner
-                    .scan_detached(data_bytes.clone())
-                    .expect("bench: scan should not fail")
+                std::hint::black_box(
+                    scanner
+                        .scan_detached(data_bytes.clone())
+                        .expect("bench: scan should not fail"),
+                )
             });
         });
 
@@ -62,9 +64,11 @@ fn bench_scanner(c: &mut Criterion) {
             };
             let mut scanner = Scanner::new(config);
             b.iter(|| {
-                scanner
-                    .scan_detached(data_bytes.clone())
-                    .expect("bench: scan should not fail")
+                std::hint::black_box(
+                    scanner
+                        .scan_detached(data_bytes.clone())
+                        .expect("bench: scan should not fail"),
+                )
             });
         });
     }
@@ -125,7 +129,7 @@ fn bench_cri(c: &mut Criterion) {
                     }
                     start = end + 1;
                 }
-                std::hint::black_box(json_buf.len())
+                std::hint::black_box(json_buf.as_ptr());
             });
         });
     }
@@ -148,7 +152,7 @@ fn bench_transform(c: &mut Criterion) {
     let batch = scanner
         .scan_detached(bytes::Bytes::from(data.clone()))
         .expect("bench: scan should not fail");
-    group.throughput(Throughput::Elements(n as u64));
+    group.throughput(Throughput::Bytes(data.len() as u64));
     group.bench_function("select_star", |b| {
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         b.iter(|| std::hint::black_box(transform.execute_blocking(batch.clone()).unwrap()));
@@ -228,7 +232,7 @@ fn bench_output(c: &mut Criterion) {
     let meta = generators::make_metadata();
 
     // NullSink (measures overhead of scan + batch creation only)
-    group.throughput(Throughput::Elements(n as u64));
+    group.throughput(Throughput::Bytes(data.len() as u64));
     group.bench_function("null_sink", |b| {
         let mut sink = NullSink;
         b.iter(|| std::hint::black_box(sink.send_batch(&batch, &meta).unwrap()));
@@ -245,7 +249,7 @@ fn bench_output(c: &mut Criterion) {
                     .expect("JSON serialization should not fail");
                 buf.push(b'\n');
             }
-            std::hint::black_box(buf.len());
+            std::hint::black_box(&buf);
         });
     });
 
@@ -265,7 +269,7 @@ fn bench_end_to_end(c: &mut Criterion) {
     let meta = generators::make_metadata();
 
     // Full pipeline: scan → SELECT * → capture sink
-    group.throughput(Throughput::Elements(n as u64));
+    group.throughput(Throughput::Bytes(data.len() as u64));
     let data_bytes = bytes::Bytes::from(data.clone());
     group.bench_function("scan_passthrough_capture", |b| {
         let mut scanner = Scanner::new(ScanConfig::default());
@@ -348,7 +352,7 @@ fn bench_elasticsearch_serialize(c: &mut Criterion) {
             .expect("bench: scan should not fail");
         let meta = generators::make_metadata();
 
-        group.throughput(Throughput::Elements(n as u64));
+        group.throughput(Throughput::Bytes(data.len() as u64));
         group.bench_with_input(
             BenchmarkId::new("serialize_batch", n),
             &batch,
@@ -359,7 +363,7 @@ fn bench_elasticsearch_serialize(c: &mut Criterion) {
                     // the buffer does not grow unboundedly across iterations.
                     sink.serialize_batch(batch, &meta)
                         .expect("bench: serialize should not fail");
-                    std::hint::black_box(sink.serialized_len());
+                    std::hint::black_box(&sink);
                 });
             },
         );

--- a/crates/logfwd-core/benches/scanner.rs
+++ b/crates/logfwd-core/benches/scanner.rs
@@ -228,12 +228,12 @@ fn arrow_json_parse(data: &[u8]) -> arrow::record_batch::RecordBatch {
 // sonic-rs baseline: spec-compliant SIMD JSON parser → Scanner
 // ===========================================================================
 
-fn sonic_rs_parse(data: &[u8]) -> arrow::record_batch::RecordBatch {
+fn sonic_rs_parse(data: &[u8], ndjson: &mut Vec<u8>) -> arrow::record_batch::RecordBatch {
     // Use sonic-rs to produce NDJSON, then feed through Scanner::scan_detached.
     // This gives a fair comparison: sonic-rs parses, Scanner builds Arrow arrays.
     use sonic_rs::{JsonContainerTrait, JsonNumberTrait, JsonValueTrait};
 
-    let mut ndjson = Vec::with_capacity(data.len());
+    ndjson.clear();
     for line in data.split(|&b| b == b'\n') {
         if line.is_empty() {
             continue;
@@ -250,7 +250,7 @@ fn sonic_rs_parse(data: &[u8]) -> arrow::record_batch::RecordBatch {
 
     let mut scanner = Scanner::new(ScanConfig::default());
     scanner
-        .scan_detached(bytes::Bytes::from(ndjson))
+        .scan_detached(bytes::Bytes::copy_from_slice(ndjson))
         .expect("bench: scan_detached failed")
 }
 
@@ -267,17 +267,19 @@ macro_rules! bench_scenario {
 
             group.bench_function("Scanner", |b| {
                 let mut scanner = Scanner::new($config());
+                let data_bytes = bytes::Bytes::from(data.clone());
                 b.iter(|| {
                     black_box(
                         scanner
-                            .scan_detached(bytes::Bytes::from(data.clone()))
+                            .scan_detached(data_bytes.clone())
                             .expect("bench: scan should not fail"),
                     )
                 })
             });
 
             group.bench_function("sonic-rs DOM", |b| {
-                b.iter(|| black_box(sonic_rs_parse(black_box(&data))))
+                let mut ndjson = Vec::with_capacity(data.len());
+                b.iter(|| black_box(sonic_rs_parse(black_box(&data), &mut ndjson)))
             });
 
             group.bench_function("arrow-json", |b| {

--- a/crates/logfwd-output/tests/it/elasticsearch_integration.rs
+++ b/crates/logfwd-output/tests/it/elasticsearch_integration.rs
@@ -132,9 +132,7 @@ fn elasticsearch_sink_sends_bulk_data() {
 
     // Send batch
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _ = rt
-        .block_on(sink.send_batch(&batch, &metadata))
-        .expect("send_batch failed");
+    rt.block_on(sink.send_batch(&batch, &metadata)).unwrap();
 
     // Give server time to process
     std::thread::sleep(Duration::from_millis(200));
@@ -186,9 +184,7 @@ fn elasticsearch_sink_handles_empty_batch() {
 
     // Send empty batch
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _ = rt
-        .block_on(sink.send_batch(&batch, &metadata))
-        .expect("send_batch failed");
+    rt.block_on(sink.send_batch(&batch, &metadata)).unwrap();
 
     // Empty batch should not increment stats
     assert_eq!(
@@ -243,9 +239,7 @@ fn elasticsearch_sink_multiple_batches() {
         )
         .expect("batch creation failed");
 
-        let _ = rt
-            .block_on(sink.send_batch(&batch, &metadata))
-            .expect("send_batch failed");
+        rt.block_on(sink.send_batch(&batch, &metadata)).unwrap();
     }
 
     // Give server time to process
@@ -300,9 +294,7 @@ fn elasticsearch_streaming_mode_uses_chunked_transfer() {
     };
 
     let rt = tokio::runtime::Runtime::new().unwrap();
-    let _ = rt
-        .block_on(sink.send_batch(&batch, &metadata))
-        .expect("send_batch failed");
+    rt.block_on(sink.send_batch(&batch, &metadata)).unwrap();
 
     std::thread::sleep(Duration::from_millis(200));
 


### PR DESCRIPTION
This PR addresses issue #1352 "work-unit: logfwd-bench — measurement correctness phase 2".

It standardizes benchmark results across `logfwd-bench` and `logfwd-core/benches`, guarantees fair loop execution by hoisting setups out of `b.iter()`, and correctly passes references to `black_box` to prevent aggressive Dead Code Elimination by rustc.

All target files listed in the scope footprints have been patched. No unrelated logic inside crates or external dependencies have been impacted.

---
*PR created automatically by Jules for task [8469681642453954526](https://jules.google.com/task/8469681642453954526) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix benchmark correctness by using bytes-based throughput and proper `black_box` usage
> - Replaces `Elements(n)` throughput with `Bytes(data.len())` across all benchmark files so reported throughput reflects actual data volume.
> - Fixes `std::hint::black_box` calls to take buffer references (e.g. `&buf`) instead of scalar lengths or sizes, preventing the compiler from optimizing away the work being measured.
> - Moves allocations (e.g. `CriReassembler`, JSON buffers) outside benchmark loops and adds `reset()`/`clear()` calls at the start of each iteration to avoid measuring allocation overhead.
> - Refactors `cri_to_json` and `sonic_rs_parse` to write into caller-provided buffers instead of allocating on each call, consistent with the buffer-reuse approach above.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f394abf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->