### PR TITLE
Harden e2e gating + strengthen TLA verification invariants

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -49,8 +49,7 @@ wait_for() {
     if "$@" 2>/dev/null; then
         return 0
     fi
-    echo "E2E_FAIL_CATEGORY=TIMEOUT"
-    echo "FAIL[TIMEOUT]: timed out waiting for: $desc (${timeout}s)"
+    echo "FAIL: timed out waiting for: $desc (${timeout}s)"
     return 1
 }
 
@@ -149,8 +148,14 @@ k port-forward -n "$NAMESPACE" svc/blackhole-receiver 14318:4318 &
 PF_PID=$!
 
 # Wait for port-forward to accept connections instead of hardcoded sleep.
-wait_for "port-forward accepting connections" 15 \
-    curl --connect-timeout 1 --max-time 1 -sf http://localhost:14318/stats
+if ! wait_for "port-forward accepting connections" 15 \
+    curl --connect-timeout 1 --max-time 1 -sf http://localhost:14318/stats; then
+    echo ""
+    fail "PORT_FORWARD_NOT_READY" "port-forward did not start serving /stats in time"
+    k get pods -n "$NAMESPACE" -l app=blackhole-receiver -o wide 2>&1 || true
+    k logs -n "$NAMESPACE" -l app=blackhole-receiver --tail=50 2>&1 || true
+    exit 1
+fi
 
 echo "=== Phase 7: Verify ==="
 DEADLINE=$((SECONDS + TIMEOUT))

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -3,6 +3,7 @@
 # KIND e2e test for logfwd.
 # Validates the full pipeline: file tail → CRI parse → SQL transform → HTTP output.
 #
+# shellcheck disable=SC2329
 set -euo pipefail
 
 CLUSTER_NAME="${E2E_CLUSTER_NAME:-logfwd-e2e}"
@@ -19,9 +20,18 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 NO_DESTROY="${NO_DESTROY:-}"
 PF_PID=""
 CLUSTER_CREATED=0
+LOG_GENERATOR_MARKER='log-generator: all 10 markers emitted'
+DEPLOY_TIMEOUT="${E2E_DEPLOY_TIMEOUT:-120s}"
 
 k() {
     kubectl --context "$KUBE_CONTEXT" "$@"
+}
+
+fail() {
+    local token="$1"
+    shift
+    echo "E2E_FAIL_CATEGORY=$token"
+    echo "FAIL[$token]: $*"
 }
 
 # Poll a condition with backoff. Usage: wait_for <description> <timeout_s> <command...>
@@ -39,8 +49,19 @@ wait_for() {
     if "$@" 2>/dev/null; then
         return 0
     fi
-    echo "FAIL: timed out waiting for: $desc (${timeout}s)"
+    echo "E2E_FAIL_CATEGORY=TIMEOUT"
+    echo "FAIL[TIMEOUT]: timed out waiting for: $desc (${timeout}s)"
     return 1
+}
+
+log_generator_is_running() {
+    local phase
+    phase="$(k get pod -n "$NAMESPACE" log-generator -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    [ "$phase" = "Running" ]
+}
+
+log_generator_markers_emitted() {
+    k logs -n "$NAMESPACE" log-generator --tail=40 2>/dev/null | grep -q "$LOG_GENERATOR_MARKER"
 }
 
 cleanup() {
@@ -82,16 +103,16 @@ k apply -n "$NAMESPACE" -f "$SCRIPT_DIR/manifests/logfwd-daemonset.yaml"
 
 echo "=== Phase 4: Wait for readiness ==="
 if ! k wait -n "$NAMESPACE" deployment/blackhole-receiver \
-    --for=condition=available --timeout=90s; then
+    --for=condition=available --timeout="$DEPLOY_TIMEOUT"; then
     echo ""
-    echo "FAIL: blackhole-receiver deployment not available"
+    fail "RECEIVER_NOT_READY" "blackhole-receiver deployment not available"
     k describe pods -n "$NAMESPACE" -l app=blackhole-receiver 2>&1 || true
     k logs -n "$NAMESPACE" -l app=blackhole-receiver --tail=50 2>&1 || true
     exit 1
 fi
-if ! k rollout status -n "$NAMESPACE" daemonset/logfwd --timeout=90s; then
+if ! k rollout status -n "$NAMESPACE" daemonset/logfwd --timeout="$DEPLOY_TIMEOUT"; then
     echo ""
-    echo "FAIL: logfwd daemonset rollout timed out"
+    fail "LOGFWD_ROLLOUT_TIMEOUT" "logfwd daemonset rollout timed out"
     k get pods -n "$NAMESPACE" -l app=logfwd -o wide 2>&1 || true
     k describe pods -n "$NAMESPACE" -l app=logfwd 2>&1 || true
     k logs -n "$NAMESPACE" -l app=logfwd --tail=80 2>&1 || true
@@ -103,28 +124,25 @@ echo "=== Phase 5: Generate logs ==="
 k delete pod -n "$NAMESPACE" log-generator --ignore-not-found 2>/dev/null
 k apply -n "$NAMESPACE" -f "$SCRIPT_DIR/manifests/log-generator.yaml"
 
-# Wait for the generator pod to be Running instead of hardcoded sleep.
-export KUBE_CONTEXT
-export -f k
-if ! wait_for "log-generator pod running" 30 \
-    bash -c "phase=\$(k get pod -n \"$NAMESPACE\" log-generator -o jsonpath='{.status.phase}' 2>/dev/null); [ \"\$phase\" = \"Running\" ]"; then
-    GENERATOR_PHASE="$(k get pod -n "$NAMESPACE" log-generator -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+# Strictly gate marker emission before verification. This prevents races where
+# the verify loop starts before the generator has actually emitted the marker set.
+if ! wait_for "log-generator pod running" 45 log_generator_is_running; then
     echo ""
-    echo "FAIL: log-generator phase is '$GENERATOR_PHASE' (expected Running)"
+    fail "GENERATOR_NOT_RUNNING" "log-generator pod never reached Running"
+    k get pod -n "$NAMESPACE" log-generator -o wide 2>&1 || true
     k describe pod -n "$NAMESPACE" log-generator 2>&1 || true
     k logs -n "$NAMESPACE" log-generator --tail=40 2>&1 || true
     exit 1
 fi
-GENERATOR_PHASE="$(k get pod -n "$NAMESPACE" log-generator -o jsonpath='{.status.phase}' 2>/dev/null || true)"
-if [ "$GENERATOR_PHASE" != "Running" ]; then
+
+if ! wait_for "log-generator marker emission" 60 log_generator_markers_emitted; then
     echo ""
-    echo "FAIL: log-generator phase is '$GENERATOR_PHASE' (expected Running)"
+    fail "GENERATOR_MARKERS_MISSING" "log-generator never emitted the final marker batch"
+    k get pod -n "$NAMESPACE" log-generator -o wide 2>&1 || true
     k describe pod -n "$NAMESPACE" log-generator 2>&1 || true
-    k logs -n "$NAMESPACE" log-generator --tail=40 2>&1 || true
+    k logs -n "$NAMESPACE" log-generator --tail=80 2>&1 || true
     exit 1
 fi
-# Brief extra pause for CRI log path to stabilize after container start.
-sleep 3
 
 echo "=== Phase 6: Port-forward ==="
 k port-forward -n "$NAMESPACE" svc/blackhole-receiver 14318:4318 &
@@ -140,7 +158,7 @@ DELAY=2
 while [ $SECONDS -lt $DEADLINE ]; do
     if ! kill -0 "$PF_PID" 2>/dev/null; then
         echo ""
-        echo "FAIL: port-forward exited during verification (pid=$PF_PID)"
+        fail "PORT_FORWARD_DROPPED" "port-forward exited during verification (pid=$PF_PID)"
         k get pods -n "$NAMESPACE" -l app=blackhole-receiver -o wide 2>&1 || true
         exit 1
     fi
@@ -157,7 +175,7 @@ while [ $SECONDS -lt $DEADLINE ]; do
         exit 0
     elif [ "$LINES" -gt "$MAX_EXPECTED_LINES" ]; then
         echo ""
-        echo "FAIL: blackhole received $LINES lines (> max expected $MAX_EXPECTED_LINES)"
+        fail "TOO_MANY_LINES" "blackhole received $LINES lines (> max expected $MAX_EXPECTED_LINES)"
         echo "--- logfwd logs ---"
         k logs -n "$NAMESPACE" -l app=logfwd --tail=40 2>&1 || true
         exit 1
@@ -169,7 +187,7 @@ while [ $SECONDS -lt $DEADLINE ]; do
 done
 
 echo ""
-echo "FAIL: timed out after ${TIMEOUT}s — blackhole received $LINES lines, expected ${MIN_EXPECTED_LINES}..${MAX_EXPECTED_LINES}"
+fail "VERIFY_TIMEOUT" "timed out after ${TIMEOUT}s — blackhole received $LINES lines, expected ${MIN_EXPECTED_LINES}..${MAX_EXPECTED_LINES}"
 echo ""
 echo "--- logfwd DaemonSet logs ---"
 k logs -n "$NAMESPACE" -l app=logfwd --tail=80 2>&1 || true

--- a/tests/e2e/run_smoke_test.sh
+++ b/tests/e2e/run_smoke_test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+#
+# Stub-based regression test for tests/e2e/run.sh.
+# Verifies marker emission is gated before port-forward/verification.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RUN_SH="$SCRIPT_DIR/run.sh"
+TMP_ROOT="$(mktemp -d)"
+STUB_DIR="$TMP_ROOT/bin"
+STATE_DIR="$TMP_ROOT/state"
+LOG_FILE="$TMP_ROOT/invocations.log"
+mkdir -p "$STUB_DIR" "$STATE_DIR"
+
+cleanup() {
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+cat >"$STUB_DIR/kind" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${LOG_FILE:?}"
+echo "kind $*" >>"$LOG_FILE"
+case "$1" in
+  get|create|load|delete) exit 0 ;;
+esac
+exit 0
+EOF
+
+cat >"$STUB_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${LOG_FILE:?}"
+echo "docker $*" >>"$LOG_FILE"
+exit 0
+EOF
+
+cat >"$STUB_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${LOG_FILE:?}"
+STATE_DIR="${STATE_DIR:?}"
+echo "curl $*" >>"$LOG_FILE"
+case "$*" in
+  *"/stats"*)
+    test -f "$STATE_DIR/port_forward_started"
+    printf '{"lines":12}'
+    exit 0
+    ;;
+esac
+exit 1
+EOF
+
+cat >"$STUB_DIR/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LOG_FILE="${LOG_FILE:?}"
+STATE_DIR="${STATE_DIR:?}"
+echo "kubectl $*" >>"$LOG_FILE"
+
+if [ "${1:-}" = "--context" ]; then
+  shift 2
+fi
+
+case "${1:-}" in
+  create|apply|wait|rollout|delete)
+    exit 0
+    ;;
+  get)
+    if [ "${2:-}" = "pod" ] && [ "${3:-}" = "-n" ] && [ "${4:-}" = "e2e-logfwd" ] && [ "${5:-}" = "log-generator" ] && [ "${6:-}" = "-o" ] && [[ "${7:-}" == jsonpath=* ]]; then
+      counter_file="$STATE_DIR/log_generator_polls"
+      count=0
+      if [ -f "$counter_file" ]; then
+        count="$(cat "$counter_file")"
+      fi
+      count=$((count + 1))
+      printf '%s' "$count" >"$counter_file"
+      if [ "$count" -ge 3 ]; then
+        printf 'Running'
+        printf 'running' >"$STATE_DIR/log_generator_running"
+      else
+        printf 'Pending'
+      fi
+      exit 0
+    fi
+    exit 0
+    ;;
+  logs)
+    if [ "${2:-}" = "-n" ] && [ "${3:-}" = "e2e-logfwd" ] && [ "${4:-}" = "log-generator" ]; then
+      if [ -f "$STATE_DIR/log_generator_running" ]; then
+        printf '%s\n' \
+          'LOGFWD_E2E_MARKER_001' \
+          'LOGFWD_E2E_MARKER_010' \
+          'log-generator: all 10 markers emitted'
+        printf 'ready' >"$STATE_DIR/marker_ready"
+      fi
+      exit 0
+    fi
+    exit 0
+    ;;
+  port-forward)
+    test -f "$STATE_DIR/marker_ready"
+    printf 'started' >"$STATE_DIR/port_forward_started"
+    exec sleep 300
+    ;;
+esac
+
+exit 0
+EOF
+
+chmod +x "$STUB_DIR"/*
+
+PATH="$STUB_DIR:$PATH" \
+LOG_FILE="$LOG_FILE" \
+STATE_DIR="$STATE_DIR" \
+E2E_CLUSTER_NAME="smoke" \
+NO_DESTROY=1 \
+bash "$RUN_SH"
+
+logs_line="$(grep -n 'logs -n e2e-logfwd log-generator --tail=40' "$LOG_FILE" | head -n1 | cut -d: -f1 || true)"
+pf_line="$(grep -n 'port-forward -n e2e-logfwd svc/blackhole-receiver 14318:4318' "$LOG_FILE" | head -n1 | cut -d: -f1 || true)"
+
+if [ -z "$logs_line" ]; then
+  echo "FAIL: smoke test never waited for generator markers"
+  exit 1
+fi
+
+if [ -z "$pf_line" ]; then
+  echo "FAIL: smoke test never reached port-forward"
+  exit 1
+fi
+
+if [ "$logs_line" -ge "$pf_line" ]; then
+  echo "FAIL: generator markers were not gated before port-forward"
+  exit 1
+fi
+
+echo "PASS: run.sh smoke test completed with generator gating and marker ordering"

--- a/tla/PipelineBatch.cfg
+++ b/tla/PipelineBatch.cfg
@@ -8,6 +8,8 @@ CONSTANTS
 INVARIANTS
     TypeOK
     CheckpointNeverAheadOfFlushed
+    SourceProgressBounds
+    TotalProducedAccountedFor
     SingleInFlight
 
 PROPERTIES

--- a/tla/PipelineBatch.coverage.cfg
+++ b/tla/PipelineBatch.coverage.cfg
@@ -12,3 +12,4 @@ INVARIANTS
     StopReachable
     MultiSourceBatch
     DoneProducingReachable
+    RejectOccurred

--- a/tla/PipelineBatch.tla
+++ b/tla/PipelineBatch.tla
@@ -67,11 +67,14 @@ VARIABLES
 
     (* Control *)
     phase,              \* "Running" | "Stopped"
-    done_producing      \* BOOLEAN: all sources have produced their max
+    done_producing,     \* BOOLEAN: all sources have produced their max
+
+    (* Coverage ghost: records whether RejectBatch was exercised. *)
+    reject_seen         \* BOOLEAN: at least one explicit reject occurred
 
 vars == <<produced, source_offset, buf_count, buf_offsets, in_flight_id,
           in_flight_offsets, committed, next_batch_id, flushed,
-          flushed_total, acked_total, phase, done_producing>>
+          flushed_total, acked_total, phase, done_producing, reject_seen>>
 
 (* -----------------------------------------------------------------------
  * Type invariant
@@ -92,6 +95,7 @@ TypeOK ==
     /\ acked_total \in Nat
     /\ phase \in {"Running", "Stopped"}
     /\ done_producing \in BOOLEAN
+    /\ reject_seen \in BOOLEAN
 
 (* -----------------------------------------------------------------------
  * Initial state
@@ -111,6 +115,7 @@ Init ==
     /\ acked_total = 0
     /\ phase = "Running"
     /\ done_producing = FALSE
+    /\ reject_seen = FALSE
 
 (* -----------------------------------------------------------------------
  * Actions
@@ -128,7 +133,7 @@ Produce(s) ==
     /\ buf_offsets' = [buf_offsets EXCEPT ![s] = source_offset[s] + 100]
     /\ UNCHANGED <<in_flight_id, in_flight_offsets, committed,
                    next_batch_id, flushed, flushed_total, acked_total,
-                   phase, done_producing>>
+                   phase, done_producing, reject_seen>>
 
 \* Flush the accumulator: create batch, begin_send, submit to output.
 \* Models: flush_batch in pipeline.rs.
@@ -148,7 +153,7 @@ FlushBatch ==
     /\ buf_count' = 0
     /\ buf_offsets' = [s \in Sources |-> 0]
     /\ UNCHANGED <<produced, source_offset, committed, acked_total,
-                   phase, done_producing>>
+                   phase, done_producing, reject_seen>>
 
 \* Timeout flush: flush even if below threshold (batch_timeout expired).
 TimeoutFlush ==
@@ -168,7 +173,7 @@ TimeoutFlush ==
     /\ buf_count' = 0
     /\ buf_offsets' = [s \in Sources |-> 0]
     /\ UNCHANGED <<produced, source_offset, committed, acked_total,
-                   phase, done_producing>>
+                   phase, done_producing, reject_seen>>
 
 \* Output acks the in-flight batch (success).
 \* Checkpoint advances for each source that contributed to the batch.
@@ -183,7 +188,7 @@ AckBatch ==
     /\ in_flight_offsets' = [s \in Sources |-> 0]
     /\ UNCHANGED <<produced, source_offset, buf_count, buf_offsets,
                    next_batch_id, flushed, flushed_total, phase,
-                   done_producing>>
+                   done_producing, reject_seen>>
 
 \* Transform or output rejects the batch (explicit permanent error).
 \* Checkpoint STILL advances — design decision from DESIGN.md:
@@ -195,6 +200,7 @@ RejectBatch ==
         IF in_flight_offsets[s] > committed[s]
         THEN in_flight_offsets[s]
         ELSE committed[s]]
+    /\ reject_seen' = TRUE
     /\ in_flight_id' = 0
     /\ in_flight_offsets' = [s \in Sources |-> 0]
     /\ UNCHANGED <<produced, source_offset, buf_count, buf_offsets,
@@ -209,7 +215,7 @@ MarkDoneProducing ==
     /\ UNCHANGED <<produced, source_offset, buf_count, buf_offsets,
                    in_flight_id, in_flight_offsets, committed,
                    next_batch_id, flushed, flushed_total, acked_total,
-                   phase>>
+                   phase, reject_seen>>
 
 \* Stop the pipeline (all data processed).
 Stop ==
@@ -221,7 +227,7 @@ Stop ==
     /\ UNCHANGED <<produced, source_offset, buf_count, buf_offsets,
                    in_flight_id, in_flight_offsets, committed,
                    next_batch_id, flushed, flushed_total, acked_total,
-                   done_producing>>
+                   done_producing, reject_seen>>
 
 (* -----------------------------------------------------------------------
  * Next-state relation
@@ -262,6 +268,28 @@ Spec == Init /\ [][Next]_vars /\ Fairness
 CheckpointNeverAheadOfFlushed ==
     \A s \in Sources :
         committed[s] <= flushed[s]
+
+(* Every offset we track stays bounded by the source's own progress.
+ * This catches any future bug that advances buffer/flush/checkpoint state
+ * ahead of the source that produced it. *)
+SourceProgressBounds ==
+    \A s \in Sources :
+        /\ buf_offsets[s] <= source_offset[s]
+        /\ in_flight_offsets[s] <= source_offset[s]
+        /\ flushed[s] <= source_offset[s]
+        /\ committed[s] <= source_offset[s]
+
+RECURSIVE SumSources(_, _)
+SumSources(f, S) ==
+    IF S = {} THEN 0
+    ELSE LET s == CHOOSE s \in S : TRUE
+         IN f[s] + SumSources(f, S \ {s})
+
+SumAllSources(f) == SumSources(f, Sources)
+
+(* Total produced items are conserved across the buffer and flushed output. *)
+TotalProducedAccountedFor ==
+    SumAllSources(produced) = buf_count + flushed_total
 
 \* Checkpoints are monotonic.
 MonotonicCheckpoints ==
@@ -312,5 +340,8 @@ MultiSourceBatch == ~(\E s1, s2 \in Sources :
 \* done_producing is reachable — without this, EventualStop and
 \* StoppedIsStable are vacuously true (their antecedent never holds).
 DoneProducingReachable == ~done_producing
+
+\* Explicit reject branch is reachable.
+RejectOccurred == ~reject_seen
 
 ======================================================================

--- a/tla/ShutdownProtocol.cfg
+++ b/tla/ShutdownProtocol.cfg
@@ -14,5 +14,6 @@ INVARIANTS
     NoJoinBeforePipelineDrain
     NoStopBeforeJoin
     NormalStopImpliesPoolDrained
+    DrainFlagsConsistent
     IoConservation
     PipelineConservation

--- a/tla/ShutdownProtocol.coverage.cfg
+++ b/tla/ShutdownProtocol.coverage.cfg
@@ -14,6 +14,8 @@ INVARIANTS
     IoChannelFullReachable
     CpuWorkersStoppedReachable
     PipelineChannelDrainedReachable
+    WorkersJoinedReachable
+    PoolDrainedReachable
     PipelineChannelFullReachable
     NormalStopReachable
     ForceStopReachable

--- a/tla/ShutdownProtocol.tla
+++ b/tla/ShutdownProtocol.tla
@@ -401,6 +401,13 @@ NoStopBeforeJoin ==
 NormalStopImpliesPoolDrained ==
     (machine_stopped /\ ~forced) => pool_drained
 
+\* Shutdown stage flags must reflect underlying worker/channel state.
+DrainFlagsConsistent ==
+    /\ workers_joined =>
+        (cpu_workers_stopped /\ io_channels_drained /\ pipeline_channel_drained)
+    /\ pool_drained =>
+        (workers_joined /\ pool_acked = pool_pending)
+
 \* Conservation: items produced by each I/O worker = items in its io channel
 \* + items its CPU worker has forwarded.  Non-tautological: catches duplication
 \* or loss in the io -> cpu path.
@@ -447,6 +454,8 @@ ShutdownReachable == ~shutdown_signaled
 IoChannelsDrainedReachable == ~io_channels_drained
 CpuWorkersStoppedReachable == ~cpu_workers_stopped
 PipelineChannelDrainedReachable == ~pipeline_channel_drained
+WorkersJoinedReachable == ~workers_joined
+PoolDrainedReachable == ~pool_drained
 NormalStopReachable == ~(machine_stopped /\ ~forced)
 ForceStopReachable == ~(machine_stopped /\ forced)
 


### PR DESCRIPTION
## Summary
This PR tightens one low-conflict verification lane with concrete, testable changes:

1. e2e harness hardening (`tests/e2e/run.sh`)
- Adds strict generator gating: we now wait for pod `Running` and for the explicit marker emission log before port-forward/verify.
- Adds machine-readable failure category output (`E2E_FAIL_CATEGORY=...`) for key failure paths.
- Makes deploy readiness timeout configurable via `E2E_DEPLOY_TIMEOUT`.

2. e2e regression harness (`tests/e2e/run_smoke_test.sh`)
- Adds a deterministic stub-based smoke test that fails if marker gating regresses.

3. TLA safety/coverage strengthening
- `PipelineBatch`: adds `SourceProgressBounds`, `TotalProducedAccountedFor`, and reject-path reachability signal (`RejectOccurred`).
- `ShutdownProtocol`: adds `DrainFlagsConsistent` and reachability sentinels for `workers_joined` / `pool_drained`.

## Related Issues
- #1746
- #1202
- #1768
- #1769
- #1314
- #895

## Verification
Passed locally:
- `bash -n tests/e2e/run.sh tests/e2e/run_smoke_test.sh`
- `shellcheck tests/e2e/run.sh tests/e2e/run_smoke_test.sh`
- `bash tests/e2e/run_smoke_test.sh`
- `git diff --check`

TLA execution status:
- Local Java runtime is unavailable.
- Attempted to run TLC via Docker + `tla2tools.jar`, but Docker commands were hanging in this environment (including `docker ps`), so TLC execution evidence is not attached from this machine.

## Risk/Limitations
- `run_smoke_test.sh` is a stub harness; it validates ordering/guarding logic, not real Kubernetes behavior.
- TLA model edits were consistency-checked against cfg references, but TLC runs need to be executed in CI or on a machine with healthy Java/Docker runtime.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden e2e gating with categorized failure tokens and strengthen TLA verification invariants
> - Refactors [run.sh](https://github.com/strawgate/memagent/pull/1773/files#diff-c828e2e3a8ec47cc5a2cb23e04d6e2116b4a24218d0963daabd51970de043672) to gate the verification loop on the log-generator pod reaching `Running` and emitting a final marker before proceeding, replacing unconditional sleeps with polling via `wait_for`.
> - Adds a `fail` helper that emits stable `E2E_FAIL_CATEGORY=<token>` prefixed messages, with distinct tokens for each failure mode (e.g. `GENERATOR_NOT_RUNNING`, `PORT_FORWARD_NOT_READY`, `VERIFY_TIMEOUT`).
> - Makes deployment/rollout timeouts configurable via `E2E_DEPLOY_TIMEOUT` (default 120s) instead of hardcoded values.
> - Adds a smoke test in [run_smoke_test.sh](https://github.com/strawgate/memagent/pull/1773/files#diff-6bedf8fc1b3f9d0bd49cf1636af772aba6b974c0a185cdb01ea9f2fed8680a83) that validates gating order using mocked `kind`, `kubectl`, and `curl` binaries.
> - Strengthens TLA+ specs: adds `SourceProgressBounds` and `TotalProducedAccountedFor` invariants to [PipelineBatch.tla](https://github.com/strawgate/memagent/pull/1773/files#diff-511afa7063066e165d7cdca153c03b06d880dd525876d1d7347859b3a17838bf), and adds `DrainFlagsConsistent` to [ShutdownProtocol.tla](https://github.com/strawgate/memagent/pull/1773/files#diff-bd61fe98eb99ec3cbc6bdc8bd645aadc945a6c135efbad1c146a937652f47673), along with coverage reachability properties for both specs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9986e51.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->