### PR TITLE
Follow-up: unify receiver HTTP body helpers and harden health transitions

### DIFF
--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -22,17 +22,17 @@ use arrow::ipc::reader::StreamReader;
 use arrow::record_batch::RecordBatch;
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::{CONTENT_ENCODING, CONTENT_TYPE};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
-use http_body_util::BodyExt as _;
 use logfwd_types::diagnostics::ComponentHealth;
 use tokio::sync::oneshot;
 
 use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
+use crate::receiver_http::{declared_content_length, read_limited_body};
 
 /// Maximum request body size: 10 MB.
 const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
@@ -238,11 +238,15 @@ fn decode_ipc_stream(body: &[u8]) -> Result<Vec<RecordBatch>, InputError> {
 }
 
 fn store_health_event(health: &AtomicU8, event: ReceiverHealthEvent) {
-    let current = ComponentHealth::from_repr(health.load(Ordering::Relaxed));
-    health.store(
-        reduce_receiver_health(current, event).as_repr(),
-        Ordering::Relaxed,
-    );
+    let mut current = health.load(Ordering::Relaxed);
+    loop {
+        let current_health = ComponentHealth::from_repr(current);
+        let next = reduce_receiver_health(current_health, event).as_repr();
+        match health.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(observed) => current = observed,
+        }
+    }
 }
 
 async fn handle_arrow_ipc_request(
@@ -250,7 +254,8 @@ async fn handle_arrow_ipc_request(
     headers: HeaderMap,
     body: Body,
 ) -> Response {
-    if declared_content_length(&headers).is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
+    let content_length = declared_content_length(&headers);
+    if content_length.is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
 
@@ -263,7 +268,7 @@ async fn handle_arrow_ipc_request(
         Err(status) => return (status, "invalid content-type header").into_response(),
     };
 
-    let body = match read_limited_body(body).await {
+    let body = match read_limited_body(body, MAX_BODY_SIZE, content_length).await {
         Ok(body) => body,
         Err(status) => {
             let message = if status == StatusCode::PAYLOAD_TOO_LARGE {
@@ -356,13 +361,6 @@ async fn handle_arrow_ipc_request(
     }
 }
 
-fn declared_content_length(headers: &HeaderMap) -> Option<u64> {
-    headers
-        .get(CONTENT_LENGTH)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
-}
-
 fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
     let Some(value) = headers.get(CONTENT_ENCODING) else {
         return Ok(None);
@@ -377,22 +375,6 @@ fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, StatusCode>
     };
     let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
     Ok(Some(parsed.to_ascii_lowercase()))
-}
-
-async fn read_limited_body(body: Body) -> Result<Vec<u8>, StatusCode> {
-    let mut body = body;
-    let mut out = Vec::new();
-    while let Some(frame) = body.frame().await {
-        let frame = frame.map_err(|_| StatusCode::BAD_REQUEST)?;
-        let Ok(chunk) = frame.into_data() else {
-            continue;
-        };
-        if out.len().saturating_add(chunk.len()) > MAX_BODY_SIZE {
-            return Err(StatusCode::PAYLOAD_TOO_LARGE);
-        }
-        out.extend_from_slice(&chunk);
-    }
-    Ok(out)
 }
 
 impl Drop for ArrowIpcReceiver {

--- a/crates/logfwd-io/src/http_input.rs
+++ b/crates/logfwd-io/src/http_input.rs
@@ -11,17 +11,17 @@ use std::sync::{Arc, mpsc};
 
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::header::{ALLOW, CONTENT_ENCODING, CONTENT_LENGTH};
+use axum::http::header::{ALLOW, CONTENT_ENCODING};
 use axum::http::{HeaderMap, Method, Request, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::any;
 use flate2::read::GzDecoder;
-use http_body_util::BodyExt as _;
 use logfwd_types::diagnostics::ComponentHealth;
 use tokio::sync::oneshot;
 
 use crate::InputError;
 use crate::input::{InputEvent, InputSource};
+use crate::receiver_http::{declared_content_length, read_limited_body};
 
 /// Default max request body size (10 MiB).
 const DEFAULT_MAX_REQUEST_BODY_SIZE: usize = 10 * 1024 * 1024;
@@ -324,9 +324,8 @@ async fn handle_request(
             .into_response();
     }
 
-    if declared_content_length(request.headers())
-        .is_some_and(|body_len| body_len > state.max_request_body_size as u64)
-    {
+    let content_length = declared_content_length(request.headers());
+    if content_length.is_some_and(|body_len| body_len > state.max_request_body_size as u64) {
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
 
@@ -335,7 +334,13 @@ async fn handle_request(
         Err(status) => return (status, "invalid content-encoding header").into_response(),
     };
 
-    let mut body = match read_limited_body(request.into_body(), state.max_request_body_size).await {
+    let mut body = match read_limited_body(
+        request.into_body(),
+        state.max_request_body_size,
+        content_length,
+    )
+    .await
+    {
         Ok(body) => body,
         Err(status) => {
             let message = if status == StatusCode::PAYLOAD_TOO_LARGE {
@@ -403,38 +408,12 @@ async fn handle_request(
     }
 }
 
-fn declared_content_length(headers: &HeaderMap) -> Option<u64> {
-    headers
-        .get(CONTENT_LENGTH)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
-}
-
 fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
     let Some(value) = headers.get(CONTENT_ENCODING) else {
         return Ok(None);
     };
     let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
     Ok(Some(parsed.to_ascii_lowercase()))
-}
-
-async fn read_limited_body(
-    body: Body,
-    max_request_body_size: usize,
-) -> Result<Vec<u8>, StatusCode> {
-    let mut body = body;
-    let mut out = Vec::new();
-    while let Some(frame) = body.frame().await {
-        let frame = frame.map_err(|_| StatusCode::BAD_REQUEST)?;
-        let Ok(chunk) = frame.into_data() else {
-            continue;
-        };
-        if out.len().saturating_add(chunk.len()) > max_request_body_size {
-            return Err(StatusCode::PAYLOAD_TOO_LARGE);
-        }
-        out.extend_from_slice(&chunk);
-    }
-    Ok(out)
 }
 
 fn normalize_options(mut options: HttpInputOptions) -> io::Result<HttpInputOptions> {

--- a/crates/logfwd-io/src/lib.rs
+++ b/crates/logfwd-io/src/lib.rs
@@ -19,6 +19,7 @@ pub mod otap_receiver;
 pub mod otlp_receiver;
 pub(crate) mod polling_input_health;
 pub(crate) mod receiver_health;
+pub(crate) mod receiver_http;
 /// Checkpoint segment file format, writer, reader, and recovery.
 pub mod segment;
 pub mod span_exporter;

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -19,11 +19,10 @@ use arrow::ipc::reader::StreamReader;
 use arrow::record_batch::RecordBatch;
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
-use http_body_util::BodyExt as _;
 use logfwd_arrow::star_schema::{StarSchema, attrs_schema, star_to_flat};
 use logfwd_otap_proto::otap::{
     ArrowPayloadType as ProtoArrowPayloadType, BatchArrowRecords as ProtoBatchArrowRecords,
@@ -36,6 +35,7 @@ use tokio::sync::oneshot;
 use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
+use crate::receiver_http::{declared_content_length, read_limited_body};
 
 /// Maximum request body size: 10 MB.
 const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
@@ -226,11 +226,15 @@ impl OtapReceiver {
 }
 
 fn store_health_event(health: &AtomicU8, event: ReceiverHealthEvent) {
-    let current = ComponentHealth::from_repr(health.load(Ordering::Relaxed));
-    health.store(
-        reduce_receiver_health(current, event).as_repr(),
-        Ordering::Relaxed,
-    );
+    let mut current = health.load(Ordering::Relaxed);
+    loop {
+        let current_health = ComponentHealth::from_repr(current);
+        let next = reduce_receiver_health(current_health, event).as_repr();
+        match health.compare_exchange_weak(current, next, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(observed) => current = observed,
+        }
+    }
 }
 
 async fn handle_otap_request(
@@ -238,11 +242,12 @@ async fn handle_otap_request(
     headers: HeaderMap,
     body: Body,
 ) -> Response {
-    if declared_content_length(&headers).is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
+    let content_length = declared_content_length(&headers);
+    if content_length.is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
 
-    let body = match read_limited_body(body).await {
+    let body = match read_limited_body(body, MAX_BODY_SIZE, content_length).await {
         Ok(body) => body,
         Err(status) => {
             let message = if status == StatusCode::PAYLOAD_TOO_LARGE {
@@ -312,29 +317,6 @@ async fn handle_otap_request(
                 .into_response()
         }
     }
-}
-
-fn declared_content_length(headers: &HeaderMap) -> Option<u64> {
-    headers
-        .get(CONTENT_LENGTH)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
-}
-
-async fn read_limited_body(body: Body) -> Result<Vec<u8>, StatusCode> {
-    let mut body = body;
-    let mut out = Vec::new();
-    while let Some(frame) = body.frame().await {
-        let frame = frame.map_err(|_| StatusCode::BAD_REQUEST)?;
-        let Ok(chunk) = frame.into_data() else {
-            continue;
-        };
-        if out.len().saturating_add(chunk.len()) > MAX_BODY_SIZE {
-            return Err(StatusCode::PAYLOAD_TOO_LARGE);
-        }
-        out.extend_from_slice(&chunk);
-    }
-    Ok(out)
 }
 
 /// Decoded `BatchArrowRecords` message.

--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -15,14 +15,13 @@ use std::sync::{Arc, mpsc};
 use arrow::record_batch::RecordBatch;
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::{CONTENT_ENCODING, CONTENT_TYPE};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use base64::Engine as _;
 use bytes::Bytes;
 use flate2::read::GzDecoder;
-use http_body_util::BodyExt as _;
 use logfwd_arrow::{Scanner, StreamingBuilder};
 use logfwd_core::scan_config::ScanConfig;
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
@@ -35,6 +34,7 @@ use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::diagnostics::ComponentStats;
 use crate::input::{InputEvent, InputSource};
+use crate::receiver_http::{declared_content_length, read_limited_body};
 use logfwd_types::diagnostics::ComponentHealth;
 use logfwd_types::field_names;
 
@@ -273,7 +273,8 @@ async fn handle_otlp_request(
     headers: HeaderMap,
     body: Body,
 ) -> Response {
-    if declared_content_length(&headers).is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
+    let content_length = declared_content_length(&headers);
+    if content_length.is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
         record_error(state.stats.as_ref());
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
@@ -286,7 +287,7 @@ async fn handle_otlp_request(
         }
     };
 
-    let mut body = match read_limited_body(body).await {
+    let mut body = match read_limited_body(body, MAX_BODY_SIZE, content_length).await {
         Ok(body) => body,
         Err(status) => {
             record_error(state.stats.as_ref());
@@ -402,35 +403,12 @@ async fn handle_otlp_request(
     }
 }
 
-fn declared_content_length(headers: &HeaderMap) -> Option<u64> {
-    headers
-        .get(CONTENT_LENGTH)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse::<u64>().ok())
-}
-
 fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
     let Some(value) = headers.get(CONTENT_ENCODING) else {
         return Ok(None);
     };
     let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
     Ok(Some(parsed.to_ascii_lowercase()))
-}
-
-async fn read_limited_body(body: Body) -> Result<Vec<u8>, StatusCode> {
-    let mut body = body;
-    let mut out = Vec::new();
-    while let Some(frame) = body.frame().await {
-        let frame = frame.map_err(|_| StatusCode::BAD_REQUEST)?;
-        let Ok(chunk) = frame.into_data() else {
-            continue;
-        };
-        if out.len().saturating_add(chunk.len()) > MAX_BODY_SIZE {
-            return Err(StatusCode::PAYLOAD_TOO_LARGE);
-        }
-        out.extend_from_slice(&chunk);
-    }
-    Ok(out)
 }
 
 impl Drop for OtlpReceiverInput {

--- a/crates/logfwd-io/src/receiver_http.rs
+++ b/crates/logfwd-io/src/receiver_http.rs
@@ -1,0 +1,39 @@
+use axum::body::Body;
+use axum::http::{HeaderMap, StatusCode, header::CONTENT_LENGTH};
+use http_body_util::BodyExt as _;
+
+pub(crate) fn declared_content_length(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get(CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+}
+
+pub(crate) async fn read_limited_body(
+    body: Body,
+    max_body_size: usize,
+    content_length_hint: Option<u64>,
+) -> Result<Vec<u8>, StatusCode> {
+    if content_length_hint.is_some_and(|hint| hint > max_body_size as u64) {
+        return Err(StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    let mut body = body;
+    let mut out = Vec::with_capacity(
+        content_length_hint
+            .map(|hint| hint.min(max_body_size as u64) as usize)
+            .unwrap_or_default(),
+    );
+
+    while let Some(frame) = body.frame().await {
+        let frame = frame.map_err(|_| StatusCode::BAD_REQUEST)?;
+        let Ok(chunk) = frame.into_data() else {
+            continue;
+        };
+        if out.len().saturating_add(chunk.len()) > max_body_size {
+            return Err(StatusCode::PAYLOAD_TOO_LARGE);
+        }
+        out.extend_from_slice(&chunk);
+    }
+    Ok(out)
+}


### PR DESCRIPTION
## Summary
- add shared HTTP receiver helpers in `receiver_http` for `Content-Length` parsing and bounded body reads
- route OTLP, OTAP, Arrow IPC, and generic HTTP input through the shared helper to remove duplicated logic
- preallocate body buffers using `Content-Length` hints (while still enforcing max body size)
- harden OTAP/Arrow receiver health transitions with atomic CAS loops to avoid load/store races under concurrent request handling

## Context
This is a follow-up to the axum receiver migration work to address review feedback and tighten concurrency behavior.

## Validation
- `just lint`
- `cargo test -p logfwd-io otlp_receiver::tests:: -- --nocapture`
- `cargo test -p logfwd-io otap_receiver::tests:: -- --nocapture`
- `cargo test -p logfwd-io arrow_ipc_receiver::tests:: -- --nocapture`
- `cargo test -p logfwd-io http_input::tests:: -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify HTTP body helpers and fix concurrent health state transitions in receivers
> - Extracts shared `declared_content_length` and `read_limited_body` helpers into a new [`receiver_http`](https://github.com/strawgate/memagent/pull/1606/files#diff-9d9775cf63feef7bb2824a772942a5ae2b1423c21bf3d08b50070ba44c2ba2ac) module, replacing duplicated local implementations in the Arrow IPC, OTAP, OTLP, and HTTP input receivers.
> - `read_limited_body` accepts an optional content-length hint and returns 413 immediately (before reading any body data) when the declared `Content-Length` exceeds the configured limit.
> - Fixes a race condition in `store_health_event` across the Arrow IPC and OTAP receivers by replacing a non-atomic load/store sequence with a `compare_exchange_weak` CAS loop, preventing lost updates under concurrent modifications.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd86b64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->