### PR TITLE
fix: 8 correctness bugs — UDF Utf8View, console panics, Loki timestamp, Arrow IPC gzip

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -2489,8 +2489,8 @@ pipelines:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("gzip") || msg.contains("zstd"),
-            "expected arrow_ipc gzip rejection error mentioning gzip or zstd: {msg}"
+            msg.contains("arrow_ipc output only supports 'zstd'") && msg.contains("'gzip'"),
+            "expected arrow_ipc-specific gzip rejection, got: {msg}"
         );
     }
 

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -2470,6 +2470,30 @@ pipelines:
         );
     }
 
+    /// Regression: arrow_ipc output with `compression: gzip` must be rejected.
+    /// Only `zstd` is supported. Before the fix, gzip was silently accepted
+    /// and would fail at runtime.
+    #[test]
+    fn arrow_ipc_output_rejects_gzip_compression() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: file
+        path: /tmp/test.log
+    outputs:
+      - type: arrow_ipc
+        endpoint: http://localhost:4317
+        compression: gzip
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("gzip") || msg.contains("zstd"),
+            "expected arrow_ipc gzip rejection error mentioning gzip or zstd: {msg}"
+        );
+    }
+
     #[test]
     fn csv_enrichment_whitespace_path_rejected() {
         let yaml = "pipelines:\n  test:\n    inputs:\n      - type: file\n        path: /tmp/test.log\n    outputs:\n      - type: stdout\n    enrichment:\n      - type: csv\n        table_name: assets\n        path: \"   \"\n";

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -675,12 +675,14 @@ impl Config {
                         "pipeline '{name}' output '{label}': 'compression' is not supported for loki outputs"
                     )));
                 }
-                if output.output_type == OutputType::ArrowIpc
-                    && output.compression.as_deref() == Some("gzip")
-                {
-                    return Err(ConfigError::Validation(format!(
-                        "pipeline '{name}' output '{label}': arrow_ipc output only supports 'zstd' compression, not 'gzip'"
-                    )));
+                if output.output_type == OutputType::ArrowIpc {
+                    if let Some(c) = output.compression.as_deref() {
+                        if c != "zstd" {
+                            return Err(ConfigError::Validation(format!(
+                                "pipeline '{name}' output '{label}': arrow_ipc output only supports 'zstd' compression, not '{c}'"
+                            )));
+                        }
+                    }
                 }
                 if output.output_type != OutputType::Otlp && output.protocol.is_some() {
                     return Err(ConfigError::Validation(format!(

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -675,14 +675,13 @@ impl Config {
                         "pipeline '{name}' output '{label}': 'compression' is not supported for loki outputs"
                     )));
                 }
-                if output.output_type == OutputType::ArrowIpc {
-                    if let Some(c) = output.compression.as_deref() {
-                        if c != "zstd" {
-                            return Err(ConfigError::Validation(format!(
-                                "pipeline '{name}' output '{label}': arrow_ipc output only supports 'zstd' compression, not '{c}'"
-                            )));
-                        }
-                    }
+                if output.output_type == OutputType::ArrowIpc
+                    && let Some(c) = output.compression.as_deref()
+                    && c != "zstd"
+                {
+                    return Err(ConfigError::Validation(format!(
+                        "pipeline '{name}' output '{label}': arrow_ipc output only supports 'zstd' compression, not '{c}'"
+                    )));
                 }
                 if output.output_type != OutputType::Otlp && output.protocol.is_some() {
                     return Err(ConfigError::Validation(format!(

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -675,6 +675,13 @@ impl Config {
                         "pipeline '{name}' output '{label}': 'compression' is not supported for loki outputs"
                     )));
                 }
+                if output.output_type == OutputType::ArrowIpc
+                    && output.compression.as_deref() == Some("gzip")
+                {
+                    return Err(ConfigError::Validation(format!(
+                        "pipeline '{name}' output '{label}': arrow_ipc output only supports 'zstd' compression, not 'gzip'"
+                    )));
+                }
                 if output.output_type != OutputType::Otlp && output.protocol.is_some() {
                     return Err(ConfigError::Validation(format!(
                         "pipeline '{name}' output '{label}': 'protocol' is only supported for otlp outputs"

--- a/crates/logfwd-io/src/telemetry_buffer.rs
+++ b/crates/logfwd-io/src/telemetry_buffer.rs
@@ -928,7 +928,8 @@ fn attrs_to_json(attrs: &[(&str, String)]) -> String {
         .iter()
         .map(|(k, v)| {
             format!(
-                "{{\"key\":\"{k}\",\"value\":{{\"stringValue\":\"{}\"}}}}",
+                "{{\"key\":\"{}\",\"value\":{{\"stringValue\":\"{}\"}}}}",
+                json_escape(k),
                 json_escape(v)
             )
         })

--- a/crates/logfwd-io/src/telemetry_buffer.rs
+++ b/crates/logfwd-io/src/telemetry_buffer.rs
@@ -1563,4 +1563,20 @@ mod tests {
         );
         assert_eq!(lr["severityNumber"], 17); // ERROR
     }
+
+    /// Regression: attrs_to_json must properly escape keys containing quotes.
+    /// Before the fix, unescaped quotes in keys would produce invalid JSON.
+    #[test]
+    fn attrs_to_json_key_with_quote_produces_valid_json() {
+        let attrs = vec![("key\"with\"quotes", "normal_value".to_string())];
+        let json_fragment = attrs_to_json(&attrs);
+        // Wrap in braces to make it parseable as a JSON object.
+        let json = format!("{{{json_fragment}}}");
+        let parsed: serde_json::Value = serde_json::from_str(&json)
+            .expect("attrs_to_json with quoted key must produce valid JSON");
+        let arr = parsed["attributes"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["key"], "key\"with\"quotes");
+        assert_eq!(arr[0]["value"]["stringValue"], "normal_value");
+    }
 }

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -1429,6 +1429,174 @@ mod tests {
             metadata.observed_time_ns
         );
     }
+
+    #[test]
+    fn test_arrow_timestamp_microsecond_column_used_as_loki_ts() {
+        use arrow::array::TimestampMicrosecondArray;
+        use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+        let config = Arc::new(LokiConfig {
+            endpoint: "http://localhost".to_string(),
+            tenant_id: None,
+            static_labels: vec![],
+            label_columns: vec![],
+            headers: vec![],
+        });
+        let sink = LokiSink::new(
+            "test".to_string(),
+            config,
+            Arc::new(reqwest::Client::new()),
+            Arc::new(ComponentStats::new()),
+        );
+
+        let raw_us: i64 = 1_705_314_600_000_000;
+        let expected_ns: u64 = (raw_us * 1_000) as u64;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            field_names::TIMESTAMP_UNDERSCORE,
+            DataType::Timestamp(TimeUnit::Microsecond, None),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(TimestampMicrosecondArray::from(vec![raw_us]))],
+        )
+        .unwrap();
+        let metadata = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 99_999,
+        };
+
+        let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
+        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, expected_ns);
+    }
+
+    #[test]
+    fn test_arrow_timestamp_millisecond_column_used_as_loki_ts() {
+        use arrow::array::TimestampMillisecondArray;
+        use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+        let config = Arc::new(LokiConfig {
+            endpoint: "http://localhost".to_string(),
+            tenant_id: None,
+            static_labels: vec![],
+            label_columns: vec![],
+            headers: vec![],
+        });
+        let sink = LokiSink::new(
+            "test".to_string(),
+            config,
+            Arc::new(reqwest::Client::new()),
+            Arc::new(ComponentStats::new()),
+        );
+
+        let raw_ms: i64 = 1_705_314_600_000;
+        let expected_ns: u64 = (raw_ms * 1_000_000) as u64;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            field_names::TIMESTAMP_UNDERSCORE,
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(TimestampMillisecondArray::from(vec![raw_ms]))],
+        )
+        .unwrap();
+        let metadata = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 99_999,
+        };
+
+        let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
+        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, expected_ns);
+    }
+
+    #[test]
+    fn test_arrow_timestamp_second_column_used_as_loki_ts() {
+        use arrow::array::TimestampSecondArray;
+        use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+        let config = Arc::new(LokiConfig {
+            endpoint: "http://localhost".to_string(),
+            tenant_id: None,
+            static_labels: vec![],
+            label_columns: vec![],
+            headers: vec![],
+        });
+        let sink = LokiSink::new(
+            "test".to_string(),
+            config,
+            Arc::new(reqwest::Client::new()),
+            Arc::new(ComponentStats::new()),
+        );
+
+        let raw_s: i64 = 1_705_314_600;
+        let expected_ns: u64 = (raw_s * 1_000_000_000) as u64;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            field_names::TIMESTAMP_UNDERSCORE,
+            DataType::Timestamp(TimeUnit::Second, None),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(TimestampSecondArray::from(vec![raw_s]))],
+        )
+        .unwrap();
+        let metadata = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 99_999,
+        };
+
+        let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
+        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].0, expected_ns);
+    }
+
+    #[test]
+    fn test_arrow_timestamp_negative_or_overflow_falls_back_to_observed_time() {
+        use arrow::array::TimestampSecondArray;
+        use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+        let config = Arc::new(LokiConfig {
+            endpoint: "http://localhost".to_string(),
+            tenant_id: None,
+            static_labels: vec![],
+            label_columns: vec![],
+            headers: vec![],
+        });
+        let sink = LokiSink::new(
+            "test".to_string(),
+            config,
+            Arc::new(reqwest::Client::new()),
+            Arc::new(ComponentStats::new()),
+        );
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            field_names::TIMESTAMP_UNDERSCORE,
+            DataType::Timestamp(TimeUnit::Second, None),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(TimestampSecondArray::from(vec![-1, i64::MAX]))],
+        )
+        .unwrap();
+        let metadata = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 42,
+        };
+
+        let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
+        let mut entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        entries.sort_by_key(|(ts, _)| *ts);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, metadata.observed_time_ns);
+        assert_eq!(entries[1].0, metadata.observed_time_ns);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -1375,6 +1375,60 @@ mod tests {
             "Null timestamp should fall back to observed_time_ns"
         );
     }
+    /// Regression: Loki sink must read Arrow Timestamp(Nanosecond) columns
+    /// and use the actual timestamp value, not fall back to observed_time_ns.
+    /// Before the fix, the `DataType::Timestamp` arm was missing entirely and
+    /// hit the `_ => metadata.observed_time_ns` default.
+    #[test]
+    fn test_arrow_timestamp_nanosecond_column_used_as_loki_ts() {
+        use arrow::array::TimestampNanosecondArray;
+        use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+        let config = Arc::new(LokiConfig {
+            endpoint: "http://localhost".to_string(),
+            tenant_id: None,
+            static_labels: vec![],
+            label_columns: vec![],
+            headers: vec![],
+        });
+        let sink = LokiSink::new(
+            "test".to_string(),
+            config,
+            Arc::new(reqwest::Client::new()),
+            Arc::new(ComponentStats::new()),
+        );
+
+        let expected_ns: i64 = 1_705_314_600_000_000_000;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(
+                field_names::TIMESTAMP_UNDERSCORE,
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            Field::new("message", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(TimestampNanosecondArray::from(vec![expected_ns])),
+                Arc::new(arrow::array::StringArray::from(vec!["hello"])),
+            ],
+        )
+        .unwrap();
+        let metadata = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 99_999,
+        };
+
+        let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
+        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].0, expected_ns as u64,
+            "Timestamp(Nanosecond) value ({expected_ns}) must be used, not observed_time_ns ({})",
+            metadata.observed_time_ns
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -293,6 +293,32 @@ impl LokiSink {
                             parse_timestamp_nanos(col.as_string::<i64>().value(row).as_bytes())
                                 .unwrap_or(metadata.observed_time_ns)
                         }
+                        DataType::Timestamp(unit, _) => {
+                            use arrow::datatypes::{
+                                TimeUnit, TimestampMicrosecondType, TimestampMillisecondType,
+                                TimestampNanosecondType, TimestampSecondType,
+                            };
+                            let raw_ns = match unit {
+                                TimeUnit::Nanosecond => {
+                                    Some(col.as_primitive::<TimestampNanosecondType>().value(row))
+                                }
+                                TimeUnit::Microsecond => col
+                                    .as_primitive::<TimestampMicrosecondType>()
+                                    .value(row)
+                                    .checked_mul(1_000),
+                                TimeUnit::Millisecond => col
+                                    .as_primitive::<TimestampMillisecondType>()
+                                    .value(row)
+                                    .checked_mul(1_000_000),
+                                TimeUnit::Second => col
+                                    .as_primitive::<TimestampSecondType>()
+                                    .value(row)
+                                    .checked_mul(1_000_000_000),
+                            };
+                            raw_ns
+                                .and_then(|ns| u64::try_from(ns).ok())
+                                .unwrap_or(metadata.observed_time_ns)
+                        }
                         _ => metadata.observed_time_ns,
                     }
                 }

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -532,4 +532,87 @@ mod tests {
             "text fallback should be identical to json format"
         );
     }
+
+    /// Regression: console format with a Boolean column must not panic.
+    /// Before the fix, the extra-fields rendering hit `unreachable!()` for
+    /// non-string, non-numeric types.
+    #[test]
+    fn console_format_boolean_column_does_not_panic() {
+        use arrow::array::BooleanArray;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("message", DataType::Utf8, true),
+            Field::new("is_error", DataType::Boolean, true),
+        ]));
+        let msg = StringArray::from(vec![Some("hello")]);
+        let flag = BooleanArray::from(vec![Some(true)]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(msg), Arc::new(flag)]).unwrap();
+
+        let mut sink = StdoutSink::new(
+            "test-bool".to_string(),
+            StdoutFormat::Console,
+            Arc::new(ComponentStats::new()),
+        );
+        let mut out: Vec<u8> = Vec::new();
+        // Must not panic.
+        sink.write_batch_to(&batch, &make_metadata(), &mut out)
+            .unwrap();
+        let output = String::from_utf8(out).unwrap();
+        assert!(
+            output.contains("is_error=true"),
+            "boolean value should appear in output: {output:?}"
+        );
+    }
+
+    /// Regression: console format must recognise `_timestamp` as a timestamp
+    /// column. Before the fix, `_timestamp` was missing from the `find_col`
+    /// name list, so the timestamp was omitted from console output.
+    #[test]
+    fn console_format_underscore_timestamp_shown() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_timestamp", DataType::Utf8, true),
+            Field::new("message", DataType::Utf8, true),
+        ]));
+        let ts = StringArray::from(vec![Some("2024-01-15T10:30:00Z")]);
+        let msg = StringArray::from(vec![Some("hello")]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(ts), Arc::new(msg)]).unwrap();
+
+        let mut sink = StdoutSink::new(
+            "test-ts".to_string(),
+            StdoutFormat::Console,
+            Arc::new(ComponentStats::new()),
+        );
+        let mut out: Vec<u8> = Vec::new();
+        sink.write_batch_to(&batch, &make_metadata(), &mut out)
+            .unwrap();
+        let output = String::from_utf8(out).unwrap();
+        assert!(
+            output.contains("10:30:00Z"),
+            "_timestamp value should appear in console output: {output:?}"
+        );
+    }
+
+    /// Regression: console format with `_raw` as the only content column must
+    /// show the content. Before the fix, `_raw` was not in the `find_col`
+    /// message variant list, producing empty console lines.
+    #[test]
+    fn console_format_raw_as_message_column() {
+        let schema = Arc::new(Schema::new(vec![Field::new("_raw", DataType::Utf8, true)]));
+        let raw = StringArray::from(vec![Some("raw log line here")]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(raw)]).unwrap();
+
+        let mut sink = StdoutSink::new(
+            "test-raw-console".to_string(),
+            StdoutFormat::Console,
+            Arc::new(ComponentStats::new()),
+        );
+        let mut out: Vec<u8> = Vec::new();
+        sink.write_batch_to(&batch, &make_metadata(), &mut out)
+            .unwrap();
+        let output = String::from_utf8(out).unwrap();
+        assert!(
+            output.contains("raw log line here"),
+            "_raw content should appear in console output: {output:?}"
+        );
+    }
 }

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::future::Future;
 use std::io::{self, Write};
 use std::pin::Pin;
@@ -147,42 +148,28 @@ impl StdoutSink {
         let schema = batch.schema();
         let fields = schema.fields();
 
-        // Find well-known columns by name — check all canonical variants so
-        // CRI (_timestamp), OTLP (timestamp), and ES (@timestamp) sources work.
-        let ts_idx = find_col(
-            fields,
-            &[
+        // Find well-known columns by name — canonical names first, then shared
+        // variant lists from `field_names` to avoid sink drift.
+        let ts_idx = fields.iter().position(|f| {
+            field_names::matches_any(
+                f.name(),
                 field_names::TIMESTAMP,
-                field_names::TIMESTAMP_UNDERSCORE,
-                field_names::TIMESTAMP_AT,
-                field_names::TIMESTAMP_VARIANTS[0],
-                field_names::TIMESTAMP_VARIANTS[1],
-                "timestamp_str",
-            ],
-        );
-        let level_idx = find_col(
-            fields,
-            &[
+                field_names::TIMESTAMP_VARIANTS,
+            ) || f.name() == "timestamp_str"
+        });
+        let level_idx = fields.iter().position(|f| {
+            field_names::matches_any(
+                f.name(),
                 field_names::SEVERITY,
-                "level_str",
-                field_names::SEVERITY_VARIANTS[0],
-                field_names::SEVERITY_VARIANTS[1],
-                field_names::SEVERITY_VARIANTS[2],
-                field_names::SEVERITY_VARIANTS[3],
-            ],
-        );
-        let msg_idx = find_col(
-            fields,
-            &[
-                field_names::BODY,
-                "message_str",
-                field_names::BODY_VARIANTS[0],
-                "msg_str",
-                field_names::BODY_VARIANTS[1],
-                field_names::BODY_VARIANTS[2],
-                field_names::RAW,
-            ],
-        );
+                field_names::SEVERITY_VARIANTS,
+            ) || f.name() == "level_str"
+        });
+        let msg_idx = fields.iter().position(|f| {
+            field_names::matches_any(f.name(), field_names::BODY, field_names::BODY_VARIANTS)
+                || f.name() == "message_str"
+                || f.name() == "msg_str"
+                || f.name() == field_names::RAW
+        });
 
         let cols = build_col_infos(batch);
 
@@ -195,7 +182,7 @@ impl StdoutSink {
                 if !col.is_null(row) {
                     let ts = safe_col_to_string(col, row);
                     // Show just the time portion if it's a full ISO timestamp.
-                    let short = ts.find('T').map_or(ts.as_str(), |i| &ts[i + 1..]);
+                    let short = ts.find('T').map_or(ts.as_ref(), |i| &ts[i + 1..]);
                     if self.color {
                         self.buf.extend_from_slice(b"\x1b[2m");
                     }
@@ -213,7 +200,7 @@ impl StdoutSink {
                 if !col.is_null(row) {
                     let level = safe_col_to_string(col, row);
                     if self.color {
-                        let color = match level.as_str() {
+                        let color = match level.as_ref() {
                             "ERROR" => "\x1b[1;31m", // bold red
                             "WARN" => "\x1b[33m",    // yellow
                             "INFO" => "\x1b[32m",    // green
@@ -323,12 +310,12 @@ impl StdoutSink {
 ///
 /// Unlike `str_value` (which panics on non-string types), this handles all
 /// Arrow data types via `array_value_to_string` for non-Utf8 columns.
-fn safe_col_to_string(col: &dyn Array, row: usize) -> String {
+fn safe_col_to_string<'a>(col: &'a dyn Array, row: usize) -> Cow<'a, str> {
     match col.data_type() {
-        DataType::Utf8 => col.as_string::<i32>().value(row).to_string(),
-        DataType::Utf8View => col.as_string_view().value(row).to_string(),
-        DataType::LargeUtf8 => col.as_string::<i64>().value(row).to_string(),
-        _ => safe_array_value_to_string(col, row),
+        DataType::Utf8 => Cow::Borrowed(col.as_string::<i32>().value(row)),
+        DataType::Utf8View => Cow::Borrowed(col.as_string_view().value(row)),
+        DataType::LargeUtf8 => Cow::Borrowed(col.as_string::<i64>().value(row)),
+        _ => Cow::Owned(safe_array_value_to_string(col, row)),
     }
 }
 
@@ -341,16 +328,6 @@ fn safe_array_value_to_string(col: &dyn Array, row: usize) -> String {
             "<format_error>".to_string()
         }
     }
-}
-
-/// Find a column index by trying multiple name variants.
-fn find_col(fields: &arrow::datatypes::Fields, names: &[&str]) -> Option<usize> {
-    for name in names {
-        if let Some(idx) = fields.iter().position(|f| f.name() == *name) {
-            return Some(idx);
-        }
-    }
-    None
 }
 
 // ---------------------------------------------------------------------------
@@ -625,6 +602,60 @@ mod tests {
         assert!(
             output.contains("raw log line here"),
             "_raw content should appear in console output: {output:?}"
+        );
+    }
+
+    #[test]
+    fn console_format_utf8view_message_column() {
+        use arrow::array::StringViewArray;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "message",
+            DataType::Utf8View,
+            true,
+        )]));
+        let msg = StringViewArray::from(vec![Some("view log line")]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(msg)]).unwrap();
+
+        let mut sink = StdoutSink::new(
+            "test-utf8view-console".to_string(),
+            StdoutFormat::Console,
+            Arc::new(ComponentStats::new()),
+        );
+        let mut out: Vec<u8> = Vec::new();
+        sink.write_batch_to(&batch, &make_metadata(), &mut out)
+            .unwrap();
+        let output = String::from_utf8(out).unwrap();
+        assert!(
+            output.contains("view log line"),
+            "Utf8View message should appear in console output: {output:?}"
+        );
+    }
+
+    #[test]
+    fn console_format_largeutf8_message_column() {
+        use arrow::array::LargeStringArray;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "message",
+            DataType::LargeUtf8,
+            true,
+        )]));
+        let msg = LargeStringArray::from(vec![Some("large log line")]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(msg)]).unwrap();
+
+        let mut sink = StdoutSink::new(
+            "test-largeutf8-console".to_string(),
+            StdoutFormat::Console,
+            Arc::new(ComponentStats::new()),
+        );
+        let mut out: Vec<u8> = Vec::new();
+        sink.write_batch_to(&batch, &make_metadata(), &mut out)
+            .unwrap();
+        let output = String::from_utf8(out).unwrap();
+        assert!(
+            output.contains("large log line"),
+            "LargeUtf8 message should appear in console output: {output:?}"
         );
     }
 }

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -275,8 +275,12 @@ impl StdoutSink {
                         let v = arr
                             .as_primitive::<arrow::datatypes::Float64Type>()
                             .value(row);
-                        self.buf
-                            .extend_from_slice(ryu::Buffer::new().format_finite(v).as_bytes());
+                        if v.is_finite() {
+                            self.buf
+                                .extend_from_slice(ryu::Buffer::new().format_finite(v).as_bytes());
+                        } else {
+                            self.buf.extend_from_slice(v.to_string().as_bytes());
+                        }
                     }
                     DataType::Struct(_) => {
                         // Encode structs (e.g. grok() or geo_lookup() results) as

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -311,7 +311,7 @@ impl StdoutSink {
 ///
 /// Unlike `str_value` (which panics on non-string types), this handles all
 /// Arrow data types via `array_value_to_string` for non-Utf8 columns.
-fn safe_col_to_string<'a>(col: &'a dyn Array, row: usize) -> Cow<'a, str> {
+fn safe_col_to_string(col: &dyn Array, row: usize) -> Cow<'_, str> {
     match col.data_type() {
         DataType::Utf8 => Cow::Borrowed(col.as_string::<i32>().value(row)),
         DataType::Utf8View => Cow::Borrowed(col.as_string_view().value(row)),

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -148,28 +148,25 @@ impl StdoutSink {
         let schema = batch.schema();
         let fields = schema.fields();
 
-        // Find well-known columns by name — canonical names first, then shared
-        // variant lists from `field_names` to avoid sink drift.
-        let ts_idx = fields.iter().position(|f| {
-            field_names::matches_any(
-                f.name(),
-                field_names::TIMESTAMP,
-                field_names::TIMESTAMP_VARIANTS,
-            ) || f.name() == "timestamp_str"
-        });
-        let level_idx = fields.iter().position(|f| {
-            field_names::matches_any(
-                f.name(),
-                field_names::SEVERITY,
-                field_names::SEVERITY_VARIANTS,
-            ) || f.name() == "level_str"
-        });
-        let msg_idx = fields.iter().position(|f| {
-            field_names::matches_any(f.name(), field_names::BODY, field_names::BODY_VARIANTS)
-                || f.name() == "message_str"
-                || f.name() == "msg_str"
-                || f.name() == field_names::RAW
-        });
+        // Resolve canonical names first, then variants, then conflict suffixes.
+        let ts_idx = find_preferred_column(
+            fields,
+            field_names::TIMESTAMP,
+            field_names::TIMESTAMP_VARIANTS,
+            &[],
+        );
+        let level_idx = find_preferred_column(
+            fields,
+            field_names::SEVERITY,
+            field_names::SEVERITY_VARIANTS,
+            &[],
+        );
+        let msg_idx = find_preferred_column(
+            fields,
+            field_names::BODY,
+            field_names::BODY_VARIANTS,
+            &[field_names::RAW],
+        );
 
         let cols = build_col_infos(batch);
 
@@ -317,6 +314,43 @@ fn safe_col_to_string<'a>(col: &'a dyn Array, row: usize) -> Cow<'a, str> {
         DataType::LargeUtf8 => Cow::Borrowed(col.as_string::<i64>().value(row)),
         _ => Cow::Owned(safe_array_value_to_string(col, row)),
     }
+}
+
+fn find_preferred_column(
+    fields: &arrow::datatypes::Fields,
+    canonical: &str,
+    variants: &[&str],
+    extra_fallback: &[&str],
+) -> Option<usize> {
+    if let Some(idx) = find_exact_column(fields, canonical) {
+        return Some(idx);
+    }
+    for &name in variants {
+        if let Some(idx) = find_exact_column(fields, name) {
+            return Some(idx);
+        }
+    }
+    for &name in extra_fallback {
+        if let Some(idx) = find_exact_column(fields, name) {
+            return Some(idx);
+        }
+    }
+
+    for base in std::iter::once(canonical)
+        .chain(variants.iter().copied())
+        .chain(extra_fallback.iter().copied())
+    {
+        let conflict_str = format!("{base}__str");
+        if let Some(idx) = find_exact_column(fields, conflict_str.as_str()) {
+            return Some(idx);
+        }
+    }
+
+    None
+}
+
+fn find_exact_column(fields: &arrow::datatypes::Fields, name: &str) -> Option<usize> {
+    fields.iter().position(|f| f.name() == name)
 }
 
 /// Convert an Arrow value to string without panicking or silently erasing errors.
@@ -656,6 +690,76 @@ mod tests {
         assert!(
             output.contains("large log line"),
             "LargeUtf8 message should appear in console output: {output:?}"
+        );
+    }
+
+    #[test]
+    fn console_format_prefers_canonical_message_over_raw() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(field_names::RAW, DataType::Utf8, true),
+            Field::new(field_names::BODY, DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("raw line")])),
+                Arc::new(StringArray::from(vec![Some("parsed message")])),
+            ],
+        )
+        .expect("valid batch");
+
+        let mut sink = StdoutSink::new(
+            "test-canonical-message".to_string(),
+            StdoutFormat::Console,
+            Arc::new(ComponentStats::new()),
+        );
+        let mut out: Vec<u8> = Vec::new();
+        sink.write_batch_to(&batch, &make_metadata(), &mut out)
+            .expect("console write");
+        let output = String::from_utf8(out).expect("utf8");
+        assert!(
+            output.contains("parsed message"),
+            "canonical message must win when message and _raw are both present: {output:?}"
+        );
+        assert!(
+            !output.contains("raw line"),
+            "_raw must not shadow canonical message: {output:?}"
+        );
+    }
+
+    #[test]
+    fn console_format_prefers_canonical_timestamp_over_variant() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(field_names::TIMESTAMP_UNDERSCORE, DataType::Utf8, true),
+            Field::new(field_names::TIMESTAMP, DataType::Utf8, true),
+            Field::new(field_names::BODY, DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("2024-01-01T00:00:00Z")])),
+                Arc::new(StringArray::from(vec![Some("2025-01-01T01:02:03Z")])),
+                Arc::new(StringArray::from(vec![Some("hello")])),
+            ],
+        )
+        .expect("valid batch");
+
+        let mut sink = StdoutSink::new(
+            "test-canonical-timestamp".to_string(),
+            StdoutFormat::Console,
+            Arc::new(ComponentStats::new()),
+        );
+        let mut out: Vec<u8> = Vec::new();
+        sink.write_batch_to(&batch, &make_metadata(), &mut out)
+            .expect("console write");
+        let output = String::from_utf8(out).expect("utf8");
+        assert!(
+            output.starts_with("01:02:03Z  hello"),
+            "canonical timestamp must be selected before _timestamp: {output:?}"
+        );
+        assert!(
+            !output.starts_with("00:00:00Z"),
+            "_timestamp variant must not shadow canonical timestamp in leading slot: {output:?}"
         );
     }
 }

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -11,6 +11,8 @@ use tokio::io::AsyncWriteExt;
 use logfwd_types::diagnostics::ComponentStats;
 
 use super::sink::{SendResult, Sink, SinkFactory};
+use arrow::util::display::array_value_to_string;
+
 use super::{
     BatchMetadata, ColVariant, build_col_infos, get_array, is_null, str_value, write_json_value,
     write_row_json,
@@ -144,10 +146,42 @@ impl StdoutSink {
         let schema = batch.schema();
         let fields = schema.fields();
 
-        // Find well-known columns by name (with or without type suffix).
-        let ts_idx = find_col(fields, &["timestamp_str", "timestamp"]);
-        let level_idx = find_col(fields, &["level_str", "level"]);
-        let msg_idx = find_col(fields, &["message_str", "message", "msg_str", "msg"]);
+        // Find well-known columns by name — check all canonical variants so
+        // CRI (_timestamp), OTLP (timestamp), and ES (@timestamp) sources work.
+        let ts_idx = find_col(
+            fields,
+            &[
+                "timestamp",
+                "_timestamp",
+                "@timestamp",
+                "time",
+                "ts",
+                "timestamp_str",
+            ],
+        );
+        let level_idx = find_col(
+            fields,
+            &[
+                "level",
+                "level_str",
+                "severity",
+                "log_level",
+                "loglevel",
+                "lvl",
+            ],
+        );
+        let msg_idx = find_col(
+            fields,
+            &[
+                "message",
+                "message_str",
+                "msg",
+                "msg_str",
+                "_msg",
+                "body",
+                "_raw",
+            ],
+        );
 
         let cols = build_col_infos(batch);
 
@@ -158,9 +192,9 @@ impl StdoutSink {
             if let Some(idx) = ts_idx {
                 let col = batch.column(idx);
                 if !col.is_null(row) {
-                    let ts = str_value(col, row);
+                    let ts = safe_col_to_string(col, row);
                     // Show just the time portion if it's a full ISO timestamp.
-                    let short = ts.find('T').map_or(ts, |i| &ts[i + 1..]);
+                    let short = ts.find('T').map_or(ts.as_str(), |i| &ts[i + 1..]);
                     if self.color {
                         self.buf.extend_from_slice(b"\x1b[2m");
                     }
@@ -176,9 +210,9 @@ impl StdoutSink {
             if let Some(idx) = level_idx {
                 let col = batch.column(idx);
                 if !col.is_null(row) {
-                    let level = str_value(col, row);
+                    let level = safe_col_to_string(col, row);
                     if self.color {
-                        let color = match level {
+                        let color = match level.as_str() {
                             "ERROR" => "\x1b[1;31m", // bold red
                             "WARN" => "\x1b[33m",    // yellow
                             "INFO" => "\x1b[32m",    // green
@@ -200,7 +234,8 @@ impl StdoutSink {
             if let Some(idx) = msg_idx {
                 let col = batch.column(idx);
                 if !col.is_null(row) {
-                    self.buf.extend_from_slice(str_value(col, row).as_bytes());
+                    let msg = safe_col_to_string(col, row);
+                    self.buf.extend_from_slice(msg.as_bytes());
                 }
             }
 
@@ -266,7 +301,8 @@ impl StdoutSink {
                         write_json_value(arr, row, &mut self.buf)?;
                     }
                     _ => {
-                        self.buf.extend_from_slice(str_value(arr, row).as_bytes());
+                        let s = array_value_to_string(arr, row).unwrap_or_default();
+                        self.buf.extend_from_slice(s.as_bytes());
                     }
                 }
 
@@ -279,6 +315,19 @@ impl StdoutSink {
             dest.write_all(&self.buf)?;
         }
         Ok(())
+    }
+}
+
+/// Safely convert any Arrow column value to a display string.
+///
+/// Unlike `str_value` (which panics on non-string types), this handles all
+/// Arrow data types via `array_value_to_string` for non-Utf8 columns.
+fn safe_col_to_string(col: &dyn Array, row: usize) -> String {
+    match col.data_type() {
+        DataType::Utf8 => col.as_string::<i32>().value(row).to_string(),
+        DataType::Utf8View => col.as_string_view().value(row).to_string(),
+        DataType::LargeUtf8 => col.as_string::<i64>().value(row).to_string(),
+        _ => array_value_to_string(col, row).unwrap_or_default(),
     }
 }
 

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -151,9 +151,9 @@ impl StdoutSink {
         let ts_idx = find_col(
             fields,
             &[
-                "timestamp",
                 "_timestamp",
                 "@timestamp",
+                "timestamp",
                 "time",
                 "ts",
                 "timestamp_str",

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -9,6 +9,7 @@ use arrow::record_batch::RecordBatch;
 use tokio::io::AsyncWriteExt;
 
 use logfwd_types::diagnostics::ComponentStats;
+use logfwd_types::field_names;
 
 use super::sink::{SendResult, Sink, SinkFactory};
 use arrow::util::display::array_value_to_string;
@@ -151,35 +152,35 @@ impl StdoutSink {
         let ts_idx = find_col(
             fields,
             &[
-                "_timestamp",
-                "@timestamp",
-                "timestamp",
-                "time",
-                "ts",
+                field_names::TIMESTAMP,
+                field_names::TIMESTAMP_UNDERSCORE,
+                field_names::TIMESTAMP_AT,
+                field_names::TIMESTAMP_VARIANTS[0],
+                field_names::TIMESTAMP_VARIANTS[1],
                 "timestamp_str",
             ],
         );
         let level_idx = find_col(
             fields,
             &[
-                "level",
+                field_names::SEVERITY,
                 "level_str",
-                "severity",
-                "log_level",
-                "loglevel",
-                "lvl",
+                field_names::SEVERITY_VARIANTS[0],
+                field_names::SEVERITY_VARIANTS[1],
+                field_names::SEVERITY_VARIANTS[2],
+                field_names::SEVERITY_VARIANTS[3],
             ],
         );
         let msg_idx = find_col(
             fields,
             &[
-                "message",
+                field_names::BODY,
                 "message_str",
-                "msg",
+                field_names::BODY_VARIANTS[0],
                 "msg_str",
-                "_msg",
-                "body",
-                "_raw",
+                field_names::BODY_VARIANTS[1],
+                field_names::BODY_VARIANTS[2],
+                field_names::RAW,
             ],
         );
 
@@ -301,7 +302,7 @@ impl StdoutSink {
                         write_json_value(arr, row, &mut self.buf)?;
                     }
                     _ => {
-                        let s = array_value_to_string(arr, row).unwrap_or_default();
+                        let s = safe_array_value_to_string(arr, row);
                         self.buf.extend_from_slice(s.as_bytes());
                     }
                 }
@@ -327,7 +328,18 @@ fn safe_col_to_string(col: &dyn Array, row: usize) -> String {
         DataType::Utf8 => col.as_string::<i32>().value(row).to_string(),
         DataType::Utf8View => col.as_string_view().value(row).to_string(),
         DataType::LargeUtf8 => col.as_string::<i64>().value(row).to_string(),
-        _ => array_value_to_string(col, row).unwrap_or_default(),
+        _ => safe_array_value_to_string(col, row),
+    }
+}
+
+/// Convert an Arrow value to string without panicking or silently erasing errors.
+fn safe_array_value_to_string(col: &dyn Array, row: usize) -> String {
+    match array_value_to_string(col, row) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!(error = %e, dtype = ?col.data_type(), row, "stdout: value formatting failed");
+            "<format_error>".to_string()
+        }
     }
 }
 

--- a/crates/logfwd-transform/src/udf/geo_lookup.rs
+++ b/crates/logfwd-transform/src/udf/geo_lookup.rs
@@ -1,4 +1,4 @@
-//! UDF: geo_lookup(ip: Utf8) -> Struct{country_code, country_name, city, region, latitude, longitude, asn, org}
+//! UDF: geo_lookup(ip: Utf8|Utf8View|LargeUtf8) -> Struct{country_code, country_name, city, region, latitude, longitude, asn, org}
 //!
 //! Enriches log records with geographic location data based on IP addresses.
 //! Wraps a pluggable [`GeoDatabase`] backend — use [`MmdbDatabase`] for
@@ -55,7 +55,7 @@ fn geo_result_type() -> DataType {
 // GeoLookupUdf
 // ---------------------------------------------------------------------------
 
-/// UDF: geo_lookup(ip: Utf8) -> Struct{country_code, country_name, city, region, latitude, longitude, asn, org}
+/// UDF: geo_lookup(ip: Utf8|Utf8View|LargeUtf8) -> Struct{country_code, country_name, city, region, latitude, longitude, asn, org}
 ///
 /// Calls the underlying [`GeoDatabase`] for each row. Returns a struct with all
 /// NULL fields for IPs that cannot be resolved (private ranges, malformed, absent

--- a/crates/logfwd-transform/src/udf/geo_lookup.rs
+++ b/crates/logfwd-transform/src/udf/geo_lookup.rs
@@ -694,6 +694,47 @@ mod tests {
         assert!(cc.is_null(1));
     }
 
+    /// Regression: geo_lookup() must accept Utf8View input columns.
+    /// Before the fix, the signature only included Utf8 and the UDF would
+    /// reject Utf8View arrays (e.g. from Parquet readers or certain transforms).
+    #[test]
+    fn geo_lookup_utf8view_input() {
+        use arrow::array::StringViewArray;
+
+        let db = make_db();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ip",
+            DataType::Utf8View,
+            true,
+        )]));
+        let arr: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("1.2.3.4"),
+            Some("5.6.7.8"),
+            None,
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![arr]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            db,
+            "SELECT get_field(geo_lookup(ip), 'country_code') AS cc FROM logs",
+        ));
+
+        let cc = result
+            .column_by_name("cc")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(cc.value(0), "US");
+        assert_eq!(cc.value(1), "DE");
+        assert!(cc.is_null(2));
+    }
+
     #[test]
     fn geo_lookup_mixed_rows() {
         let db = make_db();

--- a/crates/logfwd-transform/src/udf/geo_lookup.rs
+++ b/crates/logfwd-transform/src/udf/geo_lookup.rs
@@ -143,29 +143,75 @@ impl ScalarUDFImpl for GeoLookupUdf {
                 let mut asn = Int64Builder::with_capacity(num_rows);
                 let mut org = StringBuilder::with_capacity(num_rows, num_rows * 16);
 
-                for row in 0..num_rows {
-                    let result = if array.is_null(row) {
-                        None
-                    } else {
-                        let ip = match array.data_type() {
-                            DataType::Utf8 => array.as_string::<i32>().value(row),
-                            DataType::Utf8View => array.as_string_view().value(row),
-                            DataType::LargeUtf8 => array.as_string::<i64>().value(row),
-                            _ => "",
-                        };
-                        self.db.lookup(ip)
-                    };
-                    append_result(
-                        result.as_ref(),
-                        &mut country_code,
-                        &mut country_name,
-                        &mut city,
-                        &mut region,
-                        &mut latitude,
-                        &mut longitude,
-                        &mut asn,
-                        &mut org,
-                    );
+                match array.data_type() {
+                    DataType::Utf8 => {
+                        let strings = array.as_string::<i32>();
+                        for row in 0..num_rows {
+                            let result = if strings.is_null(row) {
+                                None
+                            } else {
+                                self.db.lookup(strings.value(row))
+                            };
+                            append_result(
+                                result.as_ref(),
+                                &mut country_code,
+                                &mut country_name,
+                                &mut city,
+                                &mut region,
+                                &mut latitude,
+                                &mut longitude,
+                                &mut asn,
+                                &mut org,
+                            );
+                        }
+                    }
+                    DataType::Utf8View => {
+                        let strings = array.as_string_view();
+                        for row in 0..num_rows {
+                            let result = if strings.is_null(row) {
+                                None
+                            } else {
+                                self.db.lookup(strings.value(row))
+                            };
+                            append_result(
+                                result.as_ref(),
+                                &mut country_code,
+                                &mut country_name,
+                                &mut city,
+                                &mut region,
+                                &mut latitude,
+                                &mut longitude,
+                                &mut asn,
+                                &mut org,
+                            );
+                        }
+                    }
+                    DataType::LargeUtf8 => {
+                        let strings = array.as_string::<i64>();
+                        for row in 0..num_rows {
+                            let result = if strings.is_null(row) {
+                                None
+                            } else {
+                                self.db.lookup(strings.value(row))
+                            };
+                            append_result(
+                                result.as_ref(),
+                                &mut country_code,
+                                &mut country_name,
+                                &mut city,
+                                &mut region,
+                                &mut latitude,
+                                &mut longitude,
+                                &mut asn,
+                                &mut org,
+                            );
+                        }
+                    }
+                    other => {
+                        return Err(datafusion::error::DataFusionError::Execution(format!(
+                            "geo_lookup() input must be Utf8/Utf8View/LargeUtf8, got {other:?}"
+                        )));
+                    }
                 }
 
                 let struct_array = build_struct_array(
@@ -708,6 +754,44 @@ mod tests {
             true,
         )]));
         let arr: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("1.2.3.4"),
+            Some("5.6.7.8"),
+            None,
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![arr]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            db,
+            "SELECT get_field(geo_lookup(ip), 'country_code') AS cc FROM logs",
+        ));
+
+        let cc = result
+            .column_by_name("cc")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(cc.value(0), "US");
+        assert_eq!(cc.value(1), "DE");
+        assert!(cc.is_null(2));
+    }
+
+    #[test]
+    fn geo_lookup_largeutf8_input() {
+        use arrow::array::LargeStringArray;
+
+        let db = make_db();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ip",
+            DataType::LargeUtf8,
+            true,
+        )]));
+        let arr: ArrayRef = Arc::new(LargeStringArray::from(vec![
             Some("1.2.3.4"),
             Some("5.6.7.8"),
             None,

--- a/crates/logfwd-transform/src/udf/geo_lookup.rs
+++ b/crates/logfwd-transform/src/udf/geo_lookup.rs
@@ -91,7 +91,11 @@ impl GeoLookupUdf {
     pub fn new(db: Arc<dyn GeoDatabase>) -> Self {
         Self {
             signature: Signature::new(
-                TypeSignature::Exact(vec![DataType::Utf8]),
+                TypeSignature::OneOf(vec![
+                    TypeSignature::Exact(vec![DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::Utf8View]),
+                    TypeSignature::Exact(vec![DataType::LargeUtf8]),
+                ]),
                 Volatility::Immutable,
             ),
             db,
@@ -127,8 +131,7 @@ impl ScalarUDFImpl for GeoLookupUdf {
 
         match input {
             ColumnarValue::Array(array) => {
-                let str_array = array.as_string::<i32>();
-                let num_rows = str_array.len();
+                let num_rows = array.len();
 
                 // One builder per struct field.
                 let mut country_code = StringBuilder::with_capacity(num_rows, num_rows * 4);
@@ -141,10 +144,16 @@ impl ScalarUDFImpl for GeoLookupUdf {
                 let mut org = StringBuilder::with_capacity(num_rows, num_rows * 16);
 
                 for row in 0..num_rows {
-                    let result = if str_array.is_null(row) {
+                    let result = if array.is_null(row) {
                         None
                     } else {
-                        self.db.lookup(str_array.value(row))
+                        let ip = match array.data_type() {
+                            DataType::Utf8 => array.as_string::<i32>().value(row),
+                            DataType::Utf8View => array.as_string_view().value(row),
+                            DataType::LargeUtf8 => array.as_string::<i64>().value(row),
+                            _ => "",
+                        };
+                        self.db.lookup(ip)
                     };
                     append_result(
                         result.as_ref(),
@@ -175,7 +184,9 @@ impl ScalarUDFImpl for GeoLookupUdf {
             ColumnarValue::Scalar(scalar) => {
                 // Single-value path: look up once, return a scalar struct.
                 let ip_str = match scalar {
-                    datafusion::common::ScalarValue::Utf8(Some(s)) => Some(s.as_str()),
+                    datafusion::common::ScalarValue::Utf8(Some(s))
+                    | datafusion::common::ScalarValue::Utf8View(Some(s))
+                    | datafusion::common::ScalarValue::LargeUtf8(Some(s)) => Some(s.as_str()),
                     _ => None,
                 };
                 let result = ip_str.and_then(|ip| self.db.lookup(ip));

--- a/crates/logfwd-transform/src/udf/grok.rs
+++ b/crates/logfwd-transform/src/udf/grok.rs
@@ -523,6 +523,45 @@ mod tests {
         }
     }
 
+    /// Regression: grok() must accept Utf8View input columns.
+    /// Before the fix, Utf8View was not in the signature's OneOf list and the
+    /// UDF would fail with a type-mismatch error.
+    #[test]
+    fn test_grok_utf8view_input() {
+        use arrow::array::StringViewArray;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "message",
+            DataType::Utf8View,
+            true,
+        )]));
+        let msgs: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("GET /api/users 200"),
+            Some("POST /api/orders 500"),
+            None,
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![msgs]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            "SELECT get_field(grok(message, '%{WORD:method} %{URIPATH:path} %{NUMBER:status}'), 'method') AS http_method FROM logs",
+        ));
+
+        let method = result
+            .column_by_name("http_method")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(method.value(0), "GET");
+        assert_eq!(method.value(1), "POST");
+        assert!(method.is_null(2));
+    }
+
     #[test]
     fn test_grok_rejects_array_pattern_argument() {
         let schema = Arc::new(Schema::new(vec![

--- a/crates/logfwd-transform/src/udf/grok.rs
+++ b/crates/logfwd-transform/src/udf/grok.rs
@@ -156,8 +156,11 @@ impl ScalarUDFImpl for GrokUdf {
     ) -> DfResult<arrow::datatypes::FieldRef> {
         // If the pattern argument is a literal, extract field names and return Struct type.
         if args.scalar_arguments.len() >= 2
-            && let Some(datafusion::common::ScalarValue::Utf8(Some(pattern_str))) =
-                args.scalar_arguments[1]
+            && let Some(
+                datafusion::common::ScalarValue::Utf8(Some(pattern_str))
+                | datafusion::common::ScalarValue::Utf8View(Some(pattern_str))
+                | datafusion::common::ScalarValue::LargeUtf8(Some(pattern_str)),
+            ) = args.scalar_arguments[1]
             && let Ok(compiled) = compile_grok(pattern_str)
         {
             let fields: Vec<Field> = compiled
@@ -238,33 +241,89 @@ impl ScalarUDFImpl for GrokUdf {
                     .map(|_| StringBuilder::with_capacity(num_rows, num_rows * 32))
                     .collect();
 
-                for row in 0..num_rows {
-                    if array.is_null(row) {
-                        for b in &mut builders {
-                            b.append_null();
-                        }
-                        continue;
-                    }
-                    let val = match array.data_type() {
-                        DataType::Utf8 => array.as_string::<i32>().value(row),
-                        DataType::Utf8View => array.as_string_view().value(row),
-                        DataType::LargeUtf8 => array.as_string::<i64>().value(row),
-                        _ => "",
-                    };
-                    match compiled.pattern.match_against(val) {
-                        Some(matches) => {
-                            for (i, name) in compiled.field_names.iter().enumerate() {
-                                match matches.get(name) {
-                                    Some(v) => builders[i].append_value(v),
-                                    None => builders[i].append_null(),
+                match array.data_type() {
+                    DataType::Utf8 => {
+                        let strings = array.as_string::<i32>();
+                        for row in 0..num_rows {
+                            if strings.is_null(row) {
+                                for b in &mut builders {
+                                    b.append_null();
+                                }
+                                continue;
+                            }
+                            match compiled.pattern.match_against(strings.value(row)) {
+                                Some(matches) => {
+                                    for (i, name) in compiled.field_names.iter().enumerate() {
+                                        match matches.get(name) {
+                                            Some(v) => builders[i].append_value(v),
+                                            None => builders[i].append_null(),
+                                        }
+                                    }
+                                }
+                                None => {
+                                    for b in &mut builders {
+                                        b.append_null();
+                                    }
                                 }
                             }
                         }
-                        None => {
-                            for b in &mut builders {
-                                b.append_null();
+                    }
+                    DataType::Utf8View => {
+                        let strings = array.as_string_view();
+                        for row in 0..num_rows {
+                            if strings.is_null(row) {
+                                for b in &mut builders {
+                                    b.append_null();
+                                }
+                                continue;
+                            }
+                            match compiled.pattern.match_against(strings.value(row)) {
+                                Some(matches) => {
+                                    for (i, name) in compiled.field_names.iter().enumerate() {
+                                        match matches.get(name) {
+                                            Some(v) => builders[i].append_value(v),
+                                            None => builders[i].append_null(),
+                                        }
+                                    }
+                                }
+                                None => {
+                                    for b in &mut builders {
+                                        b.append_null();
+                                    }
+                                }
                             }
                         }
+                    }
+                    DataType::LargeUtf8 => {
+                        let strings = array.as_string::<i64>();
+                        for row in 0..num_rows {
+                            if strings.is_null(row) {
+                                for b in &mut builders {
+                                    b.append_null();
+                                }
+                                continue;
+                            }
+                            match compiled.pattern.match_against(strings.value(row)) {
+                                Some(matches) => {
+                                    for (i, name) in compiled.field_names.iter().enumerate() {
+                                        match matches.get(name) {
+                                            Some(v) => builders[i].append_value(v),
+                                            None => builders[i].append_null(),
+                                        }
+                                    }
+                                }
+                                None => {
+                                    for b in &mut builders {
+                                        b.append_null();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    other => {
+                        return Err(datafusion::error::DataFusionError::Execution(format!(
+                            "grok() input must be Utf8/Utf8View/LargeUtf8, got {other:?}"
+                        )));
                     }
                 }
 
@@ -536,6 +595,42 @@ mod tests {
             true,
         )]));
         let msgs: ArrayRef = Arc::new(StringViewArray::from(vec![
+            Some("GET /api/users 200"),
+            Some("POST /api/orders 500"),
+            None,
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![msgs]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            "SELECT get_field(grok(message, '%{WORD:method} %{URIPATH:path} %{NUMBER:status}'), 'method') AS http_method FROM logs",
+        ));
+
+        let method = result
+            .column_by_name("http_method")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(method.value(0), "GET");
+        assert_eq!(method.value(1), "POST");
+        assert!(method.is_null(2));
+    }
+
+    #[test]
+    fn test_grok_largeutf8_input() {
+        use arrow::array::LargeStringArray;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "message",
+            DataType::LargeUtf8,
+            true,
+        )]));
+        let msgs: ArrayRef = Arc::new(LargeStringArray::from(vec![
             Some("GET /api/users 200"),
             Some("POST /api/orders 500"),
             None,

--- a/crates/logfwd-transform/src/udf/grok.rs
+++ b/crates/logfwd-transform/src/udf/grok.rs
@@ -109,7 +109,14 @@ impl GrokUdf {
     pub fn new() -> Self {
         Self {
             signature: Signature::new(
-                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
+                TypeSignature::OneOf(vec![
+                    TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::Utf8View, DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8View]),
+                    TypeSignature::Exact(vec![DataType::Utf8View, DataType::Utf8View]),
+                    TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Utf8View]),
+                ]),
                 Volatility::Immutable,
             ),
             grok_cache: Mutex::new(HashMap::new()),
@@ -182,7 +189,11 @@ impl ScalarUDFImpl for GrokUdf {
 
         // Extract pattern string.
         let pattern_str = match pattern {
-            ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(s))) => s.clone(),
+            ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(s)))
+            | ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8View(Some(s)))
+            | ColumnarValue::Scalar(datafusion::common::ScalarValue::LargeUtf8(Some(s))) => {
+                s.clone()
+            }
             ColumnarValue::Scalar(s) => {
                 let s = s.to_string();
                 s.trim_matches('"').trim_matches('\'').to_string()
@@ -218,8 +229,7 @@ impl ScalarUDFImpl for GrokUdf {
 
         match input {
             ColumnarValue::Array(array) => {
-                let str_array = array.as_string::<i32>();
-                let num_rows = str_array.len();
+                let num_rows = array.len();
 
                 // Build one StringBuilder per capture group.
                 let mut builders: Vec<StringBuilder> = compiled
@@ -229,13 +239,18 @@ impl ScalarUDFImpl for GrokUdf {
                     .collect();
 
                 for row in 0..num_rows {
-                    if str_array.is_null(row) {
+                    if array.is_null(row) {
                         for b in &mut builders {
                             b.append_null();
                         }
                         continue;
                     }
-                    let val = str_array.value(row);
+                    let val = match array.data_type() {
+                        DataType::Utf8 => array.as_string::<i32>().value(row),
+                        DataType::Utf8View => array.as_string_view().value(row),
+                        DataType::LargeUtf8 => array.as_string::<i64>().value(row),
+                        _ => "",
+                    };
                     match compiled.pattern.match_against(val) {
                         Some(matches) => {
                             for (i, name) in compiled.field_names.iter().enumerate() {

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -83,6 +83,21 @@ impl RegexpExtractUdf {
                         DataType::Utf8View,
                         DataType::Int64,
                     ]),
+                    TypeSignature::Exact(vec![
+                        DataType::Utf8,
+                        DataType::LargeUtf8,
+                        DataType::Int64,
+                    ]),
+                    TypeSignature::Exact(vec![
+                        DataType::Utf8View,
+                        DataType::LargeUtf8,
+                        DataType::Int64,
+                    ]),
+                    TypeSignature::Exact(vec![
+                        DataType::LargeUtf8,
+                        DataType::LargeUtf8,
+                        DataType::Int64,
+                    ]),
                 ]),
                 Volatility::Immutable,
             ),

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -459,6 +459,45 @@ mod tests {
         );
     }
 
+    /// Regression: regexp_extract() must accept Utf8View input columns.
+    /// Before the fix, Utf8View was not in the signature and would cause a
+    /// type-mismatch error at planning time.
+    #[test]
+    fn test_regexp_extract_utf8view_input() {
+        use arrow::array::StringViewArray;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "msg",
+            DataType::Utf8View,
+            true,
+        )]));
+        let msgs: Arc<dyn Array> = Arc::new(StringViewArray::from(vec![
+            Some("status=200 user=alice"),
+            Some("status=500 user=bob"),
+            None,
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![msgs]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            "SELECT regexp_extract(msg, 'status=(\\d+)', 1) AS status FROM logs",
+        ));
+
+        let status = result
+            .column_by_name("status")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(status.value(0), "200");
+        assert_eq!(status.value(1), "500");
+        assert!(status.is_null(2));
+    }
+
     #[test]
     fn test_regexp_extract_rejects_array_pattern_argument() {
         let schema = Arc::new(Schema::new(vec![

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -2,6 +2,8 @@
 //!
 //! Spark-compatible regex extraction. Returns the capture group at the given
 //! index (1-based), or the full match if index is 0. Returns NULL on no match.
+//! `string` and `pattern` accept Utf8, Utf8View, or LargeUtf8 expressions;
+//! `pattern` must still be a scalar literal at runtime.
 //!
 //! ```sql
 //! SELECT regexp_extract(message_str, 'status=(\d+)', 1) AS status FROM logs
@@ -24,11 +26,10 @@ use regex::Regex;
 
 /// UDF: regexp_extract(string, pattern, group_index) -> Utf8
 ///
-/// - `string`: the input column (Utf8)
-/// - `pattern`: regex pattern with capture groups (Utf8 literal)
-/// - `group_index`: 0 for full match, 1+ for capture groups (Int64)
-///
-/// Returns NULL when the pattern doesn't match or the group index is out of range.
+/// SQL shape: `regexp_extract(<text>, <regex-literal>, <group-index>)`.
+/// `<text>` and `<regex-literal>` may be Utf8, Utf8View, or LargeUtf8
+/// expressions; `<group-index>` is Int64 (`0` = full match, `1+` = capture).
+/// Returns NULL when the pattern does not match or the group index is out of range.
 #[derive(Debug)]
 pub struct RegexpExtractUdf {
     signature: Signature,

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -186,23 +186,59 @@ impl ScalarUDFImpl for RegexpExtractUdf {
                 let num_rows = array.len();
                 let mut builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
 
-                for i in 0..num_rows {
-                    if array.is_null(i) {
-                        builder.append_null();
-                        continue;
+                match array.data_type() {
+                    DataType::Utf8 => {
+                        let strings = array.as_string::<i32>();
+                        for i in 0..num_rows {
+                            if strings.is_null(i) {
+                                builder.append_null();
+                                continue;
+                            }
+                            match re.captures(strings.value(i)) {
+                                Some(caps) => match caps.get(idx) {
+                                    Some(m) => builder.append_value(m.as_str()),
+                                    None => builder.append_null(),
+                                },
+                                None => builder.append_null(),
+                            }
+                        }
                     }
-                    let val = match array.data_type() {
-                        DataType::Utf8 => array.as_string::<i32>().value(i),
-                        DataType::Utf8View => array.as_string_view().value(i),
-                        DataType::LargeUtf8 => array.as_string::<i64>().value(i),
-                        _ => "",
-                    };
-                    match re.captures(val) {
-                        Some(caps) => match caps.get(idx) {
-                            Some(m) => builder.append_value(m.as_str()),
-                            None => builder.append_null(),
-                        },
-                        None => builder.append_null(),
+                    DataType::Utf8View => {
+                        let strings = array.as_string_view();
+                        for i in 0..num_rows {
+                            if strings.is_null(i) {
+                                builder.append_null();
+                                continue;
+                            }
+                            match re.captures(strings.value(i)) {
+                                Some(caps) => match caps.get(idx) {
+                                    Some(m) => builder.append_value(m.as_str()),
+                                    None => builder.append_null(),
+                                },
+                                None => builder.append_null(),
+                            }
+                        }
+                    }
+                    DataType::LargeUtf8 => {
+                        let strings = array.as_string::<i64>();
+                        for i in 0..num_rows {
+                            if strings.is_null(i) {
+                                builder.append_null();
+                                continue;
+                            }
+                            match re.captures(strings.value(i)) {
+                                Some(caps) => match caps.get(idx) {
+                                    Some(m) => builder.append_value(m.as_str()),
+                                    None => builder.append_null(),
+                                },
+                                None => builder.append_null(),
+                            }
+                        }
+                    }
+                    other => {
+                        return Err(datafusion::error::DataFusionError::Execution(format!(
+                            "regexp_extract() input must be Utf8/Utf8View/LargeUtf8, got {other:?}"
+                        )));
                     }
                 }
 
@@ -495,6 +531,42 @@ mod tests {
             .unwrap();
         assert_eq!(status.value(0), "200");
         assert_eq!(status.value(1), "500");
+        assert!(status.is_null(2));
+    }
+
+    #[test]
+    fn test_regexp_extract_largeutf8_input() {
+        use arrow::array::LargeStringArray;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "msg",
+            DataType::LargeUtf8,
+            true,
+        )]));
+        let msgs: Arc<dyn Array> = Arc::new(LargeStringArray::from(vec![
+            Some("status=201 user=carol"),
+            Some("status=404 user=dave"),
+            None,
+        ]));
+        let batch = RecordBatch::try_new(schema, vec![msgs]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            "SELECT regexp_extract(msg, 'status=(\\d+)', 1) AS status FROM logs",
+        ));
+
+        let status = result
+            .column_by_name("status")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(status.value(0), "201");
+        assert_eq!(status.value(1), "404");
         assert!(status.is_null(2));
     }
 

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -64,7 +64,26 @@ impl RegexpExtractUdf {
     pub fn new() -> Self {
         Self {
             signature: Signature::new(
-                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Int64]),
+                TypeSignature::OneOf(vec![
+                    TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Int64]),
+                    TypeSignature::Exact(vec![DataType::Utf8View, DataType::Utf8, DataType::Int64]),
+                    TypeSignature::Exact(vec![
+                        DataType::LargeUtf8,
+                        DataType::Utf8,
+                        DataType::Int64,
+                    ]),
+                    TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8View, DataType::Int64]),
+                    TypeSignature::Exact(vec![
+                        DataType::Utf8View,
+                        DataType::Utf8View,
+                        DataType::Int64,
+                    ]),
+                    TypeSignature::Exact(vec![
+                        DataType::LargeUtf8,
+                        DataType::Utf8View,
+                        DataType::Int64,
+                    ]),
+                ]),
                 Volatility::Immutable,
             ),
             regex_cache: Mutex::new(HashMap::new()),
@@ -102,7 +121,11 @@ impl ScalarUDFImpl for RegexpExtractUdf {
 
         // Extract the pattern string (must be a constant/scalar).
         let pattern_str = match pattern {
-            ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(s))) => s.clone(),
+            ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(s)))
+            | ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8View(Some(s)))
+            | ColumnarValue::Scalar(datafusion::common::ScalarValue::LargeUtf8(Some(s))) => {
+                s.clone()
+            }
             ColumnarValue::Scalar(s) => {
                 let s = s.to_string();
                 s.trim_matches('"').trim_matches('\'').to_string()
@@ -160,16 +183,20 @@ impl ScalarUDFImpl for RegexpExtractUdf {
 
         match input {
             ColumnarValue::Array(array) => {
-                let str_array = array.as_string::<i32>();
-                let mut builder =
-                    StringBuilder::with_capacity(str_array.len(), str_array.len() * 32);
+                let num_rows = array.len();
+                let mut builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
 
-                for i in 0..str_array.len() {
-                    if str_array.is_null(i) {
+                for i in 0..num_rows {
+                    if array.is_null(i) {
                         builder.append_null();
                         continue;
                     }
-                    let val = str_array.value(i);
+                    let val = match array.data_type() {
+                        DataType::Utf8 => array.as_string::<i32>().value(i),
+                        DataType::Utf8View => array.as_string_view().value(i),
+                        DataType::LargeUtf8 => array.as_string::<i64>().value(i),
+                        _ => "",
+                    };
                     match re.captures(val) {
                         Some(caps) => match caps.get(idx) {
                             Some(m) => builder.append_value(m.as_str()),


### PR DESCRIPTION
## Summary

Fixes 8 correctness bugs found across the UDF, output sink, and config validation layers.

### UDF Utf8View type support (fixes #1723, #1724)

The production scanner (`StreamingBuilder::finish_batch`) produces `Utf8View` columns, but `geo_lookup()`, `grok()`, and `regexp_extract()` only accepted `Utf8` in their type signatures. Any SQL query using these UDFs on scanner-produced columns failed with a type error. The `hash()` and `json_extract()` UDFs already handled all three string types correctly.

- Added `Utf8View` and `LargeUtf8` to all three UDFs' type signatures
- Updated array access to dispatch on `data_type()` instead of assuming `StringArray`
- Updated scalar pattern matching to accept `Utf8View`/`LargeUtf8` scalars

### Console format crash prevention (fixes #1725, #1726, #1729, #1730)

The console format (`stdout.rs write_console`) had multiple crash paths:

1. **`str_value()` panics on non-string types**: The catch-all `_ =>` arm for extra fields called `str_value()`, which hits `unreachable!()` for Boolean, Int32, UInt64, Timestamp, etc. columns. Replaced with `array_value_to_string()`.

2. **Well-known column panics on struct/non-string types**: `find_col` searches by name only, then calls `str_value()` on the result. If `timestamp` or `level` is a struct conflict column (mixed types), this panics. Added `safe_col_to_string()` helper that handles all types.

3. **Missing timestamp variants**: `find_col` only checked `["timestamp_str", "timestamp"]`, missing `_timestamp` (CRI), `@timestamp` (ES), `time`, `ts`. CRI pipelines never showed timestamps.

4. **Empty output for raw-text**: `_raw` was excluded from both the message search and extra fields, so raw-text pipelines showed nothing. Added `_raw` and `body` to the message column search.

### Arrow IPC gzip rejection (fixes #1727)

Config validation accepted `compression: gzip` for Arrow IPC outputs, but `ArrowIpcSink::maybe_compress` silently skipped gzip — data was sent uncompressed. Added config-time rejection with a clear error message.

### Loki Timestamp type support (fixes #1728)

The Loki sink's timestamp extraction handled `Int64`, `UInt64`, `Utf8`, `Utf8View`, `LargeUtf8` but fell through to `observed_time_ns` for `DataType::Timestamp`. SQL transforms producing `Timestamp` columns (via `CAST`, `DATE_TRUNC`, `NOW()`) had their timestamps silently replaced with batch ingestion time. Added full `Timestamp(unit, _)` handling with proper `TimeUnit` conversion.

## Test plan

- [x] `cargo test -p logfwd-output` — all tests pass
- [x] `cargo test -p logfwd-transform` — all tests pass (78 passed)
- [x] `cargo clippy -p logfwd-output -p logfwd-transform -p logfwd-config -- -D warnings` — clean
- [ ] Regression tests to be added in follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 8 correctness bugs across UDF Utf8View support, console panics, Loki timestamps, and Arrow IPC gzip validation
> - Extends `geo_lookup()`, `grok()`, and `regexp_extract()` UDFs to accept `Utf8View` and `LargeUtf8` input columns and scalar patterns in addition to `Utf8`.
> - Fixes console output (`stdout`) to handle `Utf8View`/`LargeUtf8` columns and non-string types (e.g. booleans) without panicking; uses `find_preferred_column` to resolve canonical field names and `safe_col_to_string` for safe formatting.
> - Fixes Loki sink to extract timestamps from Arrow `Timestamp` columns (nanosecond, microsecond, millisecond, second), converting to nanoseconds and falling back to `observed_time_ns` on overflow or invalid values.
> - Adds validation in `Config.validate` to reject Arrow IPC outputs configured with compression other than `zstd`, and escapes JSON attribute keys in `attrs_to_json` to prevent malformed JSON output.
> - Behavioral Change: Arrow IPC configs with `compression: gzip` now fail at load time with an explicit error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b2c8bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->