### PR TITLE
pipeline: typed delivery outcomes at worker/checkpoint seam

### DIFF
--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -1700,7 +1700,6 @@ fn build_input_state(
                 }),
                 event_created_unix_nano_field: generator_cfg
                     .and_then(|c| c.event_created_unix_nano_field.clone()),
-                ..Default::default()
             };
             let format = cfg.format.clone().unwrap_or(Format::Json);
             validate_input_format(name, InputType::Generator, &format)?;

--- a/crates/logfwd/src/pipeline/checkpoint_policy.rs
+++ b/crates/logfwd/src/pipeline/checkpoint_policy.rs
@@ -22,7 +22,13 @@ pub(super) enum TicketDisposition {
 pub(super) const fn default_ticket_disposition(outcome: &DeliveryOutcome) -> TicketDisposition {
     match outcome {
         DeliveryOutcome::Delivered => TicketDisposition::Ack,
-        _ => TicketDisposition::Reject,
+        DeliveryOutcome::Rejected { .. }
+        | DeliveryOutcome::RetryExhausted
+        | DeliveryOutcome::TimedOut
+        | DeliveryOutcome::PoolClosed
+        | DeliveryOutcome::WorkerChannelClosed
+        | DeliveryOutcome::NoWorkersAvailable
+        | DeliveryOutcome::InternalFailure => TicketDisposition::Reject,
     }
 }
 

--- a/crates/logfwd/src/worker_pool.rs
+++ b/crates/logfwd/src/worker_pool.rs
@@ -112,6 +112,7 @@ pub enum DeliveryOutcome {
 }
 
 impl DeliveryOutcome {
+    /// Returns `true` if this outcome represents successful delivery to the sink.
     pub const fn is_delivered(&self) -> bool {
         matches!(self, Self::Delivered)
     }


### PR DESCRIPTION
## Summary
- replace the boolean worker ack flag with a typed DeliveryOutcome enum in worker_pool
- add a dedicated checkpoint policy seam (pipeline/checkpoint_policy.rs) that maps outcomes to ticket disposition
- preserve compatibility behavior for now: delivered batches ACK tickets, all non-delivery outcomes reject tickets
- update pipeline and worker-pool tests to assert concrete outcomes instead of a bool

## Why
Issue #1520 asks for an explicit, typed contract between delivery results and checkpoint behavior. This PR introduces that seam without changing current checkpoint semantics.

## Validation
- cargo fmt --check
- cargo test -p logfwd worker_pool::tests:: -- --nocapture
- cargo test -p logfwd pipeline::tests:: -- --nocapture
- cargo test -p logfwd checkpoint_policy::tests:: -- --nocapture

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace boolean delivery results with typed `DeliveryOutcome` enum at worker/checkpoint seam
> - Introduces `DeliveryOutcome` enum in [worker_pool.rs](https://github.com/strawgate/memagent/pull/1531/files#diff-7aaeb25da3bfad836d812c3bfdc7af0d310b9d60b8920d9e9f07b97ab201533b) with variants `Delivered`, `Rejected { reason }`, `RetryExhausted`, `TimedOut`, `PoolClosed`, `WorkerChannelClosed`, `NoWorkersAvailable`, and `InternalFailure`, replacing the previous `success: bool` on `AckItem`.
> - Adds `checkpoint_policy` module in [pipeline.rs](https://github.com/strawgate/memagent/pull/1531/files#diff-871beaad2d14990b89072990f0a821dd4266ab3e624d58590ec24abc1047056d) with a `TicketDisposition` enum and `default_ticket_disposition()` function that maps `DeliveryOutcome` to `Ack` or `Reject`.
> - Updates `ack_all_tickets()` signature from `success: bool` to `disposition: TicketDisposition`, and all call sites to use explicit dispositions per branch (e.g. transform error → Reject, permanent processor error → Ack/drop).
> - Rejection reasons are bounded to 256 bytes via `bound_rejection_reason()` to prevent oversized messages.
> - Behavioral Change: runtime ticket finalization behavior is preserved exactly; only the internal representation changed from boolean to typed enum.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8abea8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->