### PR TITLE
fix(io): receiver shutdown lifecycle ownership (#1549)

### DIFF
--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -23,6 +23,7 @@ use arrow::record_batch::RecordBatch;
 use logfwd_types::diagnostics::ComponentHealth;
 
 use crate::InputError;
+use crate::background_http_task::BackgroundHttpTask;
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
 
 /// Maximum request body size: 10 MB.
@@ -40,11 +41,9 @@ pub struct ArrowIpcReceiver {
     rx: Option<mpsc::Receiver<RecordBatch>>,
     /// The address the HTTP server is bound to.
     addr: std::net::SocketAddr,
-    server: Arc<tiny_http::Server>,
+    background_task: BackgroundHttpTask,
     shutdown: Arc<AtomicBool>,
     health: Arc<AtomicU8>,
-    /// Keep the server thread handle alive.
-    handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl ArrowIpcReceiver {
@@ -272,10 +271,9 @@ impl ArrowIpcReceiver {
             name: name.into(),
             rx: Some(rx),
             addr: bound_addr,
-            server,
+            background_task: BackgroundHttpTask::new(server, handle),
             shutdown,
             health,
-            handle: Some(handle),
         })
     }
 
@@ -328,12 +326,7 @@ impl ArrowIpcReceiver {
     /// Coarse runtime health for readiness and diagnostics integration.
     pub fn health(&self) -> ComponentHealth {
         let stored = ComponentHealth::from_repr(self.health.load(Ordering::Relaxed));
-        if self
-            .handle
-            .as_ref()
-            .is_some_and(std::thread::JoinHandle::is_finished)
-            && !self.shutdown.load(Ordering::Relaxed)
-        {
+        if self.background_task.is_finished() && !self.shutdown.load(Ordering::Relaxed) {
             ComponentHealth::Failed
         } else {
             stored
@@ -383,10 +376,6 @@ impl Drop for ArrowIpcReceiver {
         );
         self.shutdown.store(true, Ordering::Relaxed);
         self.rx.take();
-        self.server.unblock();
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
         let current = ComponentHealth::from_repr(self.health.load(Ordering::Relaxed));
         self.health.store(
             reduce_receiver_health(current, ReceiverHealthEvent::ShutdownCompleted).as_repr(),

--- a/crates/logfwd-io/src/background_http_task.rs
+++ b/crates/logfwd-io/src/background_http_task.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+/// Owns a tiny_http server and its background worker thread.
+///
+/// Drop unblocks the server and joins the thread to prevent leaked listeners
+/// and leaked thread ownership.
+pub(crate) struct BackgroundHttpTask {
+    server: Arc<tiny_http::Server>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl BackgroundHttpTask {
+    pub(crate) fn new(server: Arc<tiny_http::Server>, handle: JoinHandle<()>) -> Self {
+        Self {
+            server,
+            handle: Some(handle),
+        }
+    }
+
+    pub(crate) fn is_finished(&self) -> bool {
+        self.handle.as_ref().is_some_and(JoinHandle::is_finished)
+    }
+}
+
+impl Drop for BackgroundHttpTask {
+    fn drop(&mut self) {
+        self.server.unblock();
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}

--- a/crates/logfwd-io/src/diagnostics.rs
+++ b/crates/logfwd-io/src/diagnostics.rs
@@ -8,6 +8,8 @@ use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Meter};
 
+use crate::background_http_task::BackgroundHttpTask;
+
 // Re-export ComponentStats from logfwd-types so existing `logfwd_io::diagnostics::ComponentStats`
 // paths keep working.
 pub use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
@@ -401,21 +403,16 @@ pub struct MemoryStats {
 pub struct ServerHandle {
     running: Arc<AtomicBool>,
     sampler_handle: Option<JoinHandle<()>>,
-    http_server: Arc<tiny_http::Server>,
-    http_handle: Option<JoinHandle<()>>,
+    _http_task: BackgroundHttpTask,
 }
 
 impl Drop for ServerHandle {
     fn drop(&mut self) {
         // Signal the sampler loop to exit.
         self.running.store(false, Ordering::Relaxed);
-        // Unblock the HTTP thread's `incoming_requests()` iterator.
-        self.http_server.unblock();
-        // Join both threads (ignore panics — we're in Drop).
+        // Join sampler thread; HTTP thread is unblocked and joined by
+        // `BackgroundHttpTask` during field drop.
         if let Some(h) = self.sampler_handle.take() {
-            let _ = h.join();
-        }
-        if let Some(h) = self.http_handle.take() {
             let _ = h.join();
         }
     }
@@ -553,8 +550,7 @@ impl DiagnosticsServer {
             ServerHandle {
                 running,
                 sampler_handle: Some(sampler_handle),
-                http_server,
-                http_handle: Some(http_handle),
+                _http_task: BackgroundHttpTask::new(Arc::clone(&http_server), http_handle),
             },
             bound_addr,
         ))
@@ -1566,6 +1562,23 @@ mod tests {
         let body = text.split("\r\n\r\n").nth(1).unwrap_or("").to_string();
 
         (status, body)
+    }
+
+    #[test]
+    fn diagnostics_server_handle_drop_releases_port() {
+        let server = DiagnosticsServer::new("127.0.0.1:0");
+        let (handle, addr) = server.start().expect("server bind failed");
+        let port = addr.port();
+
+        drop(handle);
+        thread::sleep(std::time::Duration::from_millis(50));
+
+        let rebound_addr = format!("127.0.0.1:{port}");
+        let result = tiny_http::Server::http(&rebound_addr);
+        assert!(
+            result.is_ok(),
+            "failed to rebind diagnostics port {port} after drop"
+        );
     }
 
     #[test]

--- a/crates/logfwd-io/src/lib.rs
+++ b/crates/logfwd-io/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod atomic_write;
+pub(crate) mod background_http_task;
 pub mod error;
 pub use error::InputError;
 

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -27,6 +27,7 @@ use logfwd_types::diagnostics::ComponentHealth;
 use prost::Message;
 
 use crate::InputError;
+use crate::background_http_task::BackgroundHttpTask;
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
 
 /// Maximum request body size: 10 MB.
@@ -65,10 +66,9 @@ pub struct OtapReceiver {
     name: String,
     rx: Option<mpsc::Receiver<RecordBatch>>,
     addr: std::net::SocketAddr,
-    server: Arc<tiny_http::Server>,
+    background_task: BackgroundHttpTask,
     shutdown: Arc<AtomicBool>,
     health: Arc<AtomicU8>,
-    handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl OtapReceiver {
@@ -282,10 +282,9 @@ impl OtapReceiver {
             name: name.into(),
             rx: Some(rx),
             addr: bound_addr,
-            server,
+            background_task: BackgroundHttpTask::new(server, handle),
             shutdown,
             health,
-            handle: Some(handle),
         })
     }
 
@@ -338,12 +337,7 @@ impl OtapReceiver {
     /// Coarse runtime health for readiness and diagnostics integration.
     pub fn health(&self) -> ComponentHealth {
         let stored = ComponentHealth::from_repr(self.health.load(Ordering::Relaxed));
-        if self
-            .handle
-            .as_ref()
-            .is_some_and(std::thread::JoinHandle::is_finished)
-            && !self.shutdown.load(Ordering::Relaxed)
-        {
+        if self.background_task.is_finished() && !self.shutdown.load(Ordering::Relaxed) {
             ComponentHealth::Failed
         } else {
             stored
@@ -509,10 +503,6 @@ impl Drop for OtapReceiver {
         );
         self.shutdown.store(true, Ordering::Relaxed);
         self.rx.take();
-        self.server.unblock();
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
         let current = ComponentHealth::from_repr(self.health.load(Ordering::Relaxed));
         self.health.store(
             reduce_receiver_health(current, ReceiverHealthEvent::ShutdownCompleted).as_repr(),

--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -25,6 +25,7 @@ use opentelemetry_proto::tonic::common::v1::any_value::Value;
 use prost::Message;
 
 use crate::InputError;
+use crate::background_http_task::BackgroundHttpTask;
 use crate::diagnostics::ComponentStats;
 use crate::input::{InputEvent, InputSource};
 use logfwd_types::diagnostics::ComponentHealth;
@@ -42,9 +43,7 @@ pub struct OtlpReceiverInput {
     rx: Option<mpsc::Receiver<ReceiverPayload>>,
     /// The address the HTTP server is bound to.
     addr: std::net::SocketAddr,
-    server: Arc<tiny_http::Server>,
-    /// Keep the server thread handle alive.
-    handle: Option<std::thread::JoinHandle<()>>,
+    background_task: BackgroundHttpTask,
     /// Shutdown mechanism for the background thread.
     is_running: Arc<AtomicBool>,
     /// Source-owned health snapshot for readiness and diagnostics.
@@ -424,8 +423,7 @@ impl OtlpReceiverInput {
             name: name.into(),
             rx: Some(rx),
             addr: bound_addr,
-            server,
-            handle: Some(handle),
+            background_task: BackgroundHttpTask::new(server, handle),
             is_running,
             health,
         })
@@ -443,10 +441,6 @@ impl Drop for OtlpReceiverInput {
             .store(ComponentHealth::Stopping.as_repr(), Ordering::Relaxed);
         self.is_running.store(false, Ordering::Relaxed);
         self.rx.take();
-        self.server.unblock();
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
         self.health
             .store(ComponentHealth::Stopped.as_repr(), Ordering::Relaxed);
     }
@@ -504,12 +498,7 @@ impl InputSource for OtlpReceiverInput {
 
     fn health(&self) -> ComponentHealth {
         let stored = ComponentHealth::from_repr(self.health.load(Ordering::Relaxed));
-        if self
-            .handle
-            .as_ref()
-            .is_some_and(std::thread::JoinHandle::is_finished)
-            && self.is_running.load(Ordering::Relaxed)
-        {
+        if self.background_task.is_finished() && self.is_running.load(Ordering::Relaxed) {
             ComponentHealth::Failed
         } else {
             stored
@@ -2558,7 +2547,13 @@ mod tests {
     fn receiver_health_reports_failed_when_server_thread_exits() {
         let mut receiver = OtlpReceiverInput::new("test-health-failed", "127.0.0.1:0")
             .expect("should bind successfully");
-        receiver.handle = Some(std::thread::spawn(|| {}));
+        // Ensure the real worker exits before replacing the ownership task in-test.
+        receiver.is_running.store(false, Ordering::Relaxed);
+        receiver.background_task = BackgroundHttpTask::new(
+            Arc::new(tiny_http::Server::http("127.0.0.1:0").expect("bind synthetic test server")),
+            std::thread::spawn(|| {}),
+        );
+        receiver.is_running.store(true, Ordering::Relaxed);
         std::thread::sleep(Duration::from_millis(10));
 
         assert_eq!(receiver.health(), ComponentHealth::Failed);


### PR DESCRIPTION
## What This Changes
- Introduces explicit shutdown lifecycle ownership for receiver background tasks.
- Aligns `arrow_ipc_receiver`, `otlp_receiver`, and `otap_receiver` on consistent task startup/teardown behavior.
- Keeps diagnostics wiring coherent during startup, steady-state, and shutdown transitions.

## Why
Issue #1549 requires deterministic receiver shutdown so background tasks are not leaked and shutdown ordering is predictable.

## Testing
- Not re-run in this integration pass.
- Please run: `just ci`.

## Context
- Implementation transcript: https://chatgpt.com/codex/tasks/task_e_69d577e1b564832e85c60c5a642e1eba
