### PR TITLE
fix(io): omit trailing comma for empty JSON objects in source path injection

### DIFF
--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -454,11 +454,20 @@ fn inject_source_path_metadata(chunk: &[u8], source_path: &std::path::Path, out:
             .iter()
             .position(|&b| !matches!(b, b' ' | b'\t' | b'\r'));
         if let Some(obj_start) = first_nonws.filter(|&idx| line[idx] == b'{') {
+            let rest = &line[obj_start + 1..];
+            let rest_is_empty_obj = rest
+                .iter()
+                .position(|&b| !matches!(b, b' ' | b'\t' | b'\r'))
+                .is_some_and(|i| rest[i] == b'}');
             out.extend_from_slice(&line[..obj_start]);
             out.extend_from_slice(b"{\"_source_path\":\"");
             json_escape_bytes(source_path_bytes, out);
-            out.extend_from_slice(b"\",");
-            out.extend_from_slice(&line[obj_start + 1..]);
+            if rest_is_empty_obj {
+                out.push(b'"');
+            } else {
+                out.extend_from_slice(b"\",");
+            }
+            out.extend_from_slice(rest);
         } else {
             out.extend_from_slice(line);
         }
@@ -1483,5 +1492,50 @@ mod tests {
 
         let out = collect_data(framed.poll().unwrap());
         assert_eq!(out, b"{\"msg\":\"hello\"}\n");
+    }
+
+    #[test]
+    fn inject_source_path_empty_object() {
+        let path = std::path::Path::new("/var/log/test.log");
+        let mut out = Vec::new();
+        inject_source_path_metadata(b"{}", path, &mut out);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            r#"{"_source_path":"/var/log/test.log"}"#,
+        );
+    }
+
+    #[test]
+    fn inject_source_path_whitespace_only_object() {
+        let path = std::path::Path::new("/var/log/test.log");
+        let mut out = Vec::new();
+        inject_source_path_metadata(b"{  }", path, &mut out);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            r#"{"_source_path":"/var/log/test.log"  }"#,
+        );
+    }
+
+    #[test]
+    fn inject_source_path_normal_object() {
+        let path = std::path::Path::new("/var/log/test.log");
+        let mut out = Vec::new();
+        inject_source_path_metadata(b"{\"msg\":\"hi\"}", path, &mut out);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            r#"{"_source_path":"/var/log/test.log","msg":"hi"}"#,
+        );
+    }
+
+    #[test]
+    fn inject_source_path_multiline_with_empty_object() {
+        let path = std::path::Path::new("/a/b.log");
+        let mut out = Vec::new();
+        inject_source_path_metadata(b"{}\n{\"k\":\"v\"}\n", path, &mut out);
+        let result = String::from_utf8(out).unwrap();
+        assert_eq!(
+            result,
+            "{\"_source_path\":\"/a/b.log\"}\n{\"_source_path\":\"/a/b.log\",\"k\":\"v\"}\n",
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Fix `inject_source_path_metadata` producing invalid JSON (`{"_source_path":"...",}`) when the input is an empty object like `{}` or `{ }`
- After inserting `_source_path`, detect whether the remaining content is whitespace-only before `}` and omit the trailing comma in that case
- Add regression tests for `{}`, `{ }`, normal objects, and multiline chunks mixing empty and non-empty objects

Closes #1607

## Test plan
- [x] `cargo test -p logfwd-io --lib -- inject_source_path` (5 tests pass)
- [x] `cargo clippy -p logfwd-io -- -D warnings` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix trailing comma in `inject_source_path_metadata` for empty JSON objects
> When injecting `_source_path` into an empty JSON object (`{}` or `{  }`), the function previously appended a trailing comma, producing invalid JSON. The fix detects whether the object is empty by checking the first non-whitespace character after the opening brace, and omits the comma when no other fields follow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f981bc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->