### PR TITLE
fix(io): framed overflow drops tainted fragments (#1554)

### DIFF
--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -233,7 +233,7 @@ impl InputSource for FramedInput {
                             .process_lines(&chunk[process_start..], &mut self.out_buf);
                     }
 
-                    let line_count = memchr::memchr_iter(b'\n', &chunk).count();
+                    let line_count = memchr::memchr_iter(b'\n', &chunk[process_start..]).count();
                     self.stats.inc_lines(line_count as u64);
 
                     if !self.out_buf.is_empty() {
@@ -724,10 +724,12 @@ mod tests {
             vec![InputEvent::Data {
                 bytes: big,
                 source_id: Some(sid),
+                accounted_bytes: 0,
             }],
             vec![InputEvent::Data {
                 bytes: second_bytes.to_vec(),
                 source_id: Some(sid),
+                accounted_bytes: 0,
             }],
         ])
         .with_offsets(vec![(sid, ByteOffset(total))]);


### PR DESCRIPTION
## What This Changes
- Tracks overflow-tainted remainder state in `FramedInput`.
- Drops the first completed line after remainder overflow truncation to prevent emitting synthetic mid-line fragments.
- Expands regression coverage for overflow/remainder behavior and checkpoint interaction.

## Why
Issue #1554 is about correctness after framed overflow: we should never emit garbled fragments created by truncation boundaries.

## Testing
- Not re-run in this integration pass.
- Please run: `just ci`.

## Context
- Implementation transcript: https://chatgpt.com/codex/tasks/task_e_69d577e54720832ebb26a7f07a239ae4


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Discard tainted fragments after remainder overflow in framed input
> - When the remainder buffer overflows `MAX_REMAINDER_BYTES`, a `overflow_tainted` flag is set on `SourceState` to mark that the buffer no longer holds a complete line prefix.
> - The first line completed after an overflow (the synthetic mid-line fragment) is now dropped rather than emitted, and the taint flag is cleared.
> - EOF flushing also respects the taint flag, discarding the fragment rather than emitting it with an appended newline.
> - Two new tests verify that overflow fragments are dropped and that checkpoints advance correctly after the tainted fragment is discarded.
> - Behavioral Change: previously, the first line emitted after an overflow contained truncated/corrupt data; it is now silently dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa59665.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->