### PR TITLE
ci: rerun resolved-review dismissal on PR synchronize

### DIFF
--- a/.github/workflows/dismiss-resolved-reviews.yml
+++ b/.github/workflows/dismiss-resolved-reviews.yml
@@ -1,6 +1,8 @@
 name: "Auto: dismiss resolved review requests"
 
 on:
+  pull_request:
+    types: [synchronize]
   pull_request_review:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:


### PR DESCRIPTION
## Summary
- add a `pull_request` `synchronize` trigger to the resolved-review dismissal workflow

## Why
- this lets the workflow recompute dismissal eligibility when new commits land on a PR
- it avoids `pull_request_target` while still covering the common case where authors push follow-up fixes after resolving review feedback

## Testing
- validated workflow YAML parses successfully


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger resolved-review dismissal workflow on PR synchronize
> Adds the `pull_request: [synchronize]` event to [dismiss-resolved-reviews.yml](.github/workflows/dismiss-resolved-reviews.yml) so the workflow also runs when new commits are pushed to a PR, not only on review events.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 470a707.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->