### PR TITLE
fix(transform): handle NULL _raw rows in json/json_int/json_float UDFs

### DIFF
--- a/crates/logfwd-transform/src/udf/json_extract.rs
+++ b/crates/logfwd-transform/src/udf/json_extract.rs
@@ -76,23 +76,24 @@ fn is_conflict_struct_fields(fields: &arrow::datatypes::Fields) -> bool {
 /// Reconstruct an NDJSON buffer from `raw_array`, run the scanner for
 /// `field_name`, and return the resulting [`RecordBatch`].
 ///
-/// # NULL handling limitation
+/// # NULL handling
 ///
-/// When `raw_array` contains NULL entries, this function emits an empty line
-/// for each NULL (a bare `\n`) before calling the scanner. The scanner skips
-/// empty lines and therefore produces fewer output rows than the length of
-/// `raw_array`. The row-count check at the end of this function will catch
-/// that mismatch and return a `DataFusionError::Execution` containing the
-/// text `"scanner row count mismatch"`. This is a known limitation: callers
-/// (and tests) that need to handle NULL `_raw` rows must either pre-filter
-/// NULLs or treat the resulting error as expected.
+/// NULL entries in `raw_array` are represented as empty JSON objects (`{}\n`)
+/// so the scanner always produces the same number of rows as `raw_array.len()`.
+/// The extracted field for those rows is NULL (absent from `{}`), which is
+/// the semantically correct result: `json(NULL, 'key')` → NULL.
 fn parse_raw(raw_array: &StringArray, field_name: &str) -> Result<RecordBatch, DataFusionError> {
     let mut buf = Vec::with_capacity(raw_array.len() * 128);
     for i in 0..raw_array.len() {
-        if !raw_array.is_null(i) {
+        if raw_array.is_null(i) {
+            // Emit an empty object so the scanner produces a row with a null
+            // field value rather than skipping the row entirely (which would
+            // cause a row-count mismatch and an error).
+            buf.extend_from_slice(b"{}\n");
+        } else {
             buf.extend_from_slice(raw_array.value(i).as_bytes());
+            buf.push(b'\n');
         }
-        buf.push(b'\n');
     }
 
     let config = ScanConfig {
@@ -510,5 +511,102 @@ mod tests {
             col.is_null(0),
             "json_float on a quoted string must return null"
         );
+    }
+
+    /// Helper: batch with a nullable `_raw` column (some rows NULL).
+    fn make_nullable_raw_batch(rows: Vec<Option<&str>>) -> RecordBatch {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("_raw", DataType::Utf8, true),
+        ]));
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringArray::from(rows)) as arrow::array::ArrayRef],
+        )
+        .unwrap()
+    }
+
+    /// NULL `_raw` rows must yield NULL extracted fields, not a row-count
+    /// mismatch error.  Regression test for the bug where null rows emitted a
+    /// bare `\n` that the NDJSON scanner skipped, causing the output batch to
+    /// have fewer rows than the input.
+    #[tokio::test]
+    async fn test_json_null_raw_str_returns_null() {
+        let batch = make_nullable_raw_batch(vec![
+            Some(r#"{"status": "200"}"#),
+            None,
+            Some(r#"{"status": "404"}"#),
+        ]);
+        let result = query("SELECT json(_raw, 'status') as s FROM logs", batch).await;
+        assert_eq!(
+            result.num_rows(),
+            3,
+            "row count must be preserved for null _raw"
+        );
+        let col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(col.value(0), "200");
+        assert!(col.is_null(1), "null _raw must yield null extracted field");
+        assert_eq!(col.value(2), "404");
+    }
+
+    /// Same fix covers `json_int`: NULL `_raw` must yield NULL, not an error.
+    #[tokio::test]
+    async fn test_json_null_raw_int_returns_null() {
+        let batch = make_nullable_raw_batch(vec![
+            Some(r#"{"code": 200}"#),
+            None,
+            Some(r#"{"code": 500}"#),
+        ]);
+        let result = query("SELECT json_int(_raw, 'code') as c FROM logs", batch).await;
+        assert_eq!(result.num_rows(), 3);
+        let col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(col.value(0), 200);
+        assert!(col.is_null(1), "null _raw must yield null for json_int");
+        assert_eq!(col.value(2), 500);
+    }
+
+    /// Same fix covers `json_float`.
+    #[tokio::test]
+    async fn test_json_null_raw_float_returns_null() {
+        let batch =
+            make_nullable_raw_batch(vec![Some(r#"{"dur": 1.5}"#), None, Some(r#"{"dur": 3.0}"#)]);
+        let result = query("SELECT json_float(_raw, 'dur') as d FROM logs", batch).await;
+        assert_eq!(result.num_rows(), 3);
+        let col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert!((col.value(0) - 1.5).abs() < 0.001);
+        assert!(col.is_null(1), "null _raw must yield null for json_float");
+        assert!((col.value(2) - 3.0).abs() < 0.001);
+    }
+
+    /// A batch where ALL rows are NULL must produce an all-null output column
+    /// without error, and the row count must be preserved.
+    #[tokio::test]
+    async fn test_json_all_null_raw_preserves_row_count() {
+        let batch = make_nullable_raw_batch(vec![None, None, None]);
+        let result = query("SELECT json(_raw, 'status') as s FROM logs", batch).await;
+        assert_eq!(
+            result.num_rows(),
+            3,
+            "row count must be preserved when all _raw rows are null"
+        );
+        let col = result
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        for i in 0..3 {
+            assert!(col.is_null(i), "row {i} must be null");
+        }
     }
 }

--- a/crates/logfwd-transform/tests/it/json_udf_tests.rs
+++ b/crates/logfwd-transform/tests/it/json_udf_tests.rs
@@ -258,14 +258,11 @@ async fn coerce_json_string_on_integer_field() {
 // =========================================================================
 
 #[tokio::test]
-async fn null_raw_row_causes_scanner_mismatch() {
-    // KNOWN LIMITATION: when _raw contains NULL rows, the scanner produces
-    // fewer output rows than input rows because it emits a newline for the
-    // NULL row but the scanner interprets the empty line differently.
-    // This results in a "scanner row count mismatch" error.
-    //
-    // Until the UDF is patched to handle NULL _raw rows (by masking them
-    // before scanning), queries with NULL _raw will error.
+async fn null_raw_row_yields_null_not_error() {
+    // NULL _raw rows are represented as empty JSON objects `{}` before
+    // scanning so the scanner always produces the same number of rows as the
+    // input.  The extracted field for those rows is NULL (key absent from
+    // `{}`), which is the correct semantic: `json(NULL, 'key')` → NULL.
     let batch =
         make_raw_batch_nullable(&[Some(r#"{"status": 200}"#), None, Some(r#"{"status": 500}"#)]);
     let ctx = make_ctx(batch);
@@ -275,14 +272,20 @@ async fn null_raw_row_causes_scanner_mismatch() {
         .await
         .unwrap()
         .collect()
-        .await;
+        .await
+        .expect("NULL _raw rows must not cause an error");
 
-    // Document the current behaviour: this errors due to row count mismatch.
-    let err = result.expect_err("NULL _raw rows must cause a scanner row-count mismatch error");
-    assert!(
-        err.to_string().contains("scanner row count mismatch"),
-        "expected 'scanner row count mismatch' in error, got: {err}"
-    );
+    assert_eq!(result.len(), 1);
+    let batch = &result[0];
+    assert_eq!(batch.num_rows(), 3, "row count must be preserved");
+    let col = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(col.value(0), "200");
+    assert!(col.is_null(1), "null _raw must yield null extracted field");
+    assert_eq!(col.value(2), "500");
 }
 
 #[tokio::test]
@@ -804,9 +807,8 @@ async fn mixed_valid_invalid_rows_no_nulls() {
 }
 
 #[tokio::test]
-async fn mixed_valid_invalid_null_rows_errors() {
-    // Including NULL _raw rows in the batch triggers a scanner row-count
-    // mismatch (see null_raw_row_causes_scanner_mismatch test).
+async fn mixed_valid_null_rows_json_int_returns_null() {
+    // NULL _raw rows yield NULL for json_int (same fix as null_raw_row_yields_null_not_error).
     let batch =
         make_raw_batch_nullable(&[Some(r#"{"status": 200}"#), None, Some(r#"{"status": 404}"#)]);
     let ctx = make_ctx(batch);
@@ -815,12 +817,20 @@ async fn mixed_valid_invalid_null_rows_errors() {
         .await
         .unwrap()
         .collect()
-        .await;
-    let err = result.expect_err("NULL _raw rows must cause a scanner row-count mismatch error");
-    assert!(
-        err.to_string().contains("scanner row count mismatch"),
-        "expected 'scanner row count mismatch' in error, got: {err}"
-    );
+        .await
+        .expect("NULL _raw rows must not cause an error for json_int");
+
+    assert_eq!(result.len(), 1);
+    let batch = &result[0];
+    assert_eq!(batch.num_rows(), 3, "row count must be preserved");
+    let col = batch
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(col.value(0), 200);
+    assert!(col.is_null(1), "null _raw must yield null for json_int");
+    assert_eq!(col.value(2), 404);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- NULL entries in `_raw` previously caused `json()`, `json_int()`, and `json_float()` to return a "scanner row count mismatch" error at query time
- Root cause: null rows emitted a bare `\n` into the NDJSON buffer; the scanner skipped empty lines, producing fewer output rows than input rows
- Fix: emit `{}\n` (empty JSON object) for null rows so the scanner always produces the same number of rows as the input — the extracted field is NULL (key absent from `{}`), matching the expected semantics of `json(NULL, 'key') → NULL`

Closes #1639.

## Test plan

- [ ] `cargo test -p logfwd-transform` — 66 tests pass, 2 previously-error-expecting integration tests updated to assert correct (null-returning) behaviour
- [ ] Four new unit tests in `json_extract.rs`: `test_json_null_raw_str_returns_null`, `test_json_null_raw_int_returns_null`, `test_json_null_raw_float_returns_null`, `test_json_all_null_raw_preserves_row_count`
- [ ] Two integration tests updated: `null_raw_row_yields_null_not_error` (was `null_raw_row_causes_scanner_mismatch`), `mixed_valid_null_rows_json_int_returns_null` (was `mixed_valid_invalid_null_rows_errors`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix NULL `_raw` row handling in `json`, `json_int`, and `json_float` UDFs
> Previously, NULL entries in the `_raw` column caused row count mismatches because `parse_raw` emitted an empty line instead of a valid JSON object. The fix writes `{}\n` for NULL rows, so extracted fields return NULL and row counts are preserved. Regression tests covering single and all-NULL inputs are added in [json_extract.rs](https://github.com/strawgate/memagent/pull/1640/files#diff-40e6414904faf627098bb8468b7fbf2450e6aeff26f1214b1b5aee0c9a812b59) and [json_udf_tests.rs](https://github.com/strawgate/memagent/pull/1640/files#diff-4bf655982c20053e3a61ff95738a2c87f9be8d389fbb38698ed4b6e948faa268).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71a4af1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->