### PR TITLE
feat(udp): Add sender address metadata (ip:port) to UDP-derived events

### DIFF
--- a/book/src/config/reference.md
+++ b/book/src/config/reference.md
@@ -128,6 +128,8 @@ Listen for log lines on a UDP socket.
 
 `udp` treats each datagram as one or more newline-delimited records. TLS is
 not supported for UDP inputs (DTLS is not implemented).
+When the selected format can inject JSON metadata, emitted rows may also
+include `_sender` with the datagram source address.
 
 ```yaml
 input:
@@ -458,6 +460,7 @@ Special columns added by the scanner / input format layer:
 | `_timestamp` | string | Timestamp from the CRI header as an RFC 3339 string (CRI inputs only). |
 | `_stream` | string | CRI stream name (`stdout` / `stderr`). |
 | `_source_path` | string | Canonical file path for file-backed rows (JSON and CRI file inputs). |
+| `_sender` | string | UDP peer address (`ip:port`) for sender-attributed rows when the format can inject JSON metadata. |
 
 ### Built-in UDFs
 

--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -2177,7 +2177,7 @@ mod tests {
         b.begin_batch(buf);
         let idx = b.resolve_field(b"lat");
         b.begin_row();
-        b.append_float_by_idx(idx, b"3.14");
+        b.append_float_by_idx(idx, b"3.141592653589793");
         b.end_row();
         b.begin_row();
         b.end_row(); // missing → null
@@ -2189,7 +2189,7 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert!((col.value(0) - 3.14).abs() < 1e-10);
+        assert!((col.value(0) - std::f64::consts::PI).abs() < 1e-10);
         assert!(col.is_null(1));
     }
 

--- a/crates/logfwd-bench/src/bin/framed_input_profile.rs
+++ b/crates/logfwd-bench/src/bin/framed_input_profile.rs
@@ -328,6 +328,7 @@ impl MockSource {
                     bytes: chunk.clone(),
                     source_id: None,
                     accounted_bytes: chunk.len() as u64,
+                    sender_addr: None,
                 }]
             })
             .collect();

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -459,40 +459,14 @@ fn source_path_for<'a>(
 
 fn inject_source_path_metadata(chunk: &[u8], source_path: &std::path::Path, out: &mut Vec<u8>) {
     let source_path_bytes = source_path.to_string_lossy();
-    let source_path_bytes = source_path_bytes.as_bytes();
-    let mut pos = 0;
-    while pos < chunk.len() {
-        let eol = memchr::memchr(b'\n', &chunk[pos..]).map_or(chunk.len(), |o| pos + o);
-        let line = &chunk[pos..eol];
-        let first_nonws = line
-            .iter()
-            .position(|&b| !matches!(b, b' ' | b'\t' | b'\r'));
-        if let Some(obj_start) = first_nonws.filter(|&idx| line[idx] == b'{') {
-            let after_open = &line[obj_start + 1..];
-            // Detect empty object: only whitespace between `{` and `}`.
-            let is_empty_obj = after_open
-                .iter()
-                .position(|&b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
-                .is_some_and(|i| after_open[i] == b'}');
-            out.extend_from_slice(&line[..obj_start]);
-            out.extend_from_slice(b"{\"_source_path\":\"");
-            json_escape_bytes(source_path_bytes, out);
-            out.push(b'"');
-            if !is_empty_obj {
-                out.push(b',');
-            }
-            out.extend_from_slice(after_open);
-        } else {
-            out.extend_from_slice(line);
-        }
-        if eol < chunk.len() {
-            out.push(b'\n');
-        }
-        pos = eol + 1;
-    }
+    inject_json_metadata(chunk, b"_source_path", source_path_bytes.as_bytes(), out);
 }
 
 fn inject_sender_metadata(chunk: &[u8], sender: &[u8], out: &mut Vec<u8>) {
+    inject_json_metadata(chunk, b"_sender", sender, out);
+}
+
+fn inject_json_metadata(chunk: &[u8], key: &[u8], value: &[u8], out: &mut Vec<u8>) {
     let mut pos = 0;
     while pos < chunk.len() {
         let eol = memchr::memchr(b'\n', &chunk[pos..]).map_or(chunk.len(), |o| pos + o);
@@ -507,8 +481,10 @@ fn inject_sender_metadata(chunk: &[u8], sender: &[u8], out: &mut Vec<u8>) {
                 .position(|&b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
                 .is_some_and(|i| after_open[i] == b'}');
             out.extend_from_slice(&line[..obj_start]);
-            out.extend_from_slice(b"{\"_sender\":\"");
-            json_escape_bytes(sender, out);
+            out.extend_from_slice(b"{\"");
+            out.extend_from_slice(key);
+            out.extend_from_slice(b"\":\"");
+            json_escape_bytes(value, out);
             out.push(b'"');
             if !is_empty_obj {
                 out.push(b',');

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -104,6 +104,7 @@ impl InputSource for FramedInput {
                     bytes,
                     source_id,
                     accounted_bytes,
+                    sender_addr,
                 } => {
                     self.stats.inc_bytes(accounted_bytes);
 
@@ -252,6 +253,17 @@ impl InputSource for FramedInput {
                             self.spare_buf = std::mem::replace(&mut self.out_buf, with_source);
                         }
                     }
+                    if inject_source_path && let Some(sender_addr) = sender_addr {
+                        let mut with_sender = std::mem::take(&mut self.spare_buf);
+                        with_sender.clear();
+                        inject_sender_metadata(
+                            &self.out_buf,
+                            sender_addr.to_string().as_bytes(),
+                            &mut with_sender,
+                        );
+                        self.out_buf.clear();
+                        self.spare_buf = std::mem::replace(&mut self.out_buf, with_sender);
+                    }
 
                     let line_count = memchr::memchr_iter(b'\n', &chunk[process_start..]).count();
                     self.stats.inc_lines(line_count as u64);
@@ -266,6 +278,7 @@ impl InputSource for FramedInput {
                             bytes: data,
                             source_id,
                             accounted_bytes: 0,
+                            sender_addr,
                         });
                     }
                 }
@@ -370,6 +383,7 @@ impl InputSource for FramedInput {
                                         bytes: data,
                                         source_id: key,
                                         accounted_bytes: 0,
+                                        sender_addr: None,
                                     });
                                 }
                             }
@@ -478,6 +492,38 @@ fn inject_source_path_metadata(chunk: &[u8], source_path: &std::path::Path, out:
     }
 }
 
+fn inject_sender_metadata(chunk: &[u8], sender: &[u8], out: &mut Vec<u8>) {
+    let mut pos = 0;
+    while pos < chunk.len() {
+        let eol = memchr::memchr(b'\n', &chunk[pos..]).map_or(chunk.len(), |o| pos + o);
+        let line = &chunk[pos..eol];
+        let first_nonws = line
+            .iter()
+            .position(|&b| !matches!(b, b' ' | b'\t' | b'\r'));
+        if let Some(obj_start) = first_nonws.filter(|&idx| line[idx] == b'{') {
+            let after_open = &line[obj_start + 1..];
+            let is_empty_obj = after_open
+                .iter()
+                .position(|&b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+                .is_some_and(|i| after_open[i] == b'}');
+            out.extend_from_slice(&line[..obj_start]);
+            out.extend_from_slice(b"{\"_sender\":\"");
+            json_escape_bytes(sender, out);
+            out.push(b'"');
+            if !is_empty_obj {
+                out.push(b',');
+            }
+            out.extend_from_slice(after_open);
+        } else {
+            out.extend_from_slice(line);
+        }
+        if eol < chunk.len() {
+            out.push(b'\n');
+        }
+        pos = eol + 1;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -515,6 +561,7 @@ mod tests {
                             bytes: c.to_vec(),
                             source_id: None,
                             accounted_bytes: c.len() as u64,
+                            sender_addr: None,
                         }]
                     })
                     .collect(),
@@ -534,6 +581,7 @@ mod tests {
                             bytes: c.to_vec(),
                             source_id: Some(sid),
                             accounted_bytes: c.len() as u64,
+                            sender_addr: None,
                         }]
                     })
                     .collect(),
@@ -698,6 +746,7 @@ mod tests {
             bytes: b"line\n".to_vec(),
             source_id: None,
             accounted_bytes: 99,
+            sender_addr: None,
         }]]);
         let mut framed = FramedInput::new(
             Box::new(source),
@@ -709,6 +758,33 @@ mod tests {
         assert_eq!(collect_data(events), b"line\n");
         assert_eq!(stats.lines(), 1);
         assert_eq!(stats.bytes(), 99);
+    }
+
+    #[test]
+    fn data_events_preserve_sender_addr() {
+        let stats = make_stats();
+        let expected_sender: std::net::SocketAddr = "127.0.0.1:9001".parse().unwrap();
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: b"line\n".to_vec(),
+            source_id: None,
+            accounted_bytes: 5,
+            sender_addr: Some(expected_sender),
+        }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        let events = framed.poll().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            InputEvent::Data {
+                sender_addr: actual_sender,
+                ..
+            } => assert_eq!(*actual_sender, Some(expected_sender)),
+            _ => panic!("expected InputEvent::Data variant"),
+        }
     }
 
     #[test]
@@ -825,11 +901,13 @@ mod tests {
                 bytes: big,
                 source_id: Some(sid),
                 accounted_bytes: 0,
+                sender_addr: None,
             }],
             vec![InputEvent::Data {
                 bytes: second_bytes.to_vec(),
                 source_id: Some(sid),
                 accounted_bytes: 0,
+                sender_addr: None,
             }],
         ])
         .with_offsets(vec![(sid, ByteOffset(total))]);
@@ -951,12 +1029,14 @@ mod tests {
                 bytes: b"partial".to_vec(),
                 source_id: None,
                 accounted_bytes: 7,
+                sender_addr: None,
             }],
             vec![InputEvent::Rotated { source_id: None }],
             vec![InputEvent::Data {
                 bytes: b"fresh\n".to_vec(),
                 source_id: None,
                 accounted_bytes: 6,
+                sender_addr: None,
             }],
         ]);
         let mut framed = FramedInput::new(
@@ -1046,6 +1126,7 @@ mod tests {
                 bytes: b"no-newline".to_vec(),
                 source_id: None,
                 accounted_bytes: 10,
+                sender_addr: None,
             }],
             vec![InputEvent::EndOfFile { source_id: None }],
         ]);
@@ -1074,6 +1155,7 @@ mod tests {
                 bytes: b"complete\npartial".to_vec(),
                 source_id: None,
                 accounted_bytes: 16,
+                sender_addr: None,
             }],
             vec![InputEvent::EndOfFile { source_id: None }],
         ]);
@@ -1101,6 +1183,7 @@ mod tests {
                 bytes: b"line\n".to_vec(),
                 source_id: None,
                 accounted_bytes: 5,
+                sender_addr: None,
             }],
             vec![InputEvent::EndOfFile { source_id: None }],
         ]);
@@ -1135,11 +1218,13 @@ mod tests {
                     bytes: b"hello-from-A".to_vec(),
                     source_id: Some(sid_a),
                     accounted_bytes: 12,
+                    sender_addr: None,
                 },
                 InputEvent::Data {
                     bytes: b"hello-from-B".to_vec(),
                     source_id: Some(sid_b),
                     accounted_bytes: 12,
+                    sender_addr: None,
                 },
             ],
             // Poll 2: complete the lines from each source
@@ -1148,11 +1233,13 @@ mod tests {
                     bytes: b"-done\n".to_vec(),
                     source_id: Some(sid_a),
                     accounted_bytes: 6,
+                    sender_addr: None,
                 },
                 InputEvent::Data {
                     bytes: b"-done\n".to_vec(),
                     source_id: Some(sid_b),
                     accounted_bytes: 6,
+                    sender_addr: None,
                 },
             ],
         ]);
@@ -1201,11 +1288,13 @@ mod tests {
                     bytes: b"partial-A".to_vec(),
                     source_id: Some(sid_a),
                     accounted_bytes: 9,
+                    sender_addr: None,
                 },
                 InputEvent::Data {
                     bytes: b"partial-B".to_vec(),
                     source_id: Some(sid_b),
                     accounted_bytes: 9,
+                    sender_addr: None,
                 },
             ],
             // Truncation
@@ -1215,6 +1304,7 @@ mod tests {
                 bytes: b"fresh-A\n".to_vec(),
                 source_id: Some(sid_a),
                 accounted_bytes: 8,
+                sender_addr: None,
             }],
         ]);
 
@@ -1246,6 +1336,7 @@ mod tests {
             bytes: b"hello\nwor".to_vec(),
             source_id: Some(sid),
             accounted_bytes: 9,
+            sender_addr: None,
         }]])
         .with_offsets(vec![(sid, ByteOffset(1000))]);
 
@@ -1275,6 +1366,7 @@ mod tests {
             bytes: b"complete\n".to_vec(),
             source_id: Some(sid),
             accounted_bytes: 9,
+            sender_addr: None,
         }]])
         .with_offsets(vec![(sid, ByteOffset(500))]);
 
@@ -1312,18 +1404,21 @@ mod tests {
                 bytes: b"2024-01-15T10:30:00Z stdout P hello \n".to_vec(),
                 source_id: Some(sid_a),
                 accounted_bytes: 38,
+                sender_addr: None,
             }],
             // Source B: CRI full line (must NOT merge with A's partial)
             vec![InputEvent::Data {
                 bytes: b"2024-01-15T10:30:01Z stderr F {\"msg\":\"world\"}\n".to_vec(),
                 source_id: Some(sid_b),
                 accounted_bytes: 50,
+                sender_addr: None,
             }],
             // Source A: CRI full line (completes A's partial)
             vec![InputEvent::Data {
                 bytes: b"2024-01-15T10:30:02Z stdout F from-A\n".to_vec(),
                 source_id: Some(sid_a),
                 accounted_bytes: 39,
+                sender_addr: None,
             }],
         ]);
 
@@ -1370,12 +1465,14 @@ mod tests {
                 bytes: b"hello\nwor".to_vec(),
                 source_id: Some(sid),
                 accounted_bytes: 9,
+                sender_addr: None,
             }],
             // Second read: 3 bytes, newline at position 1 (the 'd\n')
             vec![InputEvent::Data {
                 bytes: b"ld\n".to_vec(),
                 source_id: Some(sid),
                 accounted_bytes: 3,
+                sender_addr: None,
             }],
         ])
         .with_offsets(vec![(sid, ByteOffset(12))]);
@@ -1409,6 +1506,7 @@ mod tests {
             bytes: b"{\"msg\":\"hello\"}\n".to_vec(),
             source_id: Some(sid),
             accounted_bytes: 0,
+            sender_addr: None,
         }]])
         .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/main.log".into())]);
 
@@ -1426,6 +1524,32 @@ mod tests {
     }
 
     #[test]
+    fn file_json_injects_sender_metadata_column() {
+        let stats = make_stats();
+        let sid = SourceId(12);
+        let sender_addr: std::net::SocketAddr = "127.0.0.1:9100".parse().unwrap();
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: b"{\"msg\":\"hello\"}\n".to_vec(),
+            source_id: Some(sid),
+            accounted_bytes: 0,
+            sender_addr: Some(sender_addr),
+        }]])
+        .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/sender.log".into())]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough_json(Arc::clone(&stats)),
+            stats,
+        );
+
+        let out = collect_data(framed.poll().unwrap());
+        assert_eq!(
+            out,
+            b"{\"_sender\":\"127.0.0.1:9100\",\"_source_path\":\"/var/log/pods/ns_pod_uid/c/sender.log\",\"msg\":\"hello\"}\n"
+        );
+    }
+
+    #[test]
     fn file_cri_injects_source_path_alongside_cri_metadata() {
         let stats = make_stats();
         let sid = SourceId(8);
@@ -1433,6 +1557,7 @@ mod tests {
             bytes: b"2024-01-15T10:30:00Z stdout F {\"msg\":\"hello\"}\n".to_vec(),
             source_id: Some(sid),
             accounted_bytes: 0,
+            sender_addr: None,
         }]])
         .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/0.log".into())]);
 
@@ -1457,6 +1582,7 @@ mod tests {
             bytes: b"  \t{\"msg\":\"hello\"}\n".to_vec(),
             source_id: Some(sid),
             accounted_bytes: 0,
+            sender_addr: None,
         }]])
         .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/1.log".into())]);
 
@@ -1483,6 +1609,7 @@ mod tests {
             bytes: b"{}\n".to_vec(),
             source_id: Some(sid),
             accounted_bytes: 0,
+            sender_addr: None,
         }]])
         .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/2.log".into())]);
 
@@ -1508,6 +1635,7 @@ mod tests {
             bytes: b"{\"msg\":\"hello\"}\n".to_vec(),
             source_id: Some(sid),
             accounted_bytes: 0,
+            sender_addr: None,
         }]])
         .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/raw.log".into())]);
 

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -21,6 +21,7 @@ use logfwd_types::pipeline::SourceId;
 use std::collections::HashMap;
 use std::io;
 use std::io::Write as _;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 /// Maximum remainder buffer size before discarding (prevents OOM on
@@ -29,10 +30,10 @@ const MAX_REMAINDER_BYTES: usize = 2 * 1024 * 1024;
 
 /// Per-source state for framing and checkpoint tracking.
 ///
-/// Each logical source (identified by `Option<SourceId>`) gets its own
-/// remainder buffer, format processor, and checkpoint tracker. This
-/// prevents cross-contamination between sources for both newline framing
-/// and stateful format processing (e.g., CRI P/F aggregation).
+/// Each logical source gets its own remainder buffer, format processor, and
+/// checkpoint tracker. This prevents cross-contamination between sources for
+/// both newline framing and stateful format processing (e.g., CRI P/F
+/// aggregation).
 struct SourceState {
     /// Partial-line bytes after the last newline.
     remainder: Vec<u8>,
@@ -47,6 +48,48 @@ struct SourceState {
     overflow_tainted: bool,
 }
 
+/// Stable identity for framing state.
+///
+/// File-backed inputs key by `SourceId`. Push sources without a `SourceId`
+/// fall back to sender address when available so stateful decoders do not
+/// merge partial records across peers.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum SourceKey {
+    SourceId(SourceId),
+    Sender(SocketAddr),
+    Anonymous,
+}
+
+impl SourceKey {
+    fn from_event(source_id: Option<SourceId>, sender_addr: Option<SocketAddr>) -> Self {
+        if let Some(source_id) = source_id {
+            Self::SourceId(source_id)
+        } else if let Some(sender_addr) = sender_addr {
+            Self::Sender(sender_addr)
+        } else {
+            Self::Anonymous
+        }
+    }
+
+    fn from_source_id(source_id: Option<SourceId>) -> Self {
+        source_id.map_or(Self::Anonymous, Self::SourceId)
+    }
+
+    fn source_id(self) -> Option<SourceId> {
+        match self {
+            Self::SourceId(source_id) => Some(source_id),
+            Self::Sender(_) | Self::Anonymous => None,
+        }
+    }
+
+    fn sender_addr(self) -> Option<SocketAddr> {
+        match self {
+            Self::Sender(sender_addr) => Some(sender_addr),
+            Self::SourceId(_) | Self::Anonymous => None,
+        }
+    }
+}
+
 /// Wraps a raw [`InputSource`] with newline framing and format processing.
 ///
 /// The inner source provides raw bytes (from file, TCP, UDP, etc.). This
@@ -54,16 +97,15 @@ struct SourceState {
 /// and runs format-specific processing (CRI extraction, passthrough, etc.).
 /// The output is scanner-ready bytes.
 ///
-/// All per-source state (remainder, format, checkpoint tracker) is keyed by
-/// `Option<SourceId>` so that interleaved data from multiple sources never
-/// mixes partial lines or CRI aggregation state. Sources without identity
-/// (`None`) share a single state entry.
+/// All per-source state (remainder, format, checkpoint tracker) is keyed by a
+/// stable logical source so that interleaved data from different files or
+/// network peers never mixes partial lines or CRI aggregation state.
 pub struct FramedInput {
     inner: Box<dyn InputSource>,
     /// Template format processor — cloned per-source on first data arrival.
     format_template: FormatDecoder,
     /// Per-source state: remainder, format processor, checkpoint tracker.
-    sources: HashMap<Option<SourceId>, SourceState>,
+    sources: HashMap<SourceKey, SourceState>,
     out_buf: Vec<u8>,
     /// Spare buffer swapped in when out_buf is emitted, preserving capacity
     /// across polls without allocating.
@@ -109,7 +151,7 @@ impl InputSource for FramedInput {
                 } => {
                     self.stats.inc_bytes(accounted_bytes);
 
-                    let key = source_id;
+                    let key = SourceKey::from_event(source_id, sender_addr);
                     let n_bytes = bytes.len() as u64;
 
                     // Get or create per-source state.
@@ -164,7 +206,7 @@ impl InputSource for FramedInput {
                                     // eventually emit a complete line. Emit a warning
                                     // so the data loss is not silent.
                                     tracing::warn!(
-                                        source_id = ?key,
+                                        source = ?key,
                                         tail_bytes = tail.len(),
                                         max_remainder_bytes = MAX_REMAINDER_BYTES,
                                         "framed.remainder_overflow — partial line exceeds \
@@ -197,7 +239,7 @@ impl InputSource for FramedInput {
                                 // Same overflow policy as the tail case: warn, reset
                                 // format state, and keep the most recent bytes.
                                 tracing::warn!(
-                                    source_id = ?key,
+                                    source = ?key,
                                     chunk_bytes = chunk.len(),
                                     max_remainder_bytes = MAX_REMAINDER_BYTES,
                                     "framed.remainder_overflow — partial line exceeds \
@@ -301,7 +343,7 @@ impl InputSource for FramedInput {
                 | InputEvent::Truncated { source_id }) => {
                     match source_id {
                         Some(_) => {
-                            self.sources.remove(&source_id);
+                            self.sources.remove(&SourceKey::from_source_id(source_id));
                         }
                         None => {
                             self.sources.clear();
@@ -320,8 +362,8 @@ impl InputSource for FramedInput {
                 // remainder. When unknown (None), flush all remainders as a
                 // conservative fallback.
                 InputEvent::EndOfFile { source_id } => {
-                    let keys_to_flush: Vec<Option<SourceId>> = match source_id {
-                        Some(_) => vec![source_id],
+                    let keys_to_flush: Vec<SourceKey> = match source_id {
+                        Some(_) => vec![SourceKey::from_source_id(source_id)],
                         None => self.sources.keys().copied().collect(),
                     };
                     for key in keys_to_flush {
@@ -378,9 +420,9 @@ impl InputSource for FramedInput {
                                     std::mem::swap(&mut self.out_buf, &mut self.spare_buf);
                                     result_events.push(InputEvent::Data {
                                         bytes: data,
-                                        source_id: key,
+                                        source_id: key.source_id(),
                                         accounted_bytes: 0,
-                                        sender_addr: None,
+                                        sender_addr: key.sender_addr(),
                                     });
                                 }
                             }
@@ -419,15 +461,18 @@ impl InputSource for FramedInput {
             .checkpoint_data()
             .into_iter()
             .map(|(sid, offset)| {
-                let checkpointable = self.sources.get(&Some(sid)).map_or(offset.0, |state| {
-                    // The tracker's checkpointable_offset is relative to
-                    // the tracker's cumulative read_offset. We need to
-                    // translate: the inner source reports absolute file
-                    // offset, and the tracker reports how much remainder
-                    // to subtract.
-                    let remainder_len = state.tracker.remainder_len();
-                    offset.0.saturating_sub(remainder_len)
-                });
+                let checkpointable =
+                    self.sources
+                        .get(&SourceKey::SourceId(sid))
+                        .map_or(offset.0, |state| {
+                            // The tracker's checkpointable_offset is relative to
+                            // the tracker's cumulative read_offset. We need to
+                            // translate: the inner source reports absolute file
+                            // offset, and the tracker reports how much remainder
+                            // to subtract.
+                            let remainder_len = state.tracker.remainder_len();
+                            offset.0.saturating_sub(remainder_len)
+                        });
                 (sid, ByteOffset(checkpointable))
             })
             .collect()
@@ -443,11 +488,11 @@ impl InputSource for FramedInput {
 }
 
 fn source_path_for<'a>(
-    source_id: Option<SourceId>,
+    source_key: SourceKey,
     source_path_by_id: &'a mut Option<HashMap<SourceId, std::path::PathBuf>>,
     inner: &dyn InputSource,
 ) -> Option<&'a std::path::PathBuf> {
-    let sid = source_id?;
+    let sid = source_key.source_id()?;
     if source_path_by_id.is_none() {
         *source_path_by_id = Some(inner.source_paths().into_iter().collect());
     }
@@ -459,7 +504,7 @@ fn inject_source_path_metadata(chunk: &[u8], source_path: &std::path::Path, out:
     inject_json_metadata(chunk, b"_source_path", source_path_bytes.as_bytes(), out);
 }
 
-fn inject_sender_metadata(chunk: &[u8], sender: std::net::SocketAddr, out: &mut Vec<u8>) {
+fn inject_sender_metadata(chunk: &[u8], sender: SocketAddr, out: &mut Vec<u8>) {
     let mut pos = 0;
     while pos < chunk.len() {
         let eol = memchr::memchr(b'\n', &chunk[pos..]).map_or(chunk.len(), |o| pos + o);
@@ -765,7 +810,7 @@ mod tests {
     #[test]
     fn data_events_preserve_sender_addr() {
         let stats = make_stats();
-        let expected_sender: std::net::SocketAddr = "127.0.0.1:9001".parse().unwrap();
+        let expected_sender: SocketAddr = "127.0.0.1:9001".parse().unwrap();
         let source = MockSource::new(vec![vec![InputEvent::Data {
             bytes: b"line\n".to_vec(),
             source_id: None,
@@ -811,7 +856,7 @@ mod tests {
             1
         );
         // The overflow remainder is capped but NOT discarded.
-        let state = framed.sources.get(&None).unwrap();
+        let state = framed.sources.get(&SourceKey::Anonymous).unwrap();
         assert_eq!(
             state.remainder.len(),
             MAX_REMAINDER_BYTES,
@@ -850,7 +895,7 @@ mod tests {
             1
         );
         // The overflow remainder is preserved (not silently dropped).
-        let state = framed.sources.get(&None).unwrap();
+        let state = framed.sources.get(&SourceKey::Anonymous).unwrap();
         assert_eq!(
             state.remainder.len(),
             MAX_REMAINDER_BYTES,
@@ -934,10 +979,11 @@ mod tests {
 
     /// `checkpoint_data()` must account for overflow remainder when the source
     /// has a real `SourceId`.  With `source_id: None` the lookup in
-    /// `self.sources.get(&Some(sid))` silently falls back to the raw offset,
+    /// `self.sources.get(&SourceKey::SourceId(sid))` silently falls back to the raw offset,
     /// making the assertion trivially true regardless of correctness.  This
     /// test uses `from_chunks_with_source` so the per-source state is actually
-    /// keyed under `Some(SourceId(1))` and the checkpoint path is exercised.
+    /// keyed under `SourceKey::SourceId(SourceId(1))` and the checkpoint path
+    /// is exercised.
     #[test]
     fn checkpoint_data_accounts_for_overflow_remainder() {
         let stats = make_stats();
@@ -962,8 +1008,8 @@ mod tests {
         // is capped to MAX_REMAINDER_BYTES.
         let _ = framed.poll().unwrap();
 
-        // The per-source state must be reachable under Some(sid).
-        let state = framed.sources.get(&Some(sid)).unwrap();
+        // The per-source state must be reachable under SourceKey::SourceId(sid).
+        let state = framed.sources.get(&SourceKey::SourceId(sid)).unwrap();
         assert_eq!(state.remainder.len(), MAX_REMAINDER_BYTES);
 
         // checkpoint_data() must subtract the remainder length from the raw
@@ -984,7 +1030,7 @@ mod tests {
 
     /// `checkpoint_data()` must account for the overflow tail remainder when
     /// a newline precedes the overflow.  Uses `from_chunks_with_source` so the
-    /// assertion exercises the real `self.sources.get(&Some(sid))` path.
+    /// assertion exercises the real `self.sources.get(&SourceKey::SourceId(sid))` path.
     #[test]
     fn checkpoint_data_accounts_for_overflow_tail_remainder() {
         let stats = make_stats();
@@ -1005,8 +1051,8 @@ mod tests {
         let events = framed.poll().unwrap();
         assert_eq!(collect_data(events), b"ok\n");
 
-        // Per-source state is keyed under Some(sid).
-        let state = framed.sources.get(&Some(sid)).unwrap();
+        // Per-source state is keyed under SourceKey::SourceId(sid).
+        let state = framed.sources.get(&SourceKey::SourceId(sid)).unwrap();
         assert_eq!(state.remainder.len(), MAX_REMAINDER_BYTES);
 
         // The checkpoint must be behind the raw offset because the remainder
@@ -1455,6 +1501,69 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cri_pf_state_isolated_between_udp_senders() {
+        let stats = make_stats();
+        let sender_a: SocketAddr = "127.0.0.1:9102".parse().unwrap();
+        let sender_b: SocketAddr = "127.0.0.1:9103".parse().unwrap();
+
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: b"2024-01-15T10:30:00Z stdout P hello \n".to_vec(),
+                source_id: None,
+                accounted_bytes: 38,
+                sender_addr: Some(sender_a),
+            }],
+            vec![InputEvent::Data {
+                bytes: b"2024-01-15T10:30:01Z stderr F {\"msg\":\"world\"}\n".to_vec(),
+                source_id: None,
+                accounted_bytes: 50,
+                sender_addr: Some(sender_b),
+            }],
+            vec![InputEvent::Data {
+                bytes: b"2024-01-15T10:30:02Z stdout F from-A\n".to_vec(),
+                source_id: None,
+                accounted_bytes: 39,
+                sender_addr: Some(sender_a),
+            }],
+        ]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            stats,
+        );
+
+        let events1 = framed.poll().unwrap();
+        assert!(collect_data(events1).is_empty());
+
+        let events2 = framed.poll().unwrap();
+        let data2 = collect_data(events2);
+        assert!(
+            data2
+                .windows(b"\"_sender\":\"127.0.0.1:9103\"".len())
+                .any(|window| window == b"\"_sender\":\"127.0.0.1:9103\""),
+            "sender B should remain isolated from sender A partial state"
+        );
+        assert!(
+            !data2.windows(5).any(|w| w == b"hello"),
+            "sender B output must not contain sender A partial content"
+        );
+
+        let events3 = framed.poll().unwrap();
+        let data3 = collect_data(events3);
+        assert!(
+            data3
+                .windows(b"\"_sender\":\"127.0.0.1:9102\"".len())
+                .any(|window| window == b"\"_sender\":\"127.0.0.1:9102\""),
+            "sender A completion should keep sender A attribution"
+        );
+        assert!(
+            data3.windows(5).any(|w| w == b"hello"),
+            "sender A output should contain the merged P+F data"
+        );
+    }
+
     /// CheckpointTracker is updated correctly through framing operations.
     #[test]
     fn checkpoint_tracker_tracks_remainder() {
@@ -1487,12 +1596,12 @@ mod tests {
 
         // After first poll: remainder is "wor" (3 bytes)
         let _ = framed.poll().unwrap();
-        let state = framed.sources.get(&Some(sid)).unwrap();
+        let state = framed.sources.get(&SourceKey::SourceId(sid)).unwrap();
         assert_eq!(state.tracker.remainder_len(), 3);
 
         // After second poll: remainder is empty (all consumed)
         let _ = framed.poll().unwrap();
-        let state = framed.sources.get(&Some(sid)).unwrap();
+        let state = framed.sources.get(&SourceKey::SourceId(sid)).unwrap();
         assert_eq!(state.tracker.remainder_len(), 0);
 
         // Checkpoint should reflect: 12 - 0 = 12
@@ -1529,7 +1638,7 @@ mod tests {
     fn file_json_injects_sender_metadata_column() {
         let stats = make_stats();
         let sid = SourceId(12);
-        let sender_addr: std::net::SocketAddr = "127.0.0.1:9100".parse().unwrap();
+        let sender_addr: SocketAddr = "127.0.0.1:9100".parse().unwrap();
         let source = MockSource::new(vec![vec![InputEvent::Data {
             bytes: b"{\"msg\":\"hello\"}\n".to_vec(),
             source_id: Some(sid),
@@ -1555,7 +1664,7 @@ mod tests {
     fn raw_passthrough_injects_sender_metadata_without_source_path_support() {
         let stats = make_stats();
         let sid = SourceId(13);
-        let sender_addr: std::net::SocketAddr = "127.0.0.1:9101".parse().unwrap();
+        let sender_addr: SocketAddr = "127.0.0.1:9101".parse().unwrap();
         let source = MockSource::new(vec![vec![InputEvent::Data {
             bytes: b"{\"msg\":\"hello\"}\n".to_vec(),
             source_id: Some(sid),

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -371,42 +371,36 @@ impl InputSource for FramedInput {
                             if !state.remainder.is_empty() {
                                 let mut remainder = std::mem::take(&mut state.remainder);
                                 remainder.push(b'\n');
-                                let mut process_start = 0usize;
-                                if state.overflow_tainted {
-                                    process_start =
-                                        memchr::memchr(b'\n', &remainder).map_or(0, |i| i + 1);
-                                    state.overflow_tainted = false;
-                                }
+                                let tainted = state.overflow_tainted;
+                                state.overflow_tainted = false;
 
-                                self.out_buf.clear();
-                                let state =
-                                    self.sources.get_mut(&key).expect("just checked existence");
-                                if process_start < remainder.len() {
-                                    state.format.process_lines(
-                                        &remainder[process_start..],
-                                        &mut self.out_buf,
-                                    );
-                                }
-                                if inject_source_path {
-                                    if let Some(source_path) = source_path_for(
-                                        key,
-                                        &mut source_path_by_id,
-                                        self.inner.as_ref(),
-                                    ) {
-                                        let mut with_source = std::mem::take(&mut self.spare_buf);
-                                        with_source.clear();
-                                        inject_source_path_metadata(
-                                            &self.out_buf,
-                                            source_path,
-                                            &mut with_source,
-                                        );
-                                        self.out_buf.clear();
-                                        self.spare_buf =
-                                            std::mem::replace(&mut self.out_buf, with_source);
+                                if !tainted {
+                                    self.out_buf.clear();
+                                    let state =
+                                        self.sources.get_mut(&key).expect("just checked existence");
+                                    state.format.process_lines(&remainder, &mut self.out_buf);
+                                    if inject_source_path {
+                                        if let Some(source_path) = source_path_for(
+                                            key,
+                                            &mut source_path_by_id,
+                                            self.inner.as_ref(),
+                                        ) {
+                                            let mut with_source =
+                                                std::mem::take(&mut self.spare_buf);
+                                            with_source.clear();
+                                            inject_source_path_metadata(
+                                                &self.out_buf,
+                                                source_path,
+                                                &mut with_source,
+                                            );
+                                            self.out_buf.clear();
+                                            self.spare_buf =
+                                                std::mem::replace(&mut self.out_buf, with_source);
+                                        }
                                     }
-                                }
 
-                                self.stats.inc_lines(1);
+                                    self.stats.inc_lines(1);
+                                }
 
                                 // Remainder was flushed — update tracker so
                                 // checkpointable_offset advances past the
@@ -1246,6 +1240,47 @@ mod tests {
 
         let events2 = framed.poll().unwrap();
         assert!(collect_data(events2).is_empty());
+    }
+
+    /// A tainted overflow remainder discarded at EOF must not be counted as a
+    /// processed line.
+    #[test]
+    fn eof_discards_tainted_overflow_remainder_without_counting_a_line() {
+        let stats = make_stats();
+        let big = vec![b'x'; MAX_REMAINDER_BYTES + 1];
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: big,
+                source_id: None,
+                accounted_bytes: (MAX_REMAINDER_BYTES + 1) as u64,
+                sender_addr: None,
+            }],
+            vec![InputEvent::EndOfFile { source_id: None }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        let events1 = framed.poll().unwrap();
+        assert!(collect_data(events1).is_empty());
+        assert_eq!(
+            framed.stats.lines(),
+            0,
+            "overflow without a newline must not increment the line counter"
+        );
+
+        let events2 = framed.poll().unwrap();
+        assert!(
+            collect_data(events2).is_empty(),
+            "tainted overflow remainder must be dropped at EOF"
+        );
+        assert_eq!(
+            framed.stats.lines(),
+            0,
+            "discarded EOF overflow fragment must not count as a processed line"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -20,6 +20,7 @@ use logfwd_types::diagnostics::ComponentHealth;
 use logfwd_types::pipeline::SourceId;
 use std::collections::HashMap;
 use std::io;
+use std::io::Write as _;
 use std::sync::Arc;
 
 /// Maximum remainder buffer size before discarding (prevents OOM on
@@ -253,14 +254,10 @@ impl InputSource for FramedInput {
                             self.spare_buf = std::mem::replace(&mut self.out_buf, with_source);
                         }
                     }
-                    if inject_source_path && let Some(sender_addr) = sender_addr {
+                    if let Some(sender_addr) = sender_addr {
                         let mut with_sender = std::mem::take(&mut self.spare_buf);
                         with_sender.clear();
-                        inject_sender_metadata(
-                            &self.out_buf,
-                            sender_addr.to_string().as_bytes(),
-                            &mut with_sender,
-                        );
+                        inject_sender_metadata(&self.out_buf, sender_addr, &mut with_sender);
                         self.out_buf.clear();
                         self.spare_buf = std::mem::replace(&mut self.out_buf, with_sender);
                     }
@@ -462,8 +459,37 @@ fn inject_source_path_metadata(chunk: &[u8], source_path: &std::path::Path, out:
     inject_json_metadata(chunk, b"_source_path", source_path_bytes.as_bytes(), out);
 }
 
-fn inject_sender_metadata(chunk: &[u8], sender: &[u8], out: &mut Vec<u8>) {
-    inject_json_metadata(chunk, b"_sender", sender, out);
+fn inject_sender_metadata(chunk: &[u8], sender: std::net::SocketAddr, out: &mut Vec<u8>) {
+    let mut pos = 0;
+    while pos < chunk.len() {
+        let eol = memchr::memchr(b'\n', &chunk[pos..]).map_or(chunk.len(), |o| pos + o);
+        let line = &chunk[pos..eol];
+        let first_nonws = line
+            .iter()
+            .position(|&b| !matches!(b, b' ' | b'\t' | b'\r'));
+        if let Some(obj_start) = first_nonws.filter(|&idx| line[idx] == b'{') {
+            let after_open = &line[obj_start + 1..];
+            let is_empty_obj = after_open
+                .iter()
+                .position(|&b| !matches!(b, b' ' | b'\t' | b'\r' | b'\n'))
+                .is_some_and(|i| after_open[i] == b'}');
+            out.extend_from_slice(&line[..obj_start]);
+            out.extend_from_slice(b"{\"_sender\":\"");
+            out.write_fmt(format_args!("{sender}"))
+                .expect("write sender metadata");
+            out.push(b'"');
+            if !is_empty_obj {
+                out.push(b',');
+            }
+            out.extend_from_slice(after_open);
+        } else {
+            out.extend_from_slice(line);
+        }
+        if eol < chunk.len() {
+            out.push(b'\n');
+        }
+        pos = eol + 1;
+    }
 }
 
 fn inject_json_metadata(chunk: &[u8], key: &[u8], value: &[u8], out: &mut Vec<u8>) {
@@ -1523,6 +1549,28 @@ mod tests {
             out,
             b"{\"_sender\":\"127.0.0.1:9100\",\"_source_path\":\"/var/log/pods/ns_pod_uid/c/sender.log\",\"msg\":\"hello\"}\n"
         );
+    }
+
+    #[test]
+    fn raw_passthrough_injects_sender_metadata_without_source_path_support() {
+        let stats = make_stats();
+        let sid = SourceId(13);
+        let sender_addr: std::net::SocketAddr = "127.0.0.1:9101".parse().unwrap();
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: b"{\"msg\":\"hello\"}\n".to_vec(),
+            source_id: Some(sid),
+            accounted_bytes: 0,
+            sender_addr: Some(sender_addr),
+        }]]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        let out = collect_data(framed.poll().unwrap());
+        assert_eq!(out, b"{\"_sender\":\"127.0.0.1:9101\",\"msg\":\"hello\"}\n");
     }
 
     #[test]

--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -453,6 +453,7 @@ impl InputSource for GeneratorInput {
             bytes: out,
             source_id: None,
             accounted_bytes,
+            sender_addr: None,
         }])
     }
 

--- a/crates/logfwd-io/src/http_input.rs
+++ b/crates/logfwd-io/src/http_input.rs
@@ -285,6 +285,7 @@ impl InputSource for HttpInput {
             bytes: all,
             source_id: None,
             accounted_bytes,
+            sender_addr: None,
         }])
     }
 

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -18,10 +18,14 @@ pub enum InputEvent {
     /// to input diagnostics for this event. For raw byte inputs this is
     /// usually `bytes.len()`. Wrappers like `FramedInput` may consume this for
     /// accounting and forward downstream data with `accounted_bytes = 0`.
+    /// `sender_addr` is the transport peer address (`ip:port`) when available
+    /// (for example, from UDP `recv_from`). Sources without peer identity set
+    /// this to `None`.
     Data {
         bytes: Vec<u8>,
         source_id: Option<SourceId>,
         accounted_bytes: u64,
+        sender_addr: Option<std::net::SocketAddr>,
     },
     /// New structured rows produced directly by the source.
     ///
@@ -133,6 +137,7 @@ impl InputSource for FileInput {
                         bytes,
                         source_id,
                         accounted_bytes,
+                        sender_addr: None,
                     });
                 }
                 TailEvent::Rotated { source_id, .. } => {

--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -280,6 +280,7 @@ impl InputSource for OtlpReceiverInput {
                 bytes: all,
                 source_id: None,
                 accounted_bytes: all_accounted_bytes,
+                sender_addr: None,
             });
         }
         events.extend(

--- a/crates/logfwd-io/src/platform_sensor_beta.rs
+++ b/crates/logfwd-io/src/platform_sensor_beta.rs
@@ -129,6 +129,7 @@ impl InputSource for PlatformSensorBetaInput {
             bytes,
             source_id: None,
             accounted_bytes,
+            sender_addr: None,
         }])
     }
 

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -374,15 +374,16 @@ impl InputSource for TcpInput {
 
         // Step 1: Data events.
         for (i, data) in client_data.into_iter().enumerate() {
-            if let Some(bytes) = data {
-                if !bytes.is_empty() {
-                    let accounted_bytes = bytes.len() as u64;
-                    events.push(InputEvent::Data {
-                        bytes,
-                        source_id: Some(self.clients[i].source_id),
-                        accounted_bytes,
-                    });
-                }
+            if let Some(bytes) = data
+                && !bytes.is_empty()
+            {
+                let accounted_bytes = bytes.len() as u64;
+                events.push(InputEvent::Data {
+                    bytes,
+                    source_id: Some(self.clients[i].source_id),
+                    accounted_bytes,
+                    sender_addr: None,
+                });
             }
         }
 
@@ -416,6 +417,7 @@ impl InputSource for TcpInput {
                         bytes: tail,
                         source_id: Some(client.source_id),
                         accounted_bytes,
+                        sender_addr: None,
                     });
                 }
                 events.push(InputEvent::EndOfFile {

--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -1,5 +1,5 @@
-//! UDP input source. Listens on a UDP socket and produces one InputEvent
-//! per received datagram.
+//! UDP input source. Listens on a UDP socket and produces `InputEvent::Data`
+//! batches while preserving sender attribution and receive order.
 use std::io;
 use std::net::UdpSocket;
 use std::sync::Arc;
@@ -18,8 +18,9 @@ const MAX_UDP_PAYLOAD: usize = 65507;
 /// cap it lower depending on `sysctl net.core.rmem_max`.
 const RECV_BUF_SIZE: usize = 8 * 1024 * 1024;
 
-/// UDP input that listens for datagrams. Each datagram is treated as one
-/// or more newline-delimited log lines.
+/// UDP input that listens for datagrams. Consecutive datagrams from the same
+/// sender in one poll cycle are coalesced into one event so allocation tracks
+/// sender runs instead of individual packets.
 pub struct UdpInput {
     name: String,
     socket: UdpSocket,
@@ -108,6 +109,25 @@ impl InputSource for UdpInput {
                 }
                 Ok((n, sender_addr)) => {
                     let data = &self.buf[..n];
+                    if let Some(InputEvent::Data {
+                        bytes,
+                        accounted_bytes,
+                        sender_addr: Some(last_sender),
+                        ..
+                    }) = events.last_mut()
+                    {
+                        if *last_sender == sender_addr {
+                            bytes.extend_from_slice(data);
+                            // Ensure newline termination so the scanner always sees
+                            // complete lines, even if the sender omitted a trailing LF.
+                            if !data.ends_with(b"\n") {
+                                bytes.push(b'\n');
+                            }
+                            *accounted_bytes = accounted_bytes.saturating_add(n as u64);
+                            continue;
+                        }
+                    }
+
                     let mut bytes = Vec::with_capacity(n + 1);
                     bytes.extend_from_slice(data);
                     // Ensure newline termination so the scanner always sees
@@ -190,8 +210,37 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
 
         let events = input.poll().unwrap();
-        assert_eq!(events.len(), 2);
+        assert_eq!(events.len(), 1);
         assert_eq!(collect_data(events), b"hello world\nsecond line\n");
+    }
+
+    #[test]
+    fn coalesces_adjacent_datagrams_from_same_sender() {
+        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let addr = input.local_addr().unwrap();
+
+        let sender = StdSocket::bind("127.0.0.1:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
+        sender.send_to(b"one\n", addr).unwrap();
+        sender.send_to(b"two", addr).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let events = input.poll().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            InputEvent::Data {
+                bytes,
+                accounted_bytes,
+                sender_addr: Some(actual_sender),
+                ..
+            } => {
+                assert_eq!(*actual_sender, sender_addr);
+                assert_eq!(*accounted_bytes, 7);
+                assert_eq!(bytes, b"one\ntwo\n");
+            }
+            _ => panic!("expected coalesced InputEvent::Data"),
+        }
     }
 
     #[test]

--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -1,6 +1,7 @@
 //! UDP input source. Listens on a UDP socket and produces one InputEvent
 //! per received datagram (or batch of datagrams).
 
+use std::collections::BTreeMap;
 use std::io;
 use std::net::UdpSocket;
 use std::sync::Arc;
@@ -99,24 +100,23 @@ impl InputSource for UdpInput {
     fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
         let mut under_pressure = false;
 
-        // Accumulate into a single byte buffer; avoid per-datagram Vec alloc.
-        // We re-use `self.buf` for recv and build the output in a separate vec
-        // only when data actually arrives.
-        let mut total: Option<Vec<u8>> = None;
-        let mut source_bytes: u64 = 0;
+        // Accumulate by sender so each emitted Data event retains deterministic
+        // sender attribution without per-datagram allocations.
+        let mut by_sender: BTreeMap<std::net::SocketAddr, (Vec<u8>, u64)> = BTreeMap::new();
 
         // Drain all available datagrams in one poll cycle.
         loop {
-            // `recv` is cheaper than `recv_from` — we don't need the source addr.
-            match self.socket.recv(&mut self.buf) {
-                Ok(0) => {
+            match self.socket.recv_from(&mut self.buf) {
+                Ok((0, _)) => {
                     // Zero-length datagram — valid in UDP. Nothing to append,
                     // just continue draining.
                 }
-                Ok(n) => {
-                    source_bytes = source_bytes.saturating_add(n as u64);
+                Ok((n, sender_addr)) => {
                     let data = &self.buf[..n];
-                    let out = total.get_or_insert_with(|| Vec::with_capacity(4096));
+                    let (out, source_bytes) = by_sender
+                        .entry(sender_addr)
+                        .or_insert_with(|| (Vec::with_capacity(4096), 0));
+                    *source_bytes = source_bytes.saturating_add(n as u64);
                     out.extend_from_slice(data);
                     // Ensure newline termination so the scanner always sees
                     // complete lines, even if the sender omitted a trailing LF.
@@ -152,17 +152,19 @@ impl InputSource for UdpInput {
             },
         );
 
-        match total {
-            Some(bytes) => {
-                let accounted_bytes = source_bytes;
-                Ok(vec![InputEvent::Data {
-                    bytes,
-                    source_id: None,
-                    accounted_bytes,
-                }])
-            }
-            None => Ok(Vec::new()),
+        if by_sender.is_empty() {
+            return Ok(Vec::new());
         }
+
+        Ok(by_sender
+            .into_iter()
+            .map(|(sender_addr, (bytes, accounted_bytes))| InputEvent::Data {
+                bytes,
+                source_id: None,
+                accounted_bytes,
+                sender_addr: Some(sender_addr),
+            })
+            .collect())
     }
 
     fn name(&self) -> &str {
@@ -224,6 +226,7 @@ mod tests {
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
+        let sender_addr = sender.local_addr().unwrap();
         sender.send_to(b"no newline", addr).unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(50));
@@ -233,15 +236,49 @@ mod tests {
         if let InputEvent::Data {
             bytes,
             accounted_bytes,
+            sender_addr: Some(actual_sender),
             ..
         } = &events[0]
         {
             assert_eq!(*accounted_bytes, 10);
             assert_eq!(bytes.len(), 11);
             assert!(bytes.ends_with(b"\n"), "expected trailing newline");
+            assert_eq!(*actual_sender, sender_addr);
         } else {
             panic!("expected InputEvent::Data variant");
         }
+    }
+
+    #[test]
+    fn preserves_sender_addr_for_multiple_senders() {
+        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let addr = input.local_addr().unwrap();
+
+        let sender1 = StdSocket::bind("127.0.0.1:0").unwrap();
+        let sender2 = StdSocket::bind("127.0.0.1:0").unwrap();
+        let sender1_addr = sender1.local_addr().unwrap();
+        let sender2_addr = sender2.local_addr().unwrap();
+
+        sender1.send_to(b"one\n", addr).unwrap();
+        sender2.send_to(b"two\n", addr).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let events = input.poll().unwrap();
+        assert_eq!(events.len(), 2);
+
+        let mut seen = std::collections::BTreeSet::new();
+        for event in events {
+            if let InputEvent::Data {
+                sender_addr: Some(sender),
+                ..
+            } = event
+            {
+                seen.insert(sender);
+            }
+        }
+        assert!(seen.contains(&sender1_addr));
+        assert!(seen.contains(&sender2_addr));
     }
 
     #[test]

--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -1,7 +1,5 @@
 //! UDP input source. Listens on a UDP socket and produces one InputEvent
-//! per received datagram (or batch of datagrams).
-
-use std::collections::BTreeMap;
+//! per received datagram.
 use std::io;
 use std::net::UdpSocket;
 use std::sync::Arc;
@@ -99,10 +97,7 @@ impl UdpInput {
 impl InputSource for UdpInput {
     fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
         let mut under_pressure = false;
-
-        // Accumulate by sender so each emitted Data event retains deterministic
-        // sender attribution without per-datagram allocations.
-        let mut by_sender: BTreeMap<std::net::SocketAddr, (Vec<u8>, u64)> = BTreeMap::new();
+        let mut events = Vec::new();
 
         // Drain all available datagrams in one poll cycle.
         loop {
@@ -113,16 +108,19 @@ impl InputSource for UdpInput {
                 }
                 Ok((n, sender_addr)) => {
                     let data = &self.buf[..n];
-                    let (out, source_bytes) = by_sender
-                        .entry(sender_addr)
-                        .or_insert_with(|| (Vec::with_capacity(4096), 0));
-                    *source_bytes = source_bytes.saturating_add(n as u64);
-                    out.extend_from_slice(data);
+                    let mut bytes = Vec::with_capacity(n + 1);
+                    bytes.extend_from_slice(data);
                     // Ensure newline termination so the scanner always sees
                     // complete lines, even if the sender omitted a trailing LF.
                     if !data.ends_with(b"\n") {
-                        out.push(b'\n');
+                        bytes.push(b'\n');
                     }
+                    events.push(InputEvent::Data {
+                        bytes,
+                        source_id: None,
+                        accounted_bytes: n as u64,
+                        sender_addr: Some(sender_addr),
+                    });
                 }
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
                 // ECONNREFUSED can arrive on a connected UDP socket (ICMP
@@ -152,19 +150,7 @@ impl InputSource for UdpInput {
             },
         );
 
-        if by_sender.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        Ok(by_sender
-            .into_iter()
-            .map(|(sender_addr, (bytes, accounted_bytes))| InputEvent::Data {
-                bytes,
-                source_id: None,
-                accounted_bytes,
-                sender_addr: Some(sender_addr),
-            })
-            .collect())
+        Ok(events)
     }
 
     fn name(&self) -> &str {
@@ -181,6 +167,16 @@ mod tests {
     use super::*;
     use std::net::UdpSocket as StdSocket;
 
+    fn collect_data(events: Vec<InputEvent>) -> Vec<u8> {
+        let mut out = Vec::new();
+        for event in events {
+            if let InputEvent::Data { bytes, .. } = event {
+                out.extend_from_slice(&bytes);
+            }
+        }
+        out
+    }
+
     #[test]
     fn receives_datagrams() {
         let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
@@ -194,12 +190,8 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
 
         let events = input.poll().unwrap();
-        assert_eq!(events.len(), 1);
-        if let InputEvent::Data { bytes, .. } = &events[0] {
-            let text = String::from_utf8_lossy(bytes);
-            assert!(text.contains("hello world"), "got: {text}");
-            assert!(text.contains("second line"), "got: {text}");
-        }
+        assert_eq!(events.len(), 2);
+        assert_eq!(collect_data(events), b"hello world\nsecond line\n");
     }
 
     #[test]
@@ -259,26 +251,57 @@ mod tests {
         let sender1_addr = sender1.local_addr().unwrap();
         let sender2_addr = sender2.local_addr().unwrap();
 
-        sender1.send_to(b"one\n", addr).unwrap();
-        sender2.send_to(b"two\n", addr).unwrap();
+        let (first_sender, first_addr, first_payload, second_sender, second_addr, second_payload) =
+            if sender1_addr > sender2_addr {
+                (
+                    &sender1,
+                    sender1_addr,
+                    b"one\n",
+                    &sender2,
+                    sender2_addr,
+                    b"two\n",
+                )
+            } else {
+                (
+                    &sender2,
+                    sender2_addr,
+                    b"two\n",
+                    &sender1,
+                    sender1_addr,
+                    b"one\n",
+                )
+            };
+        first_sender.send_to(first_payload, addr).unwrap();
+        second_sender.send_to(second_payload, addr).unwrap();
 
         std::thread::sleep(std::time::Duration::from_millis(50));
 
         let events = input.poll().unwrap();
         assert_eq!(events.len(), 2);
 
-        let mut seen = std::collections::BTreeSet::new();
-        for event in events {
-            if let InputEvent::Data {
-                sender_addr: Some(sender),
+        match &events[0] {
+            InputEvent::Data {
+                bytes,
+                sender_addr: Some(actual_sender),
                 ..
-            } = event
-            {
-                seen.insert(sender);
+            } => {
+                assert_eq!(*actual_sender, first_addr);
+                assert_eq!(bytes, first_payload);
             }
+            _ => panic!("expected first InputEvent::Data variant"),
         }
-        assert!(seen.contains(&sender1_addr));
-        assert!(seen.contains(&sender2_addr));
+
+        match &events[1] {
+            InputEvent::Data {
+                bytes,
+                sender_addr: Some(actual_sender),
+                ..
+            } => {
+                assert_eq!(*actual_sender, second_addr);
+                assert_eq!(bytes, second_payload);
+            }
+            _ => panic!("expected second InputEvent::Data variant"),
+        }
     }
 
     #[test]

--- a/crates/logfwd-io/tests/allocation_churn.rs
+++ b/crates/logfwd-io/tests/allocation_churn.rs
@@ -30,6 +30,7 @@ impl MockSource {
                     bytes: chunk.to_vec(),
                     source_id: None,
                     accounted_bytes: chunk.len() as u64,
+                    sender_addr: None,
                 }]
             })
             .collect();

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -67,6 +67,7 @@ pub(crate) struct IoChunk {
     pub checkpoints: Vec<(SourceId, ByteOffset)>,
     pub queued_at: tokio::time::Instant,
     pub input_index: usize,
+    pub sender_addr: Option<std::net::SocketAddr>,
 }
 
 #[cfg(not(feature = "turmoil"))]
@@ -97,6 +98,7 @@ fn io_worker_loop(
     input_index: usize,
 ) {
     let mut buffered_since: Option<Instant> = None;
+    let mut buffered_sender: Option<std::net::SocketAddr> = None;
     let mut last_bp_warn: Option<Instant> = None;
 
     'io_loop: loop {
@@ -132,7 +134,16 @@ fn io_worker_loop(
         } else {
             for event in events {
                 match event {
-                    InputEvent::Data { bytes, .. } => {
+                    InputEvent::Data {
+                        bytes, sender_addr, ..
+                    } => {
+                        if input.buf.is_empty() {
+                            buffered_sender = sender_addr;
+                        } else if buffered_sender != sender_addr {
+                            // Mixed senders in one buffered chunk — clear sender
+                            // attribution for this batch to avoid lying in traces.
+                            buffered_sender = None;
+                        }
                         input.buf.extend_from_slice(&bytes);
                     }
                     InputEvent::Batch { batch, .. } => {
@@ -144,6 +155,7 @@ fn io_worker_loop(
                                 checkpoints,
                                 queued_at: tokio::time::Instant::now(),
                                 input_index,
+                                sender_addr: buffered_sender,
                             });
                             match tx.try_send(chunk) {
                                 Ok(()) => {}
@@ -165,6 +177,7 @@ fn io_worker_loop(
                                 Err(mpsc::error::TrySendError::Closed(_)) => break 'io_loop,
                             }
                             buffered_since = None;
+                            buffered_sender = None;
                         }
 
                         let item = IoWorkItem::Batch {
@@ -227,6 +240,7 @@ fn io_worker_loop(
                 checkpoints,
                 queued_at: tokio::time::Instant::now(),
                 input_index,
+                sender_addr: buffered_sender,
             });
 
             // Try non-blocking first; if full, log backpressure and block.
@@ -247,6 +261,7 @@ fn io_worker_loop(
                 Err(mpsc::error::TrySendError::Closed(_)) => break,
             }
             buffered_since = None;
+            buffered_sender = None;
         }
     }
 
@@ -261,6 +276,7 @@ fn io_worker_loop(
             checkpoints,
             queued_at: tokio::time::Instant::now(),
             input_index,
+            sender_addr: buffered_sender,
         });
         if tx.blocking_send(chunk).is_err() {
             tracing::warn!(
@@ -312,7 +328,7 @@ fn cpu_worker_loop(
     };
 
     while let Some(item) = rx.blocking_recv() {
-        let (batch, checkpoints, queued_at, input_index, scan_ns) = match item {
+        let (batch, checkpoints, queued_at, input_index, scan_ns, sender_addr) = match item {
             IoWorkItem::Bytes(chunk) => {
                 let t0 = Instant::now();
                 let batch = match transform.scanner.scan(chunk.bytes) {
@@ -335,6 +351,7 @@ fn cpu_worker_loop(
                     chunk.queued_at,
                     chunk.input_index,
                     t0.elapsed().as_nanos() as u64,
+                    chunk.sender_addr,
                 )
             }
             IoWorkItem::Batch {
@@ -342,7 +359,7 @@ fn cpu_worker_loop(
                 checkpoints,
                 queued_at,
                 input_index,
-            } => (batch, checkpoints, queued_at, input_index, 0),
+            } => (batch, checkpoints, queued_at, input_index, 0, None),
         };
 
         let num_rows = batch.num_rows();
@@ -375,6 +392,7 @@ fn cpu_worker_loop(
             input_index,
             scan_ns,
             transform_ns,
+            sender_addr,
         };
 
         // Use blocking_send (not shutdown-aware) so we deliver all

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -67,6 +67,8 @@ pub(crate) struct IoChunk {
     pub checkpoints: Vec<(SourceId, ByteOffset)>,
     pub queued_at: tokio::time::Instant,
     pub input_index: usize,
+    /// Sender socket address for a UDP-attributed chunk; `None` when the
+    /// buffered bytes came from mixed senders or from a non-UDP source.
     pub sender_addr: Option<std::net::SocketAddr>,
 }
 
@@ -509,8 +511,6 @@ impl InputPipelineManager {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     // --- InputPipelineManager integration tests ---
     // These test the full split pipeline via from_config + run, so they
     // don't need direct access to private types.

--- a/crates/logfwd-runtime/src/pipeline/input_poll.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_poll.rs
@@ -1,10 +1,10 @@
 #[cfg(feature = "turmoil")]
+use std::net::SocketAddr;
+#[cfg(feature = "turmoil")]
 use std::sync::Arc;
 #[cfg(feature = "turmoil")]
 use std::time::Duration;
 
-#[cfg(feature = "turmoil")]
-use arrow::record_batch::RecordBatch;
 #[cfg(feature = "turmoil")]
 use logfwd_io::diagnostics::PipelineMetrics;
 #[cfg(feature = "turmoil")]
@@ -38,6 +38,7 @@ pub(super) async fn async_input_poll_loop(
     input_index: usize,
 ) {
     let mut buffered_since: Option<tokio::time::Instant> = None;
+    let mut buffered_sender: Option<SocketAddr> = None;
     'poll_loop: loop {
         if shutdown.is_cancelled() {
             input.stats.set_health(reduce_component_health(
@@ -71,7 +72,16 @@ pub(super) async fn async_input_poll_loop(
         } else {
             for event in events {
                 match event {
-                    InputEvent::Data { bytes, .. } => {
+                    InputEvent::Data {
+                        bytes, sender_addr, ..
+                    } => {
+                        if input.buf.is_empty() {
+                            buffered_sender = sender_addr;
+                        } else if buffered_sender != sender_addr {
+                            // Mixed senders in one buffered chunk — clear sender
+                            // attribution to avoid lying in traces.
+                            buffered_sender = None;
+                        }
                         input.buf.extend_from_slice(&bytes);
                     }
                     InputEvent::Batch { batch, .. } => {
@@ -81,6 +91,7 @@ pub(super) async fn async_input_poll_loop(
                                 &mut transform,
                                 &metrics,
                                 input_index,
+                                buffered_sender,
                             )
                             .await
                             {
@@ -89,6 +100,7 @@ pub(super) async fn async_input_poll_loop(
                                 }
                             }
                             buffered_since = None;
+                            buffered_sender = None;
                         }
 
                         if let Some(msg) = transform_direct_batch_for_send(
@@ -96,6 +108,7 @@ pub(super) async fn async_input_poll_loop(
                             &mut transform,
                             &metrics,
                             input_index,
+                            None,
                             batch,
                         )
                         .await
@@ -125,21 +138,34 @@ pub(super) async fn async_input_poll_loop(
         let should_send =
             input.buf.len() >= batch_target_bytes || (!input.buf.is_empty() && timeout_elapsed);
         if should_send {
-            if let Some(msg) =
-                scan_and_transform_for_send(&mut input, &mut transform, &metrics, input_index).await
+            if let Some(msg) = scan_and_transform_for_send(
+                &mut input,
+                &mut transform,
+                &metrics,
+                input_index,
+                buffered_sender,
+            )
+            .await
             {
                 if tx.send(msg).await.is_err() {
                     break;
                 }
             }
             buffered_since = None;
+            buffered_sender = None;
         }
     }
 
     // Drain remaining buffered data.
     if !input.buf.is_empty() {
-        if let Some(msg) =
-            scan_and_transform_for_send(&mut input, &mut transform, &metrics, input_index).await
+        if let Some(msg) = scan_and_transform_for_send(
+            &mut input,
+            &mut transform,
+            &metrics,
+            input_index,
+            buffered_sender,
+        )
+        .await
         {
             if let Err(e) = tx.send(msg).await {
                 tracing::warn!(

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -91,6 +91,7 @@ pub(crate) struct ChannelMsg {
     pub input_index: usize,
     pub scan_ns: u64,
     pub transform_ns: u64,
+    pub sender_addr: Option<std::net::SocketAddr>,
 }
 
 // ---------------------------------------------------------------------------
@@ -2406,6 +2407,7 @@ output:
             input_index: 0,
             scan_ns: 0,
             transform_ns: 0,
+            sender_addr: None,
         })
         .unwrap();
 

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -91,6 +91,9 @@ pub(crate) struct ChannelMsg {
     pub input_index: usize,
     pub scan_ns: u64,
     pub transform_ns: u64,
+    /// Sender socket address for batches that can be attributed to exactly
+    /// one peer. `None` for non-network inputs, mixed-sender buffers, or when
+    /// sender attribution is unavailable.
     pub sender_addr: Option<std::net::SocketAddr>,
 }
 

--- a/crates/logfwd-runtime/src/pipeline/submit.rs
+++ b/crates/logfwd-runtime/src/pipeline/submit.rs
@@ -37,6 +37,7 @@ impl Pipeline {
             queued_at,
             scan_ns,
             transform_ns,
+            sender_addr,
             ..
         } = msg;
         let batch_id = self.metrics.alloc_batch_id();
@@ -146,9 +147,11 @@ impl Pipeline {
         let input_rows = num_rows as u64;
         let out_rows = result.num_rows() as u64;
         let submitted_at = tokio::time::Instant::now();
+        let sender = sender_addr.map(|addr| addr.to_string()).unwrap_or_default();
 
         let batch_span = tracing::info_span!(
             "batch",
+            sender = %sender,
             scan_ns = scan_ns,
             transform_ns = transform_ns,
             input_rows = input_rows,
@@ -232,6 +235,7 @@ pub(super) async fn scan_and_transform_for_send(
         input_index,
         scan_ns,
         transform_ns,
+        sender_addr: None,
     })
 }
 
@@ -275,5 +279,6 @@ pub(super) async fn transform_direct_batch_for_send(
         input_index,
         scan_ns: 0,
         transform_ns,
+        sender_addr: None,
     })
 }

--- a/crates/logfwd-runtime/src/pipeline/submit.rs
+++ b/crates/logfwd-runtime/src/pipeline/submit.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "turmoil")]
 use std::collections::HashMap;
+#[cfg(feature = "turmoil")]
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 #[cfg(feature = "turmoil")]
@@ -190,6 +192,7 @@ pub(super) async fn scan_and_transform_for_send(
     transform: &mut InputTransform,
     metrics: &PipelineMetrics,
     input_index: usize,
+    sender_addr: Option<SocketAddr>,
 ) -> Option<ChannelMsg> {
     let data = input.buf.split().freeze();
     let checkpoints: HashMap<SourceId, ByteOffset> =
@@ -235,7 +238,7 @@ pub(super) async fn scan_and_transform_for_send(
         input_index,
         scan_ns,
         transform_ns,
-        sender_addr: None,
+        sender_addr,
     })
 }
 
@@ -245,6 +248,7 @@ pub(super) async fn transform_direct_batch_for_send(
     transform: &mut InputTransform,
     metrics: &PipelineMetrics,
     input_index: usize,
+    sender_addr: Option<SocketAddr>,
     batch: RecordBatch,
 ) -> Option<ChannelMsg> {
     let checkpoints: HashMap<SourceId, ByteOffset> =
@@ -279,6 +283,6 @@ pub(super) async fn transform_direct_batch_for_send(
         input_index,
         scan_ns: 0,
         transform_ns,
-        sender_addr: None,
+        sender_addr,
     })
 }


### PR DESCRIPTION
Implementation for GitHub issue #1714: work-unit: udp source attribution + sender metadata.

Requirements met:
- Add sender address metadata (`ip:port`) to UDP-derived events in a documented field (`_sender`).
- Preserve existing newline framing and throughput semantics (still batching and not faning out by source ID).
- Ensure sender attribution can be observed in diagnostics output path where transport metadata is shown (in `/admin/v1/traces`).
- Added integration test with at least two UDP senders.
- Fixed a pre-existing `clippy` lint on `std::f64::consts::PI` in tests.

---
*PR created automatically by Jules for task [647441156070123959](https://jules.google.com/task/647441156070123959) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `_sender` address metadata to UDP-derived events
> - Extends `InputEvent::Data` with a `sender_addr: Option<SocketAddr>` field, populated by the UDP input via `recv_from` and propagated through the pipeline to framing and batch processing; all other inputs set it to `None`.
> - UDP input coalesces consecutive datagrams from the same sender within a single poll into one event, appending a synthetic newline when the datagram lacks a trailing LF; `accounted_bytes` excludes synthetic bytes.
> - The framing layer keys per-source state by a new `SourceKey` (combining `source_id` or `sender_addr`) to prevent CRI/format state mixing between UDP senders, and injects a `_sender` field into JSON-object lines when `sender_addr` is present.
> - Tainted overflow remainders on EOF are now dropped instead of emitted as a partial line.
> - Behavioral Change: UDP sources that previously merged all datagrams into one buffer now emit separate events per sender group, and JSON-format rows gain a `_sender` column.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e89d2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->