### PR TITLE
fix(generator): monotonic timestamps in GeneratorInput (#1622)

### DIFF
--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -274,7 +274,7 @@ impl GeneratorInput {
         let service = SERVICES[(seq % SERVICES.len() as u64) as usize];
         let id = 10000 + seq.wrapping_mul(7) % 90000;
         let dur = 1 + seq.wrapping_mul(13) % 500;
-        let rid = self.counter.wrapping_mul(0x517c_c1b7_2722_0a95);
+        let rid = seq.wrapping_mul(0x517c_c1b7_2722_0a95);
         let status = match seq % 20 {
             0 => 500,
             1 | 2 => 404,


### PR DESCRIPTION
## Summary

- Fix `GeneratorInput` non-monotonic timestamps (#1622)
- Replace timestamp decomposition `hour = i % 24` (wraps backward every 24 events) with a proper monotonically-increasing millisecond counter
- Update the stale `timestamps_vary_across_events` test, which was asserting the broken behavior, with `timestamps_are_monotonically_increasing` that verifies 2000 events never go backward

## Root cause

```rust
// BEFORE (non-monotonic):
let hour = i % 24;   // jumps from 23 back to 0 every 24 events
```

```rust
// AFTER (monotonic):
let total_ms = i as u64;
let msec = total_ms % 1000;
let total_sec = total_ms / 1000;
let sec = total_sec % 60;
// … etc
let hour = (total_min / 60) % 24;
```

## Test plan

- [ ] `cargo test -p logfwd-io --lib generator` — all 9 tests pass including new `timestamps_are_monotonically_increasing`
- [ ] New test exercises 2000 events (crosses the 24-event boundary 83 times) and asserts no timestamp goes backward

Fixes #1622. Distinct from #1598 (that fixed `--generate-json` CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix monotonic timestamps in `GeneratorInput.write_logs_event`
> - Replaces independent hour/minute/second cycling with a sequential millisecond counter (`seq`) anchored at `2024-01-15T00:00:00.000Z`, so each log event advances by exactly 1ms.
> - Adds `timestamp_parts()` and Howard Hinnant civil-day helpers in [generator.rs](https://github.com/strawgate/memagent/pull/1623/files#diff-155a8c1574aa241af17a394ce55d6ff3fdc41c01cdb4e7affd54f0c4e45bf71f) to convert the counter offset into a full ISO-8601 date-time, including correct day rollover.
> - Behavioral Change: generated timestamps now strictly increase across events and roll the calendar date forward after 24 hours, rather than cycling sub-fields independently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c17bf7d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->