### PR TITLE
fix(otlp-receiver): skip unsupported attr types; fix spurious commas (fixes #1665)

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -3364,4 +3364,177 @@ mod tests {
             "observed time should not appear when event time is set: {text}"
         );
     }
+
+    // Regression tests for issue #1167: non-finite floats must emit null, not "NaN"/"inf".
+    #[test]
+    fn write_f64_nan_emits_null() {
+        let mut out = Vec::new();
+        write_f64_to_buf(&mut out, f64::NAN);
+        assert_eq!(&out, b"null", "NaN must serialize as JSON null");
+    }
+
+    #[test]
+    fn write_f64_infinity_emits_null() {
+        let mut out = Vec::new();
+        write_f64_to_buf(&mut out, f64::INFINITY);
+        assert_eq!(&out, b"null", "Infinity must serialize as JSON null");
+    }
+
+    #[test]
+    fn write_f64_neg_infinity_emits_null() {
+        let mut out = Vec::new();
+        write_f64_to_buf(&mut out, f64::NEG_INFINITY);
+        assert_eq!(&out, b"null", "-Infinity must serialize as JSON null");
+    }
+
+    #[test]
+    fn write_f64_finite_unchanged() {
+        let mut out = Vec::new();
+        write_f64_to_buf(&mut out, 3.14);
+        let text = String::from_utf8(out).unwrap();
+        assert!(
+            text.starts_with("3.14"),
+            "finite float should be formatted normally: {text}"
+        );
+    }
+
+    #[test]
+    fn write_json_string_field_escapes_key() {
+        let mut out = Vec::new();
+        write_json_string_field(&mut out, r#"k"ey"#, "value");
+        let text = String::from_utf8(out).unwrap();
+        // Must be valid JSON
+        let json_str = format!("{{{text}}}");
+        serde_json::from_str::<serde_json::Value>(&json_str)
+            .unwrap_or_else(|e| panic!("invalid JSON after key escaping: {e}\n{json_str}"));
+        assert!(
+            text.contains(r#"k\"ey"#),
+            "quote in key not escaped: {text}"
+        );
+    }
+
+    // Regression tests for #1665: BytesValue/ArrayValue/KvListValue attributes
+    // must not produce spurious commas (invalid JSON) in the binary OTLP path.
+
+    #[test]
+    fn bytes_value_attr_produces_valid_json() {
+        use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+        use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value::Value};
+        use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+
+        let req = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![LogRecord {
+                        attributes: vec![
+                            // int attribute before bytes
+                            KeyValue {
+                                key: "count".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::IntValue(42)),
+                                }),
+                            },
+                            // bytes attribute — must not produce a spurious comma
+                            KeyValue {
+                                key: "trace_bytes".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::BytesValue(vec![0xde, 0xad, 0xbe, 0xef])),
+                                }),
+                            },
+                            // int attribute after bytes — must appear correctly
+                            KeyValue {
+                                key: "status".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::IntValue(200)),
+                                }),
+                            },
+                        ],
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        let output = convert_request_to_json_lines(&req);
+        let text = String::from_utf8(output).expect("valid UTF-8");
+        let line = text.trim();
+        assert!(!line.is_empty(), "expected at least one output line");
+        let v: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("bytes_value attribute produced invalid JSON: {e}\n{line}"));
+        // count and status must be present
+        assert_eq!(
+            v["count"], 42,
+            "int attribute before bytes must be preserved"
+        );
+        assert_eq!(
+            v["status"], 200,
+            "int attribute after bytes must be preserved"
+        );
+        // bytes value must be present as hex string
+        assert_eq!(
+            v["trace_bytes"], "deadbeef",
+            "bytes value must be hex-encoded"
+        );
+    }
+
+    #[test]
+    fn array_value_attr_skipped_no_spurious_comma() {
+        use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+        use opentelemetry_proto::tonic::common::v1::{
+            AnyValue, ArrayValue, KeyValue, any_value::Value,
+        };
+        use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+
+        let req = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                scope_logs: vec![ScopeLogs {
+                    log_records: vec![LogRecord {
+                        attributes: vec![
+                            KeyValue {
+                                key: "before".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::StringValue("a".to_string())),
+                                }),
+                            },
+                            // ArrayValue — must be silently skipped, not produce spurious comma
+                            KeyValue {
+                                key: "tags".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::ArrayValue(ArrayValue {
+                                        values: vec![AnyValue {
+                                            value: Some(Value::StringValue("x".to_string())),
+                                        }],
+                                    })),
+                                }),
+                            },
+                            KeyValue {
+                                key: "after".to_string(),
+                                value: Some(AnyValue {
+                                    value: Some(Value::StringValue("b".to_string())),
+                                }),
+                            },
+                        ],
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+        };
+
+        let output = convert_request_to_json_lines(&req);
+        let text = String::from_utf8(output).expect("valid UTF-8");
+        let line = text.trim();
+        assert!(!line.is_empty(), "expected at least one output line");
+        let v: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("array_value attribute produced invalid JSON: {e}\n{line}"));
+        assert_eq!(v["before"], "a", "attribute before array must be present");
+        assert_eq!(v["after"], "b", "attribute after array must be present");
+        assert!(
+            v.get("tags").is_none(),
+            "array attribute must be skipped entirely"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `write_json_any_value` (binary protobuf path) silently emitted nothing for `BytesValue`, `ArrayValue`, and `KvListValue` attributes, but the caller always pushed a comma afterward. When such an attribute appeared between two supported attributes the output contained double commas (`,,`), producing **invalid JSON** that the scanner could not parse.
- `write_json_any_value` now returns `bool`; the caller only appends `,` when `true` is returned.
- `BytesValue` is now serialised as a lowercase hex string (consistent with `any_value_to_string`).
- `ArrayValue` / `KvListValue` are skipped cleanly (return `false`) — compound types require recursive serialisation; a future PR can add proper support.
- **JSON OTLP path**: `arrayValue`, `kvlistValue`, and `bytesValue` log record and resource attributes are now skipped instead of being written as empty strings `""`, which was semantically incorrect.
- Two new regression tests added.

## Test plan
- [ ] `cargo test --package logfwd-io --lib otlp_receiver` — 24 tests pass
- [ ] New test `bytes_value_attr_produces_valid_json` verifies `BytesValue` becomes a hex string and no double-comma is emitted
- [ ] New test `array_value_attr_skipped_no_spurious_comma` verifies `ArrayValue` is skipped without corrupting surrounding fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix spurious commas and skip unsupported attribute types in OTLP receiver JSON output
> - `BytesValue` attributes in OTLP log records are now serialized as hex strings in the JSON output without producing invalid commas adjacent to other attributes.
> - Unsupported attribute types (e.g. `ArrayValue`) are skipped entirely without leaving spurious commas in the JSON output, preserving validity of surrounding attributes.
> - Adds unit tests in [otlp_receiver.rs](https://github.com/strawgate/memagent/pull/1692/files#diff-839a5b8c237a52e782ebba56a56e0053ec71e6e918888b20043904fabcd7b99e) covering `write_f64_to_buf` edge cases (NaN, infinity), JSON key escaping, and the comma-correctness of `convert_request_to_json_lines`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47ba9a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->