### PR TITLE
fix(diagnostics): stop metric-sampler thread on drop; add double-start guard

### DIFF
--- a/crates/logfwd-io/src/diagnostics.rs
+++ b/crates/logfwd-io/src/diagnostics.rs
@@ -501,14 +501,24 @@ impl DiagnosticsServer {
             .map_err(|e| io::Error::other(format!("failed to spawn metric-sampler: {e}")))?;
 
         let http_server = Arc::clone(&server);
-        let http_handle = thread::Builder::new()
+        let http_handle = match thread::Builder::new()
             .name("diagnostics-http".into())
             .spawn(move || {
                 for request in server.incoming_requests() {
                     let _ = self.handle_request(request);
                 }
-            })
-            .map_err(|e| io::Error::other(format!("failed to spawn diagnostics-http: {e}")))?;
+            }) {
+            Ok(handle) => handle,
+            Err(e) => {
+                // Stop the sampler thread before propagating the error so it
+                // does not leak.
+                running.store(false, Ordering::Relaxed);
+                let _ = sampler_handle.join();
+                return Err(io::Error::other(format!(
+                    "failed to spawn diagnostics-http: {e}"
+                )));
+            }
+        };
 
         Ok((
             ServerHandle {


### PR DESCRIPTION
## Summary

- Adds `ServerHandle` (new public type in `logfwd_io::diagnostics`) that owns both background threads spawned by `DiagnosticsServer::start()`.
- The metric-sampler loop now checks an `Arc<AtomicBool>` shutdown flag (`while running.load(Relaxed)`) instead of running forever.
- `ServerHandle::Drop` signals the flag, calls `server.unblock()` to release the HTTP thread's `incoming_requests()` iterator, then joins both threads.
- `DiagnosticsServer::start()` return type changes from `(JoinHandle<()>, SocketAddr)` to `(ServerHandle, SocketAddr)` — all existing call sites continue to compile unchanged since the handle is held via type-inferred bindings.
- Only `crates/logfwd-io/src/diagnostics.rs` is modified (74 lines added, 15 removed).

Fixes the thread leak that caused every test creating a `DiagnosticsServer` to orphan a detached `metric-sampler` thread that never terminated.

Closes #1497 (replaces closed Jules PR #1508, which regressed the fix by making large unrelated changes)

## Test plan

- [x] `cargo clippy -p logfwd-io -- -D warnings` passes
- [x] `cargo test -p logfwd-io` passes (197 unit tests + 17 integration tests, all green)
- [x] Single-file change, no unrelated modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop metric-sampler thread on drop and add double-start guard in `DiagnosticsServer`
> - Introduces a `ServerHandle` type returned by `DiagnosticsServer::start` in [diagnostics.rs](https://github.com/strawgate/memagent/pull/1524/files#diff-6bb180a311d04982be05f9e192221a4f2c0d9b4f6733fa3f46f63229ef488cdb) that owns both the sampler and HTTP threads.
> - Dropping `ServerHandle` sets a shared `AtomicBool` running flag to false, calls `http_server.unblock()` to break the request loop, and joins both threads for graceful shutdown.
> - Thread spawn failures for both the sampler and HTTP threads are now surfaced as `io::Error` instead of being silently ignored.
> - Behavioral Change: `DiagnosticsServer::start` now returns `(ServerHandle, SocketAddr)` instead of `(JoinHandle<()>, SocketAddr)`, which is a breaking API change for callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e98960a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->