### PR TITLE
fix: enforce pipeline validation during --dump-config

### DIFF
--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -724,7 +724,10 @@ fn edit_distance(a: &str, b: &str) -> usize {
 // Pipeline runner
 // ---------------------------------------------------------------------------
 
-/// Validate config by building all pipelines. Used by --validate and --dry-run.
+/// Validate config by building all pipelines. Used by `--validate`, `--dry-run`,
+/// and `--dump-config`. When `quiet` is true, success output is suppressed
+/// (errors are still printed); this is used by `--dump-config` to avoid
+/// polluting stdout with per-pipeline status lines.
 fn validate_pipelines(
     config: &logfwd_config::Config,
     dry_run: bool,


### PR DESCRIPTION
Enforces pipeline validation during `--dump-config`.

The `--dump-config` command was printing a success message (`# validated from ...`) after only performing basic YAML parsing and initial structural validation via `Config::load_str`. It bypassed the deeper pipeline topology validation performed by `Pipeline::from_config` (which `--validate` uses). This allowed structurally invalid configs (e.g., OTLP input with a raw format) to falsely report success.

This commit updates `cmd_dump_config` to invoke `validate_pipelines(..., quiet: true, ...)` after `Config::load_str`. The new `quiet` parameter suppresses the normal `ready:` console output while preserving the non-zero exit code and error surfacing of failed pipeline builds.

A regression test `test_dump_config_rejects_invalid_pipeline` is added to `cli_tests` to prevent recurrence.

Fixes #1514

---
*PR created automatically by Jules for task [1964474824190811839](https://jules.google.com/task/1964474824190811839) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce pipeline validation during `--dump-config`
> - `cmd_dump_config` now calls `validate_pipelines` (including pipeline wiring and SQL plan checks) before emitting YAML, failing with an error if validation finds issues.
> - A new `quiet` parameter on `validate_pipelines` suppresses per-pipeline "ready" lines and the success summary when set to `true`, used by `--dump-config` to avoid noisy output.
> - On success, a dim `# validated from {config_path}` notice is printed to stderr before the YAML is written to stdout.
> - A new test (`dump_config_rejects_invalid_pipeline`) covers the failure path, asserting the error contains `"error(s) during validation"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c41e60b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->