### PR TITLE
fix(config): validate workers >= 1 and batch_target_bytes > 0 at --validate time

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -628,6 +628,16 @@ impl Config {
                     "pipeline '{name}': batch_timeout_ms must be greater than 0"
                 )));
             }
+            if pipe.workers == Some(0) {
+                return Err(ConfigError::Validation(format!(
+                    "pipeline '{name}': workers must be >= 1"
+                )));
+            }
+            if pipe.batch_target_bytes == Some(0) {
+                return Err(ConfigError::Validation(format!(
+                    "pipeline '{name}': batch_target_bytes must be > 0"
+                )));
+            }
             if let Some(sql) = &pipe.transform {
                 if sql.trim().is_empty() {
                     return Err(ConfigError::Validation(format!(
@@ -2664,6 +2674,50 @@ pipelines:
         assert!(
             err.to_string().contains("only supported for loki"),
             "expected loki-only message: {err}"
+        );
+    }
+
+    /// Regression: `workers: 0` should be rejected at validate time, not only
+    /// at pipeline-build time.  Before the fix, `--validate` reported success
+    /// for this config but the pipeline failed immediately on startup.
+    #[test]
+    fn pipeline_rejects_workers_zero() {
+        let yaml = r#"
+pipelines:
+  test:
+    workers: 0
+    inputs:
+      - type: file
+        path: /tmp/test.log
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("workers"),
+            "expected workers rejection: {err}"
+        );
+    }
+
+    /// Regression: `batch_target_bytes: 0` should be rejected at validate time.
+    /// Before the fix, `--validate` reported success but the pipeline failed on
+    /// startup with "batch_target_bytes must be > 0".
+    #[test]
+    fn pipeline_rejects_batch_target_bytes_zero() {
+        let yaml = r#"
+pipelines:
+  test:
+    batch_target_bytes: 0
+    inputs:
+      - type: file
+        path: /tmp/test.log
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("batch_target_bytes"),
+            "expected batch_target_bytes rejection: {err}"
         );
     }
 }


### PR DESCRIPTION
Closes #1636. Mirrors the runtime checks from pipeline.rs into validate() so --validate catches these invalid values before startup.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate `workers >= 1` and `batch_target_bytes > 0` in pipeline config at validate time
> Adds two validation checks in `Config::from_raw` in [lib.rs](https://github.com/strawgate/memagent/pull/1637/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150): pipelines with `workers: 0` or `batch_target_bytes: 0` now return an explicit error at `--validate` time rather than silently accepting invalid values. Two corresponding tests cover each rejected case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58d8111.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->