### PR TITLE
worker-pool: terminalize tickets on sink panic

### DIFF
--- a/crates/logfwd-io/src/receiver_health.rs
+++ b/crates/logfwd-io/src/receiver_health.rs
@@ -4,7 +4,7 @@
 
 use logfwd_types::diagnostics::ComponentHealth;
 
-/// Lifecycle events that can update standalone receiver health.
+/// Lifecycle events that can update standalone receiver health snapshots.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ReceiverHealthEvent {
     /// A request delivered non-empty data into the pipeline successfully.
@@ -61,7 +61,7 @@ pub(crate) const fn reduce_receiver_health(
 
 #[cfg(test)]
 mod tests {
-    use super::{ReceiverHealthEvent, reduce_receiver_health};
+    use super::{reduce_receiver_health, ReceiverHealthEvent};
     use logfwd_types::diagnostics::ComponentHealth;
     use proptest::prelude::*;
 
@@ -145,7 +145,7 @@ mod tests {
         ) {
             let out = apply_events(ComponentHealth::Stopping, &events);
             if events.contains(&ReceiverHealthEvent::ShutdownCompleted) {
-                prop_assert!(matches!(out, ComponentHealth::Stopping | ComponentHealth::Stopped));
+                prop_assert_eq!(out, ComponentHealth::Stopped);
             } else {
                 prop_assert_eq!(out, ComponentHealth::Stopping);
             }
@@ -155,10 +155,11 @@ mod tests {
 
 #[cfg(kani)]
 mod verification {
-    use super::{ReceiverHealthEvent, reduce_receiver_health};
+    use super::{reduce_receiver_health, ReceiverHealthEvent};
     use logfwd_types::diagnostics::ComponentHealth;
 
     #[kani::proof]
+    #[kani::unwind(3)]
     fn verify_delivery_noop_preserves_current_health() {
         let current = ComponentHealth::from_repr(kani::any());
         let out = reduce_receiver_health(current, ReceiverHealthEvent::DeliveryNoop);
@@ -175,6 +176,7 @@ mod verification {
     }
 
     #[kani::proof]
+    #[kani::unwind(3)]
     fn verify_delivery_accepted_recovers_only_non_terminal_receivers() {
         let current = ComponentHealth::from_repr(kani::any());
         let out = reduce_receiver_health(current, ReceiverHealthEvent::DeliveryAccepted);
@@ -197,6 +199,7 @@ mod verification {
     }
 
     #[kani::proof]
+    #[kani::unwind(3)]
     fn verify_backpressure_degrades_only_non_terminal_receivers() {
         let current = ComponentHealth::from_repr(kani::any());
         let out = reduce_receiver_health(current, ReceiverHealthEvent::Backpressure);
@@ -219,6 +222,7 @@ mod verification {
     }
 
     #[kani::proof]
+    #[kani::unwind(3)]
     fn verify_fatal_failure_preserves_drain_phase() {
         let current = ComponentHealth::from_repr(kani::any());
         let out = reduce_receiver_health(current, ReceiverHealthEvent::FatalFailure);
@@ -239,6 +243,7 @@ mod verification {
     }
 
     #[kani::proof]
+    #[kani::unwind(3)]
     fn verify_shutdown_requested_only_moves_non_terminal_receivers_to_stopping() {
         let current = ComponentHealth::from_repr(kani::any());
         let out = reduce_receiver_health(current, ReceiverHealthEvent::ShutdownRequested);
@@ -259,6 +264,7 @@ mod verification {
     }
 
     #[kani::proof]
+    #[kani::unwind(3)]
     fn verify_shutdown_completed_stops_only_non_failed_receivers() {
         let current = ComponentHealth::from_repr(kani::any());
         let out = reduce_receiver_health(current, ReceiverHealthEvent::ShutdownCompleted);

--- a/crates/logfwd-output/src/conflict_columns.rs
+++ b/crates/logfwd-output/src/conflict_columns.rs
@@ -125,7 +125,7 @@ pub(crate) fn is_null(batch: &RecordBatch, variant: &ColVariant, row: usize) -> 
 /// Return a reference to the underlying Arrow array for a `ColVariant`.
 pub(crate) fn get_array<'b>(batch: &'b RecordBatch, variant: &ColVariant) -> Option<&'b dyn Array> {
     match variant {
-        ColVariant::Flat { col_idx, .. } => batch.columns().get(*col_idx).map(|col| col.as_ref()),
+        ColVariant::Flat { col_idx, .. } => batch.columns().get(*col_idx).map(AsRef::as_ref),
         ColVariant::StructField {
             struct_col_idx,
             field_idx,
@@ -135,7 +135,7 @@ pub(crate) fn get_array<'b>(batch: &'b RecordBatch, variant: &ColVariant) -> Opt
                 .columns()
                 .get(*struct_col_idx)
                 .and_then(|col| col.as_any().downcast_ref::<StructArray>())?;
-            sa.columns().get(*field_idx).map(|child| child.as_ref())
+            sa.columns().get(*field_idx).map(AsRef::as_ref)
         }
     }
 }

--- a/crates/logfwd-output/src/sink/health.rs
+++ b/crates/logfwd-output/src/sink/health.rs
@@ -93,7 +93,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{OutputHealthEvent, aggregate_fanout_health, reduce_output_health};
+    use super::{aggregate_fanout_health, reduce_output_health, OutputHealthEvent};
     use logfwd_types::diagnostics::ComponentHealth;
     use proptest::prelude::*;
 
@@ -276,7 +276,7 @@ mod tests {
 
 #[cfg(kani)]
 mod verification {
-    use super::{OutputHealthEvent, aggregate_fanout_health, reduce_output_health};
+    use super::{aggregate_fanout_health, reduce_output_health, OutputHealthEvent};
     use logfwd_types::diagnostics::ComponentHealth;
 
     #[kani::proof]

--- a/crates/logfwd-output/src/sink/health.rs
+++ b/crates/logfwd-output/src/sink/health.rs
@@ -37,10 +37,10 @@ pub const fn reduce_output_health(
         OutputHealthEvent::StartupRequested => match current {
             ComponentHealth::Healthy
             | ComponentHealth::Degraded
+            | ComponentHealth::Starting
             | ComponentHealth::Stopping
             | ComponentHealth::Stopped
             | ComponentHealth::Failed => current,
-            _ => ComponentHealth::Starting,
         },
         OutputHealthEvent::StartupSucceeded => match current {
             ComponentHealth::Degraded => ComponentHealth::Degraded,
@@ -93,7 +93,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{aggregate_fanout_health, reduce_output_health, OutputHealthEvent};
+    use super::{OutputHealthEvent, aggregate_fanout_health, reduce_output_health};
     use logfwd_types::diagnostics::ComponentHealth;
     use proptest::prelude::*;
 
@@ -276,7 +276,7 @@ mod tests {
 
 #[cfg(kani)]
 mod verification {
-    use super::{aggregate_fanout_health, reduce_output_health, OutputHealthEvent};
+    use super::{OutputHealthEvent, aggregate_fanout_health, reduce_output_health};
     use logfwd_types::diagnostics::ComponentHealth;
 
     #[kani::proof]

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -480,7 +480,8 @@ impl Pipeline {
                     // Heartbeat for stateful processors: send an empty batch through
                     // the chain so stateful processors can check their internal timers
                     // and emit timed-out data.
-                    if !self.processors.is_empty()
+                    if !self.aborted
+                        && !self.processors.is_empty()
                         && self.processors.iter().any(|p| p.is_stateful())
                     {
                         let empty = RecordBatch::new_empty(

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -480,8 +480,7 @@ impl Pipeline {
                     // Heartbeat for stateful processors: send an empty batch through
                     // the chain so stateful processors can check their internal timers
                     // and emit timed-out data.
-                    if !self.aborted
-                        && !self.processors.is_empty()
+                    if !self.processors.is_empty()
                         && self.processors.iter().any(|p| p.is_stateful())
                     {
                         let empty = RecordBatch::new_empty(

--- a/crates/logfwd/src/worker_pool/health.rs
+++ b/crates/logfwd/src/worker_pool/health.rs
@@ -1,0 +1,143 @@
+//! Pure health policy for output worker-pool aggregation.
+//!
+//! This module keeps terminal-state and aggregation semantics out of the
+//! runtime shell so they can be Kani-proved directly.
+
+use logfwd_io::diagnostics::ComponentHealth;
+use logfwd_output::sink::{OutputHealthEvent, reduce_output_health};
+
+/// Pool-level idle health to use after inserting a worker slot.
+///
+/// Terminal pool phases stay sticky: a new worker must not resurrect a pool
+/// that is already stopping, stopped, or failed.
+#[must_use]
+pub(super) const fn idle_health_after_worker_insert(current: ComponentHealth) -> ComponentHealth {
+    match current {
+        ComponentHealth::Stopping | ComponentHealth::Stopped | ComponentHealth::Failed => current,
+        _ => ComponentHealth::Healthy,
+    }
+}
+
+/// Reduce one worker-local health slot through an output event.
+#[must_use]
+pub(super) const fn reduce_worker_slot_health(
+    current: ComponentHealth,
+    event: OutputHealthEvent,
+) -> ComponentHealth {
+    reduce_output_health(current, event)
+}
+
+/// Aggregate the pool-level idle phase with live worker slots.
+#[must_use]
+pub(super) fn aggregate_output_health<I>(
+    idle_health: ComponentHealth,
+    worker_slots: I,
+) -> ComponentHealth
+where
+    I: IntoIterator<Item = ComponentHealth>,
+{
+    worker_slots
+        .into_iter()
+        .fold(idle_health, ComponentHealth::combine)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{aggregate_output_health, idle_health_after_worker_insert};
+    use logfwd_io::diagnostics::ComponentHealth;
+
+    #[test]
+    fn inserting_worker_keeps_terminal_pool_phases() {
+        assert_eq!(
+            idle_health_after_worker_insert(ComponentHealth::Stopping),
+            ComponentHealth::Stopping
+        );
+        assert_eq!(
+            idle_health_after_worker_insert(ComponentHealth::Stopped),
+            ComponentHealth::Stopped
+        );
+        assert_eq!(
+            idle_health_after_worker_insert(ComponentHealth::Failed),
+            ComponentHealth::Failed
+        );
+        assert_eq!(
+            idle_health_after_worker_insert(ComponentHealth::Degraded),
+            ComponentHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn aggregate_output_health_uses_worst_slot() {
+        assert_eq!(
+            aggregate_output_health(
+                ComponentHealth::Healthy,
+                [ComponentHealth::Healthy, ComponentHealth::Degraded]
+            ),
+            ComponentHealth::Degraded
+        );
+        assert_eq!(
+            aggregate_output_health(
+                ComponentHealth::Stopping,
+                [ComponentHealth::Healthy, ComponentHealth::Healthy]
+            ),
+            ComponentHealth::Stopping
+        );
+    }
+}
+
+#[cfg(kani)]
+mod verification {
+    use super::{aggregate_output_health, idle_health_after_worker_insert};
+    use logfwd_io::diagnostics::ComponentHealth;
+
+    #[kani::proof]
+    fn verify_insert_worker_preserves_terminal_pool_phase() {
+        let current = ComponentHealth::from_repr(kani::any());
+        let out = idle_health_after_worker_insert(current);
+
+        match current {
+            ComponentHealth::Stopping | ComponentHealth::Stopped | ComponentHealth::Failed => {
+                assert_eq!(out, current)
+            }
+            _ => assert_eq!(out, ComponentHealth::Healthy),
+        }
+
+        kani::cover!(
+            current == ComponentHealth::Failed,
+            "failed_pool_phase_stays_failed"
+        );
+        kani::cover!(
+            current == ComponentHealth::Degraded,
+            "non_terminal_pool_phase_recovers_to_healthy"
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(3)]
+    fn verify_aggregate_output_health_preserves_idle_terminal_state() {
+        let idle = ComponentHealth::from_repr(kani::any());
+        let a = ComponentHealth::from_repr(kani::any());
+        let b = ComponentHealth::from_repr(kani::any());
+        let out = aggregate_output_health(idle, [a, b]);
+
+        if matches!(idle, ComponentHealth::Stopping | ComponentHealth::Stopped) {
+            assert_eq!(out, idle);
+        }
+        if idle == ComponentHealth::Failed {
+            assert_eq!(out, ComponentHealth::Failed);
+        }
+
+        kani::cover!(
+            idle == ComponentHealth::Stopping
+                && a == ComponentHealth::Healthy
+                && b == ComponentHealth::Degraded,
+            "stopping_idle_dominates_children"
+        );
+        kani::cover!(
+            idle == ComponentHealth::Healthy
+                && a == ComponentHealth::Healthy
+                && b == ComponentHealth::Degraded,
+            "degraded_child_surfaces"
+        );
+    }
+}

--- a/crates/logfwd/src/worker_pool/health.rs
+++ b/crates/logfwd/src/worker_pool/health.rs
@@ -45,6 +45,7 @@ where
 mod tests {
     use super::{aggregate_output_health, idle_health_after_worker_insert};
     use logfwd_io::diagnostics::ComponentHealth;
+    use proptest::prelude::*;
 
     #[test]
     fn inserting_worker_keeps_terminal_pool_phases() {
@@ -83,6 +84,39 @@ mod tests {
             ComponentHealth::Stopping
         );
     }
+
+    fn arb_health() -> impl Strategy<Value = ComponentHealth> {
+        (0u8..=5).prop_map(ComponentHealth::from_repr)
+    }
+
+    proptest! {
+        #[test]
+        fn aggregate_output_health_matches_maximum_repr_over_all_inputs(
+            idle in arb_health(),
+            slots in proptest::collection::vec(arb_health(), 0..16)
+        ) {
+            let out = aggregate_output_health(idle, slots.iter().copied());
+            let expected = slots
+                .iter()
+                .copied()
+                .fold(idle, ComponentHealth::combine);
+            prop_assert_eq!(out, expected);
+            prop_assert!(out.as_repr() >= idle.as_repr());
+            for slot in &slots {
+                prop_assert!(out.as_repr() >= slot.as_repr());
+            }
+        }
+
+        #[test]
+        fn aggregate_output_health_is_permutation_invariant_for_live_slots(
+            idle in arb_health(),
+            slots in proptest::collection::vec(arb_health(), 0..8)
+        ) {
+            let forward = aggregate_output_health(idle, slots.iter().copied());
+            let reverse = aggregate_output_health(idle, slots.iter().rev().copied());
+            prop_assert_eq!(forward, reverse);
+        }
+    }
 }
 
 #[cfg(kani)]
@@ -114,30 +148,58 @@ mod verification {
 
     #[kani::proof]
     #[kani::unwind(3)]
-    fn verify_aggregate_output_health_preserves_idle_terminal_state() {
+    fn verify_aggregate_output_health_returns_worst_of_idle_and_children() {
         let idle = ComponentHealth::from_repr(kani::any());
         let a = ComponentHealth::from_repr(kani::any());
         let b = ComponentHealth::from_repr(kani::any());
         let out = aggregate_output_health(idle, [a, b]);
 
-        if matches!(idle, ComponentHealth::Stopping | ComponentHealth::Stopped) {
-            assert_eq!(out, idle);
-        }
-        if idle == ComponentHealth::Failed {
-            assert_eq!(out, ComponentHealth::Failed);
-        }
+        assert!(out.as_repr() >= idle.as_repr());
+        assert!(out.as_repr() >= a.as_repr());
+        assert!(out.as_repr() >= b.as_repr());
+        assert!(out == idle || out == a || out == b);
 
         kani::cover!(
             idle == ComponentHealth::Stopping
                 && a == ComponentHealth::Healthy
                 && b == ComponentHealth::Degraded,
-            "stopping_idle_dominates_children"
+            "stopping_idle_beats_ready_children"
         );
         kani::cover!(
             idle == ComponentHealth::Healthy
                 && a == ComponentHealth::Healthy
                 && b == ComponentHealth::Degraded,
             "degraded_child_surfaces"
+        );
+        kani::cover!(
+            idle == ComponentHealth::Stopping
+                && a == ComponentHealth::Failed
+                && b == ComponentHealth::Healthy,
+            "failed_child_beats_stopping_idle"
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn verify_aggregate_output_health_is_associative_over_three_children() {
+        let idle = ComponentHealth::from_repr(kani::any());
+        let a = ComponentHealth::from_repr(kani::any());
+        let b = ComponentHealth::from_repr(kani::any());
+        let c = ComponentHealth::from_repr(kani::any());
+
+        let left = aggregate_output_health(idle, [a, b, c]);
+        let right = aggregate_output_health(
+            idle,
+            [aggregate_output_health(ComponentHealth::Healthy, [a, b]), c],
+        );
+        assert_eq!(left, right);
+
+        kani::cover!(
+            idle == ComponentHealth::Healthy
+                && a == ComponentHealth::Degraded
+                && b == ComponentHealth::Starting
+                && c == ComponentHealth::Failed,
+            "mixed_three_child_associativity_case"
         );
     }
 }

--- a/crates/logfwd/tests/turmoil_sim/trace_validation.rs
+++ b/crates/logfwd/tests/turmoil_sim/trace_validation.rs
@@ -9,9 +9,11 @@ use tempfile::NamedTempFile;
 use tokio_util::sync::CancellationToken;
 
 use super::channel_input::ChannelInputSource;
-use super::instrumented_sink::InstrumentedSink;
+use super::instrumented_sink::{FailureAction, InstrumentedSink};
 use super::observable_checkpoint::ObservableCheckpointStore;
-use super::trace_bridge::{TraceEvent, TracePhase, TraceRecorder, TransitionValidator, load_trace};
+use super::trace_bridge::{
+    SinkOutcome, TraceEvent, TracePhase, TraceRecorder, TransitionValidator, load_trace,
+};
 
 fn generate_json_lines(n: usize) -> Vec<Vec<u8>> {
     (0..n)
@@ -61,6 +63,11 @@ fn trace_bridge_end_to_end_validates_runtime_transitions() {
         });
 
         pipeline.run_async(&shutdown).await.unwrap();
+        assert_eq!(
+            pipeline.in_flight_count(),
+            0,
+            "pipeline must not retain begin_send tickets after shutdown"
+        );
 
         trace.record(TraceEvent::Phase {
             phase: TracePhase::Stopped,
@@ -88,6 +95,85 @@ fn trace_bridge_end_to_end_validates_runtime_transitions() {
     validator
         .validate(&events)
         .expect("runtime trace should satisfy declared transition contract");
+}
+
+#[test]
+fn trace_bridge_sink_panic_still_terminalizes_runtime_state() {
+    let mut sim = super::build_sim(40, 1);
+
+    let trace_path = NamedTempFile::new()
+        .expect("create temp trace file")
+        .into_temp_path();
+    let trace = TraceRecorder::new(&trace_path).expect("create trace recorder");
+
+    // First send panics, later sends succeed after worker recycle.
+    let sink = InstrumentedSink::new(vec![FailureAction::Panic]).with_trace_recorder(trace.clone());
+    let (store, handle) = ObservableCheckpointStore::new();
+    let store = store.with_trace_recorder(trace.clone());
+
+    sim.client("pipeline", async move {
+        trace.record(TraceEvent::Phase {
+            phase: TracePhase::Running,
+        });
+
+        let lines = generate_json_lines(20);
+        let input = ChannelInputSource::new("test", SourceId(1), lines);
+
+        let mut pipeline = Pipeline::for_simulation("sim", Box::new(sink));
+        pipeline.set_batch_timeout(Duration::from_millis(20));
+        pipeline.set_checkpoint_flush_interval(Duration::from_millis(50));
+        let mut pipeline = pipeline
+            .with_input("test", Box::new(input))
+            .with_checkpoint_store(Box::new(store));
+
+        let shutdown = CancellationToken::new();
+        let sd = shutdown.clone();
+        let trace_for_shutdown = trace.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            trace_for_shutdown.record(TraceEvent::Phase {
+                phase: TracePhase::Draining,
+            });
+            sd.cancel();
+        });
+
+        pipeline.run_async(&shutdown).await.unwrap();
+        assert_eq!(
+            pipeline.in_flight_count(),
+            0,
+            "sink panic path must still terminalize begin_send tickets"
+        );
+
+        trace.record(TraceEvent::Phase {
+            phase: TracePhase::Stopped,
+        });
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+    assert!(
+        handle.flush_count() > 0,
+        "checkpoint store should have flushed at least once"
+    );
+
+    let events = load_trace(&trace_path).expect("load trace file");
+    assert!(!events.is_empty(), "trace must contain events");
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            TraceEvent::SinkResult {
+                outcome: SinkOutcome::Panic,
+                ..
+            }
+        )),
+        "trace should capture sink panic outcome"
+    );
+
+    let validator = TransitionValidator::default();
+    validator
+        .validate(&events)
+        .expect("panic path trace should satisfy transition contract");
 }
 
 #[test]
@@ -188,7 +274,7 @@ fn trace_validator_rejects_sink_activity_after_stopped() {
             phase: TracePhase::Stopped,
         },
         TraceEvent::SinkResult {
-            outcome: super::trace_bridge::SinkOutcome::Ok,
+            outcome: SinkOutcome::Ok,
             rows: 1,
         },
     ];

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -133,6 +133,11 @@ do not stop at patching the shell. Extract the transition policy into a local pu
 reducer or state module when feasible, then add Kani proofs for single-step invariants
 and proptest sequence coverage for multi-step behavior.
 
+If a review tool or human review finds a state-machine bug in mixed async/runtime code,
+do not stop at patching the shell. Extract the transition policy into a local pure
+reducer or state module when feasible, then add Kani proofs for single-step invariants
+and proptest sequence coverage for multi-step behavior.
+
 ### Running proofs
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -278,6 +278,16 @@ test-extended:
     cargo nextest run --profile ci --run-ignored ignored-only
     cargo test -p logfwd --features turmoil --test turmoil_sim
 
+# Focused runtime trace contract validation (turmoil simulation).
+trace-validate:
+    cargo test -p logfwd --features turmoil --test turmoil_sim trace_validation
+
+# TLA reachability/vacuity coverage models (expects invariant violations as witnesses).
+tla-coverage jar="/tmp/tla/tla2tools.jar":
+    python3 scripts/run_tlc_coverage.py --jar {{jar}} --tla-file tla/MCPipelineMachine.tla --config tla/PipelineMachine.coverage.cfg
+    python3 scripts/run_tlc_coverage.py --jar {{jar}} --tla-file tla/MCShutdownProtocol.tla --config tla/ShutdownProtocol.coverage.cfg
+    python3 scripts/run_tlc_coverage.py --jar {{jar}} --tla-file tla/MCPipelineBatch.tla --config tla/PipelineBatch.coverage.cfg
+
 # Build release binary (full package, includes DataFusion SQL)
 build:
     cargo build --release -p logfwd

--- a/scripts/run_tlc_coverage.py
+++ b/scripts/run_tlc_coverage.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Run a TLC reachability/coverage config where invariant violations are expected.
+
+Coverage configs encode each reachability witness as an invariant over the
+negated target state (~P). TLC must report each invariant as violated at least
+once. This script turns that expected non-zero TLC exit into a pass/fail check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+INVARIANT_DECL_RE = re.compile(r"^[ \t]*([A-Za-z_][A-Za-z0-9_]*)[ \t]*$")
+VIOLATION_RE = re.compile(r"Invariant[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]+is violated")
+
+
+def parse_expected_invariants(cfg_path: Path) -> list[str]:
+    lines = cfg_path.read_text(encoding="utf-8").splitlines()
+    expected: list[str] = []
+    in_block = False
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("\\*"):
+            continue
+        if not in_block:
+            if line == "INVARIANTS":
+                in_block = True
+            continue
+        # End block when a new section starts (uppercase header token).
+        if line.isupper() and not line.startswith(("TRUE", "FALSE")):
+            break
+        match = INVARIANT_DECL_RE.match(line)
+        if match:
+            expected.append(match.group(1))
+    return expected
+
+
+def run_tlc(jar: Path, tla_file: Path, cfg: Path, workers: str) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        "java",
+        "-cp",
+        str(jar),
+        "tlc2.TLC",
+        str(tla_file),
+        "-config",
+        str(cfg),
+        "-workers",
+        workers,
+        "-continue",
+    ]
+    return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--jar", required=True, type=Path, help="Path to tla2tools.jar")
+    parser.add_argument("--tla-file", required=True, type=Path, help="TLA module to run")
+    parser.add_argument("--config", required=True, type=Path, help="Coverage .cfg file")
+    parser.add_argument("--workers", default="auto", help="TLC worker setting (default: auto)")
+    args = parser.parse_args()
+
+    expected = parse_expected_invariants(args.config)
+    if not expected:
+        print(f"ERROR: no INVARIANTS parsed from {args.config}", file=sys.stderr)
+        return 2
+
+    proc = run_tlc(args.jar, args.tla_file, args.config, args.workers)
+    output = proc.stdout
+    violated = set(VIOLATION_RE.findall(output))
+    missing = [name for name in expected if name not in violated]
+
+    print(
+        f"[tlc-coverage] config={args.config} expected={len(expected)} "
+        f"violated={len(violated)} exit={proc.returncode}"
+    )
+
+    if proc.returncode == 0:
+        print("ERROR: TLC exited 0 for coverage run; expected invariant violations.", file=sys.stderr)
+        print(output, file=sys.stderr)
+        return 1
+
+    if missing:
+        print(
+            "ERROR: missing expected reachability witnesses: "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        print(output, file=sys.stderr)
+        return 1
+
+    print("[tlc-coverage] all expected reachability invariants were violated at least once")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- contain worker `send_batch` panics with `catch_unwind` and convert them into failure `AckItem`s
- reject queued work for a panicked worker before recycle, and close the worker receiver first to prevent enqueue-after-drain races
- add panic-path tests in `worker_pool` and an end-to-end pipeline test asserting all `begin_send` tickets are terminalized (`ack`/`reject`)
- document verification expectations for async shells that own tickets (failure-mode matrix + terminalization assertions)

## Why this was missed
- Kani coverage in `worker_pool` is dispatch-reducer focused, not Tokio runtime/panic behavior
- TLA specs model control-plane lifecycle at design level and intentionally exclude runtime unwind paths
- this PR adds concrete runtime tests for panic terminalization to close that gap

## Validation
- `cargo test -p logfwd worker_pool::tests::worker_panic -- --nocapture`
- `cargo test -p logfwd test_flush_batch_output_panic_still_terminalizes_tickets -- --nocapture`
- `cargo test -p logfwd`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Terminalize in-flight tickets on worker pool sink panic
> - Adds a new turmoil simulation test in [trace_validation.rs](https://github.com/strawgate/memagent/pull/1753/files#diff-7cb90de9274c1fe00e410c6b1051b3e6a488bd4c2758d22494062c544191e5ba) that injects a sink panic and asserts in-flight tickets are terminalized, the checkpoint store flushes, and a `SinkOutcome::Panic` event is recorded.
> - Adds `idle_health_after_worker_insert`, `reduce_worker_slot_health`, and `aggregate_output_health` helpers in [worker_pool/health.rs](https://github.com/strawgate/memagent/pull/1753/files#diff-ef1b20d565e7ae61ccfe626e3181a89634ed3a2243a374a007b11ee7b0c95f85) to compute pool health while preserving terminal phases (Stopping, Stopped, Failed) across worker slot changes.
> - Adds Kani proofs and proptests covering terminal phase stickiness and aggregation correctness for the new health functions.
> - Adds a `run_tlc_coverage.py` script and `tla-coverage` justfile recipe to verify TLC reachability invariants are exercised during model checking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9b89be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->