### PR TITLE
fix(receivers): replace panicky .expect() with safe Option extraction

### DIFF
--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -286,8 +286,11 @@ impl ArrowIpcReceiver {
 
     /// Try to receive all available RecordBatches (non-blocking).
     pub fn try_recv_all(&self) -> Vec<RecordBatch> {
+        let Some(rx) = self.rx.as_ref() else {
+            return Vec::new();
+        };
         let mut batches = Vec::new();
-        while let Ok(batch) = self.rx.as_ref().expect("rx is Some until drop").try_recv() {
+        while let Ok(batch) = rx.try_recv() {
             batches.push(batch);
         }
         batches
@@ -295,27 +298,26 @@ impl ArrowIpcReceiver {
 
     /// Blocking receive of the next RecordBatch.
     pub fn recv(&self) -> io::Result<RecordBatch> {
-        self.rx
-            .as_ref()
-            .expect("rx is Some until drop")
-            .recv()
+        let Some(rx) = self.rx.as_ref() else {
+            return Err(io::Error::other("Arrow IPC receiver: already closed"));
+        };
+        rx.recv()
             .map_err(|_| io::Error::other("Arrow IPC receiver: channel disconnected"))
     }
 
     /// Receive with a timeout.
     pub fn recv_timeout(&self, timeout: std::time::Duration) -> io::Result<RecordBatch> {
-        self.rx
-            .as_ref()
-            .expect("rx is Some until drop")
-            .recv_timeout(timeout)
-            .map_err(|e| match e {
-                mpsc::RecvTimeoutError::Timeout => {
-                    io::Error::new(io::ErrorKind::TimedOut, "Arrow IPC receiver: timed out")
-                }
-                mpsc::RecvTimeoutError::Disconnected => {
-                    io::Error::other("Arrow IPC receiver: channel disconnected")
-                }
-            })
+        let Some(rx) = self.rx.as_ref() else {
+            return Err(io::Error::other("Arrow IPC receiver: already closed"));
+        };
+        rx.recv_timeout(timeout).map_err(|e| match e {
+            mpsc::RecvTimeoutError::Timeout => {
+                io::Error::new(io::ErrorKind::TimedOut, "Arrow IPC receiver: timed out")
+            }
+            mpsc::RecvTimeoutError::Disconnected => {
+                io::Error::other("Arrow IPC receiver: channel disconnected")
+            }
+        })
     }
 
     /// Return the name of this receiver.

--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -314,10 +314,13 @@ impl Drop for OtlpReceiverInput {
 
 impl InputSource for OtlpReceiverInput {
     fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+        let Some(rx) = self.rx.as_ref() else {
+            return Ok(vec![]);
+        };
         let mut all = Vec::new();
 
         // Drain all available decoded batches.
-        while let Ok(data) = self.rx.as_ref().expect("rx is Some until drop").try_recv() {
+        while let Ok(data) = rx.try_recv() {
             all.extend_from_slice(&data);
         }
 


### PR DESCRIPTION
## Summary
- Post-merge commits after PR #1393 reintroduced `.expect("rx is Some until drop")` in `arrow_ipc_receiver.rs` (3 call sites) and `otlp_receiver.rs` (1 call site)
- Replaced with `let Some(rx) = self.rx.as_ref() else { ... }` to return clean errors/empty results instead of panicking during shutdown
- Matches the safe pattern already in place in `otap_receiver.rs`

Fixes #1328

## Test plan
- [x] `cargo check -p logfwd-io` passes
- [x] `cargo clippy -p logfwd-io -- -D warnings` clean
- [x] All 50 receiver tests pass (`cargo test -p logfwd-io -- arrow_ipc_receiver otlp_receiver`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace panicking `.expect()` calls with safe `Option` checks in `ArrowIpcReceiver` and `OtlpReceiverInput`
> Fixes panics that occurred when methods were called on already-closed receiver channels in [arrow_ipc_receiver.rs](https://github.com/strawgate/memagent/pull/1540/files#diff-09612a16750832e6b7a4b59dbdd6a982a63b88557c06b3d49e74545813f8a46b) and [otlp_receiver.rs](https://github.com/strawgate/memagent/pull/1540/files#diff-839a5b8c237a52e782ebba56a56e0053ec71e6e918888b20043904fabcd7b99e).
>
> - `try_recv_all` and `poll` now return an empty `Vec` instead of panicking when `self.rx` is `None`
> - `recv` and `recv_timeout` now return an `io::Error` ("already closed") instead of panicking when `self.rx` is `None`
> - Each method binds `self.rx.as_ref()` to a local variable before use, eliminating the unsafe `.expect()` calls
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e33569.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->