### PR TITLE
[Do not merge] feat(processing): tail sampling core behavior (#1555)

### DIFF
--- a/crates/logfwd/src/processor/mod.rs
+++ b/crates/logfwd/src/processor/mod.rs
@@ -3,6 +3,8 @@ use logfwd_output::BatchMetadata;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 
+pub mod tail_sampling;
+
 /// Error types for processor operations.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -124,9 +126,10 @@ pub fn cascading_flush(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::Int32Array;
+    use arrow::array::{Int32Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use std::sync::Arc;
+    use std::time::Duration;
 
     fn test_meta() -> BatchMetadata {
         BatchMetadata {
@@ -356,5 +359,76 @@ mod tests {
         })];
         let result = run_chain(&mut procs, test_batch(5), &test_meta());
         assert!(matches!(result, Err(ProcessorError::Fatal(_))));
+    }
+
+    #[test]
+    fn run_chain_tail_sampling_heartbeat_emits_rows() {
+        let mut procs: Vec<Box<dyn Processor>> = vec![Box::new(
+            tail_sampling::TailSamplingProcessor::try_new(
+                "SELECT * FROM logs",
+                "trace_id",
+                Duration::from_nanos(10),
+            )
+            .expect("tail-sampling processor"),
+        )];
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("trace_id", DataType::Utf8, true),
+            Field::new("x", DataType::Int32, false),
+        ]));
+        let input = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![Some("trace-a")])),
+                Arc::new(Int32Array::from(vec![7])),
+            ],
+        )
+        .expect("record batch");
+
+        let mut meta = test_meta();
+        meta.observed_time_ns = 100;
+        let out = run_chain(&mut procs, input, &meta).expect("buffering path");
+        assert!(
+            out.is_empty(),
+            "trace should remain buffered before timeout"
+        );
+
+        meta.observed_time_ns = 120;
+        let heartbeat = RecordBatch::new_empty(Arc::new(Schema::empty()));
+        let out = run_chain(&mut procs, heartbeat, &meta).expect("timeout heartbeat");
+        assert_eq!(out.len(), 1, "heartbeat should emit timed-out trace");
+        assert_eq!(out[0].num_rows(), 1);
+    }
+
+    #[test]
+    fn cascading_flush_with_tail_sampling_emits_buffered_rows() {
+        let mut procs: Vec<Box<dyn Processor>> = vec![Box::new(
+            tail_sampling::TailSamplingProcessor::try_new(
+                "SELECT * FROM logs",
+                "trace_id",
+                Duration::from_secs(60),
+            )
+            .expect("tail-sampling processor"),
+        )];
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("trace_id", DataType::Utf8, true),
+            Field::new("x", DataType::Int32, false),
+        ]));
+        let input = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![
+                Arc::new(StringArray::from(vec![Some("trace-b")])),
+                Arc::new(Int32Array::from(vec![42])),
+            ],
+        )
+        .expect("record batch");
+
+        let out = run_chain(&mut procs, input, &test_meta()).expect("buffering path");
+        assert!(out.is_empty());
+
+        let flushed = cascading_flush(&mut procs, &test_meta());
+        assert_eq!(flushed.len(), 1);
+        assert_eq!(flushed[0].num_rows(), 1);
     }
 }

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -45,6 +45,31 @@ impl std::fmt::Debug for TailSamplingProcessor {
 }
 
 impl TailSamplingProcessor {
+    /// Create a new `TailSamplingProcessor`.
+    ///
+    /// # Parameters
+    ///
+    /// - `query`: A DataFusion SQL query applied to each timed-out trace group as
+    ///   a sampling decision. The query runs against a virtual table named `logs`
+    ///   whose schema matches the buffered record batches. Rows returned by the
+    ///   query are emitted downstream; an empty result means the trace is dropped.
+    ///   Example: `"SELECT * FROM logs WHERE severity = 'ERROR'"`.
+    ///
+    /// - `group_by_field`: Name of the column used to group rows into trace
+    ///   buckets. Must be present in every incoming batch and must have one of
+    ///   the supported string types: `Utf8`, `Utf8View`, or `LargeUtf8`. Rows
+    ///   where this column is null bypass buffering and pass through immediately.
+    ///
+    /// - `trace_timeout`: Inactivity duration after which a trace group is
+    ///   considered complete. The timeout is evaluated against
+    ///   `BatchMetadata::observed_time_ns`: a group times out when
+    ///   `observed_time_ns - last_seen_ns >= timeout_ns`. Durations longer than
+    ///   `u64::MAX` nanoseconds are clamped to `u64::MAX`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ProcessorError::Permanent` if `query` fails to parse or compile
+    /// as a valid DataFusion SQL expression.
     pub fn try_new(
         query: impl Into<String>,
         group_by_field: impl Into<String>,
@@ -116,7 +141,11 @@ impl TailSamplingProcessor {
         }
     }
 
-    fn drain_timed_out(&mut self, now_ns: u64) -> Vec<TraceState> {
+    /// Collect the keys of timed-out trace groups (sorted by arrival order) WITHOUT
+    /// removing them from `self.traces`. Callers must remove entries explicitly
+    /// after a successful decision so that transient errors leave state intact and
+    /// can be retried on the next heartbeat/batch.
+    fn timed_out_keys(&self, now_ns: u64) -> Vec<(String, u64)> {
         let mut timed_out: Vec<(String, u64)> = self
             .traces
             .iter()
@@ -130,24 +159,20 @@ impl TailSamplingProcessor {
             .collect();
 
         timed_out.sort_by_key(|(_, ord)| *ord);
-
-        let mut drained = Vec::with_capacity(timed_out.len());
-        for (k, _) in timed_out {
-            if let Some(state) = self.traces.remove(&k) {
-                drained.push(state);
-            }
-        }
-        drained
+        timed_out
     }
 
     fn run_decision_for_state(
         &mut self,
-        state: TraceState,
+        state: &TraceState,
     ) -> Result<Option<RecordBatch>, ProcessorError> {
         if state.batches.is_empty() {
             return Ok(None);
         }
         let schema = state.batches[0].schema();
+        // TODO: schema drift — if batches were appended across schema changes the
+        // concat will fail with a schema mismatch. Consider normalising to a
+        // canonical schema at append time. Left for human review.
         let combined = concat_batches(&schema, &state.batches).map_err(|e| {
             ProcessorError::Transient(format!("failed to concat buffered trace batches: {e}"))
         })?;
@@ -181,9 +206,44 @@ impl Processor for TailSamplingProcessor {
             }
         }
 
-        for state in self.drain_timed_out(now_ns) {
-            if let Some(decided) = self.run_decision_for_state(state)? {
-                out.push(decided);
+        // TODO: drain-before-append ordering — timed-out groups are drained after
+        // the current batch is appended.  For traces that already timed out, the
+        // new rows would be flushed immediately rather than buffered for another
+        // window.  Consider draining first, then appending. Left for human review.
+        for (key, _) in self.timed_out_keys(now_ns) {
+            // Clone the batches so we can release the shared borrow on self.traces
+            // before calling run_decision_for_state (which needs &mut self for
+            // SqlTransform).  This avoids the borrow-checker conflict while keeping
+            // the entry intact until we know the decision succeeded.
+            //
+            // TODO: per-row key allocation optimisation — avoid cloning Arc<RecordBatch>
+            // here; consider storing Arc<Vec<RecordBatch>> to make cloning cheap.
+            // Left for human review.
+            let snapshot = self.traces.get(&key).map(|st| TraceState {
+                batches: st.batches.clone(),
+                last_seen_ns: st.last_seen_ns,
+                first_seen_ord: st.first_seen_ord,
+            });
+            let Some(snapshot) = snapshot else {
+                continue; // already removed (shouldn't happen in single-threaded context)
+            };
+
+            // Run the decision query against the snapshot.  Only remove the entry
+            // on success so that a transient error leaves the buffered data intact
+            // for the next call — satisfying the retry contract in processor/mod.rs.
+            match self.run_decision_for_state(&snapshot) {
+                Ok(Some(decided)) => {
+                    self.traces.remove(&key);
+                    out.push(decided);
+                }
+                Ok(None) => {
+                    // Decision query returned no rows — drop the trace.
+                    self.traces.remove(&key);
+                }
+                Err(e) => {
+                    // Transient error: leave the entry intact so it can be retried.
+                    return Err(e);
+                }
             }
         }
 
@@ -200,8 +260,18 @@ impl Processor for TailSamplingProcessor {
 
         let mut out = SmallVec::new();
         for (key, _) in keys {
-            if let Some(state) = self.traces.remove(&key) {
-                match self.run_decision_for_state(state) {
+            // Clone the batches so we can release the shared borrow on self.traces
+            // before calling run_decision_for_state (which needs &mut self).
+            let snapshot = self.traces.get(&key).map(|st| TraceState {
+                batches: st.batches.clone(),
+                last_seen_ns: st.last_seen_ns,
+                first_seen_ord: st.first_seen_ord,
+            });
+            if let Some(snapshot) = snapshot {
+                // Always remove during flush — this is a shutdown path, not a
+                // retriable operation.
+                self.traces.remove(&key);
+                match self.run_decision_for_state(&snapshot) {
                     Ok(Some(batch)) => out.push(batch),
                     Ok(None) => {}
                     Err(e) => {

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, hash_map::Entry};
+use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -125,6 +125,13 @@ impl TailSamplingProcessor {
     }
 
     fn partition_by_group(&self, batch: RecordBatch) -> Result<PartitionResult, ProcessorError> {
+        if batch.num_rows() > u32::MAX as usize {
+            return Err(ProcessorError::Permanent(format!(
+                "tail-sampling cannot partition batches larger than {} rows",
+                u32::MAX
+            )));
+        }
+
         let col_idx = batch.schema().index_of(&self.group_by_field).map_err(|_| {
             ProcessorError::Permanent(format!(
                 "tail-sampling group-by column '{}' not found",
@@ -138,15 +145,20 @@ impl TailSamplingProcessor {
         let mut null_rows = Vec::new();
 
         for row in 0..batch.num_rows() {
+            let row_u32 = u32::try_from(row).map_err(|_| {
+                ProcessorError::Permanent(format!(
+                    "tail-sampling row index {row} exceeds u32 range"
+                ))
+            })?;
             match group_col.value(row) {
                 Some(group) => {
                     if let Some((_, rows)) = grouped_rows.get_mut(group) {
-                        rows.push(row as u32);
+                        rows.push(row_u32);
                     } else {
-                        grouped_rows.insert(group.to_string(), (row, vec![row as u32]));
+                        grouped_rows.insert(group.to_string(), (row, vec![row_u32]));
                     }
                 }
-                None => null_rows.push(row as u32),
+                None => null_rows.push(row_u32),
             }
         }
 
@@ -247,7 +259,15 @@ impl TailSamplingProcessor {
         now_ns: u64,
         out: &mut SmallVec<[RecordBatch; 1]>,
     ) -> Result<(), ProcessorError> {
-        for (key, _) in self.timed_out_keys(now_ns) {
+        self.drain_group_keys_into(self.timed_out_keys(now_ns), out)
+    }
+
+    fn drain_group_keys_into(
+        &mut self,
+        keys: Vec<(String, u64)>,
+        out: &mut SmallVec<[RecordBatch; 1]>,
+    ) -> Result<(), ProcessorError> {
+        for (key, _) in keys {
             let Some(state) = self.traces.remove(&key) else {
                 continue;
             };
@@ -277,18 +297,25 @@ impl Processor for TailSamplingProcessor {
         if batch.num_rows() > 0 {
             let (grouped, passthrough) = self.partition_by_group(batch)?;
 
-            self.drain_timed_out_into(now_ns, &mut out)?;
+            let timed_out_keys = self.timed_out_keys(now_ns);
+            let timed_out_set: HashSet<&str> =
+                timed_out_keys.iter().map(|(key, _)| key.as_str()).collect();
+            let existing_after_drain = self.traces.len().saturating_sub(timed_out_keys.len());
 
             let new_group_count = grouped
                 .iter()
-                .filter(|(group, _)| !self.traces.contains_key(group))
+                .filter(|(group, _)| {
+                    !self.traces.contains_key(group) || timed_out_set.contains(group.as_str())
+                })
                 .count();
-            if self.traces.len().saturating_add(new_group_count) > self.max_buffered_traces {
+            if existing_after_drain.saturating_add(new_group_count) > self.max_buffered_traces {
                 return Err(ProcessorError::Transient(format!(
                     "tail-sampling buffered trace limit ({}) reached; retry after timeout drain or raise the limit",
                     self.max_buffered_traces
                 )));
             }
+
+            self.drain_group_keys_into(timed_out_keys, &mut out)?;
 
             for (group, sub_batch) in grouped {
                 self.append_group_batch(group, sub_batch, now_ns);
@@ -600,5 +627,43 @@ mod tests {
             }
             other => panic!("expected transient limit error, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn transient_limit_error_does_not_drop_timed_out_groups() {
+        let mut p = TailSamplingProcessor::try_new_with_limit(
+            "SELECT * FROM logs",
+            "trace_id",
+            Duration::from_nanos(10),
+            1,
+        )
+        .expect("processor");
+
+        p.process(batch(vec![Some("old")], vec![1]), &meta(100))
+            .expect("seed old group");
+
+        let err = p
+            .process(batch(vec![Some("a"), Some("b")], vec![2, 3]), &meta(111))
+            .expect_err("new groups should exceed configured cap");
+        assert!(
+            matches!(err, ProcessorError::Transient(_)),
+            "expected transient limit error"
+        );
+
+        // The timed-out "old" group must still be buffered after the transient
+        // failure, so a heartbeat can drain it.
+        let drained = p
+            .process(
+                RecordBatch::new_empty(Arc::new(Schema::empty())),
+                &meta(112),
+            )
+            .expect("heartbeat");
+        assert_eq!(drained.len(), 1);
+        let val_col = drained[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 column");
+        assert_eq!(val_col.value(0), 1);
     }
 }

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -1,9 +1,10 @@
 use std::collections::{HashMap, hash_map::Entry};
+use std::sync::Arc;
 use std::time::Duration;
 
 use arrow::array::{Array, LargeStringArray, StringArray, StringViewArray, UInt32Array};
 use arrow::compute::{concat_batches, take};
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use logfwd_output::BatchMetadata;
 use logfwd_transform::SqlTransform;
@@ -14,6 +15,8 @@ use super::{Processor, ProcessorError};
 /// Grouped partition result: a list of (group_key, sub-batch) pairs plus an
 /// optional passthrough batch for rows with a null group value.
 type PartitionResult = (Vec<(String, RecordBatch)>, Option<RecordBatch>);
+
+const DEFAULT_MAX_BUFFERED_TRACES: usize = 50_000;
 
 #[derive(Debug)]
 struct TraceState {
@@ -29,6 +32,7 @@ struct TraceState {
 pub struct TailSamplingProcessor {
     group_by_field: String,
     timeout_ns: u64,
+    max_buffered_traces: usize,
     decision: SqlTransform,
     traces: HashMap<String, TraceState>,
     next_ord: u64,
@@ -39,6 +43,7 @@ impl std::fmt::Debug for TailSamplingProcessor {
         f.debug_struct("TailSamplingProcessor")
             .field("group_by_field", &self.group_by_field)
             .field("timeout_ns", &self.timeout_ns)
+            .field("max_buffered_traces", &self.max_buffered_traces)
             .field("traces_len", &self.traces.len())
             .finish_non_exhaustive()
     }
@@ -70,11 +75,40 @@ impl TailSamplingProcessor {
     ///
     /// Returns `ProcessorError::Permanent` if `query` fails to parse or compile
     /// as a valid DataFusion SQL expression.
+    ///
+    /// Uses a default in-memory trace-group cap of `50_000` keys. To tune this,
+    /// call [`TailSamplingProcessor::try_new_with_limit`].
     pub fn try_new(
         query: impl Into<String>,
         group_by_field: impl Into<String>,
         trace_timeout: Duration,
     ) -> Result<Self, ProcessorError> {
+        Self::try_new_with_limit(
+            query,
+            group_by_field,
+            trace_timeout,
+            DEFAULT_MAX_BUFFERED_TRACES,
+        )
+    }
+
+    /// Create a new `TailSamplingProcessor` with an explicit trace-group cap.
+    ///
+    /// `max_buffered_traces` bounds the number of distinct in-flight groups kept
+    /// in memory at once. When the cap is reached and a new group arrives,
+    /// `process()` returns `ProcessorError::Transient` so callers can retry
+    /// rather than letting memory grow without bound.
+    pub fn try_new_with_limit(
+        query: impl Into<String>,
+        group_by_field: impl Into<String>,
+        trace_timeout: Duration,
+        max_buffered_traces: usize,
+    ) -> Result<Self, ProcessorError> {
+        if max_buffered_traces == 0 {
+            return Err(ProcessorError::Permanent(
+                "tail-sampling max_buffered_traces must be > 0".into(),
+            ));
+        }
+
         let query = query.into();
         let decision = SqlTransform::new(&query).map_err(|e| {
             ProcessorError::Permanent(format!("invalid tail-sampling SQL query '{query}': {e}"))
@@ -83,6 +117,7 @@ impl TailSamplingProcessor {
         Ok(Self {
             group_by_field: group_by_field.into(),
             timeout_ns,
+            max_buffered_traces,
             decision,
             traces: HashMap::new(),
             next_ord: 0,
@@ -97,26 +132,39 @@ impl TailSamplingProcessor {
             ))
         })?;
 
-        let group_col = batch.column(col_idx).as_ref();
-        let mut grouped_rows: HashMap<String, Vec<u32>> = HashMap::new();
+        let group_col =
+            GroupColumn::try_from_array(&self.group_by_field, batch.column(col_idx).as_ref())?;
+        let mut grouped_rows: HashMap<String, (usize, Vec<u32>)> = HashMap::new();
         let mut null_rows = Vec::new();
 
         for row in 0..batch.num_rows() {
-            match group_value(group_col, row)? {
-                Some(group) => grouped_rows.entry(group).or_default().push(row as u32),
+            match group_col.value(row) {
+                Some(group) => {
+                    if let Some((_, rows)) = grouped_rows.get_mut(group) {
+                        rows.push(row as u32);
+                    } else {
+                        grouped_rows.insert(group.to_string(), (row, vec![row as u32]));
+                    }
+                }
                 None => null_rows.push(row as u32),
             }
         }
 
-        let mut grouped = Vec::with_capacity(grouped_rows.len());
-        for (group, rows) in grouped_rows {
-            grouped.push((group, take_rows(&batch, &rows)?));
+        let mut grouped_ordered: Vec<(usize, String, Vec<u32>)> = grouped_rows
+            .into_iter()
+            .map(|(group, (first_seen_row, rows))| (first_seen_row, group, rows))
+            .collect();
+        grouped_ordered.sort_by_key(|(first_seen_row, _, _)| *first_seen_row);
+
+        let mut grouped = Vec::with_capacity(grouped_ordered.len());
+        for (_, group, rows) in grouped_ordered {
+            grouped.push((group, take_rows(&batch, rows)?));
         }
 
         let passthrough = if null_rows.is_empty() {
             None
         } else {
-            Some(take_rows(&batch, &null_rows)?)
+            Some(take_rows(&batch, null_rows)?)
         };
 
         Ok((grouped, passthrough))
@@ -169,11 +217,19 @@ impl TailSamplingProcessor {
         if state.batches.is_empty() {
             return Ok(None);
         }
-        let schema = state.batches[0].schema();
-        // TODO: schema drift — if batches were appended across schema changes the
-        // concat will fail with a schema mismatch. Consider normalising to a
-        // canonical schema at append time. Left for human review.
-        let combined = concat_batches(&schema, &state.batches).map_err(|e| {
+        let merged_schema = if state.batches.len() == 1 {
+            state.batches[0].schema()
+        } else {
+            let merged =
+                Schema::try_merge(state.batches.iter().map(|b| b.schema().as_ref().clone()))
+                    .map_err(|e| {
+                        ProcessorError::Transient(format!(
+                            "failed to merge buffered trace schemas: {e}"
+                        ))
+                    })?;
+            Arc::new(merged)
+        };
+        let combined = concat_batches(&merged_schema, &state.batches).map_err(|e| {
             ProcessorError::Transient(format!("failed to concat buffered trace batches: {e}"))
         })?;
         let out = self.decision.execute_blocking(combined).map_err(|e| {
@@ -184,6 +240,28 @@ impl TailSamplingProcessor {
         } else {
             Ok(Some(out))
         }
+    }
+
+    fn drain_timed_out_into(
+        &mut self,
+        now_ns: u64,
+        out: &mut SmallVec<[RecordBatch; 1]>,
+    ) -> Result<(), ProcessorError> {
+        for (key, _) in self.timed_out_keys(now_ns) {
+            let Some(state) = self.traces.remove(&key) else {
+                continue;
+            };
+
+            match self.run_decision_for_state(&state) {
+                Ok(Some(decided)) => out.push(decided),
+                Ok(None) => {}
+                Err(e) => {
+                    self.traces.insert(key, state);
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -198,53 +276,32 @@ impl Processor for TailSamplingProcessor {
 
         if batch.num_rows() > 0 {
             let (grouped, passthrough) = self.partition_by_group(batch)?;
+
+            self.drain_timed_out_into(now_ns, &mut out)?;
+
+            let new_group_count = grouped
+                .iter()
+                .filter(|(group, _)| !self.traces.contains_key(group))
+                .count();
+            if self.traces.len().saturating_add(new_group_count) > self.max_buffered_traces {
+                return Err(ProcessorError::Transient(format!(
+                    "tail-sampling buffered trace limit ({}) reached; retry after timeout drain or raise the limit",
+                    self.max_buffered_traces
+                )));
+            }
+
             for (group, sub_batch) in grouped {
                 self.append_group_batch(group, sub_batch, now_ns);
             }
             if let Some(pass) = passthrough {
                 out.push(pass);
             }
-        }
-
-        // TODO: drain-before-append ordering — timed-out groups are drained after
-        // the current batch is appended.  For traces that already timed out, the
-        // new rows would be flushed immediately rather than buffered for another
-        // window.  Consider draining first, then appending. Left for human review.
-        for (key, _) in self.timed_out_keys(now_ns) {
-            // Clone the batches so we can release the shared borrow on self.traces
-            // before calling run_decision_for_state (which needs &mut self for
-            // SqlTransform).  This avoids the borrow-checker conflict while keeping
-            // the entry intact until we know the decision succeeded.
-            //
-            // TODO: per-row key allocation optimisation — avoid cloning Arc<RecordBatch>
-            // here; consider storing Arc<Vec<RecordBatch>> to make cloning cheap.
-            // Left for human review.
-            let snapshot = self.traces.get(&key).map(|st| TraceState {
-                batches: st.batches.clone(),
-                last_seen_ns: st.last_seen_ns,
-                first_seen_ord: st.first_seen_ord,
-            });
-            let Some(snapshot) = snapshot else {
-                continue; // already removed (shouldn't happen in single-threaded context)
-            };
-
-            // Run the decision query against the snapshot.  Only remove the entry
-            // on success so that a transient error leaves the buffered data intact
-            // for the next call — satisfying the retry contract in processor/mod.rs.
-            match self.run_decision_for_state(&snapshot) {
-                Ok(Some(decided)) => {
-                    self.traces.remove(&key);
-                    out.push(decided);
-                }
-                Ok(None) => {
-                    // Decision query returned no rows — drop the trace.
-                    self.traces.remove(&key);
-                }
-                Err(e) => {
-                    // Transient error: leave the entry intact so it can be retried.
-                    return Err(e);
-                }
+            // Maintain immediate-timeout behavior for `Duration::ZERO`.
+            if self.timeout_ns == 0 {
+                self.drain_timed_out_into(now_ns, &mut out)?;
             }
+        } else {
+            self.drain_timed_out_into(now_ns, &mut out)?;
         }
 
         Ok(out)
@@ -260,27 +317,18 @@ impl Processor for TailSamplingProcessor {
 
         let mut out = SmallVec::new();
         for (key, _) in keys {
-            // Clone the batches so we can release the shared borrow on self.traces
-            // before calling run_decision_for_state (which needs &mut self).
-            let snapshot = self.traces.get(&key).map(|st| TraceState {
-                batches: st.batches.clone(),
-                last_seen_ns: st.last_seen_ns,
-                first_seen_ord: st.first_seen_ord,
-            });
-            if let Some(snapshot) = snapshot {
-                // Always remove during flush — this is a shutdown path, not a
-                // retriable operation.
-                self.traces.remove(&key);
-                match self.run_decision_for_state(&snapshot) {
-                    Ok(Some(batch)) => out.push(batch),
-                    Ok(None) => {}
-                    Err(e) => {
-                        tracing::warn!(
-                            group = %key,
-                            error = %e,
-                            "tail-sampling decision query failed during flush; buffered group dropped"
-                        );
-                    }
+            let Some(state) = self.traces.remove(&key) else {
+                continue;
+            };
+            match self.run_decision_for_state(&state) {
+                Ok(Some(batch)) => out.push(batch),
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        group = %key,
+                        error = %e,
+                        "tail-sampling decision query failed during flush; buffered group dropped"
+                    );
                 }
             }
         }
@@ -296,8 +344,8 @@ impl Processor for TailSamplingProcessor {
     }
 }
 
-fn take_rows(batch: &RecordBatch, rows: &[u32]) -> Result<RecordBatch, ProcessorError> {
-    let indices = UInt32Array::from(rows.to_vec());
+fn take_rows(batch: &RecordBatch, rows: Vec<u32>) -> Result<RecordBatch, ProcessorError> {
+    let indices = UInt32Array::from(rows);
     let mut cols = Vec::with_capacity(batch.num_columns());
     for col in batch.columns() {
         let taken = take(col.as_ref(), &indices, None).map_err(|e| {
@@ -309,39 +357,57 @@ fn take_rows(batch: &RecordBatch, rows: &[u32]) -> Result<RecordBatch, Processor
         .map_err(|e| ProcessorError::Transient(format!("failed to build partitioned batch: {e}")))
 }
 
-fn group_value(col: &dyn Array, row: usize) -> Result<Option<String>, ProcessorError> {
-    if col.is_null(row) {
-        return Ok(None);
+enum GroupColumn<'a> {
+    Utf8(&'a StringArray),
+    Utf8View(&'a StringViewArray),
+    LargeUtf8(&'a LargeStringArray),
+}
+
+impl<'a> GroupColumn<'a> {
+    fn try_from_array(field_name: &str, col: &'a dyn Array) -> Result<Self, ProcessorError> {
+        match col.data_type() {
+            DataType::Utf8 => {
+                let arr = col.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
+                    ProcessorError::Permanent(format!(
+                        "failed to read tail-sampling group-by column '{field_name}' as Utf8"
+                    ))
+                })?;
+                Ok(Self::Utf8(arr))
+            }
+            DataType::Utf8View => {
+                let arr = col
+                    .as_any()
+                    .downcast_ref::<StringViewArray>()
+                    .ok_or_else(|| {
+                        ProcessorError::Permanent(format!(
+                            "failed to read tail-sampling group-by column '{field_name}' as Utf8View"
+                        ))
+                    })?;
+                Ok(Self::Utf8View(arr))
+            }
+            DataType::LargeUtf8 => {
+                let arr = col
+                    .as_any()
+                    .downcast_ref::<LargeStringArray>()
+                    .ok_or_else(|| {
+                        ProcessorError::Permanent(format!(
+                            "failed to read tail-sampling group-by column '{field_name}' as LargeUtf8"
+                        ))
+                    })?;
+                Ok(Self::LargeUtf8(arr))
+            }
+            other => Err(ProcessorError::Permanent(format!(
+                "tail-sampling group-by column '{field_name}' has unsupported type {other:?}; expected Utf8, Utf8View, or LargeUtf8"
+            ))),
+        }
     }
 
-    match col.data_type() {
-        DataType::Utf8 => {
-            let arr = col.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
-                ProcessorError::Permanent("failed to read Utf8 group_by column".into())
-            })?;
-            Ok(Some(arr.value(row).to_string()))
+    fn value(&self, row: usize) -> Option<&str> {
+        match self {
+            Self::Utf8(arr) => (!arr.is_null(row)).then(|| arr.value(row)),
+            Self::Utf8View(arr) => (!arr.is_null(row)).then(|| arr.value(row)),
+            Self::LargeUtf8(arr) => (!arr.is_null(row)).then(|| arr.value(row)),
         }
-        DataType::Utf8View => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<StringViewArray>()
-                .ok_or_else(|| {
-                    ProcessorError::Permanent("failed to read Utf8View group_by column".into())
-                })?;
-            Ok(Some(arr.value(row).to_string()))
-        }
-        DataType::LargeUtf8 => {
-            let arr = col
-                .as_any()
-                .downcast_ref::<LargeStringArray>()
-                .ok_or_else(|| {
-                    ProcessorError::Permanent("failed to read LargeUtf8 group_by column".into())
-                })?;
-            Ok(Some(arr.value(row).to_string()))
-        }
-        other => Err(ProcessorError::Permanent(format!(
-            "tail-sampling group-by column has unsupported type: {other:?}"
-        ))),
     }
 }
 
@@ -430,5 +496,109 @@ mod tests {
         let flushed = p.flush();
         assert_eq!(flushed.len(), 2);
         assert_eq!(flushed[0].num_rows() + flushed[1].num_rows(), 2);
+    }
+
+    #[test]
+    fn timed_out_group_drains_before_appending_new_rows() {
+        let mut p = TailSamplingProcessor::try_new(
+            "SELECT * FROM logs",
+            "trace_id",
+            Duration::from_nanos(10),
+        )
+        .expect("processor");
+
+        let out = p
+            .process(batch(vec![Some("t1")], vec![1]), &meta(100))
+            .expect("initial process");
+        assert!(out.is_empty());
+
+        let out = p
+            .process(batch(vec![Some("t1")], vec![99]), &meta(111))
+            .expect("timed-out drain + append new row");
+        assert_eq!(out.len(), 1, "old timed-out window should be emitted first");
+        let val_col = out[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 column");
+        assert_eq!(val_col.value(0), 1);
+
+        let out = p
+            .process(
+                RecordBatch::new_empty(Arc::new(Schema::empty())),
+                &meta(122),
+            )
+            .expect("heartbeat");
+        assert_eq!(
+            out.len(),
+            1,
+            "new row should remain buffered as a new window"
+        );
+        let val_col = out[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64 column");
+        assert_eq!(val_col.value(0), 99);
+    }
+
+    #[test]
+    fn flush_preserves_first_seen_group_order() {
+        let mut p = TailSamplingProcessor::try_new(
+            "SELECT * FROM logs",
+            "trace_id",
+            Duration::from_secs(60),
+        )
+        .expect("processor");
+
+        p.process(
+            batch(
+                vec![Some("b"), Some("a"), Some("b"), Some("c")],
+                vec![1, 2, 3, 4],
+            ),
+            &meta(10),
+        )
+        .expect("process");
+
+        let flushed = p.flush();
+        assert_eq!(flushed.len(), 3);
+        let first_ids: Vec<&str> = flushed
+            .iter()
+            .map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("trace id column")
+                    .value(0)
+            })
+            .collect();
+        assert_eq!(first_ids, vec!["b", "a", "c"]);
+    }
+
+    #[test]
+    fn configured_trace_limit_bounds_buffer_growth() {
+        let mut p = TailSamplingProcessor::try_new_with_limit(
+            "SELECT * FROM logs",
+            "trace_id",
+            Duration::from_secs(60),
+            1,
+        )
+        .expect("processor");
+
+        let out = p
+            .process(batch(vec![Some("a")], vec![1]), &meta(10))
+            .expect("first trace");
+        assert!(out.is_empty());
+
+        let err = p
+            .process(batch(vec![Some("b")], vec![2]), &meta(11))
+            .expect_err("second distinct trace should hit configured cap");
+        match err {
+            ProcessorError::Transient(msg) => {
+                assert!(msg.contains("buffered trace limit"));
+            }
+            other => panic!("expected transient limit error, got: {other:?}"),
+        }
     }
 }

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -340,8 +340,7 @@ fn group_value(col: &dyn Array, row: usize) -> Result<Option<String>, ProcessorE
             Ok(Some(arr.value(row).to_string()))
         }
         other => Err(ProcessorError::Permanent(format!(
-            "tail-sampling group-by column '{}' has unsupported type: {other:?}",
-            col.data_type()
+            "tail-sampling group-by column has unsupported type: {other:?}"
         ))),
     }
 }

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -2,7 +2,9 @@ use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::sync::Arc;
 use std::time::Duration;
 
-use arrow::array::{Array, LargeStringArray, StringArray, StringViewArray, UInt32Array};
+use arrow::array::{
+    Array, LargeStringArray, StringArray, StringViewArray, UInt32Array, new_null_array,
+};
 use arrow::compute::{concat_batches, take};
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
@@ -238,13 +240,50 @@ impl TailSamplingProcessor {
             let merged =
                 Schema::try_merge(state.batches.iter().map(|b| b.schema().as_ref().clone()))
                     .map_err(|e| {
-                        ProcessorError::Transient(format!(
+                        ProcessorError::Permanent(format!(
                             "failed to merge buffered trace schemas: {e}"
                         ))
                     })?;
             Arc::new(merged)
         };
-        let combined = concat_batches(&merged_schema, &state.batches).map_err(|e| {
+
+        let mut aligned_batches: Vec<RecordBatch> = Vec::with_capacity(state.batches.len());
+        for batch in &state.batches {
+            let mut aligned_cols = Vec::with_capacity(merged_schema.fields().len());
+            for field in merged_schema.fields() {
+                match batch.schema().index_of(field.name()) {
+                    Ok(col_idx) => {
+                        let col = batch.column(col_idx);
+                        if col.data_type() == field.data_type() {
+                            aligned_cols.push(Arc::clone(col));
+                        } else {
+                            let casted = arrow::compute::cast(col.as_ref(), field.data_type())
+                                .map_err(|e| {
+                                    ProcessorError::Permanent(format!(
+                                        "failed to align buffered trace column '{}' from {:?} to {:?}: {e}",
+                                        field.name(),
+                                        col.data_type(),
+                                        field.data_type()
+                                    ))
+                                })?;
+                            aligned_cols.push(casted);
+                        }
+                    }
+                    Err(_) => {
+                        aligned_cols.push(new_null_array(field.data_type(), batch.num_rows()));
+                    }
+                }
+            }
+            let aligned =
+                RecordBatch::try_new(Arc::clone(&merged_schema), aligned_cols).map_err(|e| {
+                    ProcessorError::Permanent(format!(
+                        "failed to align buffered trace batch to merged schema: {e}"
+                    ))
+                })?;
+            aligned_batches.push(aligned);
+        }
+
+        let combined = concat_batches(&merged_schema, &aligned_batches).map_err(|e| {
             ProcessorError::Transient(format!("failed to concat buffered trace batches: {e}"))
         })?;
         let out = self.decision.execute_blocking(combined).map_err(|e| {
@@ -280,6 +319,17 @@ impl TailSamplingProcessor {
             match self.run_decision_for_state(&state) {
                 Ok(batch) => decided.push((key, state, batch)),
                 Err(e) => {
+                    // Deterministic schema/type incompatibilities should not
+                    // retry forever. Drop only the failing group and continue.
+                    if let ProcessorError::Permanent(permanent) = e {
+                        tracing::warn!(
+                            group = %key,
+                            error = %permanent,
+                            "dropping tail-sampling group due to permanent decision error"
+                        );
+                        continue;
+                    }
+
                     // Keep timeout drain transactional: on transient decision
                     // failure, restore all previously removed groups so retry
                     // can reevaluate the exact same buffered state.
@@ -716,22 +766,24 @@ mod tests {
         )
         .expect("append drifted schema to b");
 
-        let err = p
+        let out = p
             .process(
                 RecordBatch::new_empty(Arc::new(Schema::empty())),
                 &meta(200),
             )
-            .expect_err("mixed-schema timed-out group should error transiently");
-        assert!(
-            matches!(err, ProcessorError::Transient(_)),
-            "expected transient error"
-        );
+            .expect("permanent per-group decision errors should not fail the full batch");
 
-        // No drained group should be lost when one timed-out decision fails.
-        assert_eq!(p.traces.len(), 2);
-        let a = p.traces.get("a").expect("group a still buffered");
-        let b = p.traces.get("b").expect("group b still buffered");
-        assert_eq!(a.batches.len(), 1);
-        assert_eq!(b.batches.len(), 2);
+        // Group "a" should still flush successfully.
+        assert_eq!(out.len(), 1);
+        let trace_col = out[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("trace_id utf8 column");
+        assert_eq!(trace_col.value(0), "a");
+
+        // Group "b" has irreconcilable schema drift and should be dropped, not
+        // retried forever.
+        assert!(p.traces.is_empty());
     }
 }

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -199,10 +199,18 @@ impl Processor for TailSamplingProcessor {
 
         let mut out = SmallVec::new();
         for (key, _) in keys {
-            if let Some(state) = self.traces.remove(&key)
-                && let Ok(Some(batch)) = self.run_decision_for_state(state)
-            {
-                out.push(batch);
+            if let Some(state) = self.traces.remove(&key) {
+                match self.run_decision_for_state(state) {
+                    Ok(Some(batch)) => out.push(batch),
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            group = %key,
+                            error = %e,
+                            "tail-sampling decision query failed during flush; buffered group dropped"
+                        );
+                    }
+                }
             }
         }
         out

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -1,0 +1,356 @@
+use std::collections::{HashMap, hash_map::Entry};
+use std::time::Duration;
+
+use arrow::array::{Array, LargeStringArray, StringArray, StringViewArray, UInt32Array};
+use arrow::compute::{concat_batches, take};
+use arrow::datatypes::DataType;
+use arrow::record_batch::RecordBatch;
+use logfwd_output::BatchMetadata;
+use logfwd_transform::SqlTransform;
+use smallvec::SmallVec;
+
+use super::{Processor, ProcessorError};
+
+#[derive(Debug)]
+struct TraceState {
+    batches: Vec<RecordBatch>,
+    last_seen_ns: u64,
+    first_seen_ord: u64,
+}
+
+/// Tail-sampling core processor:
+/// - buffer rows by trace/group id
+/// - flush timed out groups on heartbeat or data batches
+/// - run decision SQL over flushed data
+pub struct TailSamplingProcessor {
+    group_by_field: String,
+    timeout_ns: u64,
+    decision: SqlTransform,
+    traces: HashMap<String, TraceState>,
+    next_ord: u64,
+}
+
+impl std::fmt::Debug for TailSamplingProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TailSamplingProcessor")
+            .field("group_by_field", &self.group_by_field)
+            .field("timeout_ns", &self.timeout_ns)
+            .field("traces_len", &self.traces.len())
+            .finish()
+    }
+}
+
+impl TailSamplingProcessor {
+    pub fn try_new(
+        query: impl Into<String>,
+        group_by_field: impl Into<String>,
+        trace_timeout: Duration,
+    ) -> Result<Self, ProcessorError> {
+        let query = query.into();
+        let decision = SqlTransform::new(&query).map_err(|e| {
+            ProcessorError::Permanent(format!("invalid tail-sampling SQL query '{query}': {e}"))
+        })?;
+        let timeout_ns = u64::try_from(trace_timeout.as_nanos()).unwrap_or(u64::MAX);
+        Ok(Self {
+            group_by_field: group_by_field.into(),
+            timeout_ns,
+            decision,
+            traces: HashMap::new(),
+            next_ord: 0,
+        })
+    }
+
+    fn partition_by_group(
+        &self,
+        batch: RecordBatch,
+    ) -> Result<(Vec<(String, RecordBatch)>, Option<RecordBatch>), ProcessorError> {
+        let col_idx = batch.schema().index_of(&self.group_by_field).map_err(|_| {
+            ProcessorError::Permanent(format!(
+                "tail-sampling group-by column '{}' not found",
+                self.group_by_field
+            ))
+        })?;
+
+        let group_col = batch.column(col_idx).as_ref();
+        let mut grouped_rows: HashMap<String, Vec<u32>> = HashMap::new();
+        let mut null_rows = Vec::new();
+
+        for row in 0..batch.num_rows() {
+            match group_value(group_col, row)? {
+                Some(group) => grouped_rows.entry(group).or_default().push(row as u32),
+                None => null_rows.push(row as u32),
+            }
+        }
+
+        let mut grouped = Vec::with_capacity(grouped_rows.len());
+        for (group, rows) in grouped_rows {
+            grouped.push((group, take_rows(&batch, &rows)?));
+        }
+
+        let passthrough = if null_rows.is_empty() {
+            None
+        } else {
+            Some(take_rows(&batch, &null_rows)?)
+        };
+
+        Ok((grouped, passthrough))
+    }
+
+    fn append_group_batch(&mut self, group: String, batch: RecordBatch, now_ns: u64) {
+        match self.traces.entry(group) {
+            Entry::Occupied(mut occ) => {
+                let st = occ.get_mut();
+                st.last_seen_ns = now_ns;
+                st.batches.push(batch);
+            }
+            Entry::Vacant(vac) => {
+                let ord = self.next_ord;
+                self.next_ord = self.next_ord.saturating_add(1);
+                vac.insert(TraceState {
+                    batches: vec![batch],
+                    last_seen_ns: now_ns,
+                    first_seen_ord: ord,
+                });
+            }
+        }
+    }
+
+    fn drain_timed_out(&mut self, now_ns: u64) -> Vec<TraceState> {
+        let mut timed_out: Vec<(String, u64)> = self
+            .traces
+            .iter()
+            .filter_map(|(k, st)| {
+                if now_ns.saturating_sub(st.last_seen_ns) >= self.timeout_ns {
+                    Some((k.clone(), st.first_seen_ord))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        timed_out.sort_by_key(|(_, ord)| *ord);
+
+        let mut drained = Vec::with_capacity(timed_out.len());
+        for (k, _) in timed_out {
+            if let Some(state) = self.traces.remove(&k) {
+                drained.push(state);
+            }
+        }
+        drained
+    }
+
+    fn run_decision_for_state(
+        &mut self,
+        state: TraceState,
+    ) -> Result<Option<RecordBatch>, ProcessorError> {
+        if state.batches.is_empty() {
+            return Ok(None);
+        }
+        let schema = state.batches[0].schema();
+        let combined = concat_batches(&schema, &state.batches).map_err(|e| {
+            ProcessorError::Transient(format!("failed to concat buffered trace batches: {e}"))
+        })?;
+        let out = self.decision.execute_blocking(combined).map_err(|e| {
+            ProcessorError::Transient(format!("tail-sampling decision query failed: {e}"))
+        })?;
+        if out.num_rows() == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(out))
+        }
+    }
+}
+
+impl Processor for TailSamplingProcessor {
+    fn process(
+        &mut self,
+        batch: RecordBatch,
+        meta: &BatchMetadata,
+    ) -> Result<SmallVec<[RecordBatch; 1]>, ProcessorError> {
+        let mut out = SmallVec::new();
+        let now_ns = meta.observed_time_ns;
+
+        if batch.num_rows() > 0 {
+            let (grouped, passthrough) = self.partition_by_group(batch)?;
+            for (group, sub_batch) in grouped {
+                self.append_group_batch(group, sub_batch, now_ns);
+            }
+            if let Some(pass) = passthrough {
+                out.push(pass);
+            }
+        }
+
+        for state in self.drain_timed_out(now_ns) {
+            if let Some(decided) = self.run_decision_for_state(state)? {
+                out.push(decided);
+            }
+        }
+
+        Ok(out)
+    }
+
+    fn flush(&mut self) -> SmallVec<[RecordBatch; 1]> {
+        let mut keys: Vec<(String, u64)> = self
+            .traces
+            .iter()
+            .map(|(k, v)| (k.clone(), v.first_seen_ord))
+            .collect();
+        keys.sort_by_key(|(_, ord)| *ord);
+
+        let mut out = SmallVec::new();
+        for (key, _) in keys {
+            if let Some(state) = self.traces.remove(&key)
+                && let Ok(Some(batch)) = self.run_decision_for_state(state)
+            {
+                out.push(batch);
+            }
+        }
+        out
+    }
+
+    fn name(&self) -> &'static str {
+        "tail_sampling"
+    }
+
+    fn is_stateful(&self) -> bool {
+        true
+    }
+}
+
+fn take_rows(batch: &RecordBatch, rows: &[u32]) -> Result<RecordBatch, ProcessorError> {
+    let indices = UInt32Array::from(rows.to_vec());
+    let mut cols = Vec::with_capacity(batch.num_columns());
+    for col in batch.columns() {
+        let taken = take(col.as_ref(), &indices, None).map_err(|e| {
+            ProcessorError::Transient(format!("failed to partition batch rows: {e}"))
+        })?;
+        cols.push(taken);
+    }
+    RecordBatch::try_new(batch.schema(), cols)
+        .map_err(|e| ProcessorError::Transient(format!("failed to build partitioned batch: {e}")))
+}
+
+fn group_value(col: &dyn Array, row: usize) -> Result<Option<String>, ProcessorError> {
+    if col.is_null(row) {
+        return Ok(None);
+    }
+
+    match col.data_type() {
+        DataType::Utf8 => {
+            let arr = col.as_any().downcast_ref::<StringArray>().ok_or_else(|| {
+                ProcessorError::Permanent("failed to read Utf8 group_by column".into())
+            })?;
+            Ok(Some(arr.value(row).to_string()))
+        }
+        DataType::Utf8View => {
+            let arr = col
+                .as_any()
+                .downcast_ref::<StringViewArray>()
+                .ok_or_else(|| {
+                    ProcessorError::Permanent("failed to read Utf8View group_by column".into())
+                })?;
+            Ok(Some(arr.value(row).to_string()))
+        }
+        DataType::LargeUtf8 => {
+            let arr = col
+                .as_any()
+                .downcast_ref::<LargeStringArray>()
+                .ok_or_else(|| {
+                    ProcessorError::Permanent("failed to read LargeUtf8 group_by column".into())
+                })?;
+            Ok(Some(arr.value(row).to_string()))
+        }
+        other => Err(ProcessorError::Permanent(format!(
+            "tail-sampling group-by column '{}' has unsupported type: {other:?}",
+            col.data_type()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{Field, Schema};
+    use std::sync::Arc;
+
+    fn batch(trace_id: Vec<Option<&str>>, val: Vec<i64>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("trace_id", DataType::Utf8, true),
+            Field::new("val", DataType::Int64, false),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(trace_id)),
+                Arc::new(Int64Array::from(val)),
+            ],
+        )
+        .expect("test batch")
+    }
+
+    fn meta(ns: u64) -> BatchMetadata {
+        BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: ns,
+        }
+    }
+
+    #[test]
+    fn timeout_emits_decided_trace() {
+        let mut p = TailSamplingProcessor::try_new(
+            "SELECT * FROM logs WHERE val >= 10",
+            "trace_id",
+            Duration::from_nanos(10),
+        )
+        .expect("processor");
+
+        let out = p
+            .process(batch(vec![Some("t1"), Some("t1")], vec![1, 20]), &meta(100))
+            .expect("process");
+        assert!(out.is_empty());
+
+        let out = p
+            .process(
+                RecordBatch::new_empty(Arc::new(Schema::empty())),
+                &meta(111),
+            )
+            .expect("heartbeat");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].num_rows(), 1);
+    }
+
+    #[test]
+    fn null_group_values_passthrough_immediately() {
+        let mut p = TailSamplingProcessor::try_new(
+            "SELECT * FROM logs",
+            "trace_id",
+            Duration::from_secs(30),
+        )
+        .expect("processor");
+
+        let out = p
+            .process(batch(vec![None, Some("t1")], vec![5, 6]), &meta(10))
+            .expect("process");
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].num_rows(), 1);
+    }
+
+    #[test]
+    fn flush_emits_buffered_data() {
+        let mut p = TailSamplingProcessor::try_new(
+            "SELECT * FROM logs WHERE val > 0",
+            "trace_id",
+            Duration::from_secs(60),
+        )
+        .expect("processor");
+
+        p.process(batch(vec![Some("a"), Some("b")], vec![1, 2]), &meta(10))
+            .expect("process");
+
+        let flushed = p.flush();
+        assert_eq!(flushed.len(), 2);
+        assert_eq!(flushed[0].num_rows() + flushed[1].num_rows(), 2);
+    }
+}

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, hash_map::Entry};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -170,6 +170,9 @@ impl TailSamplingProcessor {
 
         let mut grouped = Vec::with_capacity(grouped_ordered.len());
         for (_, group, rows) in grouped_ordered {
+            // Intentionally materialize per-group sub-batches at partition time.
+            // This keeps timeout drains/flushes simple and avoids holding
+            // row-index indirection across mutable trace windows.
             grouped.push((group, take_rows(&batch, rows)?));
         }
 
@@ -267,20 +270,34 @@ impl TailSamplingProcessor {
         keys: Vec<(String, u64)>,
         out: &mut SmallVec<[RecordBatch; 1]>,
     ) -> Result<(), ProcessorError> {
+        let mut decided: Vec<(String, TraceState, Option<RecordBatch>)> = Vec::new();
+
         for (key, _) in keys {
             let Some(state) = self.traces.remove(&key) else {
                 continue;
             };
 
             match self.run_decision_for_state(&state) {
-                Ok(Some(decided)) => out.push(decided),
-                Ok(None) => {}
+                Ok(batch) => decided.push((key, state, batch)),
                 Err(e) => {
+                    // Keep timeout drain transactional: on transient decision
+                    // failure, restore all previously removed groups so retry
+                    // can reevaluate the exact same buffered state.
                     self.traces.insert(key, state);
+                    for (restore_key, restore_state, _) in decided {
+                        self.traces.insert(restore_key, restore_state);
+                    }
                     return Err(e);
                 }
             }
         }
+
+        for (_, _, maybe_batch) in decided {
+            if let Some(batch) = maybe_batch {
+                out.push(batch);
+            }
+        }
+
         Ok(())
     }
 }
@@ -455,6 +472,21 @@ mod tests {
             vec![
                 Arc::new(StringArray::from(trace_id)),
                 Arc::new(Int64Array::from(val)),
+            ],
+        )
+        .expect("test batch")
+    }
+
+    fn batch_with_utf8_val(trace_id: Vec<Option<&str>>, val: Vec<Option<&str>>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("trace_id", DataType::Utf8, true),
+            Field::new("val", DataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(trace_id)),
+                Arc::new(StringArray::from(val)),
             ],
         )
         .expect("test batch")
@@ -665,5 +697,41 @@ mod tests {
             .downcast_ref::<Int64Array>()
             .expect("int64 column");
         assert_eq!(val_col.value(0), 1);
+    }
+
+    #[test]
+    fn timed_out_drain_is_transactional_on_decision_error() {
+        let mut p = TailSamplingProcessor::try_new(
+            "SELECT * FROM logs",
+            "trace_id",
+            Duration::from_nanos(10),
+        )
+        .expect("processor");
+
+        p.process(batch(vec![Some("a"), Some("b")], vec![1, 2]), &meta(100))
+            .expect("seed groups");
+        p.process(
+            batch_with_utf8_val(vec![Some("b")], vec![Some("schema-drift")]),
+            &meta(101),
+        )
+        .expect("append drifted schema to b");
+
+        let err = p
+            .process(
+                RecordBatch::new_empty(Arc::new(Schema::empty())),
+                &meta(200),
+            )
+            .expect_err("mixed-schema timed-out group should error transiently");
+        assert!(
+            matches!(err, ProcessorError::Transient(_)),
+            "expected transient error"
+        );
+
+        // No drained group should be lost when one timed-out decision fails.
+        assert_eq!(p.traces.len(), 2);
+        let a = p.traces.get("a").expect("group a still buffered");
+        let b = p.traces.get("b").expect("group b still buffered");
+        assert_eq!(a.batches.len(), 1);
+        assert_eq!(b.batches.len(), 2);
     }
 }

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map::Entry};
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/crates/logfwd/src/processor/tail_sampling.rs
+++ b/crates/logfwd/src/processor/tail_sampling.rs
@@ -11,6 +11,10 @@ use smallvec::SmallVec;
 
 use super::{Processor, ProcessorError};
 
+/// Grouped partition result: a list of (group_key, sub-batch) pairs plus an
+/// optional passthrough batch for rows with a null group value.
+type PartitionResult = (Vec<(String, RecordBatch)>, Option<RecordBatch>);
+
 #[derive(Debug)]
 struct TraceState {
     batches: Vec<RecordBatch>,
@@ -36,7 +40,7 @@ impl std::fmt::Debug for TailSamplingProcessor {
             .field("group_by_field", &self.group_by_field)
             .field("timeout_ns", &self.timeout_ns)
             .field("traces_len", &self.traces.len())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -60,10 +64,7 @@ impl TailSamplingProcessor {
         })
     }
 
-    fn partition_by_group(
-        &self,
-        batch: RecordBatch,
-    ) -> Result<(Vec<(String, RecordBatch)>, Option<RecordBatch>), ProcessorError> {
+    fn partition_by_group(&self, batch: RecordBatch) -> Result<PartitionResult, ProcessorError> {
         let col_idx = batch.schema().index_of(&self.group_by_field).map_err(|_| {
             ProcessorError::Permanent(format!(
                 "tail-sampling group-by column '{}' not found",


### PR DESCRIPTION
## What This Changes
- Introduces tail-sampling core processor behavior in the processing module.
- Wires the new tail-sampling processor entry point into processor registration.
- Keeps implementation focused on core behavior for iterative follow-on work.

## Why
Issue #1555 establishes the tail-sampling v1 core behavior foundation.

## Testing
- Not re-run in this integration pass.
- Please run: `just ci`.

## Context
- Implementation transcript: https://chatgpt.com/codex/tasks/task_e_69d5780983f4832ebcb9b82ed3c0bff5


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tail sampling processor that buffers and filters log records by group key
> - Introduces `TailSamplingProcessor` in [`crates/logfwd/src/processor/tail_sampling.rs`](https://github.com/strawgate/memagent/pull/1572/files#diff-8953e2a78929136ea778b1a1979edb4c6c9dd9a282e32d9c8ca4e0667ee5488b), a stateful processor that buffers incoming `RecordBatch` rows by a configurable string group-by column and flushes groups after a configurable inactivity timeout.
> - On flush (timeout or explicit `flush()`), concatenates all buffered batches for a group and runs a DataFusion SQL query against them (table name `logs`), emitting only the query result rows.
> - Rows with a null group-by value bypass buffering and pass through immediately; zero-timeout groups are flushed immediately after buffering.
> - Transient decision errors during drain preserve buffered state for retry; permanent errors (e.g. unsupported column type, invalid SQL) drop only the offending group with a warning.
> - Risk: when the buffered group count would exceed `max_buffered_traces`, `process` returns a transient error without emitting or mutating any state, which callers must handle for backpressure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d86a27c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->