### PR TITLE
fix(generator): remove high-rate EPS cap in rate-limited mode

### DIFF
--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -122,7 +122,8 @@ pub struct GeneratorInput {
     counter: u64,
     buf: Vec<u8>,
     done: bool,
-    last_batch: std::time::Instant,
+    last_refill: std::time::Instant,
+    rate_credit_events: f64,
     record_fields: RecordFields,
 }
 
@@ -260,6 +261,11 @@ struct GeneratorGeneratedFieldState {
 impl GeneratorInput {
     pub fn new(name: impl Into<String>, config: GeneratorConfig) -> Self {
         let name = name.into();
+        let initial_rate_credit_events = if config.events_per_sec > 0 {
+            config.batch_size as f64
+        } else {
+            0.0
+        };
         let mut attributes: Vec<(&String, &GeneratorAttributeValue)> =
             config.attributes.iter().collect();
         attributes.sort_by(|a, b| a.0.cmp(b.0));
@@ -284,10 +290,10 @@ impl GeneratorInput {
             counter: 0,
             done: false,
             record_fields,
-            // Use a time far in the past so the first poll() always succeeds.
-            last_batch: std::time::Instant::now()
-                .checked_sub(std::time::Duration::from_secs(3600))
-                .unwrap_or_else(std::time::Instant::now),
+            last_refill: std::time::Instant::now(),
+            // Seed one batch worth of credits so the first poll() can emit
+            // immediately in rate-limited mode.
+            rate_credit_events: initial_rate_credit_events,
         }
     }
 
@@ -296,9 +302,8 @@ impl GeneratorInput {
         self.counter
     }
 
-    fn generate_batch(&mut self) {
+    fn generate_batch(&mut self, n: usize) {
         self.buf.clear();
-        let n = self.config.batch_size;
         let batch_created_unix_nano = self
             .record_fields
             .event_created_unix_nano_field
@@ -425,35 +430,67 @@ impl InputSource for GeneratorInput {
             return Ok(vec![]);
         }
 
-        // Rate limiting: if events_per_sec > 0, return empty if called too
-        // soon rather than blocking the thread. The caller drives the poll
-        // loop and can decide how to wait.
-        if self.config.events_per_sec > 0 {
-            let target_interval = std::time::Duration::from_secs_f64(
-                self.config.batch_size as f64 / self.config.events_per_sec as f64,
-            );
-            let elapsed = self.last_batch.elapsed();
-            if elapsed < target_interval {
-                return Ok(vec![]);
-            }
-        }
-
-        self.last_batch = std::time::Instant::now();
-        self.generate_batch();
-
-        if self.buf.is_empty() {
+        if self.config.total_events > 0 && self.counter >= self.config.total_events {
+            self.done = true;
             return Ok(vec![]);
         }
 
-        // Swap buffers to preserve capacity (avoid realloc every batch).
-        let mut out = Vec::with_capacity(self.config.batch_size * 512);
-        std::mem::swap(&mut self.buf, &mut out);
-        let accounted_bytes = out.len() as u64;
-        Ok(vec![InputEvent::Data {
-            bytes: out,
-            source_id: None,
-            accounted_bytes,
-        }])
+        let mut events_to_emit = self.config.batch_size as u64;
+        if self.config.events_per_sec > 0 {
+            let now = std::time::Instant::now();
+            let elapsed_sec = now
+                .checked_duration_since(self.last_refill)
+                .unwrap_or_default()
+                .as_secs_f64();
+            self.last_refill = now;
+            self.rate_credit_events += elapsed_sec * self.config.events_per_sec as f64;
+
+            let available = self.rate_credit_events.floor() as u64;
+            if available == 0 {
+                return Ok(vec![]);
+            }
+            // Bound one poll() flush to at most ~1 second of target rate to
+            // avoid unbounded bursts after scheduler stalls.
+            let burst_cap = self
+                .config
+                .events_per_sec
+                .max(self.config.batch_size as u64);
+            events_to_emit = available.min(burst_cap);
+            self.rate_credit_events -= events_to_emit as f64;
+        }
+
+        if self.config.total_events > 0 {
+            let remaining = self.config.total_events.saturating_sub(self.counter);
+            events_to_emit = events_to_emit.min(remaining);
+        }
+
+        if events_to_emit == 0 {
+            return Ok(vec![]);
+        }
+
+        let mut out_events = Vec::new();
+        let mut remaining = events_to_emit;
+        while remaining > 0 {
+            let chunk = remaining.min(self.config.batch_size as u64) as usize;
+            self.generate_batch(chunk);
+            if self.buf.is_empty() {
+                break;
+            }
+            // Swap buffers to preserve capacity (avoid realloc every batch).
+            let mut out = Vec::with_capacity(chunk * 512);
+            std::mem::swap(&mut self.buf, &mut out);
+            let accounted_bytes = out.len() as u64;
+            out_events.push(InputEvent::Data {
+                bytes: out,
+                source_id: None,
+                accounted_bytes,
+            });
+            remaining = remaining.saturating_sub(chunk as u64);
+            if self.done {
+                break;
+            }
+        }
+        Ok(out_events)
     }
 
     fn name(&self) -> &str {
@@ -643,6 +680,49 @@ mod tests {
         // Immediate second call should return empty (not block).
         let events = input.poll().unwrap();
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn rate_limited_can_emit_multiple_batches_per_poll() {
+        let mut input = GeneratorInput::new(
+            "test",
+            GeneratorConfig {
+                batch_size: 1_000,
+                events_per_sec: 200_000,
+                total_events: 5_000,
+                ..Default::default()
+            },
+        );
+
+        // Initial seeded credits emit one batch immediately.
+        let first = input.poll().unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(input.events_generated(), 1_000);
+
+        // Simulate a 20ms scheduler interval: 4k events should be due.
+        input.last_refill = std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_millis(20))
+            .unwrap_or_else(std::time::Instant::now);
+
+        let second = input.poll().unwrap();
+        let emitted_rows: usize = second
+            .iter()
+            .map(|event| match event {
+                InputEvent::Data { bytes, .. } => {
+                    bytes.iter().filter(|byte| **byte == b'\n').count()
+                }
+                _ => 0,
+            })
+            .sum();
+
+        assert!(
+            second.len() >= 2,
+            "expected multiple batches in one poll at high EPS, got {}",
+            second.len()
+        );
+        assert_eq!(emitted_rows, 4_000);
+        assert_eq!(input.events_generated(), 5_000);
+        assert!(input.poll().unwrap().is_empty());
     }
 
     #[test]

--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -437,6 +437,7 @@ impl InputSource for GeneratorInput {
 
         let mut events_to_emit = self.config.batch_size as u64;
         if self.config.events_per_sec > 0 {
+            let batch_size = self.config.batch_size as u64;
             let now = std::time::Instant::now();
             let elapsed_sec = now
                 .checked_duration_since(self.last_refill)
@@ -445,18 +446,19 @@ impl InputSource for GeneratorInput {
             self.last_refill = now;
             self.rate_credit_events += elapsed_sec * self.config.events_per_sec as f64;
 
+            // Bound carried credits to one poll burst window so scheduler stalls
+            // do not turn into an arbitrarily large catch-up burst.
+            let burst_cap = self.config.events_per_sec.max(batch_size);
+            self.rate_credit_events = self.rate_credit_events.min(burst_cap as f64);
             let available = self.rate_credit_events.floor() as u64;
-            if available == 0 {
+            let full_batches_available = available / batch_size;
+            if full_batches_available == 0 {
                 return Ok(vec![]);
             }
-            // Bound one poll() flush to at most ~1 second of target rate to
-            // avoid unbounded bursts after scheduler stalls.
-            let burst_cap = self
-                .config
-                .events_per_sec
-                .max(self.config.batch_size as u64);
-            events_to_emit = available.min(burst_cap);
-            self.rate_credit_events -= events_to_emit as f64;
+            // Preserve the legacy "full batches only" behavior in rate-limited
+            // mode while still allowing multiple batches per poll at high EPS.
+            let max_full_batches = burst_cap / batch_size;
+            events_to_emit = full_batches_available.min(max_full_batches) * batch_size;
         }
 
         if self.config.total_events > 0 {
@@ -468,7 +470,13 @@ impl InputSource for GeneratorInput {
             return Ok(vec![]);
         }
 
-        let mut out_events = Vec::new();
+        if self.config.events_per_sec > 0 {
+            self.rate_credit_events -= events_to_emit as f64;
+        }
+
+        let expected_batches = events_to_emit.div_ceil(self.config.batch_size as u64) as usize;
+        let mut out_events = Vec::with_capacity(expected_batches);
+        let out_capacity = self.buf.capacity().max(self.config.batch_size * 512);
         let mut remaining = events_to_emit;
         while remaining > 0 {
             let chunk = remaining.min(self.config.batch_size as u64) as usize;
@@ -476,8 +484,10 @@ impl InputSource for GeneratorInput {
             if self.buf.is_empty() {
                 break;
             }
-            // Swap buffers to preserve capacity (avoid realloc every batch).
-            let mut out = Vec::with_capacity(chunk * 512);
+            // Each emitted batch owns its bytes, so this path still needs one
+            // Vec per output event. Keep the generator buffer at full-batch
+            // capacity so a short final chunk does not shrink the hot buffer.
+            let mut out = Vec::with_capacity(out_capacity);
             std::mem::swap(&mut self.buf, &mut out);
             let accounted_bytes = out.len() as u64;
             out_events.push(InputEvent::Data {
@@ -723,6 +733,73 @@ mod tests {
         assert_eq!(emitted_rows, 4_000);
         assert_eq!(input.events_generated(), 5_000);
         assert!(input.poll().unwrap().is_empty());
+    }
+
+    #[test]
+    fn rate_limited_waits_for_a_full_batch_of_credit() {
+        let mut input = GeneratorInput::new(
+            "test",
+            GeneratorConfig {
+                batch_size: 1_000,
+                events_per_sec: 500,
+                total_events: 0,
+                ..Default::default()
+            },
+        );
+
+        let first = input.poll().unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(input.events_generated(), 1_000);
+
+        input.last_refill = std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_millis(500))
+            .unwrap_or_else(std::time::Instant::now);
+        assert!(input.poll().unwrap().is_empty());
+        assert_eq!(input.events_generated(), 1_000);
+
+        input.last_refill = std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_secs(2))
+            .unwrap_or_else(std::time::Instant::now);
+        let second = input.poll().unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(input.events_generated(), 2_000);
+    }
+
+    #[test]
+    fn rate_limited_discards_credit_beyond_burst_cap() {
+        let mut input = GeneratorInput::new(
+            "test",
+            GeneratorConfig {
+                batch_size: 1_000,
+                events_per_sec: 5_000,
+                total_events: 20_000,
+                ..Default::default()
+            },
+        );
+
+        let first = input.poll().unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(input.events_generated(), 1_000);
+
+        input.last_refill = std::time::Instant::now()
+            .checked_sub(std::time::Duration::from_secs(10))
+            .unwrap_or_else(std::time::Instant::now);
+        let second = input.poll().unwrap();
+        let emitted_rows: usize = second
+            .iter()
+            .map(|event| match event {
+                InputEvent::Data { bytes, .. } => {
+                    bytes.iter().filter(|byte| **byte == b'\n').count()
+                }
+                _ => 0,
+            })
+            .sum();
+        assert_eq!(second.len(), 5);
+        assert_eq!(emitted_rows, 5_000);
+        assert_eq!(input.events_generated(), 6_000);
+
+        assert!(input.poll().unwrap().is_empty());
+        assert_eq!(input.events_generated(), 6_000);
     }
 
     #[test]

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -941,17 +941,22 @@ output:
         let mut pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter(), None)
             .unwrap_or_else(|err| panic!("unexpected pipeline build error: {err}"));
         let events = pipeline.inputs[0].source.poll().unwrap();
-        let bytes = match &events[0] {
-            InputEvent::Data { bytes, .. } => bytes,
-            _ => panic!("expected generator data event"),
-        };
+        let mut bytes = Vec::new();
+        for event in &events {
+            match event {
+                InputEvent::Data {
+                    bytes: event_bytes, ..
+                } => bytes.extend_from_slice(event_bytes),
+                _ => panic!("expected generator data event"),
+            }
+        }
         let mut scanner = Scanner::new(ScanConfig {
             wanted_fields: vec![],
             extract_all: true,
             keep_raw: false,
             validate_utf8: false,
         });
-        let batch = scanner.scan_detached(Bytes::from(bytes.clone())).unwrap();
+        let batch = scanner.scan_detached(Bytes::from(bytes)).unwrap();
         let benchmark_id = batch
             .column_by_name("benchmark_id")
             .unwrap()


### PR DESCRIPTION
## Summary
- replace batch-interval gating with credit-based rate limiting in generator input
- allow one `poll()` call to emit multiple batches when accumulated credits exceed `batch_size`
- preserve immediate first-batch behavior by seeding initial credits
- add a regression test proving high-rate mode can emit multiple batches per poll

## Root Cause
Rate-limited mode emitted at most one batch per `poll()`. With a 10ms poll cadence and `batch_size=1000`, that creates an effective ceiling near 100k EPS regardless of configured `events_per_sec`.

## Validation
- `cargo test -p logfwd-io generator::tests:: -- --nocapture`
- `CARGO_TARGET_DIR=/Users/billeaston/Documents/repos/memagent/target cargo test -p logfwd-io generator::tests::rate_limited_can_emit_multiple_batches_per_poll -- --nocapture`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace fixed-interval rate limiting with token-bucket credit system in `GeneratorInput`
> - Replaces the single-batch-per-poll, fixed-interval gate in `GeneratorInput` with a token-bucket approach that accumulates credits based on elapsed time since the last refill.
> - `poll()` can now emit multiple `Data` events per call when sufficient credit exists, bounded by `burst_cap = max(events_per_sec, batch_size)`; at least one full batch of credit is required before any emission.
> - Seeds one batch worth of credits on construction, removing the previous backdated-timestamp hack to force the first poll to succeed.
> - `generate_batch` now accepts an explicit count `n`, allowing partial batches when fewer events remain or when chunking multiple batches.
> - Behavioral Change: `poll()` in rate-limited mode may now return multiple `InputEvent::Data` items per call instead of exactly one; callers (e.g. the pipeline scanner test in [mod.rs](https://github.com/strawgate/memagent/pull/1763/files#diff-97916cb5dc28dce0511ea2f0c1abb95441b6dc4715410d1c1e5a4b8e640016b5)) must handle this.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95f56d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->