### PR TITLE
fix(otlp-receiver): skip comma when write_json_any_value emits nothing

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -520,8 +520,11 @@ fn convert_request_to_json_lines(
                 // log record attributes
                 for attr in &record.attributes {
                     if let Some(ref value) = attr.value {
+                        let before = out.len();
                         write_json_any_value(&mut out, &attr.key, value);
-                        out.push(b',');
+                        if out.len() > before {
+                            out.push(b',');
+                        }
                     }
                 }
 
@@ -1284,5 +1287,81 @@ mod tests {
         let json_str = format!("{{{text}}}");
         serde_json::from_str::<serde_json::Value>(&json_str)
             .unwrap_or_else(|e| panic!("invalid JSON after key escaping: {e}\n{json_str}"));
+    }
+
+    // Regression test for issue #1665: BytesValue / ArrayValue / KvListValue attributes
+    // are skipped by write_json_any_value but the comma was still pushed, producing
+    // spurious double-commas like {"a":"1",,"c":"3"} when a skipped attr is not last.
+    #[test]
+    fn skipped_attribute_types_do_not_produce_double_commas() {
+        use opentelemetry_proto::tonic::common::v1::any_value::Value;
+
+        let request = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![LogRecord {
+                        time_unix_nano: 1_000_000_000,
+                        severity_text: "INFO".into(),
+                        body: Some(AnyValue {
+                            value: Some(Value::StringValue("test".into())),
+                        }),
+                        attributes: vec![
+                            // This one is emitted (StringValue)
+                            KeyValue {
+                                key: "before".into(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::StringValue("first".into())),
+                                }),
+                            },
+                            // BytesValue is skipped by write_json_any_value; was
+                            // still pushing a comma, producing a double-comma.
+                            KeyValue {
+                                key: "skipped_bytes".into(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::BytesValue(vec![0xde, 0xad])),
+                                }),
+                            },
+                            // This one is emitted (StringValue); was preceded by
+                            // the spurious comma from the BytesValue above.
+                            KeyValue {
+                                key: "after".into(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::StringValue("last".into())),
+                                }),
+                            },
+                        ],
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        let body = request.encode_to_vec();
+        let json_bytes = decode_otlp_logs(&body).unwrap();
+        let text = String::from_utf8(json_bytes).unwrap();
+
+        // The output must be valid JSON — a double-comma would cause parse failure.
+        for line in text.lines() {
+            serde_json::from_str::<serde_json::Value>(line)
+                .unwrap_or_else(|e| panic!("invalid JSON (spurious double-comma?): {e}\n{line}"));
+        }
+
+        // The string attributes around the skipped BytesValue must still appear.
+        assert!(
+            text.contains("\"before\":\"first\""),
+            "missing 'before': {text}"
+        );
+        assert!(
+            text.contains("\"after\":\"last\""),
+            "missing 'after': {text}"
+        );
+
+        // The skipped BytesValue key must not appear in the output.
+        assert!(
+            !text.contains("skipped_bytes"),
+            "BytesValue key should be absent: {text}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `write_json_any_value` silently skips `BytesValue`, `ArrayValue`, and `KvListValue` attribute types (they're complex/opaque for the flat JSON model), but a comma was unconditionally pushed to `out` after every call
- When a skipped attribute was **not** the last attribute in a log record, the trailing-comma-removal loop (which only ever pops the very last byte) couldn't help — a spurious comma remained in the *middle* of the JSON object, e.g. `{"before":"x",,"after":"y"}`, which is **invalid JSON**
- Fix: snapshot `out.len()` before calling `write_json_any_value` and only push the comma if bytes were actually written

Fixes #1665

## Test plan

- [x] New unit test `skipped_attribute_types_do_not_produce_double_commas` — builds a protobuf OTLP request with a `BytesValue` attribute sandwiched between two `StringValue` attributes, decodes it, and asserts each output line parses as valid JSON (would fail before this fix)
- [x] `cargo test -p logfwd-io` passes
- [x] `cargo fmt` + `cargo clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix double commas in `convert_request_to_json_lines` when `write_json_any_value` emits nothing
> When iterating over log record attributes in [otlp_receiver.rs](https://github.com/strawgate/memagent/pull/1666/files#diff-839a5b8c237a52e782ebba56a56e0053ec71e6e918888b20043904fabcd7b99e), a comma was unconditionally appended after each attribute, producing invalid JSON when `write_json_any_value` skipped certain types (e.g. `BytesValue`). The fix checks the buffer length before and after the call and only appends a comma if output was actually written. A regression test covering the skipped-attribute scenario is also added.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4487a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->