### PR TITLE
cleanup: align workflow branch refs and output coverage

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -519,7 +519,7 @@ jobs:
           BODY="$(cat <<HEREDOC
           ## Benchmark Results --- ${DATE}
 
-          **Commit:** \`${COMMIT}\` on \`master\`
+          **Commit:** \`${COMMIT}\` on \`main\`
           **Runner:** \`ubuntu-latest\` (matrix: agent x scenario)
           **Iterations:** ${{ env.ITERATIONS }} per cell
           **Dashboard:** https://strawgate.github.io/memagent/bench/

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -81,7 +81,7 @@ jobs:
           {
             echo "## Compliance Results — ${DATE}"
             echo ""
-            echo "**Commit:** \`${COMMIT}\` on \`master\`"
+            echo "**Commit:** \`${COMMIT}\` on \`main\`"
             echo "**Runner:** \`ubuntu-latest\`"
             echo "**Overall:** ${OVERALL}"
             echo ""

--- a/.github/workflows/publish-e2e-image.yml
+++ b/.github/workflows/publish-e2e-image.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=master,enable={{is_default_branch}}
+            type=raw,value=main,enable={{is_default_branch}}
             type=raw,value=sha-${{ github.sha }}
 
       - name: Build and push e2e image

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -1813,7 +1813,10 @@ output:
             ("null", ""),
             ("elasticsearch", "endpoint: http://x"),
             ("loki", "endpoint: http://x"),
+            ("arrow_ipc", "endpoint: http://x"),
             ("file", "path: /tmp/x.ndjson"),
+            ("tcp", "endpoint: 127.0.0.1:5140"),
+            ("udp", "endpoint: 127.0.0.1:5140"),
         ] {
             let yaml = format!(
                 "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: {otype}\n  {extra}\n"


### PR DESCRIPTION
## Summary
- update active workflow/reporting surfaces to refer to  instead of 
- tag the default e2e image as  on the default branch
- expand  coverage to include accepted , , and  outputs

## Verification
- cargo test -p logfwd-config --lib all_output_types
- cargo test -p logfwd-config --lib legacy_output_aliases_are_rejected
- cargo test -p logfwd-config --lib http_output_rejected_at_validation_boundary
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align workflow branch refs from `master` to `main` and extend output type coverage test
> - Updates branch labels in [bench.yml](.github/workflows/bench.yml) and [compliance.yml](.github/workflows/compliance.yml) issue bodies from `master` to `main`.
> - Changes the Docker image tag for the default branch in [publish-e2e-image.yml](.github/workflows/publish-e2e-image.yml) from `master` to `main`.
> - Extends the `all_output_types` test in [lib.rs](crates/logfwd-config/src/lib.rs) to cover `arrow_ipc`, `tcp`, and `udp` output types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a68722f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->