### PR TITLE
fix(config): reject empty path for file inputs and empty index for elasticsearch

### DIFF
--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -949,6 +949,17 @@ pipelines:
         );
     }
 
+    /// Whitespace-only path must also be rejected (validates trim().is_empty() branch).
+    #[test]
+    fn file_input_whitespace_path_rejected() {
+        let yaml = "pipelines:\n  test:\n    inputs:\n      - type: file\n        path: \"   \"\n    outputs:\n      - type: stdout\n";
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("path") && err.to_string().contains("must not be empty"),
+            "whitespace-only path must be rejected: {err}"
+        );
+    }
+
     /// Regression test for #1653: elasticsearch index: "" must be rejected by validate().
     #[test]
     fn elasticsearch_empty_index_rejected() {
@@ -971,6 +982,17 @@ pipelines:
         assert!(
             err.to_string().contains("must not be empty"),
             "expected 'must not be empty' message: {err}"
+        );
+    }
+
+    /// Whitespace-only elasticsearch index must also be rejected.
+    #[test]
+    fn elasticsearch_whitespace_index_rejected() {
+        let yaml = "pipelines:\n  test:\n    inputs:\n      - type: file\n        path: /tmp/test.log\n    outputs:\n      - type: elasticsearch\n        endpoint: http://localhost:9200\n        index: \"   \"\n";
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("index") && err.to_string().contains("must not be empty"),
+            "whitespace-only index must be rejected: {err}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `path: ""` on file inputs now fails `--validate` with a clear error instead of silently creating a pipeline that ingests nothing
- `index: ""` on elasticsearch outputs now fails `--validate` instead of silently sending `{"index":{"_index":""}}` to ES at runtime

Both gaps follow the same pattern as #1644 (empty enrichment `table_name`).

Fixes #1653, #1654.

## Test plan

- [x] `cargo test -p logfwd-config empty` — 4 tests pass (`file_input_empty_path_rejected`, `elasticsearch_empty_index_rejected`, plus 2 pre-existing)
- [x] `cargo test -p logfwd-config` — all 80 tests pass
- [x] `cargo fmt -p logfwd-config && cargo clippy -p logfwd-config -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject empty and whitespace-only `path` for file inputs and `index` for Elasticsearch outputs
> Extends `Config::validate` in [validate.rs](https://github.com/strawgate/memagent/pull/1655/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) to reject empty or whitespace-only values in two cases: file inputs with a blank `path`, and Elasticsearch outputs with a blank `index`. Four unit tests cover the empty and whitespace variants for each case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4a2140.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->