### PR TITLE
Expose consistent transport observability parity

### DIFF
--- a/book/src/deployment/monitoring.md
+++ b/book/src/deployment/monitoring.md
@@ -31,6 +31,14 @@ server:
 | `logfwd_stage_seconds_total` | Time per stage (scan, transform, output) |
 | `logfwd_flush_reason_total` | Flush triggers (size vs timeout) |
 
+## Transport Observability
+
+The `/admin/v1/status` endpoint includes a `transport` object inside each input's JSON representation containing specific metrics for that transport type:
+
+* **File:** exposes `consecutive_error_polls`, representing the current file-tail pressure and backoff state.
+* **TCP:** exposes `accepted_connections` (total accepted) and `active_connections` (currently connected clients) indicators.
+* **UDP:** exposes `drops_detected` (datagrams dropped due to kernel buffer overflows) and `recv_buffer_size` (actual kernel receive buffer size applied) indicators.
+
 ## OTLP metrics push
 
 ```yaml

--- a/crates/logfwd-io/src/diagnostics/server.rs
+++ b/crates/logfwd-io/src/diagnostics/server.rs
@@ -790,8 +790,26 @@ impl DiagnosticsServer {
                 .inputs
                 .iter()
                 .map(|(name, typ, stats)| {
+                    let transport_json = match typ.as_str() {
+                        "file" => format!(
+                            r#","transport":{{"file":{{"consecutive_error_polls":{}}}}}"#,
+                            stats.file_error_polls.load(Ordering::Relaxed)
+                        ),
+                        "tcp" => format!(
+                            r#","transport":{{"tcp":{{"accepted_connections":{},"active_connections":{}}}}}"#,
+                            stats.tcp_accepted.load(Ordering::Relaxed),
+                            stats.tcp_active.load(Ordering::Relaxed)
+                        ),
+                        "udp" => format!(
+                            r#","transport":{{"udp":{{"drops_detected":{},"recv_buffer_size":{}}}}}"#,
+                            stats.udp_drops.load(Ordering::Relaxed),
+                            stats.udp_recv_buf.load(Ordering::Relaxed)
+                        ),
+                        _ => String::new(),
+                    };
+
                     format!(
-                        r#"{{"name":"{}","type":"{}","health":"{}","lines_total":{},"bytes_total":{},"errors":{},"rotations":{},"parse_errors":{}}}"#,
+                        r#"{{"name":"{}","type":"{}","health":"{}","lines_total":{},"bytes_total":{},"errors":{},"rotations":{},"parse_errors":{}{}}}"#,
                         esc(name),
                         esc(typ),
                         stats.health().as_str(),
@@ -800,6 +818,7 @@ impl DiagnosticsServer {
                         stats.errors(),
                         stats.rotations(),
                         stats.parse_errors(),
+                        transport_json
                     )
                 })
                 .collect();
@@ -1820,6 +1839,47 @@ output:
             "not_ready",
             "components_failed",
             false,
+        );
+    }
+
+    #[test]
+    fn test_status_endpoint_includes_transport_parity_fields() {
+        let meter = opentelemetry::global::meter("test");
+        let mut pm = PipelineMetrics::new("default", "SELECT * FROM logs", &meter);
+
+        let file_in = pm.add_input("file_in", "file");
+        file_in.file_error_polls.store(5, Ordering::Relaxed);
+
+        let tcp_in = pm.add_input("tcp_in", "tcp");
+        tcp_in.tcp_accepted.store(42, Ordering::Relaxed);
+        tcp_in.tcp_active.store(3, Ordering::Relaxed);
+
+        let udp_in = pm.add_input("udp_in", "udp");
+        udp_in.udp_drops.store(100, Ordering::Relaxed);
+        udp_in.udp_recv_buf.store(8388608, Ordering::Relaxed);
+
+        let mut server = DiagnosticsServer::new("127.0.0.1:0");
+        server.add_pipeline(Arc::new(pm));
+        let (_handle, addr) = server.start().expect("server bind failed");
+        let port = addr.port();
+
+        let (status, body) = http_get(port, "/admin/v1/status");
+        assert_eq!(status, 200);
+
+        assert!(
+            body.contains(r#""transport":{"file":{"consecutive_error_polls":5}}"#),
+            "body missing file transport: {}",
+            body
+        );
+        assert!(
+            body.contains(r#""transport":{"tcp":{"accepted_connections":42,"active_connections":3}}"#),
+            "body missing tcp transport: {}",
+            body
+        );
+        assert!(
+            body.contains(r#""transport":{"udp":{"drops_detected":100,"recv_buffer_size":8388608}}"#),
+            "body missing udp transport: {}",
+            body
         );
     }
 

--- a/crates/logfwd-io/src/diagnostics/server.rs
+++ b/crates/logfwd-io/src/diagnostics/server.rs
@@ -1865,26 +1865,31 @@ output:
 
         let (status, body) = http_get(port, "/admin/v1/status");
         assert_eq!(status, 200);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&body).expect("invalid JSON output from /admin/v1/status");
+        let inputs = parsed["pipelines"][0]["inputs"]
+            .as_array()
+            .expect("status endpoint should include pipeline inputs");
 
-        assert!(
-            body.contains(r#""transport":{"file":{"consecutive_error_polls":5}}"#),
-            "body missing file transport: {}",
-            body
-        );
-        assert!(
-            body.contains(
-                r#""transport":{"tcp":{"accepted_connections":42,"active_connections":3}}"#
-            ),
-            "body missing tcp transport: {}",
-            body
-        );
-        assert!(
-            body.contains(
-                r#""transport":{"udp":{"drops_detected":100,"recv_buffer_size":8388608}}"#
-            ),
-            "body missing udp transport: {}",
-            body
-        );
+        let file = inputs
+            .iter()
+            .find(|input| input["name"] == "file_in")
+            .expect("missing file_in input");
+        assert_eq!(file["transport"]["file"]["consecutive_error_polls"], 5);
+
+        let tcp = inputs
+            .iter()
+            .find(|input| input["name"] == "tcp_in")
+            .expect("missing tcp_in input");
+        assert_eq!(tcp["transport"]["tcp"]["accepted_connections"], 42);
+        assert_eq!(tcp["transport"]["tcp"]["active_connections"], 3);
+
+        let udp = inputs
+            .iter()
+            .find(|input| input["name"] == "udp_in")
+            .expect("missing udp_in input");
+        assert_eq!(udp["transport"]["udp"]["drops_detected"], 100);
+        assert_eq!(udp["transport"]["udp"]["recv_buffer_size"], 8_388_608);
     }
 
     #[test]

--- a/crates/logfwd-io/src/diagnostics/server.rs
+++ b/crates/logfwd-io/src/diagnostics/server.rs
@@ -1872,12 +1872,16 @@ output:
             body
         );
         assert!(
-            body.contains(r#""transport":{"tcp":{"accepted_connections":42,"active_connections":3}}"#),
+            body.contains(
+                r#""transport":{"tcp":{"accepted_connections":42,"active_connections":3}}"#
+            ),
             "body missing tcp transport: {}",
             body
         );
         assert!(
-            body.contains(r#""transport":{"udp":{"drops_detected":100,"recv_buffer_size":8388608}}"#),
+            body.contains(
+                r#""transport":{"udp":{"drops_detected":100,"recv_buffer_size":8388608}}"#
+            ),
             "body missing udp transport: {}",
             body
         );

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -101,8 +101,8 @@ pub struct FileInput {
 
 impl FileInput {
     /// Create a new `FileInput` wrapping a `FileTailer`.
-    pub fn new(name: String, paths: &[PathBuf], config: TailConfig) -> io::Result<Self> {
-        let tailer = FileTailer::new(paths, config)?;
+    pub fn new(name: String, paths: &[PathBuf], config: TailConfig, stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>) -> io::Result<Self> {
+        let tailer = FileTailer::new(paths, config, stats)?;
         Ok(FileInput { name, tailer })
     }
 
@@ -110,8 +110,8 @@ impl FileInput {
     ///
     /// Patterns are expanded immediately and re-evaluated periodically to
     /// discover files created after startup (e.g., new Kubernetes pods).
-    pub fn new_with_globs(name: String, patterns: &[&str], config: TailConfig) -> io::Result<Self> {
-        let tailer = FileTailer::new_with_globs(patterns, config)?;
+    pub fn new_with_globs(name: String, patterns: &[&str], config: TailConfig, stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>) -> io::Result<Self> {
+        let tailer = FileTailer::new_with_globs(patterns, config, stats)?;
         Ok(FileInput { name, tailer })
     }
 }

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -101,7 +101,12 @@ pub struct FileInput {
 
 impl FileInput {
     /// Create a new `FileInput` wrapping a `FileTailer`.
-    pub fn new(name: String, paths: &[PathBuf], config: TailConfig, stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>) -> io::Result<Self> {
+    pub fn new(
+        name: String,
+        paths: &[PathBuf],
+        config: TailConfig,
+        stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>,
+    ) -> io::Result<Self> {
         let tailer = FileTailer::new(paths, config, stats)?;
         Ok(FileInput { name, tailer })
     }
@@ -110,7 +115,12 @@ impl FileInput {
     ///
     /// Patterns are expanded immediately and re-evaluated periodically to
     /// discover files created after startup (e.g., new Kubernetes pods).
-    pub fn new_with_globs(name: String, patterns: &[&str], config: TailConfig, stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>) -> io::Result<Self> {
+    pub fn new_with_globs(
+        name: String,
+        patterns: &[&str],
+        config: TailConfig,
+        stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>,
+    ) -> io::Result<Self> {
         let tailer = FileTailer::new_with_globs(patterns, config, stats)?;
         Ok(FileInput { name, tailer })
     }

--- a/crates/logfwd-io/src/tail/tailer.rs
+++ b/crates/logfwd-io/src/tail/tailer.rs
@@ -84,6 +84,15 @@ fn watch_parent_for(path: &Path) -> Option<PathBuf> {
 }
 
 impl FileTailer {
+    /// Create a tailer for explicit file paths.
+    ///
+    /// The provided `paths` are watched immediately. `TailConfig` controls the
+    /// polling cadence, read buffer sizing, glob rescans, and related tailing
+    /// behavior. The shared `ComponentStats` handle is updated with file
+    /// transport diagnostics for this tailer.
+    ///
+    /// Returns an error when the underlying file watcher or initial file setup
+    /// cannot be created.
     pub fn new(
         paths: &[PathBuf],
         config: TailConfig,
@@ -148,6 +157,16 @@ impl FileTailer {
         Ok(tailer)
     }
 
+    /// Create a tailer for glob patterns.
+    ///
+    /// The provided `patterns` are expanded immediately and then watched for
+    /// future matches. `TailConfig` controls the polling cadence, read buffer
+    /// sizing, glob rescans, and related tailing behavior. The shared
+    /// `ComponentStats` handle is updated with file transport diagnostics for
+    /// this tailer.
+    ///
+    /// Returns an error when the underlying file watcher or initial file setup
+    /// cannot be created.
     pub fn new_with_globs(
         patterns: &[&str],
         config: TailConfig,

--- a/crates/logfwd-io/src/tail/tailer.rs
+++ b/crates/logfwd-io/src/tail/tailer.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use logfwd_types::diagnostics::ComponentHealth;
+use logfwd_types::diagnostics::ComponentStats;
 use logfwd_types::pipeline::SourceId;
 
 use crate::polling_input_health::{PollingInputHealthEvent, reduce_polling_input_health};
@@ -70,6 +71,7 @@ pub struct FileTailer {
     pub(super) consecutive_error_polls: u32,
     pub(super) error_backoff_until: Option<Instant>,
     health: ComponentHealth,
+    stats: std::sync::Arc<ComponentStats>,
 }
 
 fn watch_parent_for(path: &Path) -> Option<PathBuf> {
@@ -82,7 +84,11 @@ fn watch_parent_for(path: &Path) -> Option<PathBuf> {
 }
 
 impl FileTailer {
-    pub fn new(paths: &[PathBuf], config: TailConfig) -> io::Result<Self> {
+    pub fn new(
+        paths: &[PathBuf],
+        config: TailConfig,
+        stats: std::sync::Arc<ComponentStats>,
+    ) -> io::Result<Self> {
         let (tx, rx) = crossbeam_channel::unbounded();
 
         let mut watcher = notify::recommended_watcher(move |res| {
@@ -123,6 +129,7 @@ impl FileTailer {
             consecutive_error_polls: 0,
             error_backoff_until: None,
             health: ComponentHealth::Healthy,
+            stats,
         };
 
         for path in paths {
@@ -141,7 +148,11 @@ impl FileTailer {
         Ok(tailer)
     }
 
-    pub fn new_with_globs(patterns: &[&str], config: TailConfig) -> io::Result<Self> {
+    pub fn new_with_globs(
+        patterns: &[&str],
+        config: TailConfig,
+        stats: std::sync::Arc<ComponentStats>,
+    ) -> io::Result<Self> {
         let initial_paths: Vec<PathBuf> = expand_glob_patterns(patterns);
 
         if initial_paths.is_empty() {
@@ -153,7 +164,7 @@ impl FileTailer {
             }
         }
 
-        let mut tailer = Self::new(&initial_paths, config)?;
+        let mut tailer = Self::new(&initial_paths, config, stats)?;
         tailer.discovery.glob_patterns = patterns.iter().map(ToString::to_string).collect();
         Ok(tailer)
     }
@@ -216,6 +227,7 @@ impl FileTailer {
 
         if had_error {
             self.consecutive_error_polls = self.consecutive_error_polls.saturating_add(1);
+            self.stats.file_error_polls.store(self.consecutive_error_polls, std::sync::atomic::Ordering::Relaxed);
             let exponent = self.consecutive_error_polls.saturating_sub(1).min(6);
             let multiplier = 1u64 << exponent;
             let backoff_ms = INITIAL_BACKOFF_MS
@@ -233,6 +245,7 @@ impl FileTailer {
             );
         } else {
             self.consecutive_error_polls = 0;
+            self.stats.file_error_polls.store(0, std::sync::atomic::Ordering::Relaxed);
             self.error_backoff_until = None;
             self.health =
                 reduce_polling_input_health(self.health, PollingInputHealthEvent::PollHealthy);

--- a/crates/logfwd-io/src/tail/tailer.rs
+++ b/crates/logfwd-io/src/tail/tailer.rs
@@ -227,7 +227,10 @@ impl FileTailer {
 
         if had_error {
             self.consecutive_error_polls = self.consecutive_error_polls.saturating_add(1);
-            self.stats.file_error_polls.store(self.consecutive_error_polls, std::sync::atomic::Ordering::Relaxed);
+            self.stats.file_error_polls.store(
+                self.consecutive_error_polls,
+                std::sync::atomic::Ordering::Relaxed,
+            );
             let exponent = self.consecutive_error_polls.saturating_sub(1).min(6);
             let multiplier = 1u64 << exponent;
             let backoff_ms = INITIAL_BACKOFF_MS
@@ -245,7 +248,9 @@ impl FileTailer {
             );
         } else {
             self.consecutive_error_polls = 0;
-            self.stats.file_error_polls.store(0, std::sync::atomic::Ordering::Relaxed);
+            self.stats
+                .file_error_polls
+                .store(0, std::sync::atomic::Ordering::Relaxed);
             self.error_backoff_until = None;
             self.health =
                 reduce_polling_input_health(self.health, PollingInputHealthEvent::PollHealthy);

--- a/crates/logfwd-io/src/tail/tests.rs
+++ b/crates/logfwd-io/src/tail/tests.rs
@@ -122,7 +122,7 @@ fn test_tail_new_data() {
         ..Default::default()
     };
 
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // First poll should read existing content.
     let events = poll_until(
@@ -201,7 +201,7 @@ fn test_tail_truncation() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Read initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -254,7 +254,7 @@ fn test_tail_rotation() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Read initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -311,7 +311,7 @@ fn test_tail_rotation_drains_truncated_file() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // First poll — drain initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -366,7 +366,7 @@ fn test_tail_rotation_drains_old_data() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // First poll — drain initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -448,7 +448,7 @@ fn test_tail_start_from_end() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // First poll should get no data (started from end).
     std::thread::sleep(Duration::from_millis(50));
@@ -536,7 +536,7 @@ fn test_glob_initial_discovery() {
         glob_rescan_interval_ms: 60_000, // long interval — not relevant for this test
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Both files should have been discovered immediately.
     assert_eq!(tailer.num_files(), 2, "should tail both initial log files");
@@ -571,7 +571,7 @@ fn test_glob_rescan_discovers_new_file() {
         glob_rescan_interval_ms: 50,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // No files exist yet — tailer starts with nothing.
     assert_eq!(tailer.num_files(), 0, "no files should be tailed initially");
@@ -643,7 +643,7 @@ fn test_glob_rescan_no_duplicates() {
         glob_rescan_interval_ms: 50,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // File discovered at construction.
     assert_eq!(tailer.num_files(), 1);
@@ -742,7 +742,7 @@ fn test_eviction_lru() {
         max_open_files: 5,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // All 10 files discovered at construction — eviction happens during poll.
     assert_eq!(tailer.num_files(), 10, "all files opened before first poll");
@@ -783,7 +783,7 @@ fn test_evicted_file_reopen() {
         max_open_files: 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // After first poll, eviction brings count to 2.
     let _ = poll_until(
@@ -853,7 +853,7 @@ fn test_tail_growing_fingerprint() {
         ..Default::default()
     };
 
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Initial poll reads the 100 'a's.
     std::thread::sleep(Duration::from_millis(50));
@@ -908,7 +908,7 @@ fn test_deleted_file_cleanup() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Confirm file is being tailed.
     std::thread::sleep(Duration::from_millis(50));
@@ -952,7 +952,7 @@ fn test_deleted_file_cleanup_drains_truncated_file() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // First poll — drain initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -1012,7 +1012,7 @@ fn test_poll_truncated_then_data_uses_new_source_id() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // First poll — consume the initial data so offset > 0.
     std::thread::sleep(Duration::from_millis(50));
@@ -1105,7 +1105,7 @@ fn test_glob_deleted_file_removed_from_watch_paths() {
         glob_rescan_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Read initial data so the tailer advances past the initial content.
     let _ = poll_until(
@@ -1154,7 +1154,7 @@ fn test_file_offsets_returns_fingerprint_and_offset() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     std::thread::sleep(Duration::from_millis(50));
     let _ = tailer.poll().unwrap();
@@ -1180,7 +1180,7 @@ fn test_file_offsets_skips_empty_files() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     std::thread::sleep(Duration::from_millis(50));
     let _ = tailer.poll().unwrap();
 
@@ -1210,7 +1210,7 @@ fn test_file_offsets_multiple_files() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(&[path_a, path_b], config).unwrap();
+    let mut tailer = FileTailer::new(&[path_a, path_b], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     std::thread::sleep(Duration::from_millis(50));
     let _ = tailer.poll().unwrap();
 
@@ -1237,7 +1237,7 @@ fn test_file_paths_matches_offsets() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     std::thread::sleep(Duration::from_millis(50));
     let _ = tailer.poll().unwrap();
 
@@ -1273,7 +1273,7 @@ fn test_truncation_emits_truncated_event() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Read all initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -1339,7 +1339,7 @@ fn test_read_cap_clamps_exactly_at_max_read_per_poll() {
         per_file_read_budget_bytes: FileTailer::MAX_READ_PER_POLL * 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // First poll should read exactly MAX_READ_PER_POLL bytes because the
     // configured budget exceeds the hard cap and the file is larger still.
@@ -1394,7 +1394,7 @@ fn test_set_offset_validates_against_file_size() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Try to set offset beyond file size (stale checkpoint).
     tailer.set_offset(&log_path, 999_999).unwrap();
@@ -1419,7 +1419,7 @@ fn test_set_offset_by_source_validates_against_file_size() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     std::thread::sleep(Duration::from_millis(50));
     tailer.poll().unwrap();
 
@@ -1460,7 +1460,7 @@ fn test_set_offset_by_source_updates_evicted_entries() {
         max_open_files: 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Read initial data and trigger one eviction.
     std::thread::sleep(Duration::from_millis(50));
@@ -1515,7 +1515,7 @@ fn test_evicted_offsets_in_checkpoint_data() {
         max_open_files: 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Read initial data, then trigger eviction.
     std::thread::sleep(Duration::from_millis(50));
@@ -1571,7 +1571,7 @@ fn test_evicted_offset_fingerprint_mismatch() {
         max_open_files: 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Read and trigger eviction.
     std::thread::sleep(Duration::from_millis(50));
@@ -1636,7 +1636,7 @@ fn glob_rescan_respects_start_from_end() {
         glob_rescan_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // First poll: initial file is opened with start_from_end=true, so no old data.
     std::thread::sleep(Duration::from_millis(50));
@@ -1732,7 +1732,7 @@ fn test_evicted_offset_clamped_when_file_shrinks() {
         fingerprint_bytes: 4,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config).unwrap();
+    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Initial poll reads both and then evicts one due to max_open_files=1.
     let _ = poll_until(
@@ -1806,7 +1806,7 @@ fn test_nonexistent_path_does_not_panic() {
     };
 
     // Should succeed — missing files are warned but not fatal.
-    let tailer = FileTailer::new(std::slice::from_ref(&missing), config);
+    let tailer = FileTailer::new(std::slice::from_ref(&missing), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()));
     assert!(tailer.is_ok(), "missing path should not fail construction");
     assert_eq!(tailer.unwrap().num_files(), 0);
 }
@@ -1823,7 +1823,7 @@ fn test_error_backoff_grows_exponentially() {
         poll_interval_ms: 0,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     // Inject watcher errors directly through the discovery receiver.
     let (tx, rx) = crossbeam_channel::unbounded();
@@ -1873,7 +1873,7 @@ fn test_error_backoff_marks_tailer_degraded_until_clean_poll() {
         poll_interval_ms: 0,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     assert_eq!(tailer.health(), ComponentHealth::Healthy);
 
     let (tx, rx) = crossbeam_channel::unbounded();
@@ -1936,7 +1936,7 @@ fn test_per_file_budget_prevents_starvation() {
         per_file_read_budget_bytes: 64 * 1024,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(&[hot_path.clone(), cold_path.clone()], config).unwrap();
+    let mut tailer = FileTailer::new(&[hot_path.clone(), cold_path.clone()], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
 
     let events = tailer.poll().unwrap();
     let hot_bytes: usize = events
@@ -1982,7 +1982,7 @@ fn test_copytruncate_resets_offset_on_size_drop() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config).unwrap();
+    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     std::thread::sleep(Duration::from_millis(30));
     let _ = tailer.poll().unwrap();
     let prior_offset = tailer.get_offset(&log_path).unwrap();

--- a/crates/logfwd-io/src/tail/tests.rs
+++ b/crates/logfwd-io/src/tail/tests.rs
@@ -28,6 +28,24 @@ where
     }
 }
 
+fn make_file_tailer(paths: &[PathBuf], config: TailConfig) -> FileTailer {
+    FileTailer::new(
+        paths,
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap()
+}
+
+fn make_file_tailer_with_globs(patterns: &[&str], config: TailConfig) -> FileTailer {
+    FileTailer::new_with_globs(
+        patterns,
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap()
+}
+
 // ---- glob_root / glob_max_depth unit tests ----
 
 #[test]
@@ -122,12 +140,7 @@ fn test_tail_new_data() {
         ..Default::default()
     };
 
-    let mut tailer = FileTailer::new(
-        std::slice::from_ref(&log_path),
-        config,
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut tailer = make_file_tailer(std::slice::from_ref(&log_path), config);
 
     // First poll should read existing content.
     let events = poll_until(
@@ -206,12 +219,7 @@ fn test_tail_truncation() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(
-        std::slice::from_ref(&log_path),
-        config,
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut tailer = make_file_tailer(std::slice::from_ref(&log_path), config);
 
     // Read initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -264,12 +272,7 @@ fn test_tail_rotation() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(
-        std::slice::from_ref(&log_path),
-        config,
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut tailer = make_file_tailer(std::slice::from_ref(&log_path), config);
 
     // Read initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -566,12 +569,7 @@ fn test_glob_initial_discovery() {
         glob_rescan_interval_ms: 60_000, // long interval — not relevant for this test
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(
-        &[&pattern],
-        config,
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut tailer = make_file_tailer_with_globs(&[&pattern], config);
 
     // Both files should have been discovered immediately.
     assert_eq!(tailer.num_files(), 2, "should tail both initial log files");
@@ -606,12 +604,7 @@ fn test_glob_rescan_discovers_new_file() {
         glob_rescan_interval_ms: 50,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(
-        &[&pattern],
-        config,
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut tailer = make_file_tailer_with_globs(&[&pattern], config);
 
     // No files exist yet — tailer starts with nothing.
     assert_eq!(tailer.num_files(), 0, "no files should be tailed initially");

--- a/crates/logfwd-io/src/tail/tests.rs
+++ b/crates/logfwd-io/src/tail/tests.rs
@@ -122,7 +122,12 @@ fn test_tail_new_data() {
         ..Default::default()
     };
 
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // First poll should read existing content.
     let events = poll_until(
@@ -201,7 +206,12 @@ fn test_tail_truncation() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Read initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -254,7 +264,12 @@ fn test_tail_rotation() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Read initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -311,7 +326,12 @@ fn test_tail_rotation_drains_truncated_file() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // First poll — drain initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -366,7 +386,12 @@ fn test_tail_rotation_drains_old_data() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // First poll — drain initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -448,7 +473,12 @@ fn test_tail_start_from_end() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // First poll should get no data (started from end).
     std::thread::sleep(Duration::from_millis(50));
@@ -536,7 +566,12 @@ fn test_glob_initial_discovery() {
         glob_rescan_interval_ms: 60_000, // long interval — not relevant for this test
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Both files should have been discovered immediately.
     assert_eq!(tailer.num_files(), 2, "should tail both initial log files");
@@ -571,7 +606,12 @@ fn test_glob_rescan_discovers_new_file() {
         glob_rescan_interval_ms: 50,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // No files exist yet — tailer starts with nothing.
     assert_eq!(tailer.num_files(), 0, "no files should be tailed initially");
@@ -643,7 +683,12 @@ fn test_glob_rescan_no_duplicates() {
         glob_rescan_interval_ms: 50,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // File discovered at construction.
     assert_eq!(tailer.num_files(), 1);
@@ -742,7 +787,12 @@ fn test_eviction_lru() {
         max_open_files: 5,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // All 10 files discovered at construction — eviction happens during poll.
     assert_eq!(tailer.num_files(), 10, "all files opened before first poll");
@@ -783,7 +833,12 @@ fn test_evicted_file_reopen() {
         max_open_files: 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // After first poll, eviction brings count to 2.
     let _ = poll_until(
@@ -853,7 +908,12 @@ fn test_tail_growing_fingerprint() {
         ..Default::default()
     };
 
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Initial poll reads the 100 'a's.
     std::thread::sleep(Duration::from_millis(50));
@@ -908,7 +968,12 @@ fn test_deleted_file_cleanup() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Confirm file is being tailed.
     std::thread::sleep(Duration::from_millis(50));
@@ -952,7 +1017,12 @@ fn test_deleted_file_cleanup_drains_truncated_file() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // First poll — drain initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -1012,7 +1082,12 @@ fn test_poll_truncated_then_data_uses_new_source_id() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // First poll — consume the initial data so offset > 0.
     std::thread::sleep(Duration::from_millis(50));
@@ -1105,7 +1180,12 @@ fn test_glob_deleted_file_removed_from_watch_paths() {
         glob_rescan_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Read initial data so the tailer advances past the initial content.
     let _ = poll_until(
@@ -1154,7 +1234,12 @@ fn test_file_offsets_returns_fingerprint_and_offset() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     std::thread::sleep(Duration::from_millis(50));
     let _ = tailer.poll().unwrap();
@@ -1180,7 +1265,12 @@ fn test_file_offsets_skips_empty_files() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     std::thread::sleep(Duration::from_millis(50));
     let _ = tailer.poll().unwrap();
 
@@ -1210,7 +1300,12 @@ fn test_file_offsets_multiple_files() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(&[path_a, path_b], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        &[path_a, path_b],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     std::thread::sleep(Duration::from_millis(50));
     let _ = tailer.poll().unwrap();
 
@@ -1237,7 +1332,12 @@ fn test_file_paths_matches_offsets() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     std::thread::sleep(Duration::from_millis(50));
     let _ = tailer.poll().unwrap();
 
@@ -1273,7 +1373,12 @@ fn test_truncation_emits_truncated_event() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Read all initial data.
     std::thread::sleep(Duration::from_millis(50));
@@ -1339,7 +1444,12 @@ fn test_read_cap_clamps_exactly_at_max_read_per_poll() {
         per_file_read_budget_bytes: FileTailer::MAX_READ_PER_POLL * 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // First poll should read exactly MAX_READ_PER_POLL bytes because the
     // configured budget exceeds the hard cap and the file is larger still.
@@ -1394,7 +1504,12 @@ fn test_set_offset_validates_against_file_size() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Try to set offset beyond file size (stale checkpoint).
     tailer.set_offset(&log_path, 999_999).unwrap();
@@ -1419,7 +1534,12 @@ fn test_set_offset_by_source_validates_against_file_size() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     std::thread::sleep(Duration::from_millis(50));
     tailer.poll().unwrap();
 
@@ -1460,7 +1580,12 @@ fn test_set_offset_by_source_updates_evicted_entries() {
         max_open_files: 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Read initial data and trigger one eviction.
     std::thread::sleep(Duration::from_millis(50));
@@ -1515,7 +1640,12 @@ fn test_evicted_offsets_in_checkpoint_data() {
         max_open_files: 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Read initial data, then trigger eviction.
     std::thread::sleep(Duration::from_millis(50));
@@ -1571,7 +1701,12 @@ fn test_evicted_offset_fingerprint_mismatch() {
         max_open_files: 2,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Read and trigger eviction.
     std::thread::sleep(Duration::from_millis(50));
@@ -1636,7 +1771,12 @@ fn glob_rescan_respects_start_from_end() {
         glob_rescan_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // First poll: initial file is opened with start_from_end=true, so no old data.
     std::thread::sleep(Duration::from_millis(50));
@@ -1732,7 +1872,12 @@ fn test_evicted_offset_clamped_when_file_shrinks() {
         fingerprint_bytes: 4,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new_with_globs(&[&pattern], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new_with_globs(
+        &[&pattern],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Initial poll reads both and then evicts one due to max_open_files=1.
     let _ = poll_until(
@@ -1806,7 +1951,11 @@ fn test_nonexistent_path_does_not_panic() {
     };
 
     // Should succeed — missing files are warned but not fatal.
-    let tailer = FileTailer::new(std::slice::from_ref(&missing), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()));
+    let tailer = FileTailer::new(
+        std::slice::from_ref(&missing),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    );
     assert!(tailer.is_ok(), "missing path should not fail construction");
     assert_eq!(tailer.unwrap().num_files(), 0);
 }
@@ -1823,7 +1972,12 @@ fn test_error_backoff_grows_exponentially() {
         poll_interval_ms: 0,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     // Inject watcher errors directly through the discovery receiver.
     let (tx, rx) = crossbeam_channel::unbounded();
@@ -1873,7 +2027,12 @@ fn test_error_backoff_marks_tailer_degraded_until_clean_poll() {
         poll_interval_ms: 0,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     assert_eq!(tailer.health(), ComponentHealth::Healthy);
 
     let (tx, rx) = crossbeam_channel::unbounded();
@@ -1936,7 +2095,12 @@ fn test_per_file_budget_prevents_starvation() {
         per_file_read_budget_bytes: 64 * 1024,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(&[hot_path.clone(), cold_path.clone()], config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        &[hot_path.clone(), cold_path.clone()],
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
 
     let events = tailer.poll().unwrap();
     let hot_bytes: usize = events
@@ -1982,7 +2146,12 @@ fn test_copytruncate_resets_offset_on_size_drop() {
         poll_interval_ms: 10,
         ..Default::default()
     };
-    let mut tailer = FileTailer::new(std::slice::from_ref(&log_path), config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        config,
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     std::thread::sleep(Duration::from_millis(30));
     let _ = tailer.poll().unwrap();
     let prior_offset = tailer.get_offset(&log_path).unwrap();

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -248,6 +248,11 @@ impl InputSource for TcpInput {
                 // the kernel accept queue does not fill up and stall.
                 match self.listener.accept() {
                     Ok((_stream, _addr)) => {
+                        self.connections_accepted += 1;
+                        self.stats.tcp_accepted.store(
+                            self.connections_accepted,
+                            std::sync::atomic::Ordering::Relaxed,
+                        );
                         under_pressure = true;
                         continue; // dropped immediately
                     }

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -183,12 +183,13 @@ pub struct TcpInput {
     next_connection_seq: u64,
     /// Coarse control-plane health derived from the most recent poll cycle.
     health: ComponentHealth,
+    stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>,
 }
 
 impl TcpInput {
     /// Bind to `addr` (e.g. "0.0.0.0:5140") with the default idle timeout.
-    pub fn new(name: impl Into<String>, addr: &str) -> io::Result<Self> {
-        Self::with_idle_timeout(name, addr, DEFAULT_IDLE_TIMEOUT)
+    pub fn new(name: impl Into<String>, addr: &str, stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>) -> io::Result<Self> {
+        Self::with_idle_timeout(name, addr, DEFAULT_IDLE_TIMEOUT, stats)
     }
 
     /// Bind to `addr` with a custom idle timeout.
@@ -196,6 +197,7 @@ impl TcpInput {
         name: impl Into<String>,
         addr: &str,
         idle_timeout: Duration,
+        stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>,
     ) -> io::Result<Self> {
         let listener = TcpListener::bind(addr)?;
         listener.set_nonblocking(true)?;
@@ -208,6 +210,7 @@ impl TcpInput {
             connections_accepted: 0,
             next_connection_seq: 0,
             health: ComponentHealth::Healthy,
+            stats,
         })
     }
 
@@ -264,6 +267,7 @@ impl InputSource for TcpInput {
                     let sid = source_id_for_connection(self.next_connection_seq);
                     self.next_connection_seq += 1;
                     self.connections_accepted += 1;
+                    self.stats.tcp_accepted.store(self.connections_accepted, std::sync::atomic::Ordering::Relaxed);
                     self.clients.push(Client {
                         stream,
                         source_id: sid,
@@ -442,6 +446,8 @@ impl InputSource for TcpInput {
             },
         );
 
+        self.stats.tcp_active.store(self.clients.len(), std::sync::atomic::Ordering::Relaxed);
+
         Ok(events)
     }
 
@@ -462,7 +468,7 @@ mod tests {
 
     #[test]
     fn receives_tcp_data() {
-        let input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.listener.local_addr().unwrap();
 
         let mut client = StdTcpStream::connect(addr).unwrap();
@@ -490,7 +496,7 @@ mod tests {
 
     #[test]
     fn handles_disconnect() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.listener.local_addr().unwrap();
 
         {
@@ -524,7 +530,7 @@ mod tests {
 
     #[test]
     fn tcp_health_recovers_after_clean_poll() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         input.health = ComponentHealth::Degraded;
 
         let events = input.poll().unwrap();
@@ -537,7 +543,7 @@ mod tests {
     /// the partial remainder — fixes #804 / #580.
     #[test]
     fn tcp_partial_line_on_disconnect_emits_eof() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         {
@@ -587,7 +593,7 @@ mod tests {
     fn tcp_idle_timeout() {
         // Use a very short idle timeout so the test runs fast.
         let mut input =
-            TcpInput::with_idle_timeout("test", "127.0.0.1:0", Duration::from_millis(200)).unwrap();
+            TcpInput::with_idle_timeout("test", "127.0.0.1:0", Duration::from_millis(200), std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         // Connect but send nothing.
@@ -612,7 +618,7 @@ mod tests {
 
     #[test]
     fn tcp_max_line_length() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         // Spawn the writer in a background thread because write_all of >1MB
@@ -670,7 +676,7 @@ mod tests {
     fn tcp_max_line_length_exact_boundary() {
         // A line of exactly MAX_LINE_LENGTH bytes (content only, excluding \n)
         // is accepted; only records strictly larger are dropped.
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         let writer = std::thread::spawn(move || {
@@ -706,7 +712,7 @@ mod tests {
 
     #[test]
     fn tcp_octet_counted_frame_with_embedded_newline_is_single_record() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
         let mut client = StdTcpStream::connect(addr).unwrap();
         client.write_all(b"11 hello\nworld").unwrap();
@@ -727,7 +733,7 @@ mod tests {
 
     #[test]
     fn tcp_legacy_line_starting_with_digits_space_is_not_stalled_as_octet() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
         let mut client = StdTcpStream::connect(addr).unwrap();
         client.write_all(b"200 OK\n").unwrap();
@@ -752,7 +758,7 @@ mod tests {
 
     #[test]
     fn tcp_connection_storm() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         // Rapidly connect and disconnect 100 times.
@@ -782,7 +788,7 @@ mod tests {
     /// closes.  Previously those bytes were silently dropped (data loss bug).
     #[test]
     fn pending_bytes_flushed_as_data_event_on_close() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         {
@@ -833,7 +839,7 @@ mod tests {
     /// so that `FramedInput` can track per-connection remainders independently.
     #[test]
     fn distinct_source_ids_per_connection() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         let mut client_a = StdTcpStream::connect(addr).unwrap();

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -188,7 +188,11 @@ pub struct TcpInput {
 
 impl TcpInput {
     /// Bind to `addr` (e.g. "0.0.0.0:5140") with the default idle timeout.
-    pub fn new(name: impl Into<String>, addr: &str, stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>) -> io::Result<Self> {
+    pub fn new(
+        name: impl Into<String>,
+        addr: &str,
+        stats: std::sync::Arc<logfwd_types::diagnostics::ComponentStats>,
+    ) -> io::Result<Self> {
         Self::with_idle_timeout(name, addr, DEFAULT_IDLE_TIMEOUT, stats)
     }
 
@@ -267,7 +271,10 @@ impl InputSource for TcpInput {
                     let sid = source_id_for_connection(self.next_connection_seq);
                     self.next_connection_seq += 1;
                     self.connections_accepted += 1;
-                    self.stats.tcp_accepted.store(self.connections_accepted, std::sync::atomic::Ordering::Relaxed);
+                    self.stats.tcp_accepted.store(
+                        self.connections_accepted,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
                     self.clients.push(Client {
                         stream,
                         source_id: sid,
@@ -446,7 +453,9 @@ impl InputSource for TcpInput {
             },
         );
 
-        self.stats.tcp_active.store(self.clients.len(), std::sync::atomic::Ordering::Relaxed);
+        self.stats
+            .tcp_active
+            .store(self.clients.len(), std::sync::atomic::Ordering::Relaxed);
 
         Ok(events)
     }
@@ -468,7 +477,12 @@ mod tests {
 
     #[test]
     fn receives_tcp_data() {
-        let input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.listener.local_addr().unwrap();
 
         let mut client = StdTcpStream::connect(addr).unwrap();
@@ -496,7 +510,12 @@ mod tests {
 
     #[test]
     fn handles_disconnect() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.listener.local_addr().unwrap();
 
         {
@@ -530,7 +549,12 @@ mod tests {
 
     #[test]
     fn tcp_health_recovers_after_clean_poll() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         input.health = ComponentHealth::Degraded;
 
         let events = input.poll().unwrap();
@@ -543,7 +567,12 @@ mod tests {
     /// the partial remainder — fixes #804 / #580.
     #[test]
     fn tcp_partial_line_on_disconnect_emits_eof() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         {
@@ -592,8 +621,13 @@ mod tests {
     #[test]
     fn tcp_idle_timeout() {
         // Use a very short idle timeout so the test runs fast.
-        let mut input =
-            TcpInput::with_idle_timeout("test", "127.0.0.1:0", Duration::from_millis(200), std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::with_idle_timeout(
+            "test",
+            "127.0.0.1:0",
+            Duration::from_millis(200),
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         // Connect but send nothing.
@@ -618,7 +652,12 @@ mod tests {
 
     #[test]
     fn tcp_max_line_length() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         // Spawn the writer in a background thread because write_all of >1MB
@@ -676,7 +715,12 @@ mod tests {
     fn tcp_max_line_length_exact_boundary() {
         // A line of exactly MAX_LINE_LENGTH bytes (content only, excluding \n)
         // is accepted; only records strictly larger are dropped.
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         let writer = std::thread::spawn(move || {
@@ -712,7 +756,12 @@ mod tests {
 
     #[test]
     fn tcp_octet_counted_frame_with_embedded_newline_is_single_record() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
         let mut client = StdTcpStream::connect(addr).unwrap();
         client.write_all(b"11 hello\nworld").unwrap();
@@ -733,7 +782,12 @@ mod tests {
 
     #[test]
     fn tcp_legacy_line_starting_with_digits_space_is_not_stalled_as_octet() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
         let mut client = StdTcpStream::connect(addr).unwrap();
         client.write_all(b"200 OK\n").unwrap();
@@ -758,7 +812,12 @@ mod tests {
 
     #[test]
     fn tcp_connection_storm() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         // Rapidly connect and disconnect 100 times.
@@ -788,7 +847,12 @@ mod tests {
     /// closes.  Previously those bytes were silently dropped (data loss bug).
     #[test]
     fn pending_bytes_flushed_as_data_event_on_close() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         {
@@ -839,7 +903,12 @@ mod tests {
     /// so that `FramedInput` can track per-connection remainders independently.
     #[test]
     fn distinct_source_ids_per_connection() {
-        let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         let mut client_a = StdTcpStream::connect(addr).unwrap();

--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -31,11 +31,12 @@ pub struct UdpInput {
     drops_detected: Arc<AtomicU64>,
     /// Coarse control-plane health derived from the most recent poll cycle.
     health: ComponentHealth,
+    stats: Arc<logfwd_types::diagnostics::ComponentStats>,
 }
 
 impl UdpInput {
     /// Bind to `addr` (e.g. "0.0.0.0:514" for syslog).
-    pub fn new(name: impl Into<String>, addr: &str) -> io::Result<Self> {
+    pub fn new(name: impl Into<String>, addr: &str, stats: Arc<logfwd_types::diagnostics::ComponentStats>) -> io::Result<Self> {
         let parsed_addr: std::net::SocketAddr = addr.parse().map_err(io::Error::other)?;
         let domain = if parsed_addr.is_ipv4() {
             Domain::IPV4
@@ -60,6 +61,8 @@ impl UdpInput {
 
         let socket: UdpSocket = sock2.into();
 
+        stats.udp_recv_buf.store(actual_recv_buf, Ordering::Relaxed);
+
         Ok(Self {
             name: name.into(),
             socket,
@@ -67,6 +70,7 @@ impl UdpInput {
             actual_recv_buf,
             drops_detected: Arc::new(AtomicU64::new(0)),
             health: ComponentHealth::Healthy,
+            stats,
         })
     }
 
@@ -143,6 +147,8 @@ impl InputSource for UdpInput {
             }
         }
 
+        self.stats.udp_drops.store(self.drops_detected.load(Ordering::Relaxed), Ordering::Relaxed);
+
         self.health = reduce_polling_input_health(
             self.health,
             if under_pressure {
@@ -181,7 +187,7 @@ mod tests {
 
     #[test]
     fn receives_datagrams() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -202,7 +208,7 @@ mod tests {
 
     #[test]
     fn adds_trailing_newline_to_bare_datagram() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -220,7 +226,7 @@ mod tests {
 
     #[test]
     fn accounted_bytes_excludes_synthetic_trailing_newline() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -246,7 +252,7 @@ mod tests {
 
     #[test]
     fn handles_multi_line_datagram() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -264,21 +270,21 @@ mod tests {
 
     #[test]
     fn empty_when_no_data() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let events = input.poll().unwrap();
         assert!(events.is_empty());
     }
 
     #[test]
     fn buffer_is_max_udp_payload_size() {
-        let input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         assert_eq!(input.buf.len(), 65507);
     }
 
     #[test]
     fn udp_recv_buffer_size() {
         // Verify SO_RCVBUF was actually applied by reading it back.
-        let input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let actual = input.recv_buffer_size();
         // The OS may double the requested value (Linux does this) or cap it,
         // but it should be at least something reasonable (> 64 KB).
@@ -292,7 +298,7 @@ mod tests {
     fn udp_high_volume() {
         // Send 1000 datagrams in batches with pauses to avoid overwhelming
         // the kernel receive buffer on resource-constrained CI.
-        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -340,7 +346,7 @@ mod tests {
     #[test]
     fn udp_empty_datagram() {
         // Sending a 0-byte datagram must not panic.
-        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -368,7 +374,7 @@ mod tests {
 
     #[test]
     fn udp_socket_is_nonblocking() {
-        let input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         // Verify by attempting a recv on an empty socket — it should return
         // WouldBlock immediately, not block.
         let result = input.socket.recv(&mut [0u8; 1]);
@@ -385,13 +391,13 @@ mod tests {
 
     #[test]
     fn drops_detected_starts_at_zero() {
-        let input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         assert_eq!(input.drops_detected(), 0);
     }
 
     #[test]
     fn udp_health_recovers_after_clean_poll() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
         input.health = ComponentHealth::Degraded;
 
         let events = input.poll().unwrap();

--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -197,7 +197,7 @@ mod tests {
         let mut input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         let addr = input.local_addr().unwrap();
@@ -223,7 +223,7 @@ mod tests {
         let mut input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         let addr = input.local_addr().unwrap();
@@ -246,7 +246,7 @@ mod tests {
         let mut input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         let addr = input.local_addr().unwrap();
@@ -277,7 +277,7 @@ mod tests {
         let mut input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         let addr = input.local_addr().unwrap();
@@ -300,7 +300,7 @@ mod tests {
         let mut input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         let events = input.poll().unwrap();
@@ -312,7 +312,7 @@ mod tests {
         let input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         assert_eq!(input.buf.len(), 65507);
@@ -324,7 +324,7 @@ mod tests {
         let input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         let actual = input.recv_buffer_size();
@@ -343,7 +343,7 @@ mod tests {
         let mut input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         let addr = input.local_addr().unwrap();
@@ -396,7 +396,7 @@ mod tests {
         let mut input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         let addr = input.local_addr().unwrap();
@@ -429,7 +429,7 @@ mod tests {
         let input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         // Verify by attempting a recv on an empty socket — it should return
@@ -451,7 +451,7 @@ mod tests {
         let input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         assert_eq!(input.drops_detected(), 0);
@@ -462,7 +462,7 @@ mod tests {
         let mut input = UdpInput::new(
             "test",
             "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
         .unwrap();
         input.health = ComponentHealth::Degraded;

--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -36,7 +36,11 @@ pub struct UdpInput {
 
 impl UdpInput {
     /// Bind to `addr` (e.g. "0.0.0.0:514" for syslog).
-    pub fn new(name: impl Into<String>, addr: &str, stats: Arc<logfwd_types::diagnostics::ComponentStats>) -> io::Result<Self> {
+    pub fn new(
+        name: impl Into<String>,
+        addr: &str,
+        stats: Arc<logfwd_types::diagnostics::ComponentStats>,
+    ) -> io::Result<Self> {
         let parsed_addr: std::net::SocketAddr = addr.parse().map_err(io::Error::other)?;
         let domain = if parsed_addr.is_ipv4() {
             Domain::IPV4
@@ -147,7 +151,10 @@ impl InputSource for UdpInput {
             }
         }
 
-        self.stats.udp_drops.store(self.drops_detected.load(Ordering::Relaxed), Ordering::Relaxed);
+        self.stats.udp_drops.store(
+            self.drops_detected.load(Ordering::Relaxed),
+            Ordering::Relaxed,
+        );
 
         self.health = reduce_polling_input_health(
             self.health,
@@ -187,7 +194,12 @@ mod tests {
 
     #[test]
     fn receives_datagrams() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -208,7 +220,12 @@ mod tests {
 
     #[test]
     fn adds_trailing_newline_to_bare_datagram() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -226,7 +243,12 @@ mod tests {
 
     #[test]
     fn accounted_bytes_excludes_synthetic_trailing_newline() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -252,7 +274,12 @@ mod tests {
 
     #[test]
     fn handles_multi_line_datagram() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -270,21 +297,36 @@ mod tests {
 
     #[test]
     fn empty_when_no_data() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let events = input.poll().unwrap();
         assert!(events.is_empty());
     }
 
     #[test]
     fn buffer_is_max_udp_payload_size() {
-        let input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         assert_eq!(input.buf.len(), 65507);
     }
 
     #[test]
     fn udp_recv_buffer_size() {
         // Verify SO_RCVBUF was actually applied by reading it back.
-        let input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let actual = input.recv_buffer_size();
         // The OS may double the requested value (Linux does this) or cap it,
         // but it should be at least something reasonable (> 64 KB).
@@ -298,7 +340,12 @@ mod tests {
     fn udp_high_volume() {
         // Send 1000 datagrams in batches with pauses to avoid overwhelming
         // the kernel receive buffer on resource-constrained CI.
-        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -346,7 +393,12 @@ mod tests {
     #[test]
     fn udp_empty_datagram() {
         // Sending a 0-byte datagram must not panic.
-        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         let addr = input.local_addr().unwrap();
 
         let sender = StdSocket::bind("127.0.0.1:0").unwrap();
@@ -374,7 +426,12 @@ mod tests {
 
     #[test]
     fn udp_socket_is_nonblocking() {
-        let input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         // Verify by attempting a recv on an empty socket — it should return
         // WouldBlock immediately, not block.
         let result = input.socket.recv(&mut [0u8; 1]);
@@ -391,13 +448,23 @@ mod tests {
 
     #[test]
     fn drops_detected_starts_at_zero() {
-        let input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         assert_eq!(input.drops_detected(), 0);
     }
 
     #[test]
     fn udp_health_recovers_after_clean_poll() {
-        let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
         input.health = ComponentHealth::Degraded;
 
         let events = input.poll().unwrap();

--- a/crates/logfwd-io/tests/it/checkpoint_state_machine.rs
+++ b/crates/logfwd-io/tests/it/checkpoint_state_machine.rs
@@ -234,7 +234,7 @@ impl Sut {
             ..Default::default()
         };
         let paths = vec![self.log_path.clone()];
-        let mut tailer = FileTailer::new(&paths, config).expect("create tailer after crash");
+        let mut tailer = FileTailer::new(&paths, config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).expect("create tailer after crash");
 
         if saved_offset > 0 {
             let _ = tailer.set_offset(&self.log_path, saved_offset);
@@ -271,7 +271,7 @@ impl StateMachineTest for TailCheckpointTest {
         };
 
         let paths = vec![log_path.clone()];
-        let tailer = FileTailer::new(&paths, config).expect("create tailer");
+        let tailer = FileTailer::new(&paths, config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).expect("create tailer");
 
         let checkpoint_store = FileCheckpointStore::open(dir.path().join("checkpoints"))
             .expect("open checkpoint store");

--- a/crates/logfwd-io/tests/it/checkpoint_state_machine.rs
+++ b/crates/logfwd-io/tests/it/checkpoint_state_machine.rs
@@ -234,7 +234,12 @@ impl Sut {
             ..Default::default()
         };
         let paths = vec![self.log_path.clone()];
-        let mut tailer = FileTailer::new(&paths, config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).expect("create tailer after crash");
+        let mut tailer = FileTailer::new(
+            &paths,
+            config,
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .expect("create tailer after crash");
 
         if saved_offset > 0 {
             let _ = tailer.set_offset(&self.log_path, saved_offset);
@@ -271,7 +276,12 @@ impl StateMachineTest for TailCheckpointTest {
         };
 
         let paths = vec![log_path.clone()];
-        let tailer = FileTailer::new(&paths, config, std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).expect("create tailer");
+        let tailer = FileTailer::new(
+            &paths,
+            config,
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .expect("create tailer");
 
         let checkpoint_store = FileCheckpointStore::open(dir.path().join("checkpoints"))
             .expect("open checkpoint store");

--- a/crates/logfwd-io/tests/it/file_boundary_contract.rs
+++ b/crates/logfwd-io/tests/it/file_boundary_contract.rs
@@ -32,6 +32,7 @@ fn make_framed_file_input(paths: &[PathBuf]) -> FramedInput {
             glob_rescan_interval_ms: 0,
             ..Default::default()
         },
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
     )
     .expect("create file input");
 
@@ -53,6 +54,7 @@ fn make_framed_glob_input(pattern: &str) -> FramedInput {
             glob_rescan_interval_ms: 0,
             ..Default::default()
         },
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
     )
     .expect("create glob file input");
 

--- a/crates/logfwd-io/tests/it/file_boundary_contract.rs
+++ b/crates/logfwd-io/tests/it/file_boundary_contract.rs
@@ -32,7 +32,7 @@ fn make_framed_file_input(paths: &[PathBuf]) -> FramedInput {
             glob_rescan_interval_ms: 0,
             ..Default::default()
         },
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        Arc::clone(&stats),
     )
     .expect("create file input");
 
@@ -54,7 +54,7 @@ fn make_framed_glob_input(pattern: &str) -> FramedInput {
             glob_rescan_interval_ms: 0,
             ..Default::default()
         },
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        Arc::clone(&stats),
     )
     .expect("create glob file input");
 

--- a/crates/logfwd-io/tests/it/transport_e2e.rs
+++ b/crates/logfwd-io/tests/it/transport_e2e.rs
@@ -86,7 +86,7 @@ where
 
 #[test]
 fn tcp_single_line() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -103,7 +103,7 @@ fn tcp_single_line() {
 
 #[test]
 fn tcp_multiple_lines() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -129,7 +129,7 @@ fn tcp_multiple_lines() {
 
 #[test]
 fn tcp_partial_line_across_reads() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -153,7 +153,7 @@ fn tcp_partial_line_across_reads() {
 
 #[test]
 fn tcp_multiple_clients() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let handles: Vec<_> = (0..3)
@@ -191,7 +191,7 @@ fn tcp_multiple_clients() {
 
 #[test]
 fn tcp_client_disconnect_mid_stream() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     {
@@ -224,7 +224,7 @@ fn tcp_client_disconnect_mid_stream() {
 
 #[test]
 fn tcp_partial_line_disconnect_emits_eof() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     {
@@ -262,7 +262,7 @@ fn tcp_partial_line_disconnect_emits_eof() {
 
 #[test]
 fn tcp_large_message() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     // Build a 64 KB JSON line.
@@ -286,7 +286,7 @@ fn tcp_large_message() {
 
 #[test]
 fn tcp_rfc6587_octet_counting_prevents_newline_injection_split() {
-    let tcp = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let tcp = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = tcp.local_addr().unwrap();
     let stats = Arc::new(ComponentStats::new());
     let mut input = FramedInput::new(
@@ -309,7 +309,7 @@ fn tcp_rfc6587_octet_counting_prevents_newline_injection_split() {
 
 #[test]
 fn tcp_rapid_connect_disconnect() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     // Rapidly connect and disconnect 50 times.
@@ -343,7 +343,7 @@ fn tcp_rapid_connect_disconnect() {
 
 #[test]
 fn udp_single_datagram() {
-    let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -359,7 +359,7 @@ fn udp_single_datagram() {
 
 #[test]
 fn udp_multiple_datagrams() {
-    let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -392,7 +392,7 @@ fn udp_multiple_datagrams() {
 
 #[test]
 fn udp_max_size_datagram() {
-    let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     // 65507 is the max UDP payload: 65535 - 20 (IP) - 8 (UDP).
@@ -430,7 +430,7 @@ fn udp_max_size_datagram() {
 
 #[test]
 fn udp_no_trailing_newline() {
-    let mut input = UdpInput::new("test", "127.0.0.1:0").unwrap();
+    let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();

--- a/crates/logfwd-io/tests/it/transport_e2e.rs
+++ b/crates/logfwd-io/tests/it/transport_e2e.rs
@@ -6,6 +6,7 @@
 use std::io::Write;
 use std::net::{TcpStream, UdpSocket};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
@@ -86,12 +87,8 @@ where
 
 #[test]
 fn tcp_single_line() {
-    let mut input = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let stats = Arc::new(ComponentStats::new());
+    let mut input = TcpInput::new("test", "127.0.0.1:0", Arc::clone(&stats)).unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -104,16 +101,13 @@ fn tcp_single_line() {
         text.contains("{\"msg\":\"hello\"}"),
         "expected JSON line, got: {text}"
     );
+    assert_eq!(stats.tcp_accepted.load(Ordering::Relaxed), 1);
+    assert_eq!(stats.tcp_active.load(Ordering::Relaxed), 1);
 }
 
 #[test]
 fn tcp_multiple_lines() {
-    let mut input = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -139,12 +133,7 @@ fn tcp_multiple_lines() {
 
 #[test]
 fn tcp_partial_line_across_reads() {
-    let mut input = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -168,12 +157,7 @@ fn tcp_partial_line_across_reads() {
 
 #[test]
 fn tcp_multiple_clients() {
-    let mut input = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let handles: Vec<_> = (0..3)
@@ -211,12 +195,7 @@ fn tcp_multiple_clients() {
 
 #[test]
 fn tcp_client_disconnect_mid_stream() {
-    let mut input = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     {
@@ -249,12 +228,7 @@ fn tcp_client_disconnect_mid_stream() {
 
 #[test]
 fn tcp_partial_line_disconnect_emits_eof() {
-    let mut input = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     {
@@ -292,12 +266,7 @@ fn tcp_partial_line_disconnect_emits_eof() {
 
 #[test]
 fn tcp_large_message() {
-    let mut input = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     // Build a 64 KB JSON line.
@@ -321,12 +290,7 @@ fn tcp_large_message() {
 
 #[test]
 fn tcp_rfc6587_octet_counting_prevents_newline_injection_split() {
-    let tcp = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let tcp = TcpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = tcp.local_addr().unwrap();
     let stats = Arc::new(ComponentStats::new());
     let mut input = FramedInput::new(
@@ -349,12 +313,7 @@ fn tcp_rfc6587_octet_counting_prevents_newline_injection_split() {
 
 #[test]
 fn tcp_rapid_connect_disconnect() {
-    let mut input = TcpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = TcpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     // Rapidly connect and disconnect 50 times.
@@ -388,12 +347,8 @@ fn tcp_rapid_connect_disconnect() {
 
 #[test]
 fn udp_single_datagram() {
-    let mut input = UdpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let stats = Arc::new(ComponentStats::new());
+    let mut input = UdpInput::new("test", "127.0.0.1:0", Arc::clone(&stats)).unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -405,16 +360,13 @@ fn udp_single_datagram() {
         text.contains("{\"msg\":\"hello\"}"),
         "expected datagram content, got: {text}"
     );
+    assert!(stats.udp_recv_buf.load(Ordering::Relaxed) > 0);
+    assert_eq!(stats.udp_drops.load(Ordering::Relaxed), 0);
 }
 
 #[test]
 fn udp_multiple_datagrams() {
-    let mut input = UdpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = UdpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -447,12 +399,7 @@ fn udp_multiple_datagrams() {
 
 #[test]
 fn udp_max_size_datagram() {
-    let mut input = UdpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = UdpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     // 65507 is the max UDP payload: 65535 - 20 (IP) - 8 (UDP).
@@ -490,12 +437,7 @@ fn udp_max_size_datagram() {
 
 #[test]
 fn udp_no_trailing_newline() {
-    let mut input = UdpInput::new(
-        "test",
-        "127.0.0.1:0",
-        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-    )
-    .unwrap();
+    let mut input = UdpInput::new("test", "127.0.0.1:0", Arc::new(ComponentStats::new())).unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();

--- a/crates/logfwd-io/tests/it/transport_e2e.rs
+++ b/crates/logfwd-io/tests/it/transport_e2e.rs
@@ -86,7 +86,12 @@ where
 
 #[test]
 fn tcp_single_line() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -103,7 +108,12 @@ fn tcp_single_line() {
 
 #[test]
 fn tcp_multiple_lines() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -129,7 +139,12 @@ fn tcp_multiple_lines() {
 
 #[test]
 fn tcp_partial_line_across_reads() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     let mut client = TcpStream::connect(addr).unwrap();
@@ -153,7 +168,12 @@ fn tcp_partial_line_across_reads() {
 
 #[test]
 fn tcp_multiple_clients() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     let handles: Vec<_> = (0..3)
@@ -191,7 +211,12 @@ fn tcp_multiple_clients() {
 
 #[test]
 fn tcp_client_disconnect_mid_stream() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     {
@@ -224,7 +249,12 @@ fn tcp_client_disconnect_mid_stream() {
 
 #[test]
 fn tcp_partial_line_disconnect_emits_eof() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     {
@@ -262,7 +292,12 @@ fn tcp_partial_line_disconnect_emits_eof() {
 
 #[test]
 fn tcp_large_message() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     // Build a 64 KB JSON line.
@@ -286,7 +321,12 @@ fn tcp_large_message() {
 
 #[test]
 fn tcp_rfc6587_octet_counting_prevents_newline_injection_split() {
-    let tcp = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let tcp = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = tcp.local_addr().unwrap();
     let stats = Arc::new(ComponentStats::new());
     let mut input = FramedInput::new(
@@ -309,7 +349,12 @@ fn tcp_rfc6587_octet_counting_prevents_newline_injection_split() {
 
 #[test]
 fn tcp_rapid_connect_disconnect() {
-    let mut input = TcpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = TcpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     // Rapidly connect and disconnect 50 times.
@@ -343,7 +388,12 @@ fn tcp_rapid_connect_disconnect() {
 
 #[test]
 fn udp_single_datagram() {
-    let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = UdpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -359,7 +409,12 @@ fn udp_single_datagram() {
 
 #[test]
 fn udp_multiple_datagrams() {
-    let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = UdpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();
@@ -392,7 +447,12 @@ fn udp_multiple_datagrams() {
 
 #[test]
 fn udp_max_size_datagram() {
-    let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = UdpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     // 65507 is the max UDP payload: 65535 - 20 (IP) - 8 (UDP).
@@ -430,7 +490,12 @@ fn udp_max_size_datagram() {
 
 #[test]
 fn udp_no_trailing_newline() {
-    let mut input = UdpInput::new("test", "127.0.0.1:0", std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new())).unwrap();
+    let mut input = UdpInput::new(
+        "test",
+        "127.0.0.1:0",
+        std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+    )
+    .unwrap();
     let addr = input.local_addr().unwrap();
 
     let sender = UdpSocket::bind("127.0.0.1:0").unwrap();

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -92,9 +92,9 @@ pub(super) fn build_input_state(
             }
             let is_glob = path.contains('*') || path.contains('?') || path.contains('[');
             let source = if is_glob {
-                FileInput::new_with_globs(name.to_string(), &[path.as_str()], tail_config)
+                FileInput::new_with_globs(name.to_string(), &[path.as_str()], tail_config, Arc::clone(&stats))
             } else {
-                FileInput::new(name.to_string(), &[PathBuf::from(path)], tail_config)
+                FileInput::new(name.to_string(), &[PathBuf::from(path)], tail_config, Arc::clone(&stats))
             }
             .map_err(|e| format!("input '{name}': failed to create tailer: {e}"))?;
             validate_input_format(name, InputType::File, &format)?;
@@ -264,7 +264,7 @@ pub(super) fn build_input_state(
                     "input '{name}': CRI/auto format is not supported for UDP inputs (CRI is a file-based container log format)"
                 ));
             }
-            let source = logfwd_io::udp_input::UdpInput::new(name, addr)
+            let source = logfwd_io::udp_input::UdpInput::new(name, addr, Arc::clone(&stats))
                 .map_err(|e| format!("input '{name}': failed to bind UDP {addr}: {e}"))?;
             let format = cfg.format.clone().unwrap_or(Format::Json);
             validate_input_format(name, InputType::Udp, &format)?;
@@ -280,7 +280,7 @@ pub(super) fn build_input_state(
                     "input '{name}': CRI/auto format is not supported for TCP inputs (CRI is a file-based container log format)"
                 ));
             }
-            let source = logfwd_io::tcp_input::TcpInput::new(name, addr)
+            let source = logfwd_io::tcp_input::TcpInput::new(name, addr, Arc::clone(&stats))
                 .map_err(|e| format!("input '{name}': failed to bind TCP {addr}: {e}"))?;
             let format = cfg.format.clone().unwrap_or(Format::Json);
             validate_input_format(name, InputType::Tcp, &format)?;

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -92,9 +92,19 @@ pub(super) fn build_input_state(
             }
             let is_glob = path.contains('*') || path.contains('?') || path.contains('[');
             let source = if is_glob {
-                FileInput::new_with_globs(name.to_string(), &[path.as_str()], tail_config, Arc::clone(&stats))
+                FileInput::new_with_globs(
+                    name.to_string(),
+                    &[path.as_str()],
+                    tail_config,
+                    Arc::clone(&stats),
+                )
             } else {
-                FileInput::new(name.to_string(), &[PathBuf::from(path)], tail_config, Arc::clone(&stats))
+                FileInput::new(
+                    name.to_string(),
+                    &[PathBuf::from(path)],
+                    tail_config,
+                    Arc::clone(&stats),
+                )
             }
             .map_err(|e| format!("input '{name}': failed to create tailer: {e}"))?;
             validate_input_format(name, InputType::File, &format)?;

--- a/crates/logfwd-types/src/diagnostics.rs
+++ b/crates/logfwd-types/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 mod health;
 
-use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Meter};
@@ -24,6 +24,17 @@ pub struct ComponentStats {
     pub parse_errors_total: AtomicU64,
     /// Coarse lifecycle and health snapshot for readiness/diagnostics.
     health: AtomicU8,
+    // Transport specific
+    /// File: consecutive error polls.
+    pub file_error_polls: AtomicU32,
+    /// TCP: total accepted connections.
+    pub tcp_accepted: AtomicU64,
+    /// TCP: currently active connections.
+    pub tcp_active: AtomicUsize,
+    /// UDP: datagram drops detected.
+    pub udp_drops: AtomicU64,
+    /// UDP: actual kernel receive buffer size.
+    pub udp_recv_buf: AtomicUsize,
     // OTel counters (for OTLP push)
     otel_lines: Counter<u64>,
     otel_bytes: Counter<u64>,
@@ -48,6 +59,11 @@ impl ComponentStats {
             rotations_total: AtomicU64::new(0),
             parse_errors_total: AtomicU64::new(0),
             health: AtomicU8::new(initial_health.as_repr()),
+            file_error_polls: AtomicU32::new(0),
+            tcp_accepted: AtomicU64::new(0),
+            tcp_active: AtomicUsize::new(0),
+            udp_drops: AtomicU64::new(0),
+            udp_recv_buf: AtomicUsize::new(0),
             otel_lines: meter.u64_counter(format!("{prefix}_lines")).build(),
             otel_bytes: meter.u64_counter(format!("{prefix}_bytes")).build(),
             otel_errors: meter.u64_counter(format!("{prefix}_errors")).build(),

--- a/crates/logfwd-types/src/diagnostics.rs
+++ b/crates/logfwd-types/src/diagnostics.rs
@@ -2,7 +2,7 @@
 
 mod health;
 
-use std::sync::atomic::{AtomicU32, AtomicU8, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Meter};


### PR DESCRIPTION
Fixes #1716 by exposing a consistent transport observability contract across file/TCP/UDP in diagnostics output (`/admin/v1/status`).

This avoids redesigning the broad generic metrics system and relies cleanly on the existing `ComponentStats` pointer propagated down into inputs. The JSON serialization conditionally includes the new `transport` fields depending on the type of the source. Documentation and tests were comprehensively updated.

---
*PR created automatically by Jules for task [1435763340854648606](https://jules.google.com/task/1435763340854648606) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-transport diagnostics counters to `/admin/v1/status` for file, TCP, and UDP inputs
> - Adds transport-specific atomic fields to `ComponentStats` (`file_error_polls`, `tcp_accepted`, `tcp_active`, `udp_drops`, `udp_recv_buf`) and wires them into `FileTailer`, `TcpInput`, and `UdpInput` constructors and poll loops.
> - The `/admin/v1/status` endpoint now includes a `transport` object per input, exposing consecutive error polls (file), accepted/active connections (TCP), and drop count/receive buffer size (UDP).
> - Updates [monitoring.md](https://github.com/strawgate/memagent/pull/1758/files#diff-85df5aa06e7804ef0ad130a5fb954d7a0670de2a6689a3adf1ffe280b39db216) to document the new `transport` fields.
> - Behavioral Change: `FileInput::new`, `FileInput::new_with_globs`, `TcpInput::new`, `TcpInput::with_idle_timeout`, and `UdpInput::new` all require a new `Arc<ComponentStats>` argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed9218a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->