### PR TITLE
fix(tail): glob normalization — strip ./ prefix instead of prepending

### DIFF
--- a/crates/logfwd-io/src/tail.rs
+++ b/crates/logfwd-io/src/tail.rs
@@ -320,7 +320,11 @@ fn expand_glob_patterns(patterns: &[&str]) -> Vec<PathBuf> {
             // and prefixed patterns like "./*.log" match correctly (#1375).
             let entry_path = entry.path();
             let stripped = entry_path.strip_prefix(".").unwrap_or(entry_path);
-            if glob_set.is_match(entry_path) || glob_set.is_match(stripped) {
+            let prefixed = Path::new(".").join(stripped);
+            if glob_set.is_match(entry_path)
+                || glob_set.is_match(stripped)
+                || glob_set.is_match(&prefixed)
+            {
                 paths.push(entry.into_path());
             }
         }
@@ -1856,15 +1860,17 @@ mod tests {
         let _cwd_guard = CWD_LOCK.lock().unwrap();
 
         // RAII guard restores cwd even if an assert panics.
+        // RAII guard restores cwd even if an assert panics.
+        // Declared AFTER dir so it drops BEFORE dir (reverse order),
+        // ensuring cwd is restored before the temp directory is deleted.
         struct CwdGuard(PathBuf);
         impl Drop for CwdGuard {
             fn drop(&mut self) {
                 let _ = std::env::set_current_dir(&self.0);
             }
         }
-        let _restore = CwdGuard(std::env::current_dir().unwrap());
-
         let dir = tempfile::tempdir().unwrap();
+        let _restore = CwdGuard(std::env::current_dir().unwrap());
         std::env::set_current_dir(dir.path()).unwrap();
 
         let nested = PathBuf::from("logs");


### PR DESCRIPTION
## Summary

Follow-up to #1432 which merged with broken glob matching. The normalization prepended `./` (creating `././app.log`) instead of stripping it.

## Changes

- Strip `./` prefix from WalkDir entry paths before matching, so bare patterns like `*.log` match `./app.log`
- Add RAII drop guard for CWD test (restores cwd even on assert panic)
- Add test for bare `*.log` pattern — the primary #1375 failure case
- Make eviction test deterministic — both files share fingerprint prefix so stale-offset path is exercised regardless of which file is evicted

## Test plan

- [x] `cargo test -p logfwd-io -- test_expand_glob test_evicted_offset_clamped test_set_offset` — 4/4 pass
- [x] `cargo clippy -p logfwd-io -- -D warnings` — clean

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix glob normalization in `expand_glob_patterns` to strip `./` prefix instead of prepending it
> WalkDir can report paths with or without a leading `./` depending on the platform. The previous normalization only checked the raw entry path and a `./`-prefixed variant, causing bare patterns like `*.log` or `./`-prefixed patterns to fail to match in some cases.
>
> - [tail.rs](https://github.com/strawgate/memagent/pull/1452/files#diff-eb28129757c059684e16401c616b90f230c604b673f2aaf1f985be40db02079f) now derives three candidates per entry: the raw path, a stripped (no `./`) version, and an explicitly `./`-prefixed version, matching against any of the three.
> - Test `test_expand_glob_patterns_matches_dot_slash_cwd_relative` is refactored to use an RAII `CwdGuard` for safe cwd restoration and adds a case asserting bare `*.log` patterns also match cwd files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7aee45f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->