### PR TITLE
fix: 11 correctness & security bugs — SQL analysis, credential redaction, config validation

### DIFF
--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -1524,7 +1524,7 @@ fn scatter_resource_attrs(
                     for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
                         let rid = resource_ids.value(row);
                         if let Some(val) = rid_to_val.get(&rid) {
-                            *slot = val.clone();
+                            *slot = *val;
                         }
                     }
                 }
@@ -1535,7 +1535,7 @@ fn scatter_resource_attrs(
                     for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
                         let rid = resource_ids.value(row);
                         if let Some(val) = rid_to_val.get(&rid) {
-                            *slot = val.clone();
+                            *slot = *val;
                         }
                     }
                 }
@@ -1546,7 +1546,7 @@ fn scatter_resource_attrs(
                     for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
                         let rid = resource_ids.value(row);
                         if let Some(val) = rid_to_val.get(&rid) {
-                            *slot = val.clone();
+                            *slot = *val;
                         }
                     }
                 }

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -1275,6 +1275,16 @@ fn unpivot_attrs_to_flat(
         .downcast_ref::<BooleanArray>()
         .ok_or_else(|| ArrowError::SchemaError("bool not Boolean".to_string()))?;
 
+    let bytes_arr = attrs_batch
+        .column(
+            a_schema
+                .index_of("bytes")
+                .map_err(|e| ArrowError::SchemaError(format!("missing bytes: {e}")))?,
+        )
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .ok_or_else(|| ArrowError::SchemaError("bytes not Binary".to_string()))?;
+
     for row in 0..attrs_batch.num_rows() {
         let parent_id = parent_id_arr.value(row);
         let target_row = row_for(parent_id);
@@ -1325,12 +1335,26 @@ fn unpivot_attrs_to_flat(
                     }
                 }
             }
+            ATTR_TYPE_BYTES => {
+                // Bytes are stored in the binary column; hex-encode for flat schema.
+                if !bytes_arr.is_null(row)
+                    && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
+                {
+                    let hex: String =
+                        bytes_arr.value(row).iter().fold(String::new(), |mut s, b| {
+                            use std::fmt::Write;
+                            let _ = write!(s, "{b:02x}");
+                            s
+                        });
+                    v[target_row] = Some(hex);
+                }
+            }
             _ => {
-                // ATTR_TYPE_STR or ATTR_TYPE_BYTES — read from str column.
-                if !str_arr.is_null(row) {
-                    if let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1 {
-                        v[target_row] = Some(str_arr.value(row).to_string());
-                    }
+                // ATTR_TYPE_STR — read from str column.
+                if !str_arr.is_null(row)
+                    && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
+                {
+                    v[target_row] = Some(str_arr.value(row).to_string());
                 }
             }
         }

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -202,28 +202,27 @@ pub fn flat_to_star(batch: &RecordBatch) -> Result<StarSchema, ArrowError> {
     // Key: sorted string of all resource attribute values for one row.
     let mut resource_id_map: HashMap<Vec<String>, u32> = HashMap::new();
     let mut row_resource_ids: Vec<u32> = Vec::with_capacity(num_rows);
-    let mut resource_sets: Vec<(u32, Vec<(String, String)>)> = Vec::new();
+    let mut resource_template_rows: Vec<usize> = Vec::new();
 
     for row in 0..num_rows {
         let mut key_parts: Vec<String> = Vec::with_capacity(resource_cols.len());
-        let mut attrs: Vec<(String, String)> = Vec::with_capacity(resource_cols.len());
 
         for (attr_key, col_idx) in &resource_cols {
             let val = str_value_at(batch.column(*col_idx).as_ref(), row);
             key_parts.push(format!("{attr_key}={val}"));
-            attrs.push((attr_key.clone(), val));
         }
 
         let next_id = resource_id_map.len() as u32;
         let rid = *resource_id_map.entry(key_parts).or_insert_with(|| {
-            resource_sets.push((next_id, attrs));
+            resource_template_rows.push(row);
             next_id
         });
         row_resource_ids.push(rid);
     }
 
     // --- Build RESOURCE_ATTRS table ---
-    let resource_attrs_batch = build_attrs_table(&resource_sets)?;
+    let resource_attrs_batch =
+        build_resource_attrs_table(batch, &resource_cols, &resource_template_rows)?;
 
     // --- Build SCOPE_ATTRS table ---
     // Single scope: scope_id=0, name="logfwd".
@@ -536,6 +535,30 @@ fn str_value_at(arr: &dyn Array, row: usize) -> String {
             .downcast_ref::<BooleanArray>()
             .map(|a| a.value(row).to_string())
             .unwrap_or_default(),
+        DataType::Binary => arr
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .map(|a| {
+                let mut hex = String::with_capacity(a.value(row).len() * 2);
+                for b in a.value(row) {
+                    use std::fmt::Write as _;
+                    let _ = write!(&mut hex, "{b:02x}");
+                }
+                hex
+            })
+            .unwrap_or_default(),
+        DataType::LargeBinary => arr
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .map(|a| {
+                let mut hex = String::with_capacity(a.value(row).len() * 2);
+                for b in a.value(row) {
+                    use std::fmt::Write as _;
+                    let _ = write!(&mut hex, "{b:02x}");
+                }
+                hex
+            })
+            .unwrap_or_default(),
         _ => String::new(),
     }
 }
@@ -571,16 +594,20 @@ fn attr_type_for(dt: &DataType) -> u8 {
     }
 }
 
-/// Build an attrs dimension table from deduplicated resource attribute sets.
-fn build_attrs_table(sets: &[(u32, Vec<(String, String)>)]) -> Result<RecordBatch, ArrowError> {
+/// Build RESOURCE_ATTRS from deduplicated resource template rows.
+fn build_resource_attrs_table(
+    batch: &RecordBatch,
+    resource_cols: &[(String, usize)],
+    template_rows: &[usize],
+) -> Result<RecordBatch, ArrowError> {
     let schema = Arc::new(attrs_schema());
 
-    if sets.is_empty() {
+    if template_rows.is_empty() || resource_cols.is_empty() {
         return Ok(RecordBatch::new_empty(schema));
     }
 
-    // Count total rows.
-    let total: usize = sets.iter().map(|(_, attrs)| attrs.len()).sum();
+    // Upper bound: every resource row has every resource attr.
+    let total: usize = template_rows.len() * resource_cols.len();
     if total == 0 {
         return Ok(RecordBatch::new_empty(schema));
     }
@@ -588,38 +615,117 @@ fn build_attrs_table(sets: &[(u32, Vec<(String, String)>)]) -> Result<RecordBatc
     let mut parent_ids = Vec::with_capacity(total);
     let mut keys = Vec::with_capacity(total);
     let mut types = Vec::with_capacity(total);
-    let mut str_vals: Vec<Option<&str>> = Vec::with_capacity(total);
+    let mut str_vals: Vec<Option<String>> = Vec::with_capacity(total);
     let mut int_vals: Vec<Option<i64>> = Vec::with_capacity(total);
     let mut double_vals: Vec<Option<f64>> = Vec::with_capacity(total);
     let mut bool_vals: Vec<Option<bool>> = Vec::with_capacity(total);
-    let mut bytes_vals: Vec<Option<&[u8]>> = Vec::with_capacity(total);
+    let mut bytes_vals: Vec<Option<Vec<u8>>> = Vec::with_capacity(total);
 
-    for (pid, attrs) in sets {
-        for (key, val) in attrs {
-            parent_ids.push(*pid);
-            keys.push(key.as_str());
-            types.push(ATTR_TYPE_STR);
-            str_vals.push(if val.is_empty() {
-                None
-            } else {
-                Some(val.as_str())
-            });
-            int_vals.push(None);
-            double_vals.push(None);
-            bool_vals.push(None);
-            bytes_vals.push(None);
+    for (pid, &row) in template_rows.iter().enumerate() {
+        for (key, col_idx) in resource_cols {
+            let arr = batch.column(*col_idx).as_ref();
+            if arr.is_null(row) {
+                continue;
+            }
+
+            parent_ids.push(pid as u32);
+            keys.push(key.clone());
+
+            match attr_type_for(arr.data_type()) {
+                ATTR_TYPE_INT => {
+                    let value = arr
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .map(|a| a.value(row))
+                        .ok_or_else(|| {
+                            ArrowError::SchemaError("resource attr int not Int64".to_string())
+                        })?;
+                    types.push(ATTR_TYPE_INT);
+                    int_vals.push(Some(value));
+                    str_vals.push(None);
+                    double_vals.push(None);
+                    bool_vals.push(None);
+                    bytes_vals.push(None);
+                }
+                ATTR_TYPE_DOUBLE => {
+                    let value = arr
+                        .as_any()
+                        .downcast_ref::<Float64Array>()
+                        .map(|a| a.value(row))
+                        .ok_or_else(|| {
+                            ArrowError::SchemaError("resource attr double not Float64".to_string())
+                        })?;
+                    types.push(ATTR_TYPE_DOUBLE);
+                    double_vals.push(Some(value));
+                    str_vals.push(None);
+                    int_vals.push(None);
+                    bool_vals.push(None);
+                    bytes_vals.push(None);
+                }
+                ATTR_TYPE_BOOL => {
+                    let value = arr
+                        .as_any()
+                        .downcast_ref::<BooleanArray>()
+                        .map(|a| a.value(row))
+                        .ok_or_else(|| {
+                            ArrowError::SchemaError("resource attr bool not Boolean".to_string())
+                        })?;
+                    types.push(ATTR_TYPE_BOOL);
+                    bool_vals.push(Some(value));
+                    str_vals.push(None);
+                    int_vals.push(None);
+                    double_vals.push(None);
+                    bytes_vals.push(None);
+                }
+                ATTR_TYPE_BYTES => {
+                    let bytes = match arr.data_type() {
+                        DataType::Binary => arr
+                            .as_any()
+                            .downcast_ref::<BinaryArray>()
+                            .map(|a| a.value(row).to_vec()),
+                        DataType::LargeBinary => arr
+                            .as_any()
+                            .downcast_ref::<LargeBinaryArray>()
+                            .map(|a| a.value(row).to_vec()),
+                        _ => None,
+                    }
+                    .ok_or_else(|| {
+                        ArrowError::SchemaError(
+                            "resource attr bytes not Binary/LargeBinary".to_string(),
+                        )
+                    })?;
+                    types.push(ATTR_TYPE_BYTES);
+                    bytes_vals.push(Some(bytes));
+                    str_vals.push(None);
+                    int_vals.push(None);
+                    double_vals.push(None);
+                    bool_vals.push(None);
+                }
+                _ => {
+                    types.push(ATTR_TYPE_STR);
+                    str_vals.push(Some(str_value_at(arr, row)));
+                    int_vals.push(None);
+                    double_vals.push(None);
+                    bool_vals.push(None);
+                    bytes_vals.push(None);
+                }
+            }
         }
     }
 
+    let bytes_refs: Vec<Option<&[u8]>> = bytes_vals.iter().map(|v| v.as_deref()).collect();
+
     let columns: Vec<ArrayRef> = vec![
         Arc::new(UInt32Array::from(parent_ids)),
-        Arc::new(StringArray::from(keys)),
+        Arc::new(StringArray::from(
+            keys.into_iter().map(Some).collect::<Vec<_>>(),
+        )),
         Arc::new(UInt8Array::from(types)),
         Arc::new(StringArray::from(str_vals)),
         Arc::new(Int64Array::from(int_vals)),
         Arc::new(Float64Array::from(double_vals)),
         Arc::new(BooleanArray::from(bool_vals)),
-        Arc::new(BinaryArray::from(bytes_vals)),
+        Arc::new(BinaryArray::from(bytes_refs)),
     ];
 
     RecordBatch::try_new(schema, columns)
@@ -1349,13 +1455,18 @@ fn unpivot_attrs_to_flat(
                     v[target_row] = Some(hex);
                 }
             }
-            _ => {
-                // ATTR_TYPE_STR — read from str column.
+            ATTR_TYPE_STR => {
                 if !str_arr.is_null(row)
                     && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
                 {
                     v[target_row] = Some(str_arr.value(row).to_string());
                 }
+            }
+            _ => {
+                return Err(ArrowError::SchemaError(format!(
+                    "unknown attr type tag {type_tag} for key '{}'",
+                    key_arr.value(row)
+                )));
             }
         }
     }
@@ -1926,6 +2037,45 @@ mod tests {
 
         assert_eq!(payload_arr.value(0), "000fff");
         assert_eq!(payload_arr.value(1), "abcd");
+    }
+
+    #[test]
+    fn binary_resource_attrs_roundtrip_as_hex_strings() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("message", DataType::Utf8, true),
+            Field::new("_resource_payload", DataType::Binary, true),
+        ]));
+
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(StringArray::from(vec![
+                Some("row-0"),
+                Some("row-1"),
+                Some("row-2"),
+            ])),
+            Arc::new(BinaryArray::from(vec![
+                Some(&[0xde_u8, 0xad_u8, 0xbe_u8, 0xef_u8][..]),
+                Some(&[0xde_u8, 0xad_u8, 0xbe_u8, 0xef_u8][..]),
+                Some(&[0x01_u8, 0x02_u8][..]),
+            ])),
+        ];
+
+        let batch = RecordBatch::try_new(schema, columns).expect("valid batch");
+        let star = flat_to_star(&batch).expect("flat_to_star");
+        let roundtrip = star_to_flat(&star).expect("star_to_flat");
+
+        let payload_idx = roundtrip
+            .schema()
+            .index_of("_resource_payload")
+            .expect("_resource_payload col");
+        let payload_arr = roundtrip
+            .column(payload_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("_resource_payload string");
+
+        assert_eq!(payload_arr.value(0), "deadbeef");
+        assert_eq!(payload_arr.value(1), "deadbeef");
+        assert_eq!(payload_arr.value(2), "0102");
     }
 
     #[test]

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -199,17 +199,23 @@ pub fn flat_to_star(batch: &RecordBatch) -> Result<StarSchema, ArrowError> {
 
     // --- Resource deduplication ---
     // Build a map of unique resource attribute sets → resource_id.
-    // Key: sorted string of all resource attribute values for one row.
-    let mut resource_id_map: HashMap<Vec<String>, u32> = HashMap::new();
+    // Key preserves NULL vs empty-string distinctions for each attribute.
+    let mut resource_id_map: HashMap<Vec<Option<String>>, u32> = HashMap::new();
     let mut row_resource_ids: Vec<u32> = Vec::with_capacity(num_rows);
     let mut resource_template_rows: Vec<usize> = Vec::new();
 
     for row in 0..num_rows {
-        let mut key_parts: Vec<String> = Vec::with_capacity(resource_cols.len());
+        let mut key_parts: Vec<Option<String>> = Vec::with_capacity(resource_cols.len());
 
         for (attr_key, col_idx) in &resource_cols {
-            let val = str_value_at(batch.column(*col_idx).as_ref(), row);
-            key_parts.push(format!("{attr_key}={val}"));
+            let arr = batch.column(*col_idx);
+            let val = if arr.is_null(row) {
+                None
+            } else {
+                Some(str_value_at(arr.as_ref(), row))
+            };
+            let _ = attr_key; // key order is fixed by `resource_cols`.
+            key_parts.push(val);
         }
 
         let next_id = resource_id_map.len() as u32;
@@ -1499,37 +1505,72 @@ fn scatter_resource_attrs(
 
     // For each resource column, build a map of resource_id → value from
     // the template rows, then scatter to all matching rows.
-    // Resource attrs are always strings (from _resource_* flat columns).
     for &col_pos in &resource_col_indices {
-        // Phase 1: collect distinct resource_id → value.
-        let rid_to_val: HashMap<u32, Option<String>> = {
-            let values = match &flat_cols[col_pos].1 {
-                TypedColumn::Str(v) => v,
-                _ => continue,
-            };
-            let mut map: HashMap<u32, Option<String>> = HashMap::new();
-            for row in 0..num_rows {
-                let rid = resource_ids.value(row);
-                if let std::collections::hash_map::Entry::Vacant(e) = map.entry(rid) {
-                    let rid_row = rid as usize;
-                    if rid_row < num_rows {
-                        e.insert(values[rid_row].clone());
+        match &flat_cols[col_pos].1 {
+            TypedColumn::Str(values) => {
+                let rid_to_val = collect_resource_template_values(values, resource_ids, num_rows);
+                if let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1 {
+                    for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
+                        let rid = resource_ids.value(row);
+                        if let Some(val) = rid_to_val.get(&rid) {
+                            *slot = val.clone();
+                        }
                     }
                 }
             }
-            map
-        };
-
-        // Phase 2: scatter to all rows.
-        if let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1 {
-            for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
-                let rid = resource_ids.value(row);
-                if let Some(val) = rid_to_val.get(&rid) {
-                    *slot = val.clone();
+            TypedColumn::Int(values) => {
+                let rid_to_val = collect_resource_template_values(values, resource_ids, num_rows);
+                if let TypedColumn::Int(ref mut v) = flat_cols[col_pos].1 {
+                    for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
+                        let rid = resource_ids.value(row);
+                        if let Some(val) = rid_to_val.get(&rid) {
+                            *slot = val.clone();
+                        }
+                    }
+                }
+            }
+            TypedColumn::Double(values) => {
+                let rid_to_val = collect_resource_template_values(values, resource_ids, num_rows);
+                if let TypedColumn::Double(ref mut v) = flat_cols[col_pos].1 {
+                    for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
+                        let rid = resource_ids.value(row);
+                        if let Some(val) = rid_to_val.get(&rid) {
+                            *slot = val.clone();
+                        }
+                    }
+                }
+            }
+            TypedColumn::Bool(values) => {
+                let rid_to_val = collect_resource_template_values(values, resource_ids, num_rows);
+                if let TypedColumn::Bool(ref mut v) = flat_cols[col_pos].1 {
+                    for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
+                        let rid = resource_ids.value(row);
+                        if let Some(val) = rid_to_val.get(&rid) {
+                            *slot = val.clone();
+                        }
+                    }
                 }
             }
         }
     }
+}
+
+fn collect_resource_template_values<T: Clone>(
+    values: &[Option<T>],
+    resource_ids: &UInt32Array,
+    num_rows: usize,
+) -> HashMap<u32, Option<T>> {
+    let mut map: HashMap<u32, Option<T>> = HashMap::new();
+    for row in 0..num_rows {
+        let rid = resource_ids.value(row);
+        if let std::collections::hash_map::Entry::Vacant(e) = map.entry(rid) {
+            let rid_row = rid as usize;
+            if rid_row < num_rows {
+                e.insert(values[rid_row].clone());
+            }
+        }
+    }
+    map
 }
 
 // ---------------------------------------------------------------------------
@@ -1877,6 +1918,32 @@ mod tests {
     }
 
     #[test]
+    fn resource_dedup_distinguishes_null_and_empty_values() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_resource_svc", DataType::Utf8, true),
+            Field::new("message", DataType::Utf8, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(StringArray::from(vec![None, Some(""), Some("")])),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+        ];
+        let batch = RecordBatch::try_new(schema, columns).expect("valid");
+        let star = flat_to_star(&batch).expect("flat_to_star");
+        let rid_arr = star
+            .logs
+            .column(1)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .expect("resource_id");
+        assert_ne!(
+            rid_arr.value(0),
+            rid_arr.value(1),
+            "NULL and empty-string resource attrs must dedupe separately"
+        );
+        assert_eq!(rid_arr.value(1), rid_arr.value(2));
+    }
+
+    #[test]
     fn severity_mapping() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("level", DataType::Utf8, true),
@@ -2076,6 +2143,34 @@ mod tests {
         assert_eq!(payload_arr.value(0), "deadbeef");
         assert_eq!(payload_arr.value(1), "deadbeef");
         assert_eq!(payload_arr.value(2), "0102");
+    }
+
+    #[test]
+    fn typed_resource_attrs_scatter_for_duplicate_resource_ids() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("_resource_retry_count", DataType::Int64, true),
+            Field::new("message", DataType::Utf8, true),
+        ]));
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(Int64Array::from(vec![Some(5), Some(5), Some(9)])),
+            Arc::new(StringArray::from(vec!["a", "b", "c"])),
+        ];
+        let batch = RecordBatch::try_new(schema, columns).expect("valid");
+        let star = flat_to_star(&batch).expect("flat_to_star");
+        let roundtrip = star_to_flat(&star).expect("star_to_flat");
+
+        let idx = roundtrip
+            .schema()
+            .index_of("_resource_retry_count")
+            .expect("_resource_retry_count");
+        let arr = roundtrip
+            .column(idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("int64");
+        assert_eq!(arr.value(0), 5);
+        assert_eq!(arr.value(1), 5);
+        assert_eq!(arr.value(2), 9);
     }
 
     #[test]

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -1340,12 +1340,12 @@ fn unpivot_attrs_to_flat(
                 if !bytes_arr.is_null(row)
                     && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
                 {
-                    let hex: String =
-                        bytes_arr.value(row).iter().fold(String::new(), |mut s, b| {
-                            use std::fmt::Write;
-                            let _ = write!(s, "{b:02x}");
-                            s
-                        });
+                    let bytes = bytes_arr.value(row);
+                    let mut hex = String::with_capacity(bytes.len() * 2);
+                    for byte in bytes {
+                        use std::fmt::Write;
+                        let _ = write!(&mut hex, "{byte:02x}");
+                    }
                     v[target_row] = Some(hex);
                 }
             }
@@ -1896,6 +1896,36 @@ mod tests {
             }
         }
         assert!(found, "status attr not found in log_attrs");
+    }
+
+    #[test]
+    fn binary_attrs_roundtrip_as_hex_strings() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("message", DataType::Utf8, true),
+            Field::new("payload", DataType::Binary, true),
+        ]));
+
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(StringArray::from(vec![Some("row-0"), Some("row-1")])),
+            Arc::new(BinaryArray::from(vec![
+                Some(&[0x00_u8, 0x0f_u8, 0xff_u8][..]),
+                Some(&[0xab_u8, 0xcd_u8][..]),
+            ])),
+        ];
+
+        let batch = RecordBatch::try_new(schema, columns).expect("valid batch");
+        let star = flat_to_star(&batch).expect("flat_to_star");
+        let roundtrip = star_to_flat(&star).expect("star_to_flat");
+
+        let payload_idx = roundtrip.schema().index_of("payload").expect("payload col");
+        let payload_arr = roundtrip
+            .column(payload_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("payload string");
+
+        assert_eq!(payload_arr.value(0), "000fff");
+        assert_eq!(payload_arr.value(1), "abcd");
     }
 
     #[test]

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -247,6 +247,39 @@ output:
     }
 
     #[test]
+    fn validation_storage_data_dir_existing_non_directory_rejected() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time must be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "logfwd-config-storage-non-dir-{}-{unique}.tmp",
+            std::process::id()
+        ));
+        fs::write(&path, b"not-a-directory").expect("write temp file");
+
+        let yaml = format!(
+            r#"
+input:
+  type: file
+  path: /var/log/test.log
+output:
+  type: stdout
+storage:
+  data_dir: {}
+"#,
+            path.display()
+        );
+
+        let err = Config::load_str(&yaml).expect_err("non-directory storage.data_dir must fail");
+        assert!(
+            err.to_string().contains("exists but is not a directory"),
+            "expected non-directory storage.data_dir rejection, got: {err}"
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
     fn validation_udp_requires_listen() {
         let yaml = r"
 input:

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1231,10 +1231,38 @@ mod validate_host_port_tests {
     }
 }
 
+/// Redact userinfo (username:password) from a URL for safe inclusion in error
+/// messages.  Replaces `scheme://user:pass@host` with `scheme://***@host`.
+fn redact_url(endpoint: &str) -> String {
+    // Try to parse; if that fails, just redact anything between :// and @.
+    if let Ok(mut parsed) = Url::parse(endpoint) {
+        if !parsed.username().is_empty() || parsed.password().is_some() {
+            let _ = parsed.set_username("***");
+            let _ = parsed.set_password(None);
+        }
+        parsed.to_string()
+    } else if let Some(scheme_end) = endpoint.find("://") {
+        let after_scheme = &endpoint[scheme_end + 3..];
+        if let Some(at) = after_scheme.find('@') {
+            format!(
+                "{}://***@{}",
+                &endpoint[..scheme_end],
+                &after_scheme[at + 1..]
+            )
+        } else {
+            endpoint.to_string()
+        }
+    } else {
+        endpoint.to_string()
+    }
+}
+
 /// Validate that an endpoint URL has a recognised scheme and a non-empty host.
 fn validate_endpoint_url(endpoint: &str) -> Result<(), String> {
+    let safe = redact_url(endpoint);
+
     let parsed =
-        Url::parse(endpoint).map_err(|_| format!("endpoint '{endpoint}' is not a valid URL"))?;
+        Url::parse(endpoint).map_err(|_| format!("endpoint '{safe}' is not a valid URL"))?;
 
     let rest = if endpoint
         .get(..8)
@@ -1248,21 +1276,17 @@ fn validate_endpoint_url(endpoint: &str) -> Result<(), String> {
         &endpoint[7..]
     } else {
         return Err(format!(
-            "endpoint '{endpoint}' has no recognised scheme; expected 'http://' or 'https://'"
+            "endpoint '{safe}' has no recognised scheme; expected 'http://' or 'https://'"
         ));
     };
 
     // Reject malformed authority forms like `http:///bulk` or `https://?x=1`.
     if rest.is_empty() || rest.starts_with('/') || rest.starts_with('?') || rest.starts_with('#') {
-        return Err(format!(
-            "endpoint '{endpoint}' has no host after the scheme"
-        ));
+        return Err(format!("endpoint '{safe}' has no host after the scheme"));
     }
 
     if parsed.host_str().is_none_or(str::is_empty) {
-        return Err(format!(
-            "endpoint '{endpoint}' has no host after the scheme"
-        ));
+        return Err(format!("endpoint '{safe}' has no host after the scheme"));
     }
 
     Ok(())

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -929,23 +929,25 @@ impl Config {
 
             // Guard against feedback loops: reject configs where a file output
             // path matches a file input path in the same pipeline (#1596).
-            let file_input_paths: Vec<std::path::PathBuf> = pipe
+            // Collect file input paths (exact) and glob patterns separately.
+            let mut exact_input_paths: Vec<(std::path::PathBuf, std::path::PathBuf)> = Vec::new();
+            let mut glob_input_patterns: Vec<String> = Vec::new();
+
+            for input in pipe
                 .inputs
                 .iter()
                 .filter(|i| i.input_type == InputType::File)
-                .filter_map(|i| i.path.as_deref())
-                .filter(|p| !p.contains('*') && !p.contains('?'))
-                .map(std::path::PathBuf::from)
-                .collect();
-
-            let normalized_file_inputs: Vec<(std::path::PathBuf, std::path::PathBuf)> =
-                file_input_paths
-                    .into_iter()
-                    .map(|p| {
-                        let norm = normalize_path_for_compare(&p);
-                        (p, norm)
-                    })
-                    .collect();
+            {
+                if let Some(p) = input.path.as_deref() {
+                    if p.contains('*') || p.contains('?') {
+                        glob_input_patterns.push(p.to_string());
+                    } else {
+                        let pb = std::path::PathBuf::from(p);
+                        let norm = normalize_path_for_compare(&pb);
+                        exact_input_paths.push((pb, norm));
+                    }
+                }
+            }
 
             for (j, output) in pipe.outputs.iter().enumerate() {
                 let out_label = output
@@ -961,13 +963,26 @@ impl Config {
                 };
                 let out_pb = std::path::PathBuf::from(out_path);
                 let out_norm = normalize_path_for_compare(&out_pb);
-                for (in_pb, in_norm) in &normalized_file_inputs {
+
+                // Check exact input path match.
+                for (in_pb, in_norm) in &exact_input_paths {
                     if out_norm == *in_norm {
                         return Err(ConfigError::Validation(format!(
                             "pipeline '{name}' output '{out_label}': output path '{}' is the same \
                              as file input path '{}' — this creates an unbounded feedback loop",
                             out_path,
                             in_pb.display(),
+                        )));
+                    }
+                }
+
+                // Check if the output path could match any glob input pattern.
+                for glob_pattern in &glob_input_patterns {
+                    if glob_could_match(glob_pattern, out_path) {
+                        return Err(ConfigError::Validation(format!(
+                            "pipeline '{name}' output '{out_label}': output path '{out_path}' \
+                             could match file input glob '{glob_pattern}' — this creates an \
+                             unbounded feedback loop",
                         )));
                     }
                 }
@@ -1307,6 +1322,35 @@ fn validate_endpoint_url(endpoint: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Check if a file path could match a glob pattern by comparing the directory
+/// prefix. A glob like `/var/log/*.log` has prefix `/var/log/` and would match
+/// any output file in that directory with a `.log` extension.
+fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
+    let glob_path = Path::new(glob_pattern);
+    let file = Path::new(file_path);
+
+    let glob_dir = glob_path.parent().map(normalize_path_for_compare);
+    let file_dir = file.parent().map(normalize_path_for_compare);
+
+    // If the file is in the same directory as the glob, it could match.
+    if let (Some(g), Some(f)) = (&glob_dir, &file_dir)
+        && g == f
+    {
+        // Also check filename pattern if the glob has a simple `*.ext` form.
+        if let Some(glob_name) = glob_path.file_name().and_then(|n| n.to_str())
+            && let Some(file_name) = file.file_name().and_then(|n| n.to_str())
+        {
+            if let Some(ext) = glob_name.strip_prefix('*') {
+                return file_name.ends_with(ext);
+            }
+            // Pattern contains `?` or other wildcards — conservatively match.
+            return true;
+        }
+        return true;
+    }
+    false
 }
 
 /// Return the first illegal character in an Elasticsearch index name, or None.

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1304,7 +1304,7 @@ fn redact_url(endpoint: &str) -> String {
         }
     } else if let Some(at) = endpoint.rfind('@') {
         // Last-resort redaction for malformed URLs: hide authority userinfo.
-        let authority_start = endpoint.find("://").map(|idx| idx + 3).unwrap_or(0);
+        let authority_start = endpoint.find("://").map_or(0, |idx| idx + 3);
         let prefix = &endpoint[..authority_start];
         let suffix = &endpoint[at + 1..];
         format!("{prefix}{REDACTED_URL_USERINFO}@{suffix}")

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -939,7 +939,7 @@ impl Config {
                 .filter(|i| i.input_type == InputType::File)
             {
                 if let Some(p) = input.path.as_deref() {
-                    if p.contains('*') || p.contains('?') {
+                    if p.contains('*') || p.contains('?') || p.contains('[') {
                         glob_input_patterns.push(p.to_string());
                     } else {
                         let pb = std::path::PathBuf::from(p);
@@ -1339,10 +1339,30 @@ fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
     let glob_dir = glob_path.parent().map(normalize_path_for_compare);
     let file_dir = file.parent().map(normalize_path_for_compare);
 
-    // If the file is in the same directory as the glob, it could match.
-    if let (Some(g), Some(f)) = (&glob_dir, &file_dir)
-        && g == f
-    {
+    let same_directory = matches!((&glob_dir, &file_dir), (Some(g), Some(f)) if g == f);
+    let recursive_double_star = glob_pattern.contains("**");
+    let recursive_prefix_match = if recursive_double_star {
+        if let (Some(g), Some(f)) = (&glob_dir, &file_dir) {
+            let mut prefix = std::path::PathBuf::new();
+            let mut saw_recursive = false;
+            for component in g.components() {
+                if component.as_os_str() == "**" {
+                    saw_recursive = true;
+                    break;
+                }
+                prefix.push(component.as_os_str());
+            }
+            saw_recursive && f.starts_with(prefix)
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    // If the file is in the same directory as the glob (or the glob uses a
+    // recursive `**` prefix that includes the file directory), it could match.
+    if same_directory || recursive_prefix_match {
         // Also check filename pattern if the glob has a simple `*.ext` form.
         if let Some(glob_name) = glob_path.file_name().and_then(|n| n.to_str())
             && let Some(file_name) = file.file_name().and_then(|n| n.to_str())
@@ -1504,10 +1524,14 @@ pipelines:
     }
 
     #[test]
-    fn glob_could_match_nested_glob_paths_do_not_cross_directory_check() {
-        assert!(!glob_could_match(
+    fn glob_could_match_recursive_double_star_matches_nested_directories() {
+        assert!(glob_could_match(
             "/var/log/**/access.log",
             "/var/log/subdir/access.log"
+        ));
+        assert!(!glob_could_match(
+            "/var/log/**/access.log",
+            "/var/log/subdir/error.log"
         ));
     }
 }

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -33,13 +33,20 @@ impl Config {
             }
         }
 
-        // Validate storage.data_dir is not an existing regular file.
+        // Validate storage.data_dir is either absent/non-existent or an existing directory.
         if let Some(ref dir) = self.storage.data_dir {
             let path = Path::new(dir);
-            if path.is_file() {
-                return Err(ConfigError::Validation(format!(
-                    "storage.data_dir '{dir}' is a regular file, not a directory"
-                )));
+            if path.exists() {
+                let md = path.metadata().map_err(|e| {
+                    ConfigError::Validation(format!(
+                        "storage.data_dir '{dir}' metadata lookup failed: {e}"
+                    ))
+                })?;
+                if !md.is_dir() {
+                    return Err(ConfigError::Validation(format!(
+                        "storage.data_dir '{dir}' exists but is not a directory"
+                    )));
+                }
             }
         }
 
@@ -984,7 +991,7 @@ impl Config {
 
                 // Check if the output path could match any glob input pattern.
                 for glob_pattern in &glob_input_patterns {
-                    if glob_could_match(glob_pattern, out_path) {
+                    if is_glob_match_possible(glob_pattern, out_path) {
                         return Err(ConfigError::Validation(format!(
                             "pipeline '{name}' output '{out_label}': output path '{out_path}' \
                              could match file input glob '{glob_pattern}' — this creates an \
@@ -1295,6 +1302,12 @@ fn redact_url(endpoint: &str) -> String {
         } else {
             endpoint.to_string()
         }
+    } else if let Some(at) = endpoint.rfind('@') {
+        // Last-resort redaction for malformed URLs: hide authority userinfo.
+        let authority_start = endpoint.find("://").map(|idx| idx + 3).unwrap_or(0);
+        let prefix = &endpoint[..authority_start];
+        let suffix = &endpoint[at + 1..];
+        format!("{prefix}{REDACTED_URL_USERINFO}@{suffix}")
     } else {
         endpoint.to_string()
     }
@@ -1338,7 +1351,7 @@ fn validate_endpoint_url(endpoint: &str) -> Result<(), String> {
 /// Check if a file path could match a glob pattern by comparing the directory
 /// prefix. A glob like `/var/log/*.log` has prefix `/var/log/` and would match
 /// any output file in that directory with a `.log` extension.
-fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
+fn is_glob_match_possible(glob_pattern: &str, file_path: &str) -> bool {
     let glob_path = Path::new(glob_pattern);
     let file = Path::new(file_path);
 
@@ -1381,10 +1394,35 @@ fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
     } else {
         false
     };
+    let directory_wildcard_prefix_match = {
+        let raw_glob_dir = glob_path.parent().and_then(|p| p.to_str()).unwrap_or("");
+        if raw_glob_dir.contains(['*', '?', '[']) {
+            let prefix = raw_glob_dir
+                .split(|c| ['*', '?', '['].contains(&c))
+                .next()
+                .unwrap_or("")
+                .trim_end_matches(std::path::MAIN_SEPARATOR);
+            if prefix.is_empty() {
+                true
+            } else {
+                let normalized_prefix = normalize_path_lexically(Path::new(prefix));
+                let normalized_file = normalize_path_lexically(file);
+                normalized_file
+                    .to_string_lossy()
+                    .starts_with(normalized_prefix.to_string_lossy().as_ref())
+            }
+        } else {
+            false
+        }
+    };
 
     // If the file is in the same directory as the glob (or the glob uses a
     // recursive `**` prefix that includes the file directory), it could match.
-    if same_directory || recursive_prefix_match || recursive_root_match {
+    if same_directory
+        || recursive_prefix_match
+        || recursive_root_match
+        || directory_wildcard_prefix_match
+    {
         // Also check filename pattern if the glob has a simple `*.ext` form.
         if let Some(glob_name) = glob_path.file_name().and_then(|n| n.to_str())
             && let Some(file_name) = file.file_name().and_then(|n| n.to_str())
@@ -1449,11 +1487,20 @@ mod validate_endpoint_url_tests {
             );
         }
     }
+
+    #[test]
+    fn endpoint_url_redacts_userinfo_for_malformed_urls() {
+        let err = validate_endpoint_url("https://user:secret@/bulk").expect_err("must fail");
+        assert!(
+            err.contains("***redacted***") && !err.contains("secret"),
+            "malformed endpoint errors must redact userinfo: {err}"
+        );
+    }
 }
 
 #[cfg(test)]
 mod feedback_loop_tests {
-    use super::glob_could_match;
+    use super::is_glob_match_possible;
     use crate::types::Config;
 
     #[test]
@@ -1516,11 +1563,11 @@ pipelines:
 
     #[test]
     fn glob_could_match_literal_filename_requires_exact_name() {
-        assert!(glob_could_match(
+        assert!(is_glob_match_possible(
             "/var/log/access.log",
             "/var/log/access.log"
         ));
-        assert!(!glob_could_match(
+        assert!(!is_glob_match_possible(
             "/var/log/access.log",
             "/var/log/other.log"
         ));
@@ -1528,18 +1575,24 @@ pipelines:
 
     #[test]
     fn glob_could_match_wildcard_suffix_pattern() {
-        assert!(glob_could_match("/var/log/*.log", "/var/log/access.log"));
-        assert!(!glob_could_match("/var/log/*.log", "/var/log/access.txt"));
+        assert!(is_glob_match_possible(
+            "/var/log/*.log",
+            "/var/log/access.log"
+        ));
+        assert!(!is_glob_match_possible(
+            "/var/log/*.log",
+            "/var/log/access.txt"
+        ));
     }
 
     #[test]
     fn glob_could_match_rejects_different_directory() {
-        assert!(!glob_could_match("/var/log/*.log", "/tmp/access.log"));
+        assert!(!is_glob_match_possible("/var/log/*.log", "/tmp/access.log"));
     }
 
     #[test]
     fn glob_could_match_nested_wildcards_are_conservative() {
-        assert!(glob_could_match(
+        assert!(is_glob_match_possible(
             "/var/log/*test*.log",
             "/var/log/mytest_file.log"
         ));
@@ -1547,11 +1600,11 @@ pipelines:
 
     #[test]
     fn glob_could_match_recursive_double_star_matches_nested_directories() {
-        assert!(glob_could_match(
+        assert!(is_glob_match_possible(
             "/var/log/**/access.log",
             "/var/log/subdir/access.log"
         ));
-        assert!(!glob_could_match(
+        assert!(!is_glob_match_possible(
             "/var/log/**/access.log",
             "/var/log/subdir/error.log"
         ));
@@ -1559,9 +1612,25 @@ pipelines:
 
     #[test]
     fn glob_could_match_recursive_double_star_directory_only_pattern() {
-        assert!(glob_could_match("/var/log/**", "/var/log/subdir/app.log"));
-        assert!(glob_could_match("/var/log/**", "/var/log/app.log"));
-        assert!(!glob_could_match("/var/log/**", "/srv/log/app.log"));
+        assert!(is_glob_match_possible(
+            "/var/log/**",
+            "/var/log/subdir/app.log"
+        ));
+        assert!(is_glob_match_possible("/var/log/**", "/var/log/app.log"));
+        assert!(!is_glob_match_possible("/var/log/**", "/srv/log/app.log"));
+    }
+
+    #[test]
+    fn glob_could_match_directory_wildcards_are_conservative() {
+        assert!(is_glob_match_possible("/var/*/app.log", "/var/log/app.log"));
+        assert!(is_glob_match_possible(
+            "/var/log[12]/*.log",
+            "/var/log1/a.log"
+        ));
+        assert!(!is_glob_match_possible(
+            "/var/*/app.log",
+            "/srv/log/app.log"
+        ));
     }
 }
 
@@ -1650,7 +1719,7 @@ pipelines:
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
-            err.to_string().contains("contains illegal character '_'"),
+            err.to_string().contains("has illegal prefix '_'"),
             "expected prefix rejection: {err}"
         );
     }

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -33,6 +33,16 @@ impl Config {
             }
         }
 
+        // Validate storage.data_dir is not an existing regular file.
+        if let Some(ref dir) = self.storage.data_dir {
+            let path = Path::new(dir);
+            if path.is_file() {
+                return Err(ConfigError::Validation(format!(
+                    "storage.data_dir '{dir}' is a regular file, not a directory"
+                )));
+            }
+        }
+
         if self.pipelines.is_empty() {
             return Err(ConfigError::Validation(
                 "at least one pipeline must be defined".into(),
@@ -686,6 +696,13 @@ impl Config {
                                     "pipeline '{name}' output '{label}': elasticsearch 'index' must not be empty"
                                 )));
                             }
+                            if let Some(idx) = &output.index
+                                && let Some(bad) = es_illegal_index_char(idx)
+                            {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' output '{label}': elasticsearch index '{idx}' contains illegal character '{bad}'"
+                                )));
+                            }
                             if let Some(mode) = output.request_mode.as_deref()
                                 && !matches!(mode, "buffered" | "streaming")
                             {
@@ -1290,6 +1307,18 @@ fn validate_endpoint_url(endpoint: &str) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Return the first illegal character in an Elasticsearch index name, or None.
+/// ES rejects: uppercase, `*`, `?`, `"`, `<`, `>`, `|`, ` `, `,`, `#`, `:`, `\`, `/`.
+fn es_illegal_index_char(index: &str) -> Option<char> {
+    index.chars().find(|c| {
+        c.is_ascii_uppercase()
+            || matches!(
+                c,
+                '*' | '?' | '"' | '<' | '>' | '|' | ' ' | ',' | '#' | ':' | '\\' | '/'
+            )
+    })
 }
 
 #[cfg(test)]

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1345,7 +1345,14 @@ fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
             if let Some(ext) = glob_name.strip_prefix('*') {
                 return file_name.ends_with(ext);
             }
-            // Pattern contains `?` or other wildcards — conservatively match.
+
+            // Literal filename (no wildcard chars) must match exactly.
+            if !glob_name.contains(['*', '?', '[']) {
+                return glob_name == file_name;
+            }
+
+            // Pattern contains wildcard syntax we don't parse here —
+            // conservatively report a possible match.
             return true;
         }
         return true;
@@ -1391,6 +1398,7 @@ mod validate_endpoint_url_tests {
 
 #[cfg(test)]
 mod feedback_loop_tests {
+    use super::glob_could_match;
     use crate::types::Config;
 
     #[test]
@@ -1449,6 +1457,24 @@ pipelines:
             msg.contains("feedback loop") || msg.contains("same as file input"),
             "expected normalized-path feedback-loop rejection, got: {msg}"
         );
+    }
+
+    #[test]
+    fn glob_could_match_literal_filename_requires_exact_name() {
+        assert!(glob_could_match(
+            "/var/log/access.log",
+            "/var/log/access.log"
+        ));
+        assert!(!glob_could_match(
+            "/var/log/access.log",
+            "/var/log/other.log"
+        ));
+    }
+
+    #[test]
+    fn glob_could_match_wildcard_suffix_pattern() {
+        assert!(glob_could_match("/var/log/*.log", "/var/log/access.log"));
+        assert!(!glob_could_match("/var/log/*.log", "/var/log/access.txt"));
     }
 }
 

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1341,6 +1341,22 @@ fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
 
     let same_directory = matches!((&glob_dir, &file_dir), (Some(g), Some(f)) if g == f);
     let recursive_double_star = glob_pattern.contains("**");
+    let recursive_root_match = if recursive_double_star {
+        let prefix = glob_pattern
+            .split("**")
+            .next()
+            .unwrap_or("")
+            .trim_end_matches(std::path::MAIN_SEPARATOR);
+        if prefix.is_empty() {
+            false
+        } else {
+            let normalized_prefix = normalize_path_lexically(Path::new(prefix));
+            let normalized_file = normalize_path_lexically(file);
+            normalized_file.starts_with(&normalized_prefix)
+        }
+    } else {
+        false
+    };
     let recursive_prefix_match = if recursive_double_star {
         if let (Some(g), Some(f)) = (&glob_dir, &file_dir) {
             let mut prefix = std::path::PathBuf::new();
@@ -1362,7 +1378,7 @@ fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
 
     // If the file is in the same directory as the glob (or the glob uses a
     // recursive `**` prefix that includes the file directory), it could match.
-    if same_directory || recursive_prefix_match {
+    if same_directory || recursive_prefix_match || recursive_root_match {
         // Also check filename pattern if the glob has a simple `*.ext` form.
         if let Some(glob_name) = glob_path.file_name().and_then(|n| n.to_str())
             && let Some(file_name) = file.file_name().and_then(|n| n.to_str())
@@ -1533,6 +1549,13 @@ pipelines:
             "/var/log/**/access.log",
             "/var/log/subdir/error.log"
         ));
+    }
+
+    #[test]
+    fn glob_could_match_recursive_double_star_directory_only_pattern() {
+        assert!(glob_could_match("/var/log/**", "/var/log/subdir/app.log"));
+        assert!(glob_could_match("/var/log/**", "/var/log/app.log"));
+        assert!(!glob_could_match("/var/log/**", "/srv/log/app.log"));
     }
 }
 

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -699,8 +699,14 @@ impl Config {
                             if let Some(idx) = &output.index
                                 && let Some(bad) = es_illegal_index_char(idx)
                             {
+                                let reason =
+                                    if matches!(bad, '-' | '_' | '+') && idx.starts_with(bad) {
+                                        format!("has illegal prefix '{bad}'")
+                                    } else {
+                                        format!("contains illegal character '{bad}'")
+                                    };
                                 return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' output '{label}': elasticsearch index '{idx}' contains illegal character '{bad}'"
+                                    "pipeline '{name}' output '{label}': elasticsearch index '{idx}' {reason}"
                                 )));
                             }
                             if let Some(mode) = output.request_mode.as_deref()

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1265,11 +1265,15 @@ mod validate_host_port_tests {
 
 /// Redact userinfo (username:password) from a URL for safe inclusion in error
 /// messages.  Replaces `scheme://user:pass@host` with `scheme://***@host`.
+const REDACTED_URL_USERINFO: &str = "***redacted***";
+
+/// Redact userinfo (username:password) from a URL for safe inclusion in error
+/// messages.
 fn redact_url(endpoint: &str) -> String {
     // Try to parse; if that fails, just redact anything between :// and @.
     if let Ok(mut parsed) = Url::parse(endpoint) {
         if !parsed.username().is_empty() || parsed.password().is_some() {
-            let _ = parsed.set_username("***");
+            let _ = parsed.set_username(REDACTED_URL_USERINFO);
             let _ = parsed.set_password(None);
         }
         parsed.to_string()
@@ -1277,8 +1281,9 @@ fn redact_url(endpoint: &str) -> String {
         let after_scheme = &endpoint[scheme_end + 3..];
         if let Some(at) = after_scheme.find('@') {
             format!(
-                "{}://***@{}",
+                "{}://{}@{}",
                 &endpoint[..scheme_end],
+                REDACTED_URL_USERINFO,
                 &after_scheme[at + 1..]
             )
         } else {
@@ -1343,6 +1348,9 @@ fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
             && let Some(file_name) = file.file_name().and_then(|n| n.to_str())
         {
             if let Some(ext) = glob_name.strip_prefix('*') {
+                if ext.contains(['*', '?', '[']) {
+                    return true;
+                }
                 return file_name.ends_with(ext);
             }
 
@@ -1363,6 +1371,11 @@ fn glob_could_match(glob_pattern: &str, file_path: &str) -> bool {
 /// Return the first illegal character in an Elasticsearch index name, or None.
 /// ES rejects: uppercase, `*`, `?`, `"`, `<`, `>`, `|`, ` `, `,`, `#`, `:`, `\`, `/`.
 fn es_illegal_index_char(index: &str) -> Option<char> {
+    if let Some(c) = index.chars().next()
+        && matches!(c, '-' | '_' | '+')
+    {
+        return Some(c);
+    }
     index.chars().find(|c| {
         c.is_ascii_uppercase()
             || matches!(
@@ -1476,6 +1489,27 @@ pipelines:
         assert!(glob_could_match("/var/log/*.log", "/var/log/access.log"));
         assert!(!glob_could_match("/var/log/*.log", "/var/log/access.txt"));
     }
+
+    #[test]
+    fn glob_could_match_rejects_different_directory() {
+        assert!(!glob_could_match("/var/log/*.log", "/tmp/access.log"));
+    }
+
+    #[test]
+    fn glob_could_match_nested_wildcards_are_conservative() {
+        assert!(glob_could_match(
+            "/var/log/*test*.log",
+            "/var/log/mytest_file.log"
+        ));
+    }
+
+    #[test]
+    fn glob_could_match_nested_glob_paths_do_not_cross_directory_check() {
+        assert!(!glob_could_match(
+            "/var/log/**/access.log",
+            "/var/log/subdir/access.log"
+        ));
+    }
 }
 
 #[cfg(test)]
@@ -1545,6 +1579,26 @@ pipelines:
         assert!(
             err.to_string().contains("index") && err.to_string().contains("must not be empty"),
             "whitespace-only index must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn elasticsearch_index_prefix_rejected() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: file
+        path: /tmp/test.log
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        index: "_bad-index"
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("contains illegal character '_'"),
+            "expected prefix rejection: {err}"
         );
     }
 }

--- a/crates/logfwd-core/benches/scanner.rs
+++ b/crates/logfwd-core/benches/scanner.rs
@@ -231,7 +231,7 @@ fn arrow_json_parse(data: &[u8]) -> arrow::record_batch::RecordBatch {
 fn sonic_rs_parse(data: &[u8], ndjson: &mut Vec<u8>) -> arrow::record_batch::RecordBatch {
     // Use sonic-rs to produce NDJSON, then feed through Scanner::scan_detached.
     // This gives a fair comparison: sonic-rs parses, Scanner builds Arrow arrays.
-    use sonic_rs::{JsonContainerTrait, JsonNumberTrait, JsonValueTrait};
+    use sonic_rs::JsonValueTrait;
 
     ndjson.clear();
     for line in data.split(|&b| b == b'\n') {

--- a/crates/logfwd-io/src/diagnostics.rs
+++ b/crates/logfwd-io/src/diagnostics.rs
@@ -12,4 +12,4 @@ pub use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 pub use metrics::PipelineMetrics;
 pub use models::{ActiveBatch, MemoryStats};
 pub(crate) use process::process_metrics;
-pub use server::{DiagnosticsServer, ServerHandle};
+pub use server::{DiagnosticsServer, ServerHandle, redact_config_yaml};

--- a/crates/logfwd-io/src/diagnostics/server.rs
+++ b/crates/logfwd-io/src/diagnostics/server.rs
@@ -74,7 +74,10 @@ fn redact_yaml_value(value: &mut serde_yaml_ng::Value, in_auth_block: bool) {
     }
 }
 
-fn redact_config_yaml(raw_yaml: &str) -> String {
+/// Redact credentials (auth tokens, bearer tokens, endpoint userinfo) from a
+/// config YAML string. Returns the redacted YAML, or a placeholder if parsing
+/// fails.
+pub fn redact_config_yaml(raw_yaml: &str) -> String {
     let Ok(mut parsed) = serde_yaml_ng::from_str::<serde_yaml_ng::Value>(raw_yaml) else {
         return REDACTED_CONFIG_UNAVAILABLE.to_string();
     };

--- a/crates/logfwd-io/src/diagnostics/server.rs
+++ b/crates/logfwd-io/src/diagnostics/server.rs
@@ -15,9 +15,13 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const DASHBOARD_HTML: &str = include_str!("../dashboard.html");
 const REDACTED_SECRET: &str = "***redacted***";
 const REDACTED_CONFIG_UNAVAILABLE: &str = "<redacted config unavailable>";
+const REDACTED_ENDPOINT: &str = "<redacted_endpoint>";
 
 fn redact_endpoint_credentials(endpoint: &str) -> String {
     let Ok(mut parsed) = url::Url::parse(endpoint) else {
+        if endpoint.contains('@') {
+            return REDACTED_ENDPOINT.to_string();
+        }
         return endpoint.to_string();
     };
     if parsed.username().is_empty() && parsed.password().is_none() {
@@ -1288,6 +1292,24 @@ output:
         let redacted = redact_config_yaml(raw);
         assert!(!redacted.contains("not-safe"));
         assert!(redacted.contains(REDACTED_SECRET));
+    }
+
+    #[test]
+    fn redact_config_yaml_masks_malformed_endpoint_userinfo() {
+        let raw = r#"
+output:
+  type: http
+  endpoint: "https://user:pass@exa mple.com/ingest"
+"#;
+        let redacted = redact_config_yaml(raw);
+        assert!(
+            !redacted.contains("user:pass@"),
+            "malformed endpoint credentials must not be exposed"
+        );
+        assert!(
+            redacted.contains(REDACTED_ENDPOINT),
+            "malformed endpoint with userinfo should be replaced with fail-closed marker"
+        );
     }
 
     #[test]

--- a/crates/logfwd-io/src/telemetry_buffer.rs
+++ b/crates/logfwd-io/src/telemetry_buffer.rs
@@ -928,7 +928,8 @@ fn attrs_to_json(attrs: &[(&str, String)]) -> String {
         .iter()
         .map(|(k, v)| {
             format!(
-                "{{\"key\":\"{k}\",\"value\":{{\"stringValue\":\"{}\"}}}}",
+                "{{\"key\":\"{}\",\"value\":{{\"stringValue\":\"{}\"}}}}",
+                json_escape(k),
                 json_escape(v)
             )
         })

--- a/crates/logfwd-transform/src/query_analyzer.rs
+++ b/crates/logfwd-transform/src/query_analyzer.rs
@@ -206,8 +206,20 @@ fn walk_set_expr(
 
             for table_with_joins in &select.from {
                 for join in &table_with_joins.joins {
-                    if let sqlast::JoinConstraint::On(expr) = join_constraint(&join.join_operator) {
-                        collect_column_refs(expr, referenced_columns);
+                    match join_constraint(&join.join_operator) {
+                        sqlast::JoinConstraint::On(expr) => {
+                            collect_column_refs(expr, referenced_columns);
+                        }
+                        sqlast::JoinConstraint::Using(cols) => {
+                            for obj_name in cols {
+                                if let Some(part) = obj_name.0.last()
+                                    && let Some(ident) = part.as_ident()
+                                {
+                                    referenced_columns.insert(ident.value.clone());
+                                }
+                            }
+                        }
+                        sqlast::JoinConstraint::Natural | sqlast::JoinConstraint::None => {}
                     }
                 }
             }

--- a/crates/logfwd-transform/src/query_analyzer.rs
+++ b/crates/logfwd-transform/src/query_analyzer.rs
@@ -46,68 +46,13 @@ impl QueryAnalyzer {
         let mut where_clause = None;
 
         if let Statement::Query(query) = stmt {
-            if let SetExpr::Select(select) = query.body.as_ref() {
-                for item in &select.projection {
-                    match item {
-                        SelectItem::Wildcard(opts) => {
-                            uses_select_star = true;
-                            extract_except_fields(opts, &mut except_fields);
-                        }
-                        SelectItem::QualifiedWildcard(_, opts) => {
-                            uses_select_star = true;
-                            extract_except_fields(opts, &mut except_fields);
-                        }
-                        SelectItem::UnnamedExpr(expr) => {
-                            collect_column_refs(expr, &mut referenced_columns);
-                        }
-                        SelectItem::ExprWithAlias { expr, .. } => {
-                            collect_column_refs(expr, &mut referenced_columns);
-                        }
-                    }
-                }
-
-                // Walk WHERE clause for column references.
-                if let Some(ref selection) = select.selection {
-                    collect_column_refs(selection, &mut referenced_columns);
-                    where_clause = Some(selection.clone());
-                }
-
-                // Walk GROUP BY — columns may appear only here (not in SELECT or WHERE).
-                if let sqlast::GroupByExpr::Expressions(exprs, _) = &select.group_by {
-                    for e in exprs {
-                        collect_column_refs(e, &mut referenced_columns);
-                    }
-                }
-
-                // Walk HAVING — HAVING MAX(col) > N where col is not in SELECT.
-                if let Some(ref having) = select.having {
-                    collect_column_refs(having, &mut referenced_columns);
-                }
-                // Walk FROM clause — JOIN ON conditions contain column refs
-                // that the scanner must extract.
-                for table_with_joins in &select.from {
-                    for join in &table_with_joins.joins {
-                        if let sqlast::JoinConstraint::On(expr) =
-                            join_constraint(&join.join_operator)
-                        {
-                            collect_column_refs(expr, &mut referenced_columns);
-                        }
-                    }
-                }
-
-                // Walk WINDOW named definitions — PARTITION BY / ORDER BY
-                // columns may only appear in named window specs.
-                for sqlast::NamedWindowDefinition(_, named_expr) in &select.named_window {
-                    if let sqlast::NamedWindowExpr::WindowSpec(spec) = named_expr {
-                        for e in &spec.partition_by {
-                            collect_column_refs(e, &mut referenced_columns);
-                        }
-                        for ob in &spec.order_by {
-                            collect_column_refs(&ob.expr, &mut referenced_columns);
-                        }
-                    }
-                }
-            }
+            walk_set_expr(
+                query.body.as_ref(),
+                &mut referenced_columns,
+                &mut uses_select_star,
+                &mut except_fields,
+                &mut where_clause,
+            );
 
             // Walk ORDER BY — columns may appear only here (not in SELECT or WHERE).
             if let Some(ref order_by) = query.order_by {
@@ -210,6 +155,101 @@ impl QueryAnalyzer {
         };
 
         hints
+    }
+}
+
+/// Recursively walk a `SetExpr`, collecting column refs from SELECT, WHERE,
+/// GROUP BY, HAVING, FROM/JOIN, and WINDOW clauses. For `SetOperation`
+/// (UNION/INTERSECT/EXCEPT) both branches are walked.
+fn walk_set_expr(
+    set_expr: &SetExpr,
+    referenced_columns: &mut HashSet<String>,
+    uses_select_star: &mut bool,
+    except_fields: &mut Vec<String>,
+    where_clause: &mut Option<SqlExpr>,
+) {
+    match set_expr {
+        SetExpr::Select(select) => {
+            for item in &select.projection {
+                match item {
+                    SelectItem::Wildcard(opts) => {
+                        *uses_select_star = true;
+                        extract_except_fields(opts, except_fields);
+                    }
+                    SelectItem::QualifiedWildcard(_, opts) => {
+                        *uses_select_star = true;
+                        extract_except_fields(opts, except_fields);
+                    }
+                    SelectItem::UnnamedExpr(expr) => {
+                        collect_column_refs(expr, referenced_columns);
+                    }
+                    SelectItem::ExprWithAlias { expr, .. } => {
+                        collect_column_refs(expr, referenced_columns);
+                    }
+                }
+            }
+
+            if let Some(ref selection) = select.selection {
+                collect_column_refs(selection, referenced_columns);
+                *where_clause = Some(selection.clone());
+            }
+
+            if let sqlast::GroupByExpr::Expressions(exprs, _) = &select.group_by {
+                for e in exprs {
+                    collect_column_refs(e, referenced_columns);
+                }
+            }
+
+            if let Some(ref having) = select.having {
+                collect_column_refs(having, referenced_columns);
+            }
+
+            for table_with_joins in &select.from {
+                for join in &table_with_joins.joins {
+                    if let sqlast::JoinConstraint::On(expr) = join_constraint(&join.join_operator) {
+                        collect_column_refs(expr, referenced_columns);
+                    }
+                }
+            }
+
+            for sqlast::NamedWindowDefinition(_, named_expr) in &select.named_window {
+                if let sqlast::NamedWindowExpr::WindowSpec(spec) = named_expr {
+                    for e in &spec.partition_by {
+                        collect_column_refs(e, referenced_columns);
+                    }
+                    for ob in &spec.order_by {
+                        collect_column_refs(&ob.expr, referenced_columns);
+                    }
+                }
+            }
+        }
+        SetExpr::SetOperation { left, right, .. } => {
+            walk_set_expr(
+                left,
+                referenced_columns,
+                uses_select_star,
+                except_fields,
+                where_clause,
+            );
+            walk_set_expr(
+                right,
+                referenced_columns,
+                uses_select_star,
+                except_fields,
+                where_clause,
+            );
+        }
+        SetExpr::Query(query) => {
+            walk_set_expr(
+                query.body.as_ref(),
+                referenced_columns,
+                uses_select_star,
+                except_fields,
+                where_clause,
+            );
+        }
+        // Values, Table, etc. — no column refs to extract.
+        _ => {}
     }
 }
 

--- a/crates/logfwd-transform/src/query_analyzer.rs
+++ b/crates/logfwd-transform/src/query_analyzer.rs
@@ -46,22 +46,13 @@ impl QueryAnalyzer {
         let mut where_clause = None;
 
         if let Statement::Query(query) = stmt {
-            walk_set_expr(
-                query.body.as_ref(),
+            walk_query(
+                query,
                 &mut referenced_columns,
                 &mut uses_select_star,
                 &mut except_fields,
                 &mut where_clause,
             );
-
-            // Walk ORDER BY — columns may appear only here (not in SELECT or WHERE).
-            if let Some(ref order_by) = query.order_by {
-                if let sqlast::OrderByKind::Expressions(exprs) = &order_by.kind {
-                    for ob in exprs {
-                        collect_column_refs(&ob.expr, &mut referenced_columns);
-                    }
-                }
-            }
         } else {
             return Err(TransformError::Sql(
                 "Only SELECT statements are supported".to_string(),
@@ -156,6 +147,32 @@ impl QueryAnalyzer {
 
         hints
     }
+}
+
+/// Recursively walk a Query wrapper (ORDER BY + body).
+fn walk_query(
+    query: &sqlast::Query,
+    referenced_columns: &mut HashSet<String>,
+    uses_select_star: &mut bool,
+    except_fields: &mut Vec<String>,
+    where_clause: &mut Option<SqlExpr>,
+) {
+    // Walk ORDER BY — columns may appear only here.
+    if let Some(ref order_by) = query.order_by
+        && let sqlast::OrderByKind::Expressions(exprs) = &order_by.kind
+    {
+        for ob in exprs {
+            collect_column_refs(&ob.expr, referenced_columns);
+        }
+    }
+
+    walk_set_expr(
+        query.body.as_ref(),
+        referenced_columns,
+        uses_select_star,
+        except_fields,
+        where_clause,
+    );
 }
 
 /// Recursively walk a `SetExpr`, collecting column refs from SELECT, WHERE,
@@ -407,8 +424,8 @@ fn walk_table_factor(
     match factor {
         sqlast::TableFactor::Derived { subquery, .. } => {
             let mut nested_where = None;
-            walk_set_expr(
-                subquery.body.as_ref(),
+            walk_query(
+                subquery,
                 referenced_columns,
                 uses_select_star,
                 except_fields,
@@ -472,16 +489,14 @@ fn extract_join_constraint(op: &sqlast::JoinOperator) -> Option<&sqlast::JoinCon
         | J::Right(c)
         | J::RightOuter(c)
         | J::FullOuter(c)
-        | J::CrossJoin(c)
         | J::Semi(c)
         | J::LeftSemi(c)
         | J::RightSemi(c)
         | J::Anti(c)
         | J::LeftAnti(c)
         | J::RightAnti(c)
-        | J::StraightJoin(c)
         | J::AsOf { constraint: c, .. } => Some(c),
-        J::CrossApply | J::OuterApply => None,
+        J::CrossJoin | J::CrossApply | J::OuterApply => None,
     }
 }
 

--- a/crates/logfwd-transform/src/query_analyzer.rs
+++ b/crates/logfwd-transform/src/query_analyzer.rs
@@ -415,6 +415,11 @@ fn walk_table_factor(
     except_fields: &mut Vec<String>,
 ) {
     match factor {
+        sqlast::TableFactor::Table { args, .. } => {
+            if let Some(args) = args {
+                collect_function_args(&args.args, referenced_columns);
+            }
+        }
         sqlast::TableFactor::Derived { subquery, .. } => {
             let mut nested_where = None;
             walk_query(
@@ -434,6 +439,68 @@ fn walk_table_factor(
                 uses_select_star,
                 except_fields,
             );
+        }
+        sqlast::TableFactor::TableFunction { expr, .. } => {
+            collect_column_refs(expr, referenced_columns);
+        }
+        sqlast::TableFactor::Function { args, .. } => {
+            collect_function_args(args, referenced_columns);
+        }
+        sqlast::TableFactor::UNNEST { array_exprs, .. } => {
+            for expr in array_exprs {
+                collect_column_refs(expr, referenced_columns);
+            }
+        }
+        sqlast::TableFactor::Pivot {
+            table,
+            aggregate_functions,
+            value_column,
+            value_source,
+            default_on_null,
+            ..
+        } => {
+            walk_table_factor(table, referenced_columns, uses_select_star, except_fields);
+            for agg in aggregate_functions {
+                collect_column_refs(&agg.expr, referenced_columns);
+            }
+            for col in value_column {
+                referenced_columns.insert(col.value.clone());
+            }
+            match value_source {
+                sqlast::PivotValueSource::List(values) => {
+                    for value in values {
+                        collect_column_refs(&value.expr, referenced_columns);
+                    }
+                }
+                sqlast::PivotValueSource::Any(order_by) => {
+                    for ob in order_by {
+                        collect_column_refs(&ob.expr, referenced_columns);
+                    }
+                }
+                sqlast::PivotValueSource::Subquery(query) => {
+                    let mut nested_where = None;
+                    walk_query(
+                        query,
+                        referenced_columns,
+                        uses_select_star,
+                        except_fields,
+                        &mut nested_where,
+                    );
+                }
+            }
+            if let Some(expr) = default_on_null {
+                collect_column_refs(expr, referenced_columns);
+            }
+        }
+        sqlast::TableFactor::Unpivot { table, columns, .. } => {
+            walk_table_factor(table, referenced_columns, uses_select_star, except_fields);
+            for col in columns {
+                referenced_columns.insert(col.value.clone());
+            }
+        }
+        sqlast::TableFactor::JsonTable { json_expr, .. }
+        | sqlast::TableFactor::OpenJsonTable { json_expr, .. } => {
+            collect_column_refs(json_expr, referenced_columns);
         }
         _ => {}
     }
@@ -515,6 +582,31 @@ fn collect_join_constraint_columns(
     }
 }
 
+fn collect_function_arg_refs(arg: &sqlast::FunctionArg, cols: &mut HashSet<String>) {
+    match arg {
+        sqlast::FunctionArg::Unnamed(sqlast::FunctionArgExpr::Expr(e))
+        | sqlast::FunctionArg::Named {
+            arg: sqlast::FunctionArgExpr::Expr(e),
+            ..
+        } => {
+            collect_column_refs(e, cols);
+        }
+        sqlast::FunctionArg::ExprNamed { name, arg, .. } => {
+            collect_column_refs(name, cols);
+            if let sqlast::FunctionArgExpr::Expr(e) = arg {
+                collect_column_refs(e, cols);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_function_args(args: &[sqlast::FunctionArg], cols: &mut HashSet<String>) {
+    for arg in args {
+        collect_function_arg_refs(arg, cols);
+    }
+}
+
 /// Recursively collect column name references from a SQL expression.
 fn collect_column_refs(expr: &SqlExpr, cols: &mut HashSet<String>) {
     match expr {
@@ -538,18 +630,7 @@ fn collect_column_refs(expr: &SqlExpr, cols: &mut HashSet<String>) {
             match &func.args {
                 sqlast::FunctionArguments::List(arg_list) => {
                     for arg in &arg_list.args {
-                        match arg {
-                            sqlast::FunctionArg::Unnamed(sqlast::FunctionArgExpr::Expr(e)) => {
-                                collect_column_refs(e, cols);
-                            }
-                            sqlast::FunctionArg::Named {
-                                arg: sqlast::FunctionArgExpr::Expr(e),
-                                ..
-                            } => {
-                                collect_column_refs(e, cols);
-                            }
-                            _ => {}
-                        }
+                        collect_function_arg_refs(arg, cols);
                     }
                 }
                 sqlast::FunctionArguments::None => {}

--- a/crates/logfwd-transform/src/query_analyzer.rs
+++ b/crates/logfwd-transform/src/query_analyzer.rs
@@ -83,6 +83,30 @@ impl QueryAnalyzer {
                 if let Some(ref having) = select.having {
                     collect_column_refs(having, &mut referenced_columns);
                 }
+                // Walk FROM clause — JOIN ON conditions contain column refs
+                // that the scanner must extract.
+                for table_with_joins in &select.from {
+                    for join in &table_with_joins.joins {
+                        if let sqlast::JoinConstraint::On(expr) =
+                            join_constraint(&join.join_operator)
+                        {
+                            collect_column_refs(expr, &mut referenced_columns);
+                        }
+                    }
+                }
+
+                // Walk WINDOW named definitions — PARTITION BY / ORDER BY
+                // columns may only appear in named window specs.
+                for sqlast::NamedWindowDefinition(_, named_expr) in &select.named_window {
+                    if let sqlast::NamedWindowExpr::WindowSpec(spec) = named_expr {
+                        for e in &spec.partition_by {
+                            collect_column_refs(e, &mut referenced_columns);
+                        }
+                        for ob in &spec.order_by {
+                            collect_column_refs(&ob.expr, &mut referenced_columns);
+                        }
+                    }
+                }
             }
 
             // Walk ORDER BY — columns may appear only here (not in SELECT or WHERE).
@@ -316,6 +340,30 @@ fn extract_except_fields(opts: &WildcardAdditionalOptions, out: &mut Vec<String>
         out.push(except.first_element.value.clone());
         for ident in &except.additional_elements {
             out.push(ident.value.clone());
+        }
+    }
+}
+
+/// Extract the `JoinConstraint` from any `JoinOperator` variant.
+fn join_constraint(op: &sqlast::JoinOperator) -> &sqlast::JoinConstraint {
+    use sqlast::JoinOperator as J;
+    match op {
+        J::Join(c)
+        | J::Inner(c)
+        | J::Left(c)
+        | J::LeftOuter(c)
+        | J::Right(c)
+        | J::RightOuter(c)
+        | J::FullOuter(c)
+        | J::CrossJoin(c)
+        | J::Semi(c)
+        | J::LeftSemi(c)
+        | J::RightSemi(c)
+        | J::Anti(c)
+        | J::LeftAnti(c)
+        | J::RightAnti(c) => c,
+        J::CrossApply | J::OuterApply | J::AsOf { .. } | J::StraightJoin(_) => {
+            &sqlast::JoinConstraint::None
         }
     }
 }

--- a/crates/logfwd-transform/src/query_analyzer.rs
+++ b/crates/logfwd-transform/src/query_analyzer.rs
@@ -205,18 +205,12 @@ fn walk_set_expr(
             }
 
             for table_with_joins in &select.from {
-                for join in &table_with_joins.joins {
-                    if let sqlast::JoinOperator::AsOf {
-                        match_condition, ..
-                    } = &join.join_operator
-                    {
-                        collect_column_refs(match_condition, referenced_columns);
-                    }
-
-                    if let Some(constraint) = join_constraint(&join.join_operator) {
-                        collect_join_constraint_columns(constraint, referenced_columns);
-                    }
-                }
+                walk_table_with_joins(
+                    table_with_joins,
+                    referenced_columns,
+                    uses_select_star,
+                    except_fields,
+                );
             }
 
             for sqlast::NamedWindowDefinition(_, named_expr) in &select.named_window {
@@ -253,6 +247,13 @@ fn walk_set_expr(
             *where_clause = None;
         }
         SetExpr::Query(query) => {
+            if let Some(ref order_by) = query.order_by
+                && let sqlast::OrderByKind::Expressions(exprs) = &order_by.kind
+            {
+                for ob in exprs {
+                    collect_column_refs(&ob.expr, referenced_columns);
+                }
+            }
             walk_set_expr(
                 query.body.as_ref(),
                 referenced_columns,
@@ -397,8 +398,71 @@ fn extract_except_fields(opts: &WildcardAdditionalOptions, out: &mut Vec<String>
     }
 }
 
+fn walk_table_factor(
+    factor: &sqlast::TableFactor,
+    referenced_columns: &mut HashSet<String>,
+    uses_select_star: &mut bool,
+    except_fields: &mut Vec<String>,
+) {
+    match factor {
+        sqlast::TableFactor::Derived { subquery, .. } => {
+            let mut nested_where = None;
+            walk_set_expr(
+                subquery.body.as_ref(),
+                referenced_columns,
+                uses_select_star,
+                except_fields,
+                &mut nested_where,
+            );
+        }
+        sqlast::TableFactor::NestedJoin {
+            table_with_joins, ..
+        } => {
+            walk_table_with_joins(
+                table_with_joins,
+                referenced_columns,
+                uses_select_star,
+                except_fields,
+            );
+        }
+        _ => {}
+    }
+}
+
+fn walk_table_with_joins(
+    table_with_joins: &sqlast::TableWithJoins,
+    referenced_columns: &mut HashSet<String>,
+    uses_select_star: &mut bool,
+    except_fields: &mut Vec<String>,
+) {
+    walk_table_factor(
+        &table_with_joins.relation,
+        referenced_columns,
+        uses_select_star,
+        except_fields,
+    );
+    for join in &table_with_joins.joins {
+        walk_table_factor(
+            &join.relation,
+            referenced_columns,
+            uses_select_star,
+            except_fields,
+        );
+        if let sqlast::JoinOperator::AsOf {
+            match_condition, ..
+        } = &join.join_operator
+        {
+            collect_column_refs(match_condition, referenced_columns);
+        }
+
+        if let Some(constraint) = extract_join_constraint(&join.join_operator) {
+            collect_join_constraint_columns(constraint, referenced_columns);
+        }
+    }
+}
+
 /// Extract the `JoinConstraint` from any `JoinOperator` variant that carries one.
-fn join_constraint(op: &sqlast::JoinOperator) -> Option<&sqlast::JoinConstraint> {
+fn extract_join_constraint(op: &sqlast::JoinOperator) -> Option<&sqlast::JoinConstraint> {
     use sqlast::JoinOperator as J;
     match op {
         J::Join(c)

--- a/crates/logfwd-transform/src/query_analyzer.rs
+++ b/crates/logfwd-transform/src/query_analyzer.rs
@@ -206,20 +206,15 @@ fn walk_set_expr(
 
             for table_with_joins in &select.from {
                 for join in &table_with_joins.joins {
-                    match join_constraint(&join.join_operator) {
-                        sqlast::JoinConstraint::On(expr) => {
-                            collect_column_refs(expr, referenced_columns);
-                        }
-                        sqlast::JoinConstraint::Using(cols) => {
-                            for obj_name in cols {
-                                if let Some(part) = obj_name.0.last()
-                                    && let Some(ident) = part.as_ident()
-                                {
-                                    referenced_columns.insert(ident.value.clone());
-                                }
-                            }
-                        }
-                        sqlast::JoinConstraint::Natural | sqlast::JoinConstraint::None => {}
+                    if let sqlast::JoinOperator::AsOf {
+                        match_condition, ..
+                    } = &join.join_operator
+                    {
+                        collect_column_refs(match_condition, referenced_columns);
+                    }
+
+                    if let Some(constraint) = join_constraint(&join.join_operator) {
+                        collect_join_constraint_columns(constraint, referenced_columns);
                     }
                 }
             }
@@ -236,20 +231,26 @@ fn walk_set_expr(
             }
         }
         SetExpr::SetOperation { left, right, .. } => {
+            // Set-operation branches can each have independent WHERE clauses.
+            // We intentionally avoid extracting filter hints from compound
+            // queries to prevent pushing one branch's predicate to all input.
+            let mut left_where = None;
             walk_set_expr(
                 left,
                 referenced_columns,
                 uses_select_star,
                 except_fields,
-                where_clause,
+                &mut left_where,
             );
+            let mut right_where = None;
             walk_set_expr(
                 right,
                 referenced_columns,
                 uses_select_star,
                 except_fields,
-                where_clause,
+                &mut right_where,
             );
+            *where_clause = None;
         }
         SetExpr::Query(query) => {
             walk_set_expr(
@@ -396,8 +397,8 @@ fn extract_except_fields(opts: &WildcardAdditionalOptions, out: &mut Vec<String>
     }
 }
 
-/// Extract the `JoinConstraint` from any `JoinOperator` variant.
-fn join_constraint(op: &sqlast::JoinOperator) -> &sqlast::JoinConstraint {
+/// Extract the `JoinConstraint` from any `JoinOperator` variant that carries one.
+fn join_constraint(op: &sqlast::JoinOperator) -> Option<&sqlast::JoinConstraint> {
     use sqlast::JoinOperator as J;
     match op {
         J::Join(c)
@@ -413,10 +414,32 @@ fn join_constraint(op: &sqlast::JoinOperator) -> &sqlast::JoinConstraint {
         | J::RightSemi(c)
         | J::Anti(c)
         | J::LeftAnti(c)
-        | J::RightAnti(c) => c,
-        J::CrossApply | J::OuterApply | J::AsOf { .. } | J::StraightJoin(_) => {
-            &sqlast::JoinConstraint::None
+        | J::RightAnti(c)
+        | J::StraightJoin(c)
+        | J::AsOf { constraint: c, .. } => Some(c),
+        J::CrossApply | J::OuterApply => None,
+    }
+}
+
+/// Collect column references from a `JoinConstraint`.
+fn collect_join_constraint_columns(
+    constraint: &sqlast::JoinConstraint,
+    cols: &mut HashSet<String>,
+) {
+    match constraint {
+        sqlast::JoinConstraint::On(expr) => {
+            collect_column_refs(expr, cols);
         }
+        sqlast::JoinConstraint::Using(using_cols) => {
+            for obj_name in using_cols {
+                if let Some(part) = obj_name.0.last()
+                    && let Some(ident) = part.as_ident()
+                {
+                    cols.insert(ident.value.clone());
+                }
+            }
+        }
+        sqlast::JoinConstraint::Natural | sqlast::JoinConstraint::None => {}
     }
 }
 

--- a/crates/logfwd-transform/src/query_analyzer.rs
+++ b/crates/logfwd-transform/src/query_analyzer.rs
@@ -264,15 +264,8 @@ fn walk_set_expr(
             *where_clause = None;
         }
         SetExpr::Query(query) => {
-            if let Some(ref order_by) = query.order_by
-                && let sqlast::OrderByKind::Expressions(exprs) = &order_by.kind
-            {
-                for ob in exprs {
-                    collect_column_refs(&ob.expr, referenced_columns);
-                }
-            }
-            walk_set_expr(
-                query.body.as_ref(),
+            walk_query(
+                query,
                 referenced_columns,
                 uses_select_star,
                 except_fields,

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -857,6 +857,21 @@ fn test_query_analyzer_in_list_column_refs() {
     );
 }
 
+#[test]
+fn test_query_analyzer_join_on_column_refs() {
+    let a =
+        QueryAnalyzer::new("SELECT a.message FROM logs a JOIN logs b ON a.level = b.level LIMIT 5")
+            .unwrap();
+    assert!(
+        a.referenced_columns.contains("message"),
+        "SELECT column must be in referenced_columns"
+    );
+    assert!(
+        a.referenced_columns.contains("level"),
+        "JOIN ON column must be in referenced_columns"
+    );
+}
+
 // -----------------------------------------------------------------------
 
 /// Verify that a stable schema does NOT trigger repeated context recreation

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -968,6 +968,30 @@ fn test_query_analyzer_joined_derived_relation_column_refs() {
     );
 }
 
+#[test]
+fn test_query_analyzer_table_function_args_column_refs() {
+    let with_table_args = QueryAnalyzer::new("SELECT message FROM logs(level, host)").unwrap();
+    assert!(
+        with_table_args.referenced_columns.contains("level"),
+        "table-args column must be in referenced_columns"
+    );
+    assert!(
+        with_table_args.referenced_columns.contains("host"),
+        "table-args column must be in referenced_columns"
+    );
+
+    let with_table_function =
+        QueryAnalyzer::new("SELECT message FROM TABLE(my_tvf(level, host))").unwrap();
+    assert!(
+        with_table_function.referenced_columns.contains("level"),
+        "table-function arg column must be in referenced_columns"
+    );
+    assert!(
+        with_table_function.referenced_columns.contains("host"),
+        "table-function arg column must be in referenced_columns"
+    );
+}
+
 // -----------------------------------------------------------------------
 
 /// Verify that a stable schema does NOT trigger repeated context recreation

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -886,6 +886,19 @@ fn test_query_analyzer_union_column_refs() {
     );
 }
 
+#[test]
+fn test_query_analyzer_join_using_column_refs() {
+    let a = QueryAnalyzer::new("SELECT message FROM logs a JOIN logs b USING (level)").unwrap();
+    assert!(
+        a.referenced_columns.contains("message"),
+        "SELECT column must be in referenced_columns"
+    );
+    assert!(
+        a.referenced_columns.contains("level"),
+        "USING column must be in referenced_columns"
+    );
+}
+
 // -----------------------------------------------------------------------
 
 /// Verify that a stable schema does NOT trigger repeated context recreation

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -872,6 +872,20 @@ fn test_query_analyzer_join_on_column_refs() {
     );
 }
 
+#[test]
+fn test_query_analyzer_union_column_refs() {
+    let a =
+        QueryAnalyzer::new("SELECT level FROM logs UNION ALL SELECT severity FROM logs").unwrap();
+    assert!(
+        a.referenced_columns.contains("level"),
+        "left branch column must be in referenced_columns"
+    );
+    assert!(
+        a.referenced_columns.contains("severity"),
+        "right branch column must be in referenced_columns"
+    );
+}
+
 // -----------------------------------------------------------------------
 
 /// Verify that a stable schema does NOT trigger repeated context recreation

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -928,6 +928,46 @@ fn test_query_analyzer_straight_join_on_column_refs() {
     );
 }
 
+#[test]
+fn test_query_analyzer_derived_subquery_column_refs() {
+    let a = QueryAnalyzer::new(
+        "SELECT q.level FROM (SELECT level, status, host FROM logs WHERE status = '500' ORDER BY host) q",
+    )
+    .unwrap();
+    assert!(
+        a.referenced_columns.contains("level"),
+        "derived SELECT column must be in referenced_columns"
+    );
+    assert!(
+        a.referenced_columns.contains("status"),
+        "derived WHERE column must be in referenced_columns"
+    );
+    assert!(
+        a.referenced_columns.contains("host"),
+        "derived ORDER BY column must be in referenced_columns"
+    );
+}
+
+#[test]
+fn test_query_analyzer_joined_derived_relation_column_refs() {
+    let a = QueryAnalyzer::new(
+        "SELECT l.message FROM logs l JOIN (SELECT level, service FROM logs WHERE service = 'api') d ON l.level = d.level",
+    )
+    .unwrap();
+    assert!(
+        a.referenced_columns.contains("message"),
+        "outer SELECT column must be in referenced_columns"
+    );
+    assert!(
+        a.referenced_columns.contains("level"),
+        "join key from derived relation must be in referenced_columns"
+    );
+    assert!(
+        a.referenced_columns.contains("service"),
+        "derived subquery column must be in referenced_columns"
+    );
+}
+
 // -----------------------------------------------------------------------
 
 /// Verify that a stable schema does NOT trigger repeated context recreation

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -381,6 +381,19 @@ fn test_filter_hints_no_where() {
 }
 
 #[test]
+fn test_filter_hints_disabled_for_set_operation_branches() {
+    let a = QueryAnalyzer::new(
+        "SELECT * FROM logs WHERE severity <= 2 UNION ALL SELECT * FROM logs WHERE severity <= 4",
+    )
+    .unwrap();
+    let h = a.filter_hints();
+    assert!(
+        h.max_severity.is_none(),
+        "set-operation branch predicates must not be pushed globally"
+    );
+}
+
+#[test]
 fn test_filter_hints_field_pushdown() {
     let a = QueryAnalyzer::new("SELECT hostname, message FROM logs WHERE severity <= 2").unwrap();
     let h = a.filter_hints();
@@ -896,6 +909,22 @@ fn test_query_analyzer_join_using_column_refs() {
     assert!(
         a.referenced_columns.contains("level"),
         "USING column must be in referenced_columns"
+    );
+}
+
+#[test]
+fn test_query_analyzer_straight_join_on_column_refs() {
+    let a = QueryAnalyzer::new(
+        "SELECT a.message FROM logs a STRAIGHT_JOIN logs b ON a.level = b.level",
+    )
+    .unwrap();
+    assert!(
+        a.referenced_columns.contains("message"),
+        "SELECT column must be in referenced_columns"
+    );
+    assert!(
+        a.referenced_columns.contains("level"),
+        "STRAIGHT_JOIN ON column must be in referenced_columns"
     );
 }
 

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -412,8 +412,9 @@ fn cmd_effective_config(config_path: Option<&str>) -> Result<(), CliError> {
         |err| eprintln!("  {}error{}: {err}", red(), reset()),
     )?;
 
+    let redacted_yaml = logfwd_io::diagnostics::redact_config_yaml(&effective_yaml);
     eprintln!("{}# validated from {config_path}{}", dim(), reset());
-    print!("{effective_yaml}");
+    print!("{redacted_yaml}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

### Correctness
- **telemetry_buffer** `attrs_to_json`: escape attribute keys with `json_escape()` (fixes #1737)
- **star_schema** `unpivot_attrs_to_flat`: read `ATTR_TYPE_BYTES` from bytes column, hex-encode for flat schema (fixes #1749)
- **QueryAnalyzer**: walk JOIN ON conditions to collect column refs (fixes #1742)
- **QueryAnalyzer**: walk `SetExpr::SetOperation` (UNION/INTERSECT/EXCEPT) recursively (fixes #1739)

### Security
- **validate_endpoint_url**: redact userinfo from URLs in all error messages (fixes #1744)
- **effective-config CLI**: pipe YAML through `redact_config_yaml()` to mask credentials (fixes #1743)

### Config validation
- **storage.data_dir**: reject paths that exist as regular files (fixes #1740)
- **elasticsearch index**: reject names with illegal ES characters at validate time (fixes #1741)
- **glob overlap**: detect when file output path could match a file input glob pattern (fixes #1747)

## Test plan

- [x] `test_query_analyzer_join_on_column_refs` — JOIN ON columns collected
- [x] `test_query_analyzer_union_column_refs` — UNION branch columns collected
- [x] 16 star_schema tests pass
- [x] 10 query_analyzer tests pass
- [x] 8 file_output overlap tests pass
- [x] 7 ES config tests pass
- [x] `cargo clippy -D warnings` clean across all changed crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 11 correctness and security bugs in SQL analysis, credential redaction, and config validation
> - [QueryAnalyzer](https://github.com/strawgate/memagent/pull/1751/files#diff-0fba2b638d1ab36b827fc0fb381a1d162d9f8aa354be8861a9edc33b94c391af) now collects column references from ORDER BY, GROUP BY, HAVING, JOINs, subqueries, and table functions; suppresses filter pushdown for UNION/INTERSECT/EXCEPT branches to avoid incorrect predicate propagation.
> - Config validation in [validate.rs](https://github.com/strawgate/memagent/pull/1751/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) now rejects `storage.data_dir` paths that are not directories, Elasticsearch index names with illegal characters, and pipeline configs where a file output path could match a file input glob.
> - Credential redaction is now fail-closed: malformed endpoint URLs containing `@` return a `REDACTED_ENDPOINT` marker instead of leaking credentials in error messages and `effective-config` output.
> - Resource attribute deduplication in [star_schema.rs](https://github.com/strawgate/memagent/pull/1751/files#diff-fb28eb9d8306708fff07b41c8d2b450df493a129ad9ffa16eceed5676b3a0f62) now distinguishes NULL from empty-string keys, stores non-string attributes (int, double, bool, bytes) in their native types, and hex-encodes binary values.
> - Attribute keys in [telemetry_buffer.rs](https://github.com/strawgate/memagent/pull/1751/files#diff-c142941ba93a9c8c6ac9cad53012a215ffaaba9bd9c0646b5ce78e0f7d2a7586) are now JSON-escaped, preventing malformed JSON when keys contain special characters.
> - Behavioral Change: unknown attribute type tags in `unpivot_attrs_to_flat` now return a `SchemaError` instead of silently defaulting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b87c7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->