### PR TITLE
fix(cli): harden wizard terminal checks and example validation

### DIFF
--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -106,6 +106,10 @@ fn use_json_logs_for_stderr(is_terminal: bool) -> bool {
     !is_terminal
 }
 
+fn wizard_uses_interactive_terminals(stdin_is_terminal: bool, stdout_is_terminal: bool) -> bool {
+    stdin_is_terminal && stdout_is_terminal
+}
+
 macro_rules! style {
     ($color:expr, $bold:expr) => {
         if use_color() {
@@ -473,9 +477,9 @@ output:
 fn cmd_wizard() -> Result<(), CliError> {
     use config_templates::{INPUT_TEMPLATES, OUTPUT_TEMPLATES, render_config};
 
-    if !io::stdin().is_terminal() {
+    if !wizard_uses_interactive_terminals(io::stdin().is_terminal(), io::stdout().is_terminal()) {
         return Err(CliError::Config(
-            "wizard requires an interactive terminal on stdin".to_owned(),
+            "wizard requires an interactive terminal on stdin and stdout".to_owned(),
         ));
     }
     println!("{}logfwd config wizard{}", bold(), reset());
@@ -986,10 +990,13 @@ fn validate_input_format_read_only(
         InputType::Generator | InputType::Otlp => matches!(format, Format::Json),
         InputType::Udp | InputType::Tcp => matches!(format, Format::Json | Format::Raw),
         InputType::ArrowIpc => false,
-        _ => {
+        other => {
+            tracing::warn!(
+                "validate_input_format_read_only: unhandled input type {other:?} for input {name}"
+            );
             return Err(format!(
                 "input '{name}': type {:?} is not yet supported in read-only validation",
-                input_type
+                other
             ));
         }
     };
@@ -1019,6 +1026,37 @@ fn collect_yaml_files_recursive(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+fn replace_env_placeholders_for_example_validation(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut cursor = 0usize;
+
+    while let Some(rel_start) = input[cursor..].find("${") {
+        let start = cursor + rel_start;
+        out.push_str(&input[cursor..start]);
+        let value_start = start + 2;
+        if let Some(rel_end) = input[value_start..].find('}') {
+            let end = value_start + rel_end;
+            if end > value_start {
+                out.push_str("example-env-value");
+            } else {
+                out.push_str("${}");
+            }
+            cursor = end + 1;
+        } else {
+            out.push_str(&input[start..]);
+            cursor = input.len();
+            break;
+        }
+    }
+
+    if cursor < input.len() {
+        out.push_str(&input[cursor..]);
+    }
+
+    out
 }
 
 fn validate_pipelines(
@@ -1834,6 +1872,24 @@ mod cli_tests {
     }
 
     #[test]
+    fn wizard_requires_interactive_stdin_and_stdout() {
+        assert!(!wizard_uses_interactive_terminals(false, false));
+        assert!(!wizard_uses_interactive_terminals(true, false));
+        assert!(!wizard_uses_interactive_terminals(false, true));
+        assert!(wizard_uses_interactive_terminals(true, true));
+    }
+
+    #[test]
+    fn replace_env_placeholders_rewrites_all_braced_vars() {
+        let input = "a: ${FOO}\nb: ${BAR_BAZ}\nc: ${}\nd: ${UNTERMINATED";
+        let actual = replace_env_placeholders_for_example_validation(input);
+        assert_eq!(
+            actual,
+            "a: example-env-value\nb: example-env-value\nc: ${}\nd: ${UNTERMINATED"
+        );
+    }
+
+    #[test]
     fn wizard_template_renders_with_sql() {
         let input = &config_templates::INPUT_TEMPLATES[0];
         let output = &config_templates::OUTPUT_TEMPLATES[0];
@@ -1984,7 +2040,7 @@ transform: |
             };
 
             // Keep example validation hermetic: inline secrets placeholders with dummy values.
-            let raw = raw.replace("${ELASTICSEARCH_API_KEY}", "example-api-key");
+            let raw = replace_env_placeholders_for_example_validation(&raw);
 
             let config = match logfwd_config::Config::load_str(&raw) {
                 Ok(cfg) => cfg,


### PR DESCRIPTION
## Summary
- harden `wizard` interactivity checks to require **both** stdin and stdout terminal support before entering prompts
- harden read-only validation erroring for unsupported input types by emitting an explicit warning with input name/type context
- harden YAML example validation by replacing **all** `${...}` env placeholders with deterministic test values (instead of one hard-coded secret key)
- add focused tests for terminal interactivity gating and generic env placeholder rewriting

## Why this hardening belongs in this PR
- prevents wizard misuse in non-interactive contexts where stdout is piped (prompt UX breaks)
- improves diagnosability when read-only validation encounters newly-added input kinds
- removes brittle coupling to a single placeholder name in config examples and keeps read-only validation hermetic as examples evolve

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p logfwd cli_tests:: -- --nocapture`
- `cargo test -p logfwd all_yaml_examples_parse_and_validate_read_only -- --nocapture`
- `just ci`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require both stdin and stdout to be interactive TTYs in the CLI wizard
> - The wizard now checks both stdin and stdout via a new `wizard_uses_interactive_terminals` helper, replacing the previous stdin-only check. The error message is updated to mention both streams.
> - `validate_input_format_read_only` in [main.rs](https://github.com/strawgate/memagent/pull/1544/files#diff-48e7b38d2f38857cdef3f17a929b768683b2c5ee185fe3c4fb45ae95d4bcdbe4) now emits a `tracing::warn!` log when it encounters an unhandled input type before returning an error.
> - Adds a test-only `replace_env_placeholders_for_example_validation` helper that substitutes `${...}` placeholders with `example-env-value`, used by the `all_yaml_examples_parse_and_validate_read_only` test to handle arbitrary env vars in example configs.
> - Behavioral Change: the wizard now exits with an error when stdout is not a TTY, even if stdin is interactive.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6452525.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->