### PR TITLE
fix(ci): add dedicated verification guardrail (#1486)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,14 +152,6 @@ jobs:
       - name: Actionlint
         run: ./actionlint
 
-      - name: Set up Python for Kani boundary contract
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Kani boundary contract
-        run: python3 scripts/verify_kani_boundary_contract.py
-
       # --- Expensive steps below — only reached if fast checks pass ---
 
       - uses: Swatinem/rust-cache@v2
@@ -182,6 +174,23 @@ jobs:
         with:
           token: ${{ github.token }}
           args: "--deny=vuln --deny=unsound --deny=yanked"
+
+  # -------------------------------------------------------------------------
+  # Verification guardrail — fail fast when the non-core Kani boundary
+  # contract drifts so PRs get a dedicated blocking signal.
+  # -------------------------------------------------------------------------
+  verification-guardrail:
+    name: Verification guardrail
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python for Kani boundary contract
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Kani boundary contract
+        run: python3 scripts/verify_kani_boundary_contract.py
 
   # -------------------------------------------------------------------------
   # Tests — Linux and macOS in parallel
@@ -352,7 +361,7 @@ jobs:
   conclusion:
     name: CI conclusion
     if: ${{ !cancelled() }}
-    needs: [lint, test-linux, build-check]
+    needs: [verification-guardrail, lint, test-linux, build-check]
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -137,8 +137,10 @@ python3 scripts/verify_kani_boundary_contract.py
 just kani-boundary
 ```
 
-CI runs this check from the lint workflow so boundary drift is caught before
-the more expensive build and test jobs.
+CI runs this check in the dedicated `Verification guardrail` job, and the
+required `CI conclusion` status depends on that guardrail passing. This keeps
+required seam drift visible as its own blocking check instead of burying it
+inside the broader lint job.
 
 ### Proof quality requirements
 


### PR DESCRIPTION
## Summary
- move the non-core Kani boundary-contract check into its own dedicated CI job
- make `CI conclusion` depend on that guardrail so required seam drift stays blocking
- update verification docs to name the exact enforcement path

## Why
The boundary-contract validator already exists, but when it lives inside `Lint` it is easy to miss among broader lint output. Giving it its own check makes required verification drift obvious in the PR UI while still keeping the existing `CI conclusion` gate authoritative.

## Verification
- `python3 scripts/verify_kani_boundary_contract.py`
- `actionlint .github/workflows/ci.yml`

Closes #1486


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move Kani boundary contract check to a dedicated CI job
> Extracts the `verify_kani_boundary_contract.py` script from the `frontend-checks` job into a new standalone `verification-guardrail` job in [ci.yml](.github/workflows/ci.yml). The `CI conclusion` job now requires this guardrail to pass, making verification failures independently visible rather than buried in frontend checks. Updates [VERIFICATION.md](dev-docs/VERIFICATION.md) to reflect the new job name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a0bf31.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->