### PR TITLE
fix(output): serialize DataType::Struct as JSON object (fixes #1592)

### DIFF
--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -433,7 +433,7 @@ fn write_json_value(arr: &dyn Array, row: usize, out: &mut Vec<u8>) -> io::Resul
                 out.extend_from_slice(if v { b"true" } else { b"false" });
             }
         }
-        DataType::Struct(_) => {
+        DataType::Struct(schema_fields) => {
             if arr.is_null(row) {
                 out.extend_from_slice(b"null");
             } else {
@@ -442,10 +442,6 @@ fn write_json_value(arr: &dyn Array, row: usize, out: &mut Vec<u8>) -> io::Resul
                     .downcast_ref::<StructArray>()
                     .expect("DataType::Struct must downcast to StructArray");
                 out.push(b'{');
-                let schema_fields = match arr.data_type() {
-                    DataType::Struct(fields) => fields,
-                    _ => unreachable!(),
-                };
                 let num_fields = struct_arr.num_columns();
                 let mut first = true;
                 for field_idx in 0..num_fields {
@@ -1862,9 +1858,9 @@ mod write_row_json_tests {
     // Regression tests for issue #1592: grok()/geo_lookup() struct columns
     // -----------------------------------------------------------------------
 
-    /// Build a top-level grok-like struct column with three nullable Utf8
-    /// child fields (method, path, id).  Row `null_row` has the entire struct
-    /// set to null; `null_field_row` has the struct non-null but `id` null.
+    /// Build a single-row batch with a top-level grok-like struct column
+    /// containing three nullable Utf8 child fields (`method`, `path`, `id`).
+    /// When `struct_is_null` is true the entire struct cell is null.
     fn make_grok_struct_batch(
         method: Option<&str>,
         path: Option<&str>,
@@ -1956,8 +1952,8 @@ mod write_row_json_tests {
         assert_eq!(v["grok"]["method"], "POST");
         assert_eq!(v["grok"]["path"], "/upload");
         assert!(
-            v["grok"]["id"].is_null(),
-            "null child field should serialize as null, got: {}",
+            v["grok"].as_object().unwrap().contains_key("id") && v["grok"]["id"].is_null(),
+            "null child field must be present and serialize as null, got: {}",
             v["grok"]["id"]
         );
     }


### PR DESCRIPTION
## Summary

- Adds a `DataType::Struct(_)` match arm to `write_json_value` in `crates/logfwd-output/src/lib.rs` that recursively serializes struct columns as JSON objects
- Fixes the bug where `grok()` and `geo_lookup()` UDF results used directly in a SQL SELECT (not via `get_field()`) were serialized as `""` (empty string) because the wildcard arm called `str_value()` which returns `""` for non-Utf8 types
- Null struct columns now correctly emit JSON `null`; null child fields within a non-null struct also emit `null`

## Test plan

- [x] `grok_struct_serializes_as_json_object` — verifies a grok-like `Struct { method: Utf8, path: Utf8, id: Utf8 }` column serializes as a proper JSON object with correct field values
- [x] `grok_null_struct_serializes_as_null` — verifies a null-flagged struct column emits JSON `null`
- [x] `grok_struct_null_child_field_serializes_as_null` — verifies that individually-null child fields within a non-null struct emit `null`
- [x] `cargo test -p logfwd-output` — all 172 tests pass
- [x] `cargo fmt --all` — no formatting changes
- [x] `cargo clippy -p logfwd-output -- -D warnings` — no warnings

Fixes #1592

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `write_json_value` to serialize `DataType::Struct` as a JSON object instead of a quoted string
> - Adds an explicit match arm for `DataType::Struct` in [`write_json_value`](https://github.com/strawgate/memagent/pull/1595/files#diff-00ddb9f7cbde401078d0410c694ec7302918c0a95336aabc22305c3084e799c9) that downcasts to `StructArray`, opens a JSON object, and recursively serializes each child field by name.
> - Null struct cells serialize as JSON `null`; null child fields serialize as `null` while still appearing as keys in the object.
> - Previously, struct-typed columns fell through to the default branch and were serialized as a quoted string via `write_json_string(str_value(...))`.
> - Adds regression tests covering a non-null struct, a null struct cell, and a struct with null children.
>
> #### 🖇️ Linked Issues
> Fixes issue #1592, which reported that `DataType::Struct` columns were incorrectly output as quoted strings rather than JSON objects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a05ced2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->