### PR TITLE
refactor(generator): make record generator configurable

### DIFF
--- a/book/src/config/inputs.md
+++ b/book/src/config/inputs.md
@@ -27,7 +27,7 @@ data source is required.
 | `generator.total_events` | integer | No | `0` | Total events to emit before stopping. `0` means infinite. |
 | `generator.profile` | string | No | `logs` | `logs` for generic synthetic request logs, `record` for flat JSON rows assembled from attributes and generated fields. |
 | `generator.complexity` | string | No | `simple` | Size/shape for the `logs` profile: `simple` or `complex`. Ignored by the `record` profile. |
-| `generator.attributes` | object | No | `{}` | Static scalar JSON fields written into every `record` row. |
+| `generator.attributes` | object | No | `{}` | Static scalar JSON fields written into every `record` row (`string`, `number`, `boolean`, or `null`). |
 | `generator.sequence.field` | string | No | unset | Output field name for a monotonic generated sequence in `record` rows. |
 | `generator.sequence.start` | integer | No | `1` | Initial value for the generated sequence. |
 | `generator.event_created_unix_nano_field` | string | No | unset | Adds a source-created nanosecond timestamp field to each `record` row. |
@@ -46,6 +46,7 @@ input:
       service: bench-emitter
       status: 200
       sampled: true
+      deleted_at: null
     sequence:
       field: seq
     event_created_unix_nano_field: event_created_unix_nano

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -215,6 +215,7 @@ impl fmt::Display for Format {
 // ---------------------------------------------------------------------------
 
 /// Named generator output profiles.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum GeneratorProfileConfig {
@@ -226,21 +227,31 @@ pub enum GeneratorProfileConfig {
 }
 
 /// Controls the size and shape of synthetic generator rows.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum GeneratorComplexityConfig {
+    /// Flat request-style logs around a couple hundred bytes.
     #[default]
     Simple,
+    /// Request-style logs with occasional nested objects and arrays.
     Complex,
 }
 
 /// Static scalar attribute value for generated `record` rows.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(untagged)]
 pub enum GeneratorAttributeValueConfig {
+    /// JSON null scalar.
+    Null,
+    /// UTF-8 text scalar.
     String(String),
+    /// Signed 64-bit integer scalar.
     Integer(i64),
+    /// 64-bit floating point scalar.
     Float(f64),
+    /// Boolean scalar.
     Bool(bool),
 }
 
@@ -2844,6 +2855,7 @@ pipelines:
             service: bench-emitter
             status: 200
             sampled: true
+            deleted_at: null
           sequence:
             field: seq
     outputs:
@@ -2883,6 +2895,10 @@ pipelines:
         assert_eq!(
             generator.attributes.get("sampled"),
             Some(&GeneratorAttributeValueConfig::Bool(true))
+        );
+        assert_eq!(
+            generator.attributes.get("deleted_at"),
+            Some(&GeneratorAttributeValueConfig::Null)
         );
         assert_eq!(
             generator.sequence.as_ref().map(|seq| seq.field.as_str()),
@@ -2972,6 +2988,135 @@ pipelines:
             err.to_string()
                 .contains("must not duplicate a generator.attributes key"),
             "expected duplicate generated field rejection: {err}"
+        );
+    }
+
+    #[test]
+    fn generator_input_rejects_zero_batch_size() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          batch_size: 0
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("batch_size must be at least 1"),
+            "expected zero batch size rejection: {err}"
+        );
+    }
+
+    #[test]
+    fn generator_input_rejects_empty_attribute_key() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+          attributes:
+            "": run-123
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("attributes keys must not be empty"),
+            "expected empty attribute key rejection: {err}"
+        );
+    }
+
+    #[test]
+    fn generator_input_rejects_non_finite_attribute_values() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+          attributes:
+            ratio: .nan
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("float values must be finite"),
+            "expected non-finite attribute rejection: {err}"
+        );
+    }
+
+    #[test]
+    fn generator_input_rejects_empty_event_created_field_name() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+          event_created_unix_nano_field: " "
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("event_created_unix_nano_field must not be empty"),
+            "expected empty event_created field rejection: {err}"
+        );
+    }
+
+    #[test]
+    fn generator_input_rejects_event_created_field_name_duplicate_with_attribute() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+          attributes:
+            created: run-123
+          event_created_unix_nano_field: created
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("must not duplicate a generator.attributes key"),
+            "expected event_created/attribute duplication rejection: {err}"
+        );
+    }
+
+    #[test]
+    fn generator_input_rejects_event_created_field_name_duplicate_with_sequence() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+          sequence:
+            field: seq
+          event_created_unix_nano_field: seq
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("must not duplicate generator.sequence.field"),
+            "expected event_created/sequence duplication rejection: {err}"
         );
     }
 

--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -10,6 +10,7 @@ use std::io::Write;
 use crate::input::{InputEvent, InputSource};
 
 /// Controls the complexity/size of generated lines.
+#[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum GeneratorComplexity {
     /// Flat JSON object, ~200 bytes per line.
@@ -20,6 +21,7 @@ pub enum GeneratorComplexity {
 }
 
 /// Named generator output profiles.
+#[non_exhaustive]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum GeneratorProfile {
     /// Synthetic request-like JSON logs.
@@ -31,17 +33,26 @@ pub enum GeneratorProfile {
 
 /// Monotonic generated field configuration.
 pub struct GeneratorGeneratedField {
+    /// Output field name for the generated sequence in record rows.
     pub field: String,
+    /// Initial monotonic sequence value.
     pub start: u64,
 }
 
 /// Static scalar attribute value written into generated `record` rows.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 pub enum GeneratorAttributeValue {
+    /// UTF-8 text scalar.
     String(String),
+    /// Signed 64-bit integer scalar.
     Integer(i64),
+    /// 64-bit floating point scalar.
     Float(f64),
+    /// Boolean scalar.
     Bool(bool),
+    /// JSON null scalar.
+    Null,
 }
 
 /// Configuration for the generator input.
@@ -156,25 +167,43 @@ impl GeneratorInput {
     fn generate_batch(&mut self) -> io::Result<()> {
         self.buf.clear();
         let n = self.config.batch_size;
+        let batch_created_unix_nano = self
+            .record_fields
+            .event_created_unix_nano_field
+            .as_ref()
+            .map(|_| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos()
+            });
+        let mut batch_offset = 0u128;
         for _ in 0..n {
             if self.config.total_events > 0 && self.counter >= self.config.total_events {
                 self.done = true;
                 break;
             }
-            self.write_event()?;
+            let event_created_unix_nano = batch_created_unix_nano.map(|base| base + batch_offset);
+            let len_before = self.buf.len();
+            self.write_event(event_created_unix_nano)?;
+            if self.done {
+                self.buf.truncate(len_before);
+                break;
+            }
             self.buf.push(b'\n');
             self.counter += 1;
+            batch_offset += 1;
         }
         Ok(())
     }
 
-    fn write_event(&mut self) -> io::Result<()> {
+    fn write_event(&mut self, event_created_unix_nano: Option<u128>) -> io::Result<()> {
         match self.config.profile {
             GeneratorProfile::Logs => {
                 self.write_logs_event();
                 Ok(())
             }
-            GeneratorProfile::Record => self.write_record_event(),
+            GeneratorProfile::Record => self.write_record_event(event_created_unix_nano),
         }
     }
 
@@ -235,7 +264,7 @@ impl GeneratorInput {
         }
     }
 
-    fn write_record_event(&mut self) -> io::Result<()> {
+    fn write_record_event(&mut self, event_created_unix_nano: Option<u128>) -> io::Result<()> {
         self.buf.push(b'{');
         let mut first = true;
         for encoded_field in &self.record_fields.attributes {
@@ -246,19 +275,17 @@ impl GeneratorInput {
             self.buf.extend_from_slice(encoded_field);
         }
         if let Some(sequence) = &self.record_fields.sequence {
-            let value = sequence.start.checked_add(self.counter).ok_or_else(|| {
-                io::Error::other(format!(
-                    "generator sequence '{}' overflowed u64",
-                    sequence.field
-                ))
-            })?;
+            let Some(value) = sequence.start.checked_add(self.counter) else {
+                self.done = true;
+                return Ok(());
+            };
             write_json_u64_field(&mut self.buf, &sequence.field, value, &mut first);
         }
-        if let Some(field) = &self.record_fields.event_created_unix_nano_field {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default();
-            write_json_u128_field(&mut self.buf, field, now.as_nanos(), &mut first);
+        if let (Some(field), Some(event_created_unix_nano)) = (
+            &self.record_fields.event_created_unix_nano_field,
+            event_created_unix_nano,
+        ) {
+            write_json_u128_field(&mut self.buf, field, event_created_unix_nano, &mut first);
         }
         self.buf.push(b'}');
         Ok(())
@@ -366,10 +393,18 @@ fn encode_static_field(key: &str, value: &GeneratorAttributeValue) -> Vec<u8> {
             let _ = write!(&mut out, "{value}");
         }
         GeneratorAttributeValue::Float(value) => {
-            let _ = write!(&mut out, "{value}");
+            if value.is_finite() {
+                let rendered = serde_json::to_string(value).expect("finite float serializes");
+                out.extend_from_slice(rendered.as_bytes());
+            } else {
+                out.extend_from_slice(b"null");
+            }
         }
         GeneratorAttributeValue::Bool(value) => {
             out.extend_from_slice(if *value { b"true" } else { b"false" });
+        }
+        GeneratorAttributeValue::Null => {
+            out.extend_from_slice(b"null");
         }
     }
     out
@@ -722,7 +757,7 @@ mod tests {
     }
 
     #[test]
-    fn record_profile_errors_on_sequence_overflow() {
+    fn record_profile_stops_on_sequence_overflow() {
         let mut input = GeneratorInput::new(
             "bench-input",
             GeneratorConfig {
@@ -737,14 +772,18 @@ mod tests {
             },
         );
 
-        let err = match input.poll() {
-            Ok(_) => panic!("expected sequence overflow error"),
-            Err(err) => err,
+        let events = input.poll().unwrap();
+        let InputEvent::Data { bytes, .. } = &events[0] else {
+            panic!("expected Data event");
         };
-        assert!(
-            err.to_string().contains("overflowed u64"),
-            "expected sequence overflow error: {err}"
-        );
+        let rows: Vec<serde_json::Value> = bytes
+            .split(|b| *b == b'\n')
+            .filter(|line| !line.is_empty())
+            .map(|line| serde_json::from_slice(line).unwrap())
+            .collect();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["seq"], u64::MAX);
+        assert!(input.poll().unwrap().is_empty());
     }
 
     #[test]
@@ -791,5 +830,26 @@ mod tests {
         assert_eq!(row["service"], "svc\tname");
         assert_eq!(row["ratio"], 1.25);
         assert_eq!(row["sampled"], false);
+    }
+
+    #[test]
+    fn encode_static_field_serializes_floats_as_json_numbers() {
+        let encoded = encode_static_field("ratio", &GeneratorAttributeValue::Float(1.0));
+        assert_eq!(std::str::from_utf8(&encoded).unwrap(), "\"ratio\":1.0");
+    }
+
+    #[test]
+    fn encode_static_field_serializes_non_finite_floats_as_null() {
+        let encoded = encode_static_field("ratio", &GeneratorAttributeValue::Float(f64::NAN));
+        assert_eq!(std::str::from_utf8(&encoded).unwrap(), "\"ratio\":null");
+    }
+
+    #[test]
+    fn encode_static_field_serializes_null_attribute() {
+        let encoded = encode_static_field("deleted_at", &GeneratorAttributeValue::Null);
+        assert_eq!(
+            std::str::from_utf8(&encoded).unwrap(),
+            "\"deleted_at\":null"
+        );
     }
 }

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -1529,11 +1529,13 @@ fn build_input_state(
                 total_events: generator_cfg.and_then(|c| c.total_events).unwrap_or(0),
                 complexity: match generator_cfg.and_then(|c| c.complexity.clone()) {
                     Some(GeneratorComplexityConfig::Complex) => GeneratorComplexity::Complex,
-                    _ => GeneratorComplexity::Simple,
+                    Some(GeneratorComplexityConfig::Simple) | None => GeneratorComplexity::Simple,
+                    Some(_) => GeneratorComplexity::Simple,
                 },
                 profile: match generator_cfg.and_then(|c| c.profile.clone()) {
                     Some(GeneratorProfileConfig::Record) => GeneratorProfile::Record,
-                    _ => GeneratorProfile::Logs,
+                    Some(GeneratorProfileConfig::Logs) | None => GeneratorProfile::Logs,
+                    Some(_) => GeneratorProfile::Logs,
                 },
                 attributes: generator_cfg
                     .map(|c| {
@@ -1544,6 +1546,9 @@ fn build_input_state(
                                     GeneratorAttributeValueConfig::String(v) => {
                                         GeneratorAttributeValue::String(v.clone())
                                     }
+                                    GeneratorAttributeValueConfig::Null => {
+                                        GeneratorAttributeValue::Null
+                                    }
                                     GeneratorAttributeValueConfig::Integer(v) => {
                                         GeneratorAttributeValue::Integer(*v)
                                     }
@@ -1553,6 +1558,7 @@ fn build_input_state(
                                     GeneratorAttributeValueConfig::Bool(v) => {
                                         GeneratorAttributeValue::Bool(*v)
                                     }
+                                    _ => GeneratorAttributeValue::Null,
                                 };
                                 (k.clone(), value)
                             })
@@ -1656,7 +1662,9 @@ mod tests {
     use serial_test::serial;
     use std::time::Instant;
 
+    use logfwd_arrow::scanner::Scanner;
     use logfwd_config::{Format, OutputConfig, OutputType};
+    use logfwd_core::scan_config::ScanConfig;
     use logfwd_io::diagnostics::ComponentStats;
     use logfwd_test_utils::sinks::{DevNullSink, FailingSink, FrozenSink, SlowSink};
     use logfwd_test_utils::test_meter;
@@ -1821,8 +1829,50 @@ output:
 "#;
         let config = logfwd_config::Config::load_str(yaml).unwrap();
         let pipe_cfg = &config.pipelines["default"];
-        let pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter(), None);
-        assert!(pipeline.is_ok(), "got: {:?}", pipeline.err());
+        let mut pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter(), None)
+            .unwrap_or_else(|err| panic!("unexpected pipeline build error: {err}"));
+        let events = pipeline.inputs[0].source.poll().unwrap();
+        let bytes = match &events[0] {
+            InputEvent::Data { bytes, .. } => bytes,
+            _ => panic!("expected generator data event"),
+        };
+        let mut scanner = Scanner::new(ScanConfig {
+            wanted_fields: vec![],
+            extract_all: true,
+            keep_raw: false,
+            validate_utf8: false,
+        });
+        let batch = scanner.scan_detached(Bytes::from(bytes.clone())).unwrap();
+        let benchmark_id = batch
+            .column_by_name("benchmark_id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        let pod_name = batch
+            .column_by_name("pod_name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        let stream_id = batch
+            .column_by_name("stream_id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow::array::StringArray>()
+            .unwrap();
+        let seq = batch
+            .column_by_name("seq")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .unwrap();
+
+        assert_eq!(benchmark_id.value(0), "run-123");
+        assert_eq!(pod_name.value(0), "emitter-0");
+        assert_eq!(stream_id.value(0), "emitter-0");
+        assert_eq!(seq.value(0), 1);
+        assert!(batch.column_by_name("event_created_unix_nano").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the dedicated benchmark generator profile with a generic `generator.profile: record` shape
- support scalar `generator.attributes` plus generated sequence and optional source-created time fields
- tighten validation so record-only fields cannot be configured accidentally under the default `logs` profile

## Why
This keeps the generator small and fast while still making `logfwd` usable as the benchmark emitter in `memagent-e2e`. The generator emits only the source-truth fields we really need, and SQL can derive richer payload fields like `event_id`, `message`, and presentation timestamps.

## Validation
- cargo test -p logfwd-config generator_input_ -- --nocapture
- cargo test -p logfwd-io record_profile_ -- --nocapture
- cargo test -p logfwd-io generator_respects_total_events -- --nocapture
- cargo test -p logfwd test_pipeline_from_config_generator_record_profile -- --nocapture


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make the record generator configurable with profile, attributes, and sequence options
> - Adds a `generator` config block to `InputConfig` with fields: `events_per_sec`, `batch_size`, `total_events`, `profile` (logs|record), `complexity` (simple|complex), `attributes` (static scalars), `sequence` (monotonic integer field), and `event_created_unix_nano_field`.
> - Introduces a `record` profile in [generator.rs](https://github.com/strawgate/memagent/pull/1456/files#diff-155a8c1574aa241af17a394ce55d6ff3fdc41c01cdb4e7affd54f0c4e45bf71f) that emits flat JSON objects with static attributes, an optional monotonic sequence field, and an optional per-event timestamp sourced at batch time.
> - Updates [pipeline.rs](https://github.com/strawgate/memagent/pull/1456/files#diff-871beaad2d14990b89072990f0a821dd4266ab3e624d58590ec24abc1047056d) to map the new nested config to generator internals; removes the legacy `listen` rate-limiting path for generator inputs.
> - Adds validation in [lib.rs](https://github.com/strawgate/memagent/pull/1456/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150) rejecting `listen` on generator inputs, `generator` blocks on non-generator inputs, zero `batch_size`, empty/duplicate field names, non-finite float attributes, and record-only fields when profile is not `record`.
> - Behavioral Change: existing configs using `listen` for generator rate limiting will now be rejected at load time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d187daa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->