### PR TITLE
fix: restore batch trace instrumentation after I/O separation

### DIFF
--- a/crates/logfwd-io/src/diagnostics.rs
+++ b/crates/logfwd-io/src/diagnostics.rs
@@ -873,6 +873,22 @@ impl DiagnosticsServer {
                     }
                 }
 
+                // Fallback: read scan/transform timing from root span attributes
+                // (batch span carries these directly when child spans are absent)
+                let root_attr_u64 = |key: &str| -> u64 {
+                    root.attrs
+                        .iter()
+                        .find(|kv| kv[0] == key)
+                        .and_then(|kv| kv[1].parse().ok())
+                        .unwrap_or(0)
+                };
+                if scan_ns == 0 {
+                    scan_ns = root_attr_u64("scan_ns");
+                }
+                if transform_ns == 0 {
+                    transform_ns = root_attr_u64("transform_ns");
+                }
+
                 // Extract well-known attributes from root span.
                 let attr = |key: &str| -> &str {
                     root.attrs

--- a/crates/logfwd-io/src/span_exporter.rs
+++ b/crates/logfwd-io/src/span_exporter.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, UNIX_EPOCH};
 
-const MAX_SPANS: usize = 4_000; // ~1000 batches × 4 spans each
+const MAX_SPANS: usize = 16_000; // ~8000 batches × 2 spans each
 
 // ---------------------------------------------------------------------------
 // Serializable span snapshot

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -406,6 +406,7 @@ impl OtlpSink {
             }
         }
 
+        let compressed_len = payload.len();
         match req.body(payload.to_vec()).send().await {
             Ok(response) => {
                 let status = response.status();
@@ -456,6 +457,9 @@ impl OtlpSink {
                     }
                     self.stats.inc_lines(batch_rows);
                     self.stats.inc_bytes(self.encoder_buf.len() as u64);
+                    let span = tracing::Span::current();
+                    span.record("req_bytes", self.encoder_buf.len() as u64);
+                    span.record("cmp_bytes", compressed_len as u64);
                     return Ok(super::sink::SendResult::Ok);
                 }
 

--- a/crates/logfwd/src/pipeline.rs
+++ b/crates/logfwd/src/pipeline.rs
@@ -998,6 +998,14 @@ impl Pipeline {
         let out_rows = result.num_rows() as u64;
         let submitted_at = tokio::time::Instant::now();
 
+        let batch_span = tracing::info_span!(
+            "batch",
+            scan_ns = scan_ns,
+            transform_ns = transform_ns,
+            input_rows = out_rows,
+            queue_wait_ns = tracing::field::Empty,
+        );
+
         self.pool
             .submit(WorkItem {
                 num_rows: out_rows,
@@ -1008,7 +1016,7 @@ impl Pipeline {
                 scan_ns,
                 transform_ns,
                 batch_id,
-                span: tracing::Span::current(),
+                span: batch_span,
             })
             .await;
         self.metrics

--- a/crates/logfwd/src/worker_pool.rs
+++ b/crates/logfwd/src/worker_pool.rs
@@ -725,6 +725,7 @@ async fn worker_task(
                             span,
                         } = item;
                         let queue_wait_ns = submitted_at.elapsed().as_nanos() as u64;
+                        span.record("queue_wait_ns", queue_wait_ns);
                         // Record which worker picked up this batch for the live dashboard.
                         let now_ns = std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
@@ -747,6 +748,7 @@ async fn worker_task(
                         .instrument(output_span.clone())
                         .await;
                         output_span.record("retries", retries);
+                        output_span.record("send_ns", send_latency_ns);
                         let output_ns = submitted_at.elapsed().as_nanos() as u64 - queue_wait_ns;
                         // Remove from active_batches immediately — don't wait for the pipeline's
                         // ack select loop, which can be starved by flush_batch.await blocking.


### PR DESCRIPTION
## Summary

The I/O separation (Phase 2, PR #1512) removed scan/transform child spans from the pipeline, leaving all trace fields zeroed in the dashboard. Traces showed as blue lines with no stage segments, and batch metrics (req_bytes, cmp_bytes, send_ns) were never recorded on spans.

## Changes

### Pipeline (`pipeline.rs`)

### Worker Pool (`worker_pool.rs`)
- Record `queue_wait_ns` on the batch span when a worker dequeues an item
- Record `send_ns` on the output child span after send completes

### OTLP Sink (`otlp_sink.rs`)
- Capture compressed payload length before sending
- Record `req_bytes` (pre-compression protobuf) and `cmp_bytes` (post-compression gzip) on the current span after successful send

### Diagnostics (`diagnostics.rs`)
- Fall back to reading `scan_ns`/`transform_ns` from root span attributes in `serve_traces` when child spans named "scan"/"transform" are absent

### Span Exporter (`span_exporter.rs`)
- Bump `MAX_SPANS` from 4,000 → 16,000 to reduce ring churn at high throughput (4K spans churned completely in ~2s at 1.7M lines/s)

## Verification

Tested at 1.4M lines/s with 24 workers, 8MB batches, gzip compression → Elastic OTLP:
- `scan_ns: 17.8ms`, `transform_ns: 0.25ms` — stage timings populated ✅
- `input_rows: 205,000` — row counts populated ✅
- `queue_wait_ns: 2.58s` — queue wait measured ✅
- `req_bytes: 19.5MB`, `cmp_bytes: 960KB` — compression metrics populated ✅
- `send_ns: 4.98s`, `worker_id: 0` — output metrics populated ✅

Relates to #1512

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore batch trace instrumentation with span attributes for scan, transform, and send timings
> - Creates a dedicated `batch_span` per batch in [`pipeline.rs`](https://github.com/strawgate/memagent/pull/1562/files#diff-871beaad2d14990b89072990f0a821dd4266ab3e624d58590ec24abc1047056d) carrying `scan_ns`, `transform_ns`, and `input_rows`, replacing use of the current span as the work item span.
> - Records `queue_wait_ns` on the batch span and `send_ns` on the output child span in [`worker_pool.rs`](https://github.com/strawgate/memagent/pull/1562/files#diff-7aaeb25da3bfad836d812c3bfdc7af0d310b9d60b8920d9e9f07b97ab201533b) after processing completes.
> - Adds a fallback in [`diagnostics.rs`](https://github.com/strawgate/memagent/pull/1562/files#diff-6bb180a311d04982be05f9e192221a4f2c0d9b4f6733fa3f46f63229ef488cdb) to read `scan_ns` and `transform_ns` directly from root span attributes when child spans don't populate them.
> - Annotates successful sends with `req_bytes` and `cmp_bytes` in [`otlp_sink.rs`](https://github.com/strawgate/memagent/pull/1562/files#diff-56ca7e19db98793b4ef621c0d28a618a4c8af2bd492bc89cc8a21e845f25a43c).
> - Increases `MAX_SPANS` from 4,000 to 16,000 in [`span_exporter.rs`](https://github.com/strawgate/memagent/pull/1562/files#diff-ce3bead1359c14de3681dfe6a35ab54b209cf0cec34c62199279a48886f459e1) to accommodate the higher span volume from per-batch spans.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 52b233e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->