### PR TITLE
ci: make coverage job depend on test-linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,7 @@ jobs:
   # -------------------------------------------------------------------------
   coverage:
     name: Code Coverage
+    needs: [test-linux]
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     continue-on-error: true


### PR DESCRIPTION
## Summary

- Add `needs: [test-linux]` to the coverage job

Coverage re-runs the full test suite under llvm-cov instrumentation. No point starting that if the regular tests haven't passed yet. Saves ~5 min of CI time on test failures.

## Test plan

- [ ] CI runs coverage only after test-linux passes
- [ ] Coverage still runs on successful PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make coverage CI job depend on test-linux job
> Adds `needs: [test-linux]` to the `coverage` job in [ci.yml](https://github.com/strawgate/memagent/pull/1553/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) so it only runs after `test-linux` completes successfully. Previously the two jobs could run independently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00d40dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->