### PR TITLE
tla: two-tier ShutdownProtocol model for split I/O+CPU workers

### DIFF
--- a/tla/MCShutdownProtocol.tla
+++ b/tla/MCShutdownProtocol.tla
@@ -1,24 +1,14 @@
 --------------------- MODULE MCShutdownProtocol ----------------------
 (*
  * TLC model configuration for ShutdownProtocol.
- * Defines concrete constant values for model checking.
+ *
+ * Constants are set directly in the .cfg files (ShutdownProtocol.cfg,
+ * ShutdownProtocol.liveness.cfg, ShutdownProtocol.coverage.cfg).
+ *
+ * Capacities are intentionally small for TLC feasibility.
+ * Production uses IoChannelCapacity=4, PipelineChannelCapacity=16.
  *)
 
 EXTENDS ShutdownProtocol
-
-\* Safety model: 2 inputs, channel capacity 2, max 3 items each
-MCNumInputsFast == 2
-MCChannelCapacityFast == 2
-MCMaxItemsFast == 3
-
-\* Liveness model: smaller constants (O(states^2) for liveness)
-MCNumInputsLiveness == 2
-MCChannelCapacityLiveness == 2
-MCMaxItemsLiveness == 2
-
-\* Thorough model: 3 inputs
-MCNumInputsThorough == 3
-MCChannelCapacityThorough == 3
-MCMaxItemsThorough == 3
 
 ======================================================================

--- a/tla/README.md
+++ b/tla/README.md
@@ -47,11 +47,11 @@ tla/
   PipelineMachine.thorough.cfg  — thorough safety model (3 sources, 4 batches)
   PipelineMachine.coverage.cfg  — reachability / vacuity guards
 
-  # Shutdown coordination (multi-process drain protocol)
-  ShutdownProtocol.tla          — N inputs + channel + consumer + pool
-  MCShutdownProtocol.tla        — TLC config
-  ShutdownProtocol.cfg          — safety model
-  ShutdownProtocol.liveness.cfg — liveness model
+  # Shutdown coordination (two-tier I/O+CPU worker drain protocol)
+  ShutdownProtocol.tla          — N inputs with I/O+CPU workers, per-input io channels, shared pipeline channel, and pool drain
+  MCShutdownProtocol.tla        — TLC config (small capacities: IoChannel=2, Pipeline=3)
+  ShutdownProtocol.cfg          — safety model (ordering + conservation invariants)
+  ShutdownProtocol.liveness.cfg — liveness model (shutdown completion, no deadlock)
   ShutdownProtocol.coverage.cfg — reachability guards
 
   # Batching protocol (multi-source, checkpoint merge, reject handling)
@@ -137,6 +137,60 @@ java -cp /path/to/tla2tools.jar tlc2.TLC MCPipelineMachine.tla -config PipelineM
 
 ---
 
+## ShutdownProtocol.tla
+
+Models the two-tier shutdown cascade from `feat/io-compute-separation` (PR #1512).
+Per input: I/O worker -> bounded io_cpu channel -> CPU worker -> shared pipeline channel.
+
+### Model parameters
+
+| Config | NumInputs | IoChannelCapacity | PipelineChannelCapacity | MaxItems |
+|--------|-----------|-------------------|-------------------------|----------|
+| Safety | 2 | 2 | 3 | 3 |
+| Liveness | 2 | 2 | 3 | 2 |
+| Coverage | 2 | 2 | 3 | 3 |
+
+Production uses IoChannelCapacity=4, PipelineChannelCapacity=16. The protocol is
+capacity-independent so small values suffice for model checking.
+
+### What it proves
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `NoCpuStopBeforeIoDrain` | Safety | cpu_workers_stopped implies io_channels_drained |
+| `NoJoinBeforePipelineDrain` | Safety | workers_joined implies pipeline_channel_drained |
+| `NoStopBeforeJoin` | Safety | machine_stopped implies workers_joined |
+| `NormalStopImpliesPoolDrained` | Safety | normal stop (not forced) implies pool fully drained |
+| `IoConservation` | Safety | per-input: produced = in_io_channel + cpu_forwarded (no dup/loss) |
+| `PipelineConservation` | Safety | total forwarded = in_pipeline_channel + consumed (no dup/loss) |
+| `ShutdownCompletes` | Liveness | shutdown signal leads to machine_stopped |
+| `NoCpuWorkerDeadlock` | Liveness | io_channels_drained leads to cpu_workers_stopped |
+| `IoCpuChannelEventuallyDrained` | Liveness | all I/O workers stopped leads to io_channels_drained |
+| `CpuWorkersEventuallyStop` | Liveness | all I/O workers stopped leads to all CPU workers stopped |
+| `EventualStop` | Liveness | machine eventually reaches stopped state permanently |
+| `ShutdownReachable` | Reachability | shutdown_signaled is reachable (vacuity guard) |
+| `IoChannelsDrainedReachable` | Reachability | io_channels_drained is reachable |
+| `CpuWorkersStoppedReachable` | Reachability | cpu_workers_stopped is reachable |
+| `PipelineChannelDrainedReachable` | Reachability | pipeline_channel_drained is reachable |
+| `NormalStopReachable` | Reachability | normal stop is reachable |
+| `ForceStopReachable` | Reachability | force stop is reachable |
+| `IoChannelFullReachable` | Reachability | at least one io channel reaches capacity (backpressure) |
+| `PipelineChannelFullReachable` | Reachability | pipeline channel reaches capacity (backpressure) |
+
+### Key design: per-input CPU worker stop
+
+Each CPU worker independently decides to exit when its own I/O worker is dead
+and its own io_cpu channel is empty (`~io_alive[i] /\ Len(io_channels[i]) = 0`).
+This matches the implementation where each `cpu_worker`'s `io_rx.recv()` returns
+`None` independently. No global barrier is needed for individual CPU workers to exit.
+
+The global `io_channels_drained` flag can be set by two transitions:
+`MarkIoChannelsDrained` (when all I/O workers are down and all per-input channels
+are empty) or `MarkCpuWorkersStopped` (as a derived consistency observation when
+all CPU workers have exited). Neither is a precondition for `CpuWorkerStop`.
+
+---
+
 ## Relationship to Kani proofs and proptest
 
 | Layer | Tool | File | Scope |
@@ -176,7 +230,7 @@ tracks it as in_flight (it was already `begin_send`'d). The TLA+ model has no
 Rust code exactly: `fail()` returns `BatchTicket<Queued, C>` but the BTreeMap
 entry in `in_flight[source]` is not removed until `apply_ack` is called.
 
-### 2. Explicit permanent rejects advance the checkpoint
+### 2. Rejected batches advance the checkpoint
 
 `RejectBatch` is aliased to `AckBatch` — same state transition. Permanently-
 undeliverable data must not block checkpoint progress forever; that would
@@ -187,12 +241,6 @@ records) and differs from Fluent Bit (drops the route, retries via backlog).
 **Implication:** if a batch is rejected, the data in that batch is lost. This
 is the correct behavior for a log forwarder where corrupted or oversized data
 cannot be retried, but it must be explicitly documented and metered.
-
-Control-plane and retry-exhaustion failures are a different category. They
-must not be modeled as `RejectBatch`. In the current Rust rollout those
-outcomes are held unresolved so checkpoints do not advance past undelivered
-data; graceful drain may therefore fall back to `ForceStop`, with replay on
-restart covering the unresolved batches.
 
 ### 3. `pending_acks` is correctly abstracted away
 

--- a/tla/ShutdownProtocol.cfg
+++ b/tla/ShutdownProtocol.cfg
@@ -1,13 +1,18 @@
 SPECIFICATION Spec
 
+\* Small capacities for model checking; production uses IoChannelCapacity=4,
+\* PipelineChannelCapacity=16.  The protocol is capacity-independent.
 CONSTANTS
     NumInputs = 2
-    ChannelCapacity = 2
+    IoChannelCapacity = 2
+    PipelineChannelCapacity = 3
     MaxItems = 3
 
 INVARIANTS
     TypeOK
-    NoDeadlock
-    FlushAfterJoin
-    StopAfterFlush
+    NoCpuStopBeforeIoDrain
+    NoJoinBeforePipelineDrain
+    NoStopBeforeJoin
     NormalStopImpliesPoolDrained
+    IoConservation
+    PipelineConservation

--- a/tla/ShutdownProtocol.coverage.cfg
+++ b/tla/ShutdownProtocol.coverage.cfg
@@ -1,12 +1,19 @@
 SPECIFICATION Spec
 
+\* Small capacities for model checking; production uses IoChannelCapacity=4,
+\* PipelineChannelCapacity=16.  The protocol is capacity-independent.
 CONSTANTS
     NumInputs = 2
-    ChannelCapacity = 2
+    IoChannelCapacity = 2
+    PipelineChannelCapacity = 3
     MaxItems = 3
 
 INVARIANTS
     ShutdownReachable
+    IoChannelsDrainedReachable
+    IoChannelFullReachable
+    CpuWorkersStoppedReachable
+    PipelineChannelDrainedReachable
+    PipelineChannelFullReachable
     NormalStopReachable
     ForceStopReachable
-    ChannelFullReachable

--- a/tla/ShutdownProtocol.liveness.cfg
+++ b/tla/ShutdownProtocol.liveness.cfg
@@ -1,12 +1,16 @@
 SPECIFICATION Spec
 
+\* Small capacities for model checking; production uses IoChannelCapacity=4,
+\* PipelineChannelCapacity=16.  The protocol is capacity-independent.
 CONSTANTS
     NumInputs = 2
-    ChannelCapacity = 2
+    IoChannelCapacity = 2
+    PipelineChannelCapacity = 3
     MaxItems = 2
 
 PROPERTIES
     ShutdownCompletes
-    InputsEventuallyStop
-    ChannelEventuallyDrained
+    NoCpuWorkerDeadlock
+    IoCpuChannelEventuallyDrained
+    CpuWorkersEventuallyStop
     EventualStop

--- a/tla/ShutdownProtocol.tla
+++ b/tla/ShutdownProtocol.tla
@@ -1,18 +1,27 @@
 ----------------------- MODULE ShutdownProtocol -----------------------
 (*
- * Formal model of the pipeline shutdown coordination protocol from
- * crates/logfwd/src/pipeline.rs run_async().
+ * Formal model of the split input shutdown protocol used by
+ * feat/io-compute-separation (PR #1512).
  *
- * Models N input threads feeding a bounded channel consumed by a single
- * async consumer. Shutdown must:
- *   (1) Drain the channel before joining input threads (prevents deadlock)
- *   (2) Join input threads before final flush (no more data after join)
- *   (3) Drain the output pool before machine transition
- *   (4) All of the above must eventually complete (liveness)
+ * Per input, runtime has two workers:
+ *   I/O worker -> io_cpu bounded channel -> CPU worker -> shared pipeline channel
  *
- * The protocol follows the ordering in pipeline.rs:412-518:
- *   shutdown signal → drain channel → join inputs → flush remaining →
- *   drain pool → drain acks → begin_drain → stop/force_stop
+ * Production capacities:
+ *   io_cpu channel      = 4
+ *   shared pipeline rx  = 16
+ *
+ * Model-checking capacities are intentionally small (IoChannelCapacity=2,
+ * PipelineChannelCapacity=3) to keep the state space TLC-feasible.
+ * The protocol is capacity-independent so small values are sufficient.
+ *
+ * Shutdown cascade:
+ *   shutdown signal
+ *     -> I/O workers stop + drop io senders
+ *     -> per-input: io_cpu channel drains, CPU worker stops independently
+ *     -> (all CPU workers stopped) -> pipeline channel drains
+ *     -> join workers
+ *     -> drain pool
+ *     -> stop / force_stop
  *
  * This spec does NOT model:
  *   - Byte-level data or framing (modeled as abstract "items")
@@ -27,15 +36,17 @@
  * For TLC configuration, see MCShutdownProtocol.tla.
  *)
 
-EXTENDS Naturals, FiniteSets, Sequences, TLC
+EXTENDS Naturals, Sequences, TLC
 
 CONSTANTS
-    NumInputs,          \* Number of input threads (>= 1)
-    ChannelCapacity,    \* Bounded channel size (>= 1)
-    MaxItems            \* Max items any single input can produce
+    NumInputs,                \* Number of input pairs (>= 1)
+    IoChannelCapacity,        \* io_worker -> cpu_worker channel capacity
+    PipelineChannelCapacity,  \* shared cpu_worker -> pipeline channel capacity
+    MaxItems                  \* Max items any single input can produce
 
 ASSUME NumInputs >= 1 /\ NumInputs <= 4
-ASSUME ChannelCapacity >= 1 /\ ChannelCapacity <= 8
+ASSUME IoChannelCapacity >= 1 /\ IoChannelCapacity <= 4
+ASSUME PipelineChannelCapacity >= 1 /\ PipelineChannelCapacity <= 16
 ASSUME MaxItems >= 1 /\ MaxItems <= 4
 
 (* -----------------------------------------------------------------------
@@ -43,37 +54,54 @@ ASSUME MaxItems >= 1 /\ MaxItems <= 4
  * ----------------------------------------------------------------------- *)
 
 VARIABLES
-    (* Input thread state *)
-    input_produced,     \* [1..NumInputs -> Nat] items produced per input
-    input_alive,        \* [1..NumInputs -> BOOLEAN] thread still running
+    (* Per-input I/O worker state *)
+    input_produced,          \* [1..NumInputs -> Nat]
+    io_alive,                \* [1..NumInputs -> BOOLEAN]
 
-    (* Bounded channel *)
-    channel,            \* Seq of items (FIFO, bounded by ChannelCapacity)
+    (* Per-input io -> cpu channels *)
+    io_channels,             \* [1..NumInputs -> Seq(Inputs)] (bounded)
 
-    (* Consumer state *)
-    consumed,           \* Nat: total items consumed from channel
-    consumer_buf,       \* Nat: items in scan_buf not yet flushed
-    flushed,            \* Nat: total items flushed to output
+    (* Per-input CPU worker state *)
+    cpu_forwarded,           \* [1..NumInputs -> Nat]
+    cpu_alive,               \* [1..NumInputs -> BOOLEAN]
 
-    (* Output pool *)
-    pool_pending,       \* Nat: items submitted to pool, not yet acked
-    pool_acked,         \* Nat: items acked by pool
+    (* Shared pipeline channel consumed by run_async *)
+    pipeline_channel,        \* Seq(Inputs), bounded
 
-    (* Shutdown coordination *)
-    shutdown_signaled,  \* BOOLEAN: cancellation token fired
-    channel_drained,    \* BOOLEAN: channel fully drained post-shutdown
-    inputs_joined,      \* BOOLEAN: all input threads joined
-    pool_drained,       \* BOOLEAN: output pool drained
-    final_flushed,      \* BOOLEAN: remaining scan_buf flushed
-    machine_stopped,    \* BOOLEAN: PipelineMachine transitioned to Stopped
-    forced              \* BOOLEAN: force_stop was used (timeout expired)
+    (* Pipeline + output accounting *)
+    consumed,                \* Nat: items received from pipeline_channel
+    pool_pending,            \* Nat: items submitted to output pool
+    pool_acked,              \* Nat: items acked by pool
 
-vars == <<input_produced, input_alive, channel, consumed, consumer_buf,
-          flushed, pool_pending, pool_acked, shutdown_signaled,
-          channel_drained, inputs_joined, pool_drained, final_flushed,
+    (* Shutdown coordination stages *)
+    shutdown_signaled,       \* cancellation token fired
+    io_channels_drained,     \* derived: all io workers exited and io channels empty
+    cpu_workers_stopped,     \* all cpu workers exited
+    pipeline_channel_drained,\* shared pipeline channel empty after cpu stop
+    workers_joined,          \* manager.join() completed
+    pool_drained,            \* pool drain completed
+    machine_stopped,         \* PipelineMachine transitioned to Stopped
+    forced                   \* force_stop path was used
+
+vars == <<input_produced, io_alive, io_channels, cpu_forwarded, cpu_alive,
+          pipeline_channel, consumed, pool_pending, pool_acked,
+          shutdown_signaled, io_channels_drained, cpu_workers_stopped,
+          pipeline_channel_drained, workers_joined, pool_drained,
           machine_stopped, forced>>
 
 Inputs == 1..NumInputs
+
+(* -----------------------------------------------------------------------
+ * Helper: sum a function over Inputs
+ * ----------------------------------------------------------------------- *)
+
+RECURSIVE SumInputs(_, _)
+SumInputs(f, S) ==
+    IF S = {} THEN 0
+    ELSE LET x == CHOOSE x \in S : TRUE
+         IN  f[x] + SumInputs(f, S \ {x})
+
+SumAll(f) == SumInputs(f, Inputs)
 
 (* -----------------------------------------------------------------------
  * Type invariant
@@ -82,18 +110,22 @@ Inputs == 1..NumInputs
 TypeOK ==
     /\ \A i \in Inputs :
         /\ input_produced[i] \in 0..MaxItems
-        /\ input_alive[i] \in BOOLEAN
-    /\ Len(channel) \in 0..ChannelCapacity
+        /\ io_alive[i] \in BOOLEAN
+        /\ cpu_forwarded[i] \in Nat
+        /\ cpu_alive[i] \in BOOLEAN
+        /\ io_channels[i] \in Seq(Inputs)
+        /\ Len(io_channels[i]) \in 0..IoChannelCapacity
+    /\ pipeline_channel \in Seq(Inputs)
+    /\ Len(pipeline_channel) \in 0..PipelineChannelCapacity
     /\ consumed \in Nat
-    /\ consumer_buf \in Nat
-    /\ flushed \in Nat
     /\ pool_pending \in Nat
     /\ pool_acked \in Nat
     /\ shutdown_signaled \in BOOLEAN
-    /\ channel_drained \in BOOLEAN
-    /\ inputs_joined \in BOOLEAN
+    /\ io_channels_drained \in BOOLEAN
+    /\ cpu_workers_stopped \in BOOLEAN
+    /\ pipeline_channel_drained \in BOOLEAN
+    /\ workers_joined \in BOOLEAN
     /\ pool_drained \in BOOLEAN
-    /\ final_flushed \in BOOLEAN
     /\ machine_stopped \in BOOLEAN
     /\ forced \in BOOLEAN
 
@@ -103,227 +135,232 @@ TypeOK ==
 
 Init ==
     /\ input_produced = [i \in Inputs |-> 0]
-    /\ input_alive = [i \in Inputs |-> TRUE]
-    /\ channel = <<>>
+    /\ io_alive = [i \in Inputs |-> TRUE]
+    /\ io_channels = [i \in Inputs |-> <<>>]
+    /\ cpu_forwarded = [i \in Inputs |-> 0]
+    /\ cpu_alive = [i \in Inputs |-> TRUE]
+    /\ pipeline_channel = <<>>
     /\ consumed = 0
-    /\ consumer_buf = 0
-    /\ flushed = 0
     /\ pool_pending = 0
     /\ pool_acked = 0
     /\ shutdown_signaled = FALSE
-    /\ channel_drained = FALSE
-    /\ inputs_joined = FALSE
+    /\ io_channels_drained = FALSE
+    /\ cpu_workers_stopped = FALSE
+    /\ pipeline_channel_drained = FALSE
+    /\ workers_joined = FALSE
     /\ pool_drained = FALSE
-    /\ final_flushed = FALSE
     /\ machine_stopped = FALSE
     /\ forced = FALSE
 
 (* -----------------------------------------------------------------------
- * Actions: Normal operation (before shutdown)
+ * Actions: Normal operation
  * ----------------------------------------------------------------------- *)
 
-\* Input thread produces an item and sends to channel (if not full).
-\* Models input_poll_loop: poll() -> buf.extend -> blocking_send.
-InputProduce(i) ==
-    /\ input_alive[i]
+\* I/O worker polls input and sends one chunk to its io_cpu channel.
+IoProduce(i) ==
+    /\ io_alive[i]
     /\ input_produced[i] < MaxItems
-    /\ Len(channel) < ChannelCapacity     \* not full (would block)
+    /\ Len(io_channels[i]) < IoChannelCapacity
     /\ input_produced' = [input_produced EXCEPT ![i] = @ + 1]
-    /\ channel' = Append(channel, i)      \* item identity = producing input
-    /\ UNCHANGED <<input_alive, consumed, consumer_buf, flushed,
+    /\ io_channels' = [io_channels EXCEPT ![i] = Append(@, i)]
+    /\ UNCHANGED <<io_alive, cpu_forwarded, cpu_alive, pipeline_channel,
+                   consumed, pool_pending, pool_acked, shutdown_signaled,
+                   io_channels_drained, cpu_workers_stopped,
+                   pipeline_channel_drained, workers_joined, pool_drained,
+                   machine_stopped, forced>>
+
+\* CPU worker drains one chunk from its io_cpu channel and forwards to pipeline channel.
+CpuForward(i) ==
+    /\ cpu_alive[i]
+    /\ Len(io_channels[i]) > 0
+    /\ Len(pipeline_channel) < PipelineChannelCapacity
+    /\ io_channels' = [io_channels EXCEPT ![i] = Tail(@)]
+    /\ cpu_forwarded' = [cpu_forwarded EXCEPT ![i] = @ + 1]
+    /\ pipeline_channel' = Append(pipeline_channel, i)
+    /\ UNCHANGED <<input_produced, io_alive, cpu_alive, consumed,
                    pool_pending, pool_acked, shutdown_signaled,
-                   channel_drained, inputs_joined, pool_drained,
-                   final_flushed, machine_stopped, forced>>
+                   io_channels_drained, cpu_workers_stopped,
+                   pipeline_channel_drained, workers_joined, pool_drained,
+                   machine_stopped, forced>>
 
-\* Consumer receives from channel and buffers.
-\* Models: msg = rx.recv() -> scan_buf.extend.
-ConsumerReceive ==
-    /\ ~shutdown_signaled
-    /\ Len(channel) > 0
+\* Pipeline main loop receives one batch from the shared channel and submits to pool.
+ConsumePipeline ==
+    /\ Len(pipeline_channel) > 0
+    /\ pipeline_channel' = Tail(pipeline_channel)
     /\ consumed' = consumed + 1
-    /\ consumer_buf' = consumer_buf + 1
-    /\ channel' = Tail(channel)
-    /\ UNCHANGED <<input_produced, input_alive, flushed, pool_pending,
-                   pool_acked, shutdown_signaled, channel_drained,
-                   inputs_joined, pool_drained, final_flushed,
-                   machine_stopped, forced>>
-
-\* Consumer flushes buffer to output pool.
-\* Models: flush_batch (size threshold or timeout).
-\* Allowed both in normal operation AND during the drain phase
-\* (after shutdown but before inputs are joined), matching the real
-\* code's channel-drain loop (pipeline.rs:449-471).
-ConsumerFlush ==
-    /\ (~shutdown_signaled \/ (~channel_drained /\ ~inputs_joined))
-    /\ consumer_buf > 0
-    /\ flushed' = flushed + consumer_buf
     /\ pool_pending' = pool_pending + 1
-    /\ consumer_buf' = 0
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   pool_acked, shutdown_signaled, channel_drained,
-                   inputs_joined, pool_drained, final_flushed,
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pool_acked, shutdown_signaled,
+                   io_channels_drained, cpu_workers_stopped,
+                   pipeline_channel_drained, workers_joined, pool_drained,
                    machine_stopped, forced>>
 
-\* Output pool worker acks a completed batch.
-\* Models: pool.ack_rx.recv() -> apply_pool_ack.
+\* Output pool acks one submitted batch.
 PoolAck ==
     /\ pool_pending > pool_acked
     /\ pool_acked' = pool_acked + 1
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   consumer_buf, flushed, pool_pending, shutdown_signaled,
-                   channel_drained, inputs_joined, pool_drained,
-                   final_flushed, machine_stopped, forced>>
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, pipeline_channel_drained,
+                   workers_joined, pool_drained, machine_stopped, forced>>
 
 (* -----------------------------------------------------------------------
- * Actions: Shutdown sequence (ordered phases)
+ * Actions: Shutdown sequence
  * ----------------------------------------------------------------------- *)
 
-\* 1. Shutdown signal fires (cancellation token).
+\* 1) Cancellation token fires.
 SignalShutdown ==
     /\ ~shutdown_signaled
     /\ shutdown_signaled' = TRUE
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   consumer_buf, flushed, pool_pending, pool_acked,
-                   channel_drained, inputs_joined, pool_drained,
-                   final_flushed, machine_stopped, forced>>
-
-\* 2. Input threads notice shutdown and stop producing.
-\* In the real code, inputs drain their local buffer before exiting.
-\* Modeled as: input can still produce via InputProduce (now enabled
-\* during shutdown), then exits via InputShutdown.
-InputShutdown(i) ==
-    /\ shutdown_signaled
-    /\ input_alive[i]
-    /\ input_alive' = [input_alive EXCEPT ![i] = FALSE]
-    /\ UNCHANGED <<input_produced, channel, consumed, consumer_buf, flushed,
-                   pool_pending, pool_acked, shutdown_signaled,
-                   channel_drained, inputs_joined, pool_drained,
-                   final_flushed, machine_stopped, forced>>
-
-\* 3. Drain channel: consumer reads remaining messages after shutdown.
-\* CRITICAL: must happen BEFORE joining input threads to prevent deadlock.
-\* If channel is full and an input is blocked in blocking_send, joining
-\* the input thread would deadlock because the send can't complete.
-DrainChannel ==
-    /\ shutdown_signaled
-    /\ ~channel_drained
-    /\ Len(channel) > 0
-    /\ consumed' = consumed + 1
-    /\ consumer_buf' = consumer_buf + 1
-    /\ channel' = Tail(channel)
-    /\ UNCHANGED <<input_produced, input_alive, flushed, pool_pending,
-                   pool_acked, shutdown_signaled, channel_drained,
-                   inputs_joined, pool_drained, final_flushed,
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, io_channels_drained, cpu_workers_stopped,
+                   pipeline_channel_drained, workers_joined, pool_drained,
                    machine_stopped, forced>>
 
-\* Channel is fully drained when empty AND all inputs have exited.
-\* (Inputs exiting drops their Sender clones; when all are gone,
-\* rx.recv() returns None.)
-MarkChannelDrained ==
+\* 2) I/O worker exits (after any final local drain, abstracted here).
+IoWorkerStop(i) ==
     /\ shutdown_signaled
-    /\ ~channel_drained
-    /\ Len(channel) = 0
-    /\ \A i \in Inputs : ~input_alive[i]
-    /\ channel_drained' = TRUE
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   consumer_buf, flushed, pool_pending, pool_acked,
-                   shutdown_signaled, inputs_joined, pool_drained,
-                   final_flushed, machine_stopped, forced>>
+    /\ io_alive[i]
+    /\ io_alive' = [io_alive EXCEPT ![i] = FALSE]
+    /\ UNCHANGED <<input_produced, io_channels, cpu_forwarded, cpu_alive,
+                   pipeline_channel, consumed, pool_pending, pool_acked,
+                   shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, pipeline_channel_drained,
+                   workers_joined, pool_drained, machine_stopped, forced>>
 
-\* 4. Join input threads.
-\* Guard: channel must be drained first (deadlock prevention).
-JoinInputs ==
-    /\ channel_drained
-    /\ ~inputs_joined
-    /\ \A i \in Inputs : ~input_alive[i]
-    /\ inputs_joined' = TRUE
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   consumer_buf, flushed, pool_pending, pool_acked,
-                   shutdown_signaled, channel_drained, pool_drained,
-                   final_flushed, machine_stopped, forced>>
+\* 3) Observe that all io workers are down and all io_cpu channels are empty.
+\*    This is a derived observation -- not a precondition for CpuWorkerStop.
+\*    Each CPU worker independently decides based on per-input state (step 4).
+\*    Can fire before or after individual CpuWorkerStop(i) actions.
+MarkIoChannelsDrained ==
+    /\ shutdown_signaled
+    /\ ~io_channels_drained
+    /\ \A i \in Inputs : ~io_alive[i]
+    /\ \A i \in Inputs : Len(io_channels[i]) = 0
+    /\ io_channels_drained' = TRUE
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, shutdown_signaled, cpu_workers_stopped,
+                   pipeline_channel_drained, workers_joined, pool_drained,
+                   machine_stopped, forced>>
 
-\* 5. Final flush of remaining scan_buf.
-\* Guard: inputs must be joined first (no more data can arrive).
-FinalFlush ==
-    /\ inputs_joined
-    /\ ~final_flushed
-    /\ consumer_buf > 0
-    /\ flushed' = flushed + consumer_buf
-    /\ pool_pending' = pool_pending + 1
-    /\ consumer_buf' = 0
-    /\ final_flushed' = TRUE
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   pool_acked, shutdown_signaled, channel_drained,
-                   inputs_joined, pool_drained, machine_stopped, forced>>
+\* 4) CPU worker exits once its own I/O worker is dead and its io channel is empty.
+\*    This is per-input: each CPU worker independently observes that its own
+\*    io_rx returns None (io_alive[i]=FALSE and io_channels[i] empty).
+\*    No global barrier required -- matches the implementation.
+CpuWorkerStop(i) ==
+    /\ cpu_alive[i]
+    /\ ~io_alive[i]
+    /\ Len(io_channels[i]) = 0
+    /\ cpu_alive' = [cpu_alive EXCEPT ![i] = FALSE]
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   pipeline_channel, consumed, pool_pending, pool_acked,
+                   shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, pipeline_channel_drained,
+                   workers_joined, pool_drained, machine_stopped, forced>>
 
-\* Final flush with empty buffer (nothing to flush).
-FinalFlushEmpty ==
-    /\ inputs_joined
-    /\ ~final_flushed
-    /\ consumer_buf = 0
-    /\ final_flushed' = TRUE
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   consumer_buf, flushed, pool_pending, pool_acked,
-                   shutdown_signaled, channel_drained, inputs_joined,
+\* 5) Record that all CPU workers have stopped.
+\*    Gates MarkPipelineChannelDrained -- no more pipeline sends are possible.
+\*    Also derives io_channels_drained as a consistency observation: if all
+\*    CPU workers stopped via per-input CpuWorkerStop, then each io channel
+\*    was empty when its CPU worker exited and no io worker is alive to
+\*    refill it, so all io channels are drained.
+MarkCpuWorkersStopped ==
+    /\ ~cpu_workers_stopped
+    /\ \A i \in Inputs : ~cpu_alive[i]
+    /\ cpu_workers_stopped' = TRUE
+    /\ io_channels_drained' = TRUE
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, shutdown_signaled,
+                   pipeline_channel_drained, workers_joined, pool_drained,
+                   machine_stopped, forced>>
+
+\* 6) Shared pipeline channel is drained after CPU workers have exited.
+MarkPipelineChannelDrained ==
+    /\ cpu_workers_stopped
+    /\ ~pipeline_channel_drained
+    /\ Len(pipeline_channel) = 0
+    /\ pipeline_channel_drained' = TRUE
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, workers_joined, pool_drained,
+                   machine_stopped, forced>>
+
+\* 7) Join all input workers (CPU first, then I/O in implementation).
+JoinWorkers ==
+    /\ pipeline_channel_drained
+    /\ ~workers_joined
+    /\ \A i \in Inputs : ~io_alive[i]
+    /\ \A i \in Inputs : ~cpu_alive[i]
+    /\ workers_joined' = TRUE
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, pipeline_channel_drained,
                    pool_drained, machine_stopped, forced>>
 
-\* 6. Drain output pool.
-\* Guard: final flush must be done (no more work to submit).
+\* 8) Drain pool after no more channel traffic is possible.
 DrainPool ==
-    /\ final_flushed
+    /\ workers_joined
     /\ ~pool_drained
-    /\ pool_acked = pool_pending   \* all submitted work is acked
+    /\ pool_acked = pool_pending
     /\ pool_drained' = TRUE
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   consumer_buf, flushed, pool_pending, pool_acked,
-                   shutdown_signaled, channel_drained, inputs_joined,
-                   final_flushed, machine_stopped, forced>>
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, pipeline_channel_drained,
+                   workers_joined, machine_stopped, forced>>
 
-\* 7. Machine transition: begin_drain → stop (normal).
+\* 9a) Normal stop path.
 NormalStop ==
     /\ pool_drained
     /\ ~machine_stopped
-    /\ pool_acked = pool_pending   \* all batches resolved
     /\ machine_stopped' = TRUE
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   consumer_buf, flushed, pool_pending, pool_acked,
-                   shutdown_signaled, channel_drained, inputs_joined,
-                   pool_drained, final_flushed, forced>>
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, pipeline_channel_drained,
+                   workers_joined, pool_drained, forced>>
 
-\* 7b. Machine transition: force_stop (timeout expired).
+\* 9b) Timeout escape hatch.
+\*    Guards on actual outstanding backlog (pool_acked < pool_pending) rather
+\*    than the latched ~pool_drained flag, so ForceStop only fires when there
+\*    is genuinely unacked work pending.
 ForceStop ==
-    /\ final_flushed
+    /\ workers_joined
+    /\ pool_acked < pool_pending
     /\ ~machine_stopped
-    /\ ~pool_drained             \* pool didn't drain in time
     /\ machine_stopped' = TRUE
     /\ forced' = TRUE
-    /\ UNCHANGED <<input_produced, input_alive, channel, consumed,
-                   consumer_buf, flushed, pool_pending, pool_acked,
-                   shutdown_signaled, channel_drained, inputs_joined,
-                   pool_drained, final_flushed>>
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, pipeline_channel_drained,
+                   workers_joined, pool_drained>>
 
 (* -----------------------------------------------------------------------
  * Next-state relation
  * ----------------------------------------------------------------------- *)
 
 Next ==
-    \* Normal operation
-    \/ \E i \in Inputs : InputProduce(i)
-    \/ ConsumerReceive
-    \/ ConsumerFlush
+    \/ \E i \in Inputs : IoProduce(i)
+    \/ \E i \in Inputs : CpuForward(i)
+    \/ ConsumePipeline
     \/ PoolAck
-    \* Shutdown sequence
     \/ SignalShutdown
-    \/ \E i \in Inputs : InputShutdown(i)
-    \/ DrainChannel
-    \/ MarkChannelDrained
-    \/ JoinInputs
-    \/ FinalFlush
-    \/ FinalFlushEmpty
+    \/ \E i \in Inputs : IoWorkerStop(i)
+    \/ MarkIoChannelsDrained
+    \/ \E i \in Inputs : CpuWorkerStop(i)
+    \/ MarkCpuWorkersStopped
+    \/ MarkPipelineChannelDrained
+    \/ JoinWorkers
     \/ DrainPool
     \/ NormalStop
     \/ ForceStop
-    \* Terminal: machine_stopped is final.
     \/ (machine_stopped /\ UNCHANGED vars)
 
 (* -----------------------------------------------------------------------
@@ -332,19 +369,19 @@ Next ==
 
 Fairness ==
     /\ WF_vars(SignalShutdown)
-    /\ \A i \in Inputs : WF_vars(InputShutdown(i))
-    /\ WF_vars(DrainChannel)
-    /\ WF_vars(MarkChannelDrained)
-    /\ WF_vars(JoinInputs)
-    /\ WF_vars(FinalFlush)
-    /\ WF_vars(FinalFlushEmpty)
+    /\ \A i \in Inputs : WF_vars(IoWorkerStop(i))
+    /\ \A i \in Inputs : WF_vars(CpuForward(i))
+    /\ WF_vars(ConsumePipeline)
+    /\ WF_vars(MarkIoChannelsDrained)
+    /\ \A i \in Inputs : WF_vars(CpuWorkerStop(i))
+    /\ WF_vars(MarkCpuWorkersStopped)
+    /\ WF_vars(MarkPipelineChannelDrained)
+    /\ WF_vars(JoinWorkers)
+    /\ WF_vars(PoolAck)
     /\ WF_vars(DrainPool)
     /\ WF_vars(NormalStop)
-    /\ WF_vars(PoolAck)
-    \* No WF on ForceStop — it fires only as a timeout escape hatch,
-    \* not as a guaranteed step.
-    \* No WF on InputProduce, ConsumerReceive, ConsumerFlush —
-    \* the environment is not obligated to produce or consume.
+    \* No WF on ForceStop -- timeout escape, not required progress.
+    \* No WF on IoProduce -- environment is not obligated to keep producing.
 
 Spec == Init /\ [][Next]_vars /\ Fairness
 
@@ -352,50 +389,53 @@ Spec == Init /\ [][Next]_vars /\ Fairness
  * Safety properties
  * ----------------------------------------------------------------------- *)
 
-\* The shutdown ordering is maintained.
-\* Inputs are joined only after channel is drained.
-NoDeadlock ==
-    inputs_joined => channel_drained
+NoCpuStopBeforeIoDrain ==
+    cpu_workers_stopped => io_channels_drained
 
-\* Final flush happens only after inputs are joined.
-FlushAfterJoin ==
-    final_flushed => inputs_joined
+NoJoinBeforePipelineDrain ==
+    workers_joined => pipeline_channel_drained
 
-\* Machine stops only after final flush.
-StopAfterFlush ==
-    machine_stopped => final_flushed
+NoStopBeforeJoin ==
+    machine_stopped => workers_joined
 
-\* Normal stop implies pool fully drained.
-\* DrainCompleteness for the shutdown protocol.
 NormalStopImpliesPoolDrained ==
     (machine_stopped /\ ~forced) => pool_drained
 
-\* Helper: sum of a function over its domain
-RECURSIVE SumProdHelper(_, _, _)
-SumProdHelper(f, remaining, acc) ==
-    IF remaining = {} THEN acc
-    ELSE LET x == CHOOSE x \in remaining : TRUE
-         IN SumProdHelper(f, remaining \ {x}, acc + f[x])
-SumProd(f) == SumProdHelper(f, DOMAIN f, 0)
+\* Conservation: items produced by each I/O worker = items in its io channel
+\* + items its CPU worker has forwarded.  Non-tautological: catches duplication
+\* or loss in the io -> cpu path.
+IoConservation ==
+    \A i \in Inputs :
+        input_produced[i] = Len(io_channels[i]) + cpu_forwarded[i]
+
+\* Conservation: total items forwarded by all CPU workers = items currently
+\* in the pipeline channel + items consumed from it.  Non-tautological: catches
+\* duplication or loss in the cpu -> pipeline path.
+PipelineConservation ==
+    SumAll(cpu_forwarded) = Len(pipeline_channel) + consumed
 
 (* -----------------------------------------------------------------------
  * Liveness properties
  * ----------------------------------------------------------------------- *)
 
-\* Shutdown eventually completes.
 ShutdownCompletes ==
     shutdown_signaled ~> machine_stopped
 
-\* Once shutdown is signaled, all inputs eventually exit.
-InputsEventuallyStop ==
-    \A i \in Inputs :
-        shutdown_signaled ~> ~input_alive[i]
+\* Required by issue #1529:
+\* CPU workers must not deadlock waiting on pipeline backpressure forever.
+NoCpuWorkerDeadlock ==
+    io_channels_drained ~> cpu_workers_stopped
 
-\* Channel is eventually drained after shutdown.
-ChannelEventuallyDrained ==
-    shutdown_signaled ~> channel_drained
+\* Required by issue #1529:
+\* After I/O workers stop, io_cpu channels eventually drain.
+IoCpuChannelEventuallyDrained ==
+    (\A i \in Inputs : ~io_alive[i]) ~> io_channels_drained
 
-\* Machine eventually stops (by normal or force path).
+\* Required by issue #1529:
+\* Once I/O workers stop, CPU workers eventually stop.
+CpuWorkersEventuallyStop ==
+    (\A i \in Inputs : ~io_alive[i]) ~> (\A i \in Inputs : ~cpu_alive[i])
+
 EventualStop ==
     <>[](machine_stopped)
 
@@ -403,9 +443,16 @@ EventualStop ==
  * Reachability / vacuity guards
  * ----------------------------------------------------------------------- *)
 
-ShutdownReachable == ~shutdown_signaled  \* violation = shutdown fires
+ShutdownReachable == ~shutdown_signaled
+IoChannelsDrainedReachable == ~io_channels_drained
+CpuWorkersStoppedReachable == ~cpu_workers_stopped
+PipelineChannelDrainedReachable == ~pipeline_channel_drained
 NormalStopReachable == ~(machine_stopped /\ ~forced)
 ForceStopReachable == ~(machine_stopped /\ forced)
-ChannelFullReachable == ~(Len(channel) = ChannelCapacity)
+
+\* Backpressure reachability: witness that bounded channels can become full.
+\* Important for shutdown deadlock analysis -- TLC must explore these states.
+IoChannelFullReachable == ~(\E i \in Inputs : Len(io_channels[i]) = IoChannelCapacity)
+PipelineChannelFullReachable == ~(Len(pipeline_channel) = PipelineChannelCapacity)
 
 ======================================================================


### PR DESCRIPTION
## Summary
- rewrites `tla/ShutdownProtocol.tla` to model the split input architecture (`io_worker -> io_cpu channel -> cpu_worker -> pipeline channel`)
- updates safety/liveness/coverage configs to use separate `IoChannelCapacity` and `PipelineChannelCapacity`
- updates `MCShutdownProtocol.tla` constants and `tla/README.md` module description

## Verification
- `/opt/homebrew/opt/openjdk@21/bin/java -cp /tmp/tla/tla2tools.jar tlc2.TLC MCShutdownProtocol.tla -config ShutdownProtocol.cfg`
- `/opt/homebrew/opt/openjdk@21/bin/java -cp /tmp/tla/tla2tools.jar tlc2.TLC MCShutdownProtocol.tla -config ShutdownProtocol.liveness.cfg`
- `/opt/homebrew/opt/openjdk@21/bin/java -cp /tmp/tla/tla2tools.jar tlc2.TLC MCShutdownProtocol.tla -config ShutdownProtocol.coverage.cfg` (expected reachability invariant violation style)

Closes #1529


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace single-channel ShutdownProtocol TLA+ model with two-tier I/O+CPU worker architecture
> - Rewrites [ShutdownProtocol.tla](https://github.com/strawgate/memagent/pull/1535/files#diff-bd61fe98eb99ec3cbc6bdc8bd645aadc945a6c135efbad1c146a937652f47673) to model per-input I/O workers feeding bounded `io_channels` to per-input CPU workers, which forward items to a shared `pipeline_channel`.
> - Replaces `ChannelCapacity` with separate `IoChannelCapacity=2` and `PipelineChannelCapacity=3` constants across all `.cfg` files.
> - Replaces old invariants (`NoDeadlock`, `FlushAfterJoin`, `StopAfterFlush`) with ordering and conservation invariants (`NoCpuStopBeforeIoDrain`, `NoJoinBeforePipelineDrain`, `IoConservation`, `PipelineConservation`).
> - Updates liveness properties to target the split model: `NoCpuWorkerDeadlock`, `IoCpuChannelEventuallyDrained`, `CpuWorkersEventuallyStop`.
> - Moves hard-coded model constants out of `MCShutdownProtocol.tla` into `.cfg` files and rewrites the README to document the two-tier drain protocol.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5f11e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->