### PR TITLE
fix(e2e): export KUBE_CONTEXT for bash -c subshell

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -104,6 +104,7 @@ k delete pod -n "$NAMESPACE" log-generator --ignore-not-found 2>/dev/null
 k apply -n "$NAMESPACE" -f "$SCRIPT_DIR/manifests/log-generator.yaml"
 
 # Wait for the generator pod to be Running instead of hardcoded sleep.
+export KUBE_CONTEXT
 export -f k
 if ! wait_for "log-generator pod running" 30 \
     bash -c "phase=\$(k get pod -n \"$NAMESPACE\" log-generator -o jsonpath='{.status.phase}' 2>/dev/null); [ \"\$phase\" = \"Running\" ]"; then


### PR DESCRIPTION
## Summary

- Export `KUBE_CONTEXT` before `export -f k` so the variable is available when `bash -c` runs the `k` function inside `wait_for`
- Without this, the child shell inherits the `k` function but `$KUBE_CONTEXT` is empty, so kubectl runs without `--context`

Fixes #1609

## Test plan

- [ ] Run `tests/e2e/run.sh` on a KIND cluster and confirm the `wait_for "log-generator pod running"` step passes
- [ ] Verify `bash -c 'echo $KUBE_CONTEXT'` after the export line prints the expected value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `KUBE_CONTEXT` so `bash -c` subshells in e2e tests inherit it
> In [run.sh](https://github.com/strawgate/memagent/pull/1611/files#diff-c828e2e3a8ec47cc5a2cb23e04d6e2116b4a24218d0963daabd51970de043672), `KUBE_CONTEXT` was set but not exported, so the `bash -c` command used inside `wait_for` checks ran without it. Adding `export` makes the variable available to all child processes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7bd9eb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->