### PR TITLE
fix(otlp-receiver): use observed_time_unix_nano as fallback when time_unix_nano is 0 (fixes #1690)

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -581,17 +581,25 @@ fn decode_otlp_logs_json(body: &[u8]) -> Result<Vec<u8>, InputError> {
             for record in records {
                 out.push(b'{');
 
+                // timestamp: prefer timeUnixNano, fall back to observedTimeUnixNano
+                // when event time is unknown (fixes #1690).
+                let mut ts_val = 0u64;
                 if let Some(ts) = record.get("timeUnixNano") {
-                    let parsed = parse_protojson_u64(ts).ok_or_else(|| {
+                    ts_val = parse_protojson_u64(ts).ok_or_else(|| {
                         InputError::Receiver(
                             "invalid OTLP JSON timeUnixNano: not a valid uint64".into(),
                         )
                     })?;
-                    if parsed > 0 {
-                        write_json_key(&mut out, field_names::TIMESTAMP);
-                        write_u64_to_buf(&mut out, parsed);
-                        out.push(b',');
+                }
+                if ts_val == 0 {
+                    if let Some(obs) = record.get("observedTimeUnixNano") {
+                        ts_val = parse_protojson_u64(obs).unwrap_or(0);
                     }
+                }
+                if ts_val > 0 {
+                    write_json_key(&mut out, field_names::TIMESTAMP);
+                    write_u64_to_buf(&mut out, ts_val);
+                    out.push(b',');
                 }
 
                 if let Some(sev) = record.get("severityText").and_then(|v| v.as_str()) {
@@ -920,10 +928,17 @@ fn convert_request_to_batch(request: &ExportLogsServiceRequest) -> Result<Record
             for record in &scope_logs.log_records {
                 builder.begin_row();
 
-                if record.time_unix_nano > 0
-                    && let Ok(ts) = i64::try_from(record.time_unix_nano)
-                {
-                    builder.append_i64_value_by_idx(timestamp_idx, ts);
+                // timestamp: prefer time_unix_nano, fall back to
+                // observed_time_unix_nano when event time is unknown (#1690).
+                let ts_raw = if record.time_unix_nano > 0 {
+                    record.time_unix_nano
+                } else {
+                    record.observed_time_unix_nano
+                };
+                if let Ok(ts) = i64::try_from(ts_raw) {
+                    if ts > 0 {
+                        builder.append_i64_value_by_idx(timestamp_idx, ts);
+                    }
                 }
 
                 if !record.severity_text.is_empty() {
@@ -2378,6 +2393,35 @@ mod tests {
         assert!(
             row.get(field_names::TIMESTAMP).is_none(),
             "unknown timestamp should be omitted, not emitted as 0"
+        );
+    }
+
+    /// JSON OTLP path: when timeUnixNano is 0 but observedTimeUnixNano is set,
+    /// the timestamp must use the observed time (issue #1690).
+    #[test]
+    fn json_path_uses_observed_time_when_event_time_is_zero() {
+        let json_lines = decode_otlp_logs_json(
+            br#"{
+                "resourceLogs": [{
+                    "scopeLogs": [{
+                        "logRecords": [{
+                            "timeUnixNano": "0",
+                            "observedTimeUnixNano": "1705314700000000000",
+                            "body": {"stringValue": "hello"}
+                        }]
+                    }]
+                }]
+            }"#,
+        )
+        .expect("valid OTLP JSON");
+
+        let line = String::from_utf8(json_lines).expect("utf8");
+        let row: serde_json::Value = serde_json::from_str(line.lines().next().unwrap()).unwrap();
+        assert_eq!(
+            row.get(field_names::TIMESTAMP)
+                .and_then(serde_json::Value::as_u64),
+            Some(1_705_314_700_000_000_000),
+            "JSON path must fall back to observedTimeUnixNano when timeUnixNano==0"
         );
     }
 


### PR DESCRIPTION
## Summary

- OTLP senders set `time_unix_nano=0` when event time is unknown and rely on `observed_time_unix_nano` as the primary timestamp
- The receiver ignored `observed_time_unix_nano` entirely, so those records arrived with no `_timestamp` field
- Now falls back to `observed_time_unix_nano` when `time_unix_nano == 0`

## Test plan

- `uses_observed_time_when_event_time_is_zero`: verifies fallback to `observed_time_unix_nano`
- `prefers_event_time_over_observed_time`: verifies `time_unix_nano` takes priority when both are set
- All 24 otlp_receiver tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use `observed_time_unix_nano` as fallback timestamp when `time_unix_nano` is 0 in OTLP receiver
> - In all three OTLP log ingestion paths ([otlp_receiver.rs](https://github.com/strawgate/memagent/pull/1691/files#diff-839a5b8c237a52e782ebba56a56e0053ec71e6e918888b20043904fabcd7b99e): JSON decode, protobuf-to-JSON-lines, protobuf-to-batch), the `TIMESTAMP` field is now set from `observed_time_unix_nano` when `time_unix_nano` is 0 or absent.
> - Previously, logs with a zero event time emitted no `TIMESTAMP` at all; now they fall back to the observed time if it is positive.
> - `time_unix_nano` still takes precedence when it is non-zero.
> - New tests cover fallback behavior, precedence, and regression for each path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01d84fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->