### PR TITLE
fix(pipeline): hold checkpoints on transient delivery failures (#1001)

### DIFF
--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -1028,7 +1028,7 @@ impl Pipeline {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
-    /// Apply a pool `AckItem` — ack or reject its tickets and advance the machine.
+    /// Apply a pool `AckItem` at the worker/checkpoint seam.
     ///
     /// Called from the `select!` loop when a pool worker finishes a batch.
     fn apply_pool_ack(&mut self, ack: AckItem) {
@@ -1044,13 +1044,15 @@ impl Pipeline {
             self.metrics
                 .record_batch_latency(ack.submitted_at.elapsed().as_nanos() as u64);
         } else {
-            self.metrics.inc_dropped_batch();
+            if ack.outcome.is_permanent_reject() {
+                self.metrics.inc_dropped_batch();
+            }
             self.metrics.output_error(&ack.output_name);
         }
         self.ack_all_tickets(ack.tickets, default_ticket_disposition(&ack.outcome));
     }
 
-    /// Ack or reject all Sending tickets and apply receipts to the machine.
+    /// Finalize Sending tickets and apply receipts to the machine when present.
     /// When a checkpoint advances, the new offset is persisted to the store.
     /// Flushes are throttled to at most once per 5 seconds to avoid fsync storms.
     fn ack_all_tickets(
@@ -1062,24 +1064,37 @@ impl Pipeline {
             return;
         };
         let mut any_advanced = false;
+        let mut held = 0usize;
         for ticket in tickets {
             let receipt = match disposition {
-                TicketDisposition::Ack => ticket.ack(),
-                TicketDisposition::Reject => ticket.reject(),
+                TicketDisposition::Ack => Some(ticket.ack()),
+                TicketDisposition::Reject => Some(ticket.reject()),
+                TicketDisposition::Hold => {
+                    held += 1;
+                    None
+                }
             };
-            let advance = machine.apply_ack(receipt);
-            if advance.advanced {
-                if let (Some(ref mut store), Some(offset)) =
-                    (self.checkpoint_store.as_mut(), advance.checkpoint)
-                {
-                    store.update(SourceCheckpoint {
-                        source_id: advance.source.0,
-                        path: None, // path is metadata, not required for restore
-                        offset,
-                    });
-                    any_advanced = true;
+            if let Some(receipt) = receipt {
+                let advance = machine.apply_ack(receipt);
+                if advance.advanced {
+                    if let (Some(ref mut store), Some(offset)) =
+                        (self.checkpoint_store.as_mut(), advance.checkpoint)
+                    {
+                        store.update(SourceCheckpoint {
+                            source_id: advance.source.0,
+                            path: None, // path is metadata, not required for restore
+                            offset,
+                        });
+                        any_advanced = true;
+                    }
                 }
             }
+        }
+        if held > 0 {
+            tracing::warn!(
+                held_tickets = held,
+                "pipeline: leaving tickets unresolved so checkpoints do not advance past undelivered data"
+            );
         }
         // Flush to disk at most once per checkpoint_flush_interval to amortize fsync cost.
         // Advance the timer even on failure to prevent retry flooding.
@@ -2504,8 +2519,8 @@ output:
         assert!(result.unwrap().is_ok(), "immediate shutdown must not error");
     }
 
-    /// Output errors must not crash the pipeline — batches are dropped
-    /// and processing continues.
+    /// Output errors must not crash the pipeline. Retry/control-plane
+    /// failures are surfaced as output errors without advancing checkpoints.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_async_output_errors_do_not_crash() {
         let dir = tempfile::tempdir().unwrap();
@@ -2566,16 +2581,13 @@ output:
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_async_fanout_output_errors_only_increment_failing_output() {
+    async fn test_async_fanout_output_errors_do_not_count_as_permanent_drops() {
         // This test verifies that a persistently-failing output does not
-        // crash the pipeline and is recorded as a dropped batch.
+        // crash the pipeline and is not misclassified as a permanent drop.
         //
         // With the async worker pool, retries are built into the pool. An
-        // always-failing sink causes the pool to exhaust retries and return
-        // AckItem { success: false }, which increments dropped_batches_total.
-        //
-        // Per-sink error tracking within async fanout is not currently
-        // supported by the pool's AckItem protocol (tracked in issue #702).
+        // always-failing sink causes the pool to exhaust retries and return a
+        // non-delivered AckItem outcome that should HOLD the checkpoint seam.
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("fanout_output_err.log");
 
@@ -2605,7 +2617,8 @@ pipelines:
         let config = logfwd_config::Config::load_str(&yaml).unwrap();
         let pipe_cfg = &config.pipelines["default"];
         let mut pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter(), None).unwrap();
-        // always-failing: fails every call — pool exhausts retries → dropped
+        // always-failing: fails every call — pool exhausts retries and the
+        // pipeline must hold checkpoint progress instead of rejecting it.
         pipeline = pipeline.with_sink(Box::new(FailingSink::new(u32::MAX)));
         pipeline.batch_timeout = Duration::from_millis(20);
 
@@ -2624,13 +2637,23 @@ pipelines:
             "fanout output errors should not crash pipeline"
         );
 
+        let lines_in = pipeline
+            .metrics
+            .transform_in
+            .lines_total
+            .load(Ordering::Relaxed);
+        assert!(
+            lines_in > 0,
+            "data should still reach transform despite output failure"
+        );
+
         let dropped = pipeline
             .metrics
             .dropped_batches_total
             .load(Ordering::Relaxed);
-        assert!(
-            dropped > 0,
-            "expected dropped_batches_total > 0, got {dropped}"
+        assert_eq!(
+            dropped, 0,
+            "retry/control-plane failures should not count as permanent drops"
         );
     }
 
@@ -3138,7 +3161,7 @@ output:
         std::thread::spawn(move || {
             let deadline = Instant::now() + Duration::from_secs(5);
             loop {
-                if metrics.dropped_batches_total.load(Ordering::Relaxed) > 0 {
+                if metrics.outputs[0].2.errors() > 0 {
                     std::thread::sleep(Duration::from_millis(50));
                     sd.cancel();
                     return;

--- a/crates/logfwd/src/pipeline/checkpoint_policy.rs
+++ b/crates/logfwd/src/pipeline/checkpoint_policy.rs
@@ -10,25 +10,32 @@ use crate::worker_pool::DeliveryOutcome;
 pub(super) enum TicketDisposition {
     Ack,
     Reject,
+    Hold,
 }
 
-/// Compatibility policy for `#1520`.
+/// Delivery outcome -> checkpoint policy for `#1520`.
 ///
-/// Current behavior is preserved:
+/// Policy:
 /// - successful delivery ACKs tickets
-/// - all non-delivery outcomes reject tickets (checkpoint still advances via
-///   `BatchTicket::reject` semantics)
+/// - explicit permanent rejection rejects tickets and advances the checkpoint
+/// - all other failures hold tickets unresolved so the checkpoint does not
+///   advance past undelivered data
+///
+/// Hold is intentionally conservative. The current runtime does not yet retain
+/// enough batch payload state to requeue these batches in-process, so the
+/// immediate effect is "do not advance; replay on restart if shutdown forces a
+/// stop while these tickets remain unresolved."
 #[must_use]
 pub(super) const fn default_ticket_disposition(outcome: &DeliveryOutcome) -> TicketDisposition {
     match outcome {
         DeliveryOutcome::Delivered => TicketDisposition::Ack,
-        DeliveryOutcome::Rejected { .. }
-        | DeliveryOutcome::RetryExhausted
+        DeliveryOutcome::Rejected { .. } => TicketDisposition::Reject,
+        DeliveryOutcome::RetryExhausted
         | DeliveryOutcome::TimedOut
         | DeliveryOutcome::PoolClosed
         | DeliveryOutcome::WorkerChannelClosed
         | DeliveryOutcome::NoWorkersAvailable
-        | DeliveryOutcome::InternalFailure => TicketDisposition::Reject,
+        | DeliveryOutcome::InternalFailure => TicketDisposition::Hold,
     }
 }
 
@@ -46,12 +53,19 @@ mod tests {
     }
 
     #[test]
-    fn all_non_delivery_outcomes_reject_tickets_in_compat_mode() {
+    fn explicit_rejects_advance_checkpoints() {
         let rejected = DeliveryOutcome::Rejected {
             reason: "bad request".to_string(),
         };
+        assert_eq!(
+            default_ticket_disposition(&rejected),
+            TicketDisposition::Reject
+        );
+    }
+
+    #[test]
+    fn control_plane_and_retry_failures_hold_tickets() {
         for outcome in [
-            rejected,
             DeliveryOutcome::RetryExhausted,
             DeliveryOutcome::TimedOut,
             DeliveryOutcome::PoolClosed,
@@ -61,7 +75,49 @@ mod tests {
         ] {
             assert_eq!(
                 default_ticket_disposition(&outcome),
-                TicketDisposition::Reject
+                TicketDisposition::Hold
+            );
+        }
+    }
+}
+
+#[cfg(kani)]
+mod kani_proofs {
+    use super::{TicketDisposition, default_ticket_disposition};
+    use crate::worker_pool::DeliveryOutcome;
+
+    #[kani::proof]
+    fn verify_default_ticket_disposition_delivered_acks() {
+        assert_eq!(
+            default_ticket_disposition(&DeliveryOutcome::Delivered),
+            TicketDisposition::Ack
+        );
+    }
+
+    #[kani::proof]
+    fn verify_default_ticket_disposition_rejected_advances() {
+        let rejected = DeliveryOutcome::Rejected {
+            reason: "bad request".to_owned(),
+        };
+        assert_eq!(
+            default_ticket_disposition(&rejected),
+            TicketDisposition::Reject
+        );
+    }
+
+    #[kani::proof]
+    fn verify_default_ticket_disposition_non_terminal_failures_hold() {
+        for outcome in [
+            DeliveryOutcome::RetryExhausted,
+            DeliveryOutcome::TimedOut,
+            DeliveryOutcome::PoolClosed,
+            DeliveryOutcome::WorkerChannelClosed,
+            DeliveryOutcome::NoWorkersAvailable,
+            DeliveryOutcome::InternalFailure,
+        ] {
+            assert_eq!(
+                default_ticket_disposition(&outcome),
+                TicketDisposition::Hold
             );
         }
     }

--- a/crates/logfwd/src/worker_pool.rs
+++ b/crates/logfwd/src/worker_pool.rs
@@ -112,9 +112,20 @@ pub enum DeliveryOutcome {
 }
 
 impl DeliveryOutcome {
-    /// Returns `true` if this outcome represents successful delivery to the sink.
+    /// Returns `true` when the batch reached the sink successfully.
+    ///
+    /// This is the compatibility gate used by the pipeline metrics path and
+    /// checkpoint policy while the typed delivery contract is rolled out.
     pub const fn is_delivered(&self) -> bool {
         matches!(self, Self::Delivered)
+    }
+
+    /// Returns `true` when the sink rejected the data permanently.
+    ///
+    /// This is the only worker outcome that should currently advance the
+    /// checkpoint without successful delivery.
+    pub const fn is_permanent_reject(&self) -> bool {
+        matches!(self, Self::Rejected { .. })
     }
 }
 
@@ -403,9 +414,9 @@ impl OutputWorkerPool {
     /// 3. If at `max_workers` and all full, async-wait on the front worker.
     ///    This yields the tokio task until a worker drains its queue.
     ///
-    /// # Panics
-    ///
-    /// Panics if the pool has already been drained (cancel token fired).
+    /// Submits after drain are rejected immediately: the pool logs a warning
+    /// and emits an [`AckItem`] with [`DeliveryOutcome::PoolClosed`] unless the
+    /// ack channel is already closed too.
     pub async fn submit(&mut self, item: WorkItem) {
         if self.cancel.is_cancelled() {
             // Pool has been drained — reject the item immediately rather than
@@ -1163,6 +1174,50 @@ mod kani_proofs {
         kani::cover!(max_workers > 1, "multi-worker capacity exercised");
         let outcome = dispatch_step(&[], max_workers);
         assert_eq!(outcome, DispatchOutcome::SpawnNew);
+    }
+
+    // -----------------------------------------------------------------------
+    // Proof 7: is_delivered matches the enum variant exactly.
+    // -----------------------------------------------------------------------
+    #[kani::proof]
+    fn verify_delivery_outcome_is_delivered_contract() {
+        let rejected = DeliveryOutcome::Rejected {
+            reason: "bad request".to_owned(),
+        };
+        assert!(DeliveryOutcome::Delivered.is_delivered());
+        for outcome in [
+            rejected,
+            DeliveryOutcome::RetryExhausted,
+            DeliveryOutcome::TimedOut,
+            DeliveryOutcome::PoolClosed,
+            DeliveryOutcome::WorkerChannelClosed,
+            DeliveryOutcome::NoWorkersAvailable,
+            DeliveryOutcome::InternalFailure,
+        ] {
+            assert!(!outcome.is_delivered());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Proof 8: only explicit Rejected outcomes count as permanent rejects.
+    // -----------------------------------------------------------------------
+    #[kani::proof]
+    fn verify_delivery_outcome_is_permanent_reject_contract() {
+        let rejected = DeliveryOutcome::Rejected {
+            reason: "bad request".to_owned(),
+        };
+        assert!(rejected.is_permanent_reject());
+        for outcome in [
+            DeliveryOutcome::Delivered,
+            DeliveryOutcome::RetryExhausted,
+            DeliveryOutcome::TimedOut,
+            DeliveryOutcome::PoolClosed,
+            DeliveryOutcome::WorkerChannelClosed,
+            DeliveryOutcome::NoWorkersAvailable,
+            DeliveryOutcome::InternalFailure,
+        ] {
+            assert!(!outcome.is_permanent_reject());
+        }
     }
 }
 

--- a/crates/logfwd/tests/turmoil_sim/bug_hunt.rs
+++ b/crates/logfwd/tests/turmoil_sim/bug_hunt.rs
@@ -177,16 +177,14 @@ fn worker_panic_does_not_block_drain() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 3: Rejected batch checkpoint behavior
+// Test 3: Explicit permanent reject checkpoint behavior
 // ---------------------------------------------------------------------------
 //
-// Bug hypothesis: `record_ack_and_advance` treats reject identically to
-// ack — checkpoint advances past rejected data. If data at offset
-// 1000-2000 is rejected (NOT delivered), the checkpoint advances to 2000,
-// and on restart that data is permanently skipped.
+// Contract: explicit permanent rejects still advance checkpoints. If a sink
+// returns a true non-retriable reject, replaying the same bytes forever would
+// create an infinite loop.
 //
-// This test DOCUMENTS the current behavior — whether reject advances the
-// checkpoint or not.
+// This test documents the intended behavior for explicit permanent rejects.
 
 #[test]
 fn rejected_batch_checkpoint_behavior() {
@@ -233,34 +231,14 @@ fn rejected_batch_checkpoint_behavior() {
     // Subsequent batches succeed.
     eprintln!("rejected_batch test: {delivered} rows delivered, {calls} send_batch calls");
 
-    // DOCUMENT: does the checkpoint advance past the rejected batch?
+    // DOCUMENT: explicit permanent rejects still advance the checkpoint.
     // In pipeline.rs `ack_all_tickets`, reject calls `ticket.reject()` which
     // still produces an AckReceipt that feeds into `record_ack_and_advance`.
-    // The machine treats reject and ack identically for checkpoint advancement.
-    //
-    // If durable offset > 0, the checkpoint advanced past SOME data.
-    // The question is whether it advanced past the rejected batch specifically.
     let durable = ckpt_handle.durable_offset(1);
     let updates = ckpt_handle.update_count(1);
 
     eprintln!("rejected_batch test: durable offset = {durable:?}, checkpoint updates = {updates}");
 
-    // CONFIRMED BUG / DESIGN DECISION: The checkpoint advances past rejected
-    // (undelivered) data. With default batch_target_bytes (64KB), all 20 lines
-    // fit into a single batch. That batch is rejected (0 rows delivered), yet
-    // the checkpoint advances to offset 520 (past all 20 lines).
-    //
-    // In `ack_all_tickets`, both `ticket.ack()` and `ticket.reject()` produce
-    // AckReceipts that feed into `record_ack_and_advance`. The machine treats
-    // them identically — checkpoint advances past rejected data.
-    //
-    // On restart, this data would be permanently skipped.
-    //
-    // Whether this is a bug depends on the rejection reason:
-    //   - Server 400 (bad data): advancing is correct (retry would fail again)
-    //   - Server 429 (rate limit): should NOT reject, should RetryAfter
-    //   - Transient server error: should NOT reject, should IO error + retry
-    //
     // All 20 lines fit in 1 batch (64KB target). That batch is rejected.
     assert_eq!(
         delivered, 0,
@@ -271,13 +249,9 @@ fn rejected_batch_checkpoint_behavior() {
         "expected exactly 1 send_batch call (1 batch, rejected)"
     );
 
-    // CONFIRMED BUG (issue #1001): checkpoint advances past rejected data.
-    // The PipelineMachine treats reject() identically to ack() for checkpoint
-    // advancement. On restart, rejected data is permanently skipped.
     assert!(
         durable.is_some() && durable.unwrap() > 0,
-        "CONFIRMED: checkpoint MUST advance past rejected data (current behavior). \
-         If this assertion fails, someone fixed issue #1001 — update this test. \
+        "permanent rejects must still advance checkpoint progress; \
          durable={durable:?}"
     );
 
@@ -286,7 +260,82 @@ fn rejected_batch_checkpoint_behavior() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 4: RetryAfter respects server-specified backoff timing
+// Test 4: Retry exhaustion must not advance checkpoints
+// ---------------------------------------------------------------------------
+//
+// Contract: retry/control-plane failures should hold checkpoint progress.
+// The current runtime does not retain enough payload state to retry these
+// batches in-process, so the conservative behavior is to leave them
+// unresolved and rely on replay after restart.
+
+#[test]
+fn retry_exhausted_does_not_advance_checkpoint() {
+    let mut sim = super::build_sim(120, 1);
+
+    let factory = Arc::new(InstrumentedSinkFactory::new(vec![vec![
+        FailureAction::IoError(std::io::ErrorKind::TimedOut),
+        FailureAction::IoError(std::io::ErrorKind::TimedOut),
+        FailureAction::IoError(std::io::ErrorKind::TimedOut),
+        FailureAction::IoError(std::io::ErrorKind::TimedOut),
+    ]]));
+    let delivered_counter = factory.delivered_counter();
+    let call_counter = factory.call_counter();
+
+    let (store, ckpt_handle) = ObservableCheckpointStore::new();
+
+    sim.client("pipeline", async move {
+        let lines = generate_json_lines(20);
+        let input = ChannelInputSource::new("test", SourceId(1), lines);
+
+        let mut pipeline = Pipeline::for_simulation_with_factory("sim", factory, 1);
+        pipeline.set_batch_timeout(Duration::from_millis(20));
+        pipeline.set_checkpoint_flush_interval(Duration::from_millis(100));
+        let mut pipeline = pipeline
+            .with_input("test", Box::new(input))
+            .with_checkpoint_store(Box::new(store));
+
+        let shutdown = CancellationToken::new();
+        let sd = shutdown.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            sd.cancel();
+        });
+
+        pipeline.run_async(&shutdown).await.unwrap();
+        Ok(())
+    });
+
+    sim.run().unwrap();
+
+    let delivered = delivered_counter.load(Ordering::Relaxed);
+    let calls = call_counter.load(Ordering::Relaxed);
+    let durable = ckpt_handle.durable_offset(1);
+    let updates = ckpt_handle.update_count(1);
+
+    eprintln!(
+        "retry_exhausted test: delivered={delivered} calls={calls} durable={durable:?} updates={updates}"
+    );
+
+    assert_eq!(
+        delivered, 0,
+        "expected no rows delivered after retry exhaustion"
+    );
+    assert_eq!(
+        calls, 4,
+        "expected 1 initial attempt + 3 retries before RetryExhausted"
+    );
+    assert!(
+        durable.is_none(),
+        "retry exhaustion must not advance checkpoint progress; durable={durable:?}"
+    );
+    assert_eq!(
+        updates, 0,
+        "retry exhaustion must not write checkpoint updates"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: RetryAfter respects server-specified backoff timing
 // ---------------------------------------------------------------------------
 //
 // Bug hypothesis: `process_item` resets `delay = Duration::from_millis(100)`

--- a/crates/logfwd/tests/turmoil_sim/network_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/network_sim.rs
@@ -29,15 +29,15 @@ fn generate_json_lines(n: usize) -> Vec<Vec<u8>> {
         .collect()
 }
 
-/// Test: retry exhaustion drops batch and pipeline does not hang.
+/// Test: retry exhaustion holds checkpoint progress and pipeline does not hang.
 ///
 /// Invariant probed: worker pool retry exhaustion (MAX_RETRIES=3, so 4 total
-/// attempts). When all attempts fail, the batch is rejected, the pipeline
-/// increments dropped_batch, and shutdown completes (no deadlock).
+/// attempts). When all attempts fail, the batch must not advance checkpoints,
+/// and shutdown completes via the force-stop/replay path (no deadlock).
 ///
 /// Script: all calls return IoError(ConnectionRefused).
 #[test]
-fn retry_exhaustion_drops_batch_and_advances() {
+fn retry_exhaustion_holds_checkpoint_and_completes_shutdown() {
     let mut sim = super::build_sim(120, 1);
 
     let mut script = Vec::new();

--- a/dev-docs/ADAPTER_CONTRACT.md
+++ b/dev-docs/ADAPTER_CONTRACT.md
@@ -187,6 +187,14 @@ The file path is:
 - Duplicate delivery is acceptable when required for at-least-once recovery.
 - Copytruncate is explicitly documented as a race window, not treated as an
   exactly-once path.
+- Successful delivery advances checkpoints.
+- Explicit permanent sink rejection may also advance checkpoints; this is the
+  deliberate escape hatch for malformed or otherwise non-retriable data.
+- Retry exhaustion, dispatch failure, timeout, and other control-plane failures
+  must not advance checkpoints past undelivered data.
+- The current worker/pipeline seam does not yet retain enough batch payload
+  state to requeue held batches in-process, so non-advancing failures are
+  replayed on restart if shutdown force-stops with unresolved tickets.
 
 ## Diagnostics And Control-Plane Contract
 

--- a/dev-docs/DESIGN.md
+++ b/dev-docs/DESIGN.md
@@ -160,6 +160,12 @@ BTreeMap entry in `in_flight[source]` is not removed until `apply_ack` is called
 This models the Rust code exactly: `fail()` returns `BatchTicket<Queued, C>` but does not
 touch the BTreeMap.
 
+Current implication at the worker/checkpoint seam: a non-advancing failure
+cannot be resolved by calling `fail()` alone unless the runtime still holds the
+batch payload and can resubmit it. Until that richer retry path exists, held
+worker outcomes remain unresolved and are replayed after restart if shutdown
+force-stops with tickets still in flight.
+
 ### Suffix only on type conflict
 
 Bare column names by default. Suffixed columns (`_int`, `_str`, `_float`) only when a

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -267,8 +267,9 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 | `logfwd-io/receiver_health.rs` | Standalone receiver health reducer (`noop`, backpressure, fatal, shutdown) | Kani exhaustive (6 proofs) + unit tests + proptest sequence checks |
 | `logfwd-io/format.rs` | CRI metadata injection, Auto-mode fallthrough to passthrough | Kani (4 proofs: inject_cri_metadata output structure, JSON vs plain-text path dispatch) |
 | `logfwd-io/tail.rs` | File tailer EOF emission state machine (eof_emitted flag) | Kani (4 proofs: at-most-once emission per streak, data-reset invariant, two-poll sequence, reset-cycle) |
+| `logfwd/pipeline/checkpoint_policy.rs` | Typed delivery outcome -> checkpoint disposition mapping (`Ack`, `Reject`, `Hold`) | Kani exhaustive (3 proofs) + unit tests |
 | `logfwd/worker_pool/health.rs` | Pool idle-phase insertion + worker-slot aggregation policy | Kani exhaustive (3 proofs) + unit tests + proptest aggregation checks |
-| `logfwd/worker_pool.rs` | MRU dispatch decision + runtime worker-pool integration | Kani (3 dispatch proofs) + unit tests for worker-slot aggregation, drain-phase stickiness, and create-failure behavior |
+| `logfwd/worker_pool.rs` | MRU dispatch decision + typed delivery outcome helpers | Kani (8 dispatch/outcome proofs) + unit tests for worker-slot aggregation, drain-phase stickiness, and create-failure behavior |
 | `logfwd-arrow/storage_builder.rs` | StructArray conflict column assembly | Kani (2 proofs: duplicate name guard, row count invariant) + unit tests |
 | `logfwd-arrow/streaming_builder.rs` | StructArray conflict column assembly (StringView) | Kani (2 proofs: duplicate name guard, row count invariant) + unit tests |
 | `logfwd-arrow/conflict_schema.rs` | Conflict-struct detection + row-level precedence selection | Kani recommended (2 proofs) + unit tests |

--- a/dev-docs/verification/kani-boundary-contract.toml
+++ b/dev-docs/verification/kani-boundary-contract.toml
@@ -109,6 +109,12 @@ reason = "Worker dispatch helpers already expose bounded local proof seams."
 issue = 1314
 
 [[seams]]
+path = "crates/logfwd/src/pipeline/checkpoint_policy.rs"
+status = "required"
+reason = "The typed delivery outcome -> checkpoint disposition compatibility mapping is a local pure seam."
+issue = 1314
+
+[[seams]]
 path = "crates/logfwd/src/worker_pool/health.rs"
 status = "required"
 reason = "Pool-level health insertion and aggregation policy is isolated here and should remain Kani-covered."

--- a/tla/PipelineBatch.tla
+++ b/tla/PipelineBatch.tla
@@ -15,8 +15,8 @@
  *     machine is Stopped (no silent drops during normal operation).
  *   CheckpointNeverAheadOfFlushed: the committed checkpoint for a
  *     source never exceeds what has actually been flushed to output.
- *   RejectAdvancesCheckpoint: transform errors advance the checkpoint
- *     to prevent infinite retry loops on restart.
+ *   RejectAdvancesCheckpoint: explicit permanent rejects advance the
+ *     checkpoint to prevent infinite retry loops on restart.
  *   MonotonicCheckpoints: checkpoints never decrease.
  *
  * What this spec does NOT model:
@@ -185,9 +185,9 @@ AckBatch ==
                    next_batch_id, flushed, flushed_total, phase,
                    done_producing>>
 
-\* Transform or output rejects the batch (permanent error).
+\* Transform or output rejects the batch (explicit permanent error).
 \* Checkpoint STILL advances — design decision from DESIGN.md:
-\* "Rejected batches advance the checkpoint."
+\* "Explicit permanent rejects advance the checkpoint."
 RejectBatch ==
     /\ in_flight_id > 0
     /\ acked_total' = acked_total + 1
@@ -275,7 +275,7 @@ MonotonicCheckpoints ==
 SingleInFlight ==
     in_flight_id \in 0..next_batch_id
 
-\* Reject advances checkpoint (same as ack — design decision).
+\* Explicit permanent reject advances checkpoint (same as ack — design decision).
 \* This is modeled by RejectBatch having the same committed update as AckBatch.
 \* Verified structurally: RejectBatch and AckBatch have identical committed' assignments.
 

--- a/tla/PipelineMachine.tla
+++ b/tla/PipelineMachine.tla
@@ -151,11 +151,14 @@ BeginSend(s, b) ==
 \* apply_ack (ack OR reject): batch leaves in_flight, checkpoint may advance.
 \*
 \* Reject note: RejectBatch has the same state transition as AckBatch.
+\* This is intentionally reserved for explicit permanent rejects only.
 \* Permanently-undeliverable data must not block checkpoint progress
 \* (would stall drain indefinitely). At-least-once is weakened to
-\* at-most-once only for rejected batches. This matches Filebeat's behavior
-\* (advance past malformed records) and differs from Fluent Bit (which drops
-\* the route but re-tries via a separate backlog).
+\* at-most-once only for rejected batches.
+\*
+\* Retry/control-plane failures are a different category and must not be
+\* modeled as RejectBatch. The current Rust rollout keeps those batches
+\* unresolved so checkpoints do not advance past undelivered data.
 \*
 \* For metrics/observability, the Rust receipt.delivered flag distinguishes
 \* ack from reject. That distinction is not modeled here (orthogonal to

--- a/tla/README.md
+++ b/tla/README.md
@@ -176,7 +176,7 @@ tracks it as in_flight (it was already `begin_send`'d). The TLA+ model has no
 Rust code exactly: `fail()` returns `BatchTicket<Queued, C>` but the BTreeMap
 entry in `in_flight[source]` is not removed until `apply_ack` is called.
 
-### 2. Rejected batches advance the checkpoint
+### 2. Explicit permanent rejects advance the checkpoint
 
 `RejectBatch` is aliased to `AckBatch` — same state transition. Permanently-
 undeliverable data must not block checkpoint progress forever; that would
@@ -187,6 +187,12 @@ records) and differs from Fluent Bit (drops the route, retries via backlog).
 **Implication:** if a batch is rejected, the data in that batch is lost. This
 is the correct behavior for a log forwarder where corrupted or oversized data
 cannot be retried, but it must be explicitly documented and metered.
+
+Control-plane and retry-exhaustion failures are a different category. They
+must not be modeled as `RejectBatch`. In the current Rust rollout those
+outcomes are held unresolved so checkpoints do not advance past undelivered
+data; graceful drain may therefore fall back to `ForceStop`, with replay on
+restart covering the unresolved batches.
 
 ### 3. `pending_acks` is correctly abstracted away
 

--- a/tla/ShutdownProtocol.tla
+++ b/tla/ShutdownProtocol.tla
@@ -19,6 +19,10 @@
  *   - Scanner, transform, or output sink details
  *   - Checkpoint arithmetic (proven by Kani on CheckpointTracker)
  *   - The PipelineMachine lifecycle (modeled in PipelineMachine.tla)
+ *   - The exact distinction between explicit permanent reject and held
+ *     retry/control-plane failures at the worker/checkpoint seam. The
+ *     current runtime may force-stop with unresolved held batches so they
+ *     replay on restart.
  *
  * For TLC configuration, see MCShutdownProtocol.tla.
  *)


### PR DESCRIPTION
Cherry-pick of b8aa5b93 from #1531's branch (`codex/1520-typed-delivery-outcome`). Adds `TicketDisposition::Hold` for transient failures so checkpoint doesn't advance past undelivered data.

- `Rejected` -> `Reject` (checkpoint advances, data was permanently refused)
- `RetryExhausted`, `TimedOut`, `PoolClosed`, `WorkerChannelClosed`, `NoWorkersAvailable`, `InternalFailure` -> `Hold` (checkpoint paused, replay on restart)

Fixes #1001.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hold checkpoints on transient delivery failures instead of treating them as permanent rejects
> - Introduces a `Hold` variant to `TicketDisposition` in [`checkpoint_policy.rs`](https://github.com/strawgate/memagent/pull/1542/files#diff-1ba4d48b3d7ea79045f3adf9701914b481817e551b3e305dead537ac9b810d7e); non-permanent failures (retry exhaustion, timeouts, pool/channel errors) now map to `Hold` instead of `Reject`.
> - `Pipeline.ack_all_tickets` skips checkpoint advancement when any tickets are held, logging a warning that checkpoints will not advance past undelivered data.
> - `Pipeline.apply_pool_ack` increments `dropped_batches_total` only for explicit permanent sink rejects (`DeliveryOutcome::Rejected`), not for transient failures.
> - Adds `DeliveryOutcome.is_permanent_reject` helper to distinguish permanent sink rejections from other failure modes.
> - Behavioral Change: held batches replay on restart if the pipeline is force-stopped before they resolve; checkpoints no longer advance on retry exhaustion or control-plane failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized caf771f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->