### PR TITLE
fix(scanner): strip CRLF carriage return from line ranges (#1625)

### DIFF
--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -1282,6 +1282,29 @@ mod tests {
         assert!(builder.rows.is_empty());
         assert!(builder.raws.is_empty());
     }
+
+    /// A bare LF empty line is skipped even with keep_raw=true.
+    /// Empty lines never produce rows — there is no content to capture.
+    #[test]
+    fn empty_lf_line_skipped_even_with_keep_raw() {
+        let buf = b"\n{\"x\":\"1\"}\n\n";
+        let config = ScanConfig {
+            wanted_fields: alloc::vec![],
+            extract_all: true,
+            keep_raw: true,
+            validate_utf8: false,
+        };
+        let mut builder = TestBuilder::new();
+        scan_streaming(buf, &config, &mut builder);
+
+        assert_eq!(
+            builder.rows.len(),
+            1,
+            "only the JSON row, empty lines skipped"
+        );
+        assert_eq!(builder.raws.len(), 1, "one _raw for the JSON row");
+        assert_eq!(builder.raws[0].as_deref(), Some("{\"x\":\"1\"}"));
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes trailing \r leaking into the _raw field when input uses CRLF line endings (#1625)
- In scan_streaming(), shrink line end by 1 when the byte before the \n is \r
- Applies to all lines including the last unterminated line

## Test plan
- [x] New test crlf_stripped_from_raw_and_fields: verifies two CRLF lines produce _raw without trailing \r and field values without \r
- [x] New test crlf_only_line_is_empty: verifies \r\n-only line is treated as empty and skipped
- [x] All 111 logfwd-core tests pass

Fixes #1625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `scan_streaming` to strip CRLF line endings and skip empty lines
> - In [json_scanner.rs](https://github.com/strawgate/memagent/pull/1626/files#diff-f842a445752f7ba8d2712a1cab0b428512dda1a4324d1c1a408435633f32b582), `scan_streaming` now strips trailing `\r` before pushing each line range, normalizing Windows CRLF to LF before JSON parsing and `_raw` exposure.
> - Lines that are empty after stripping (CRLF-only lines, lone `\r`, or empty LF lines) are skipped and produce no output rows, even when `keep_raw` is true.
> - Behavioral Change: inputs with CRLF line endings now produce the same rows as LF inputs; previously, `\r` could leak into parsed fields and `_raw`, and empty lines could emit spurious rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 302e5e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->