### PR TITLE
fix(output): normalize conflict struct columns before flat_to_star in OTAP sink

### DIFF
--- a/crates/logfwd-arrow/src/conflict_schema.rs
+++ b/crates/logfwd-arrow/src/conflict_schema.rs
@@ -101,6 +101,18 @@ fn is_conflict_struct(fields: &Fields) -> bool {
             .all(|field| is_conflict_child_name(field.name().as_str()))
 }
 
+/// Returns `true` if `schema` contains at least one conflict-struct column (i.e. a
+/// `Struct` whose child field names are all in `{"int", "float", "str", "bool"}`).
+///
+/// Use this as a cheap pre-check before calling [`normalize_conflict_columns`] to avoid
+/// an unnecessary `RecordBatch::clone()` when the batch has no conflict columns.
+pub fn has_conflict_struct_columns(schema: &Schema) -> bool {
+    schema
+        .fields()
+        .iter()
+        .any(|f| matches!(f.data_type(), DataType::Struct(cf) if is_conflict_struct(cf)))
+}
+
 /// Replace every conflict struct column with a flat `Utf8` column of the same name.
 ///
 /// A struct column is a conflict struct iff all its child field names are in

--- a/crates/logfwd-output/src/otap_sink.rs
+++ b/crates/logfwd-output/src/otap_sink.rs
@@ -55,7 +55,7 @@ use logfwd_otap_proto::otap::{
 };
 use prost::Message;
 
-use logfwd_arrow::conflict_schema::normalize_conflict_columns;
+use logfwd_arrow::conflict_schema::{has_conflict_struct_columns, normalize_conflict_columns};
 use logfwd_arrow::star_schema::flat_to_star;
 use logfwd_types::diagnostics::ComponentStats;
 
@@ -305,16 +305,12 @@ impl OtapSink {
         }
 
         // Normalize conflict struct columns (e.g. `status: Struct { int, str }`)
-        // to flat Utf8 before the star schema pivot. Without this, struct columns
-        // are silently dropped (str_value_at returns "" for Struct types).
-        // The same normalization is done in the OTLP sink (otlp_sink.rs:146).
+        // to flat Utf8 before the star schema pivot. Without this, struct-valued
+        // attributes can still produce star-schema rows, but their rendered value
+        // is empty because str_value_at returns "" for Struct types.
+        // The OTLP sink applies the same normalization before encoding.
         let normalized;
-        let batch = if batch
-            .schema()
-            .fields()
-            .iter()
-            .any(|f| matches!(f.data_type(), arrow::datatypes::DataType::Struct(_)))
-        {
+        let batch = if has_conflict_struct_columns(batch.schema().as_ref()) {
             normalized = normalize_conflict_columns(batch.clone());
             &normalized
         } else {
@@ -1031,11 +1027,12 @@ mod tests {
     }
 
     /// Regression test for #1656: conflict struct columns must be normalized
-    /// (not silently dropped) before the flat→star pivot in encode_batch.
+    /// before the flat→star pivot in encode_batch.
     ///
     /// Without the fix, a `status` column of type `Struct { int: Int64, str: Utf8 }`
-    /// would produce no LOG_ATTRS rows because `str_value_at` returns "" for
-    /// Struct data types. With the fix, it is coalesced to a Utf8 column first.
+    /// would still emit LOG_ATTRS rows for non-null values, but the attribute string
+    /// value would not be populated correctly because `str_value_at` returns "" for
+    /// Struct data types. With the fix, the column is coalesced to a Utf8 column first.
     #[test]
     fn conflict_struct_column_is_normalized_not_dropped() {
         use arrow::array::{Array, ArrayRef, Int64Array, StructArray};
@@ -1076,7 +1073,7 @@ mod tests {
         let stats = Arc::new(ComponentStats::new());
         let mut sink = OtapSink::new("test".to_string(), config, client, counter, stats);
 
-        // Must not error (before the fix, it would silently drop the struct column).
+        // Must not error (before the fix, struct column values would be rendered as empty strings).
         let batch_id = sink
             .encode_batch(&batch)
             .expect("encode_batch should succeed");
@@ -1087,7 +1084,11 @@ mod tests {
             decode_batch_arrow_records(&sink.proto_buf).expect("decode_batch_arrow_records");
         assert_eq!(payloads.len(), 4);
 
-        let log_attrs_ipc = &payloads[1].2;
+        let log_attrs_ipc = payloads
+            .iter()
+            .find(|(_, ptype, _)| *ptype == ArrowPayloadType::LogAttrs as u32)
+            .map(|(_, _, ipc)| ipc)
+            .expect("LOG_ATTRS payload must be present");
         let log_attrs_batches = deserialize_ipc(log_attrs_ipc).expect("deserialize log_attrs IPC");
         let log_attrs = log_attrs_batches
             .into_iter()


### PR DESCRIPTION
## Summary

- The OTLP sink already normalizes conflict struct columns (e.g. `status: Struct { int, str }`) before encoding because `str_value_at()` in `star_schema.rs` returns `""` for `Struct` data types, silently dropping all such columns
- The OTAP sink's `encode_batch()` was calling `flat_to_star()` directly on the raw batch without this normalization step, so any conflict-schema column produced no `LOG_ATTRS` rows and was silently lost
- Fix mirrors the OTLP sink pattern: if any batch column has a `Struct` data type, call `normalize_conflict_columns()` first

## Test plan

- [ ] New test `conflict_struct_column_is_normalized_not_dropped` fails before the fix and passes after
- [ ] `cargo test -p logfwd-output` — all tests pass
- [ ] `cargo fmt -p logfwd-output && cargo clippy -p logfwd-output -- -D warnings` — clean

Fixes #1656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize conflict struct columns before `flat_to_star` in OTAP sink
> - In [`otap_sink.rs`](https://github.com/strawgate/memagent/pull/1660/files#diff-5315ee02bf5eb3064a09f568f785e7a96c849ec26d45af9413f6bdd1211eb55f), `encode_batch` now checks for conflict-struct columns (structs whose children are all named among `int`, `float`, `str`, `bool`) and normalizes them to flat `Utf8` before the star-schema pivot.
> - A new helper [`has_conflict_struct_columns`](https://github.com/strawgate/memagent/pull/1660/files#diff-243b81ab977350bb9d0db5578da38bd18527e6ec0b48d85df050686846781c4c) scans the schema's top-level fields to detect conflict structs, avoiding an unnecessary clone when none are present.
> - Without this fix, conflict-struct columns were silently dropped by `flat_to_star` instead of being coalesced into string values.
> - A regression test verifies that a batch with a `status: Struct { int: Int64, str: Utf8 }` column produces a `LOG_ATTRS` payload containing the `status` key with coalesced values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 230b487.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->