### PR TITLE
ci: add TLC/proptest verification drift guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,10 @@ jobs:
           python-version: "3.11"
       - name: Kani boundary contract
         run: python3 scripts/verify_kani_boundary_contract.py
+      - name: TLC matrix contract
+        run: python3 scripts/verify_tlc_matrix_contract.py
+      - name: Proptest regression policy
+        run: python3 scripts/verify_proptest_regressions.py
 
   # -------------------------------------------------------------------------
   # Tests — Linux and macOS in parallel

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -162,6 +162,20 @@ job in `.github/workflows/ci.yml`):
 A matching path change in a **draft** PR does not trigger the job; the PR must
 be marked ready for review first.
 
+### Verification guardrail checks
+
+The CI `Verification guardrail` job runs these lightweight anti-drift checks:
+
+- `scripts/verify_kani_boundary_contract.py` — validates non-core Kani seam policy
+- `scripts/verify_tlc_matrix_contract.py` — validates TLC matrix coverage for expected `tla/*.cfg` models
+- `scripts/verify_proptest_regressions.py` — validates persisted proptest regression-file policy and approved `failure_persistence: None` usage
+
+Run them locally:
+
+```bash
+just verification-guardrail
+```
+
 ### Proof quality requirements
 
 Every Kani proof MUST:

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -167,7 +167,7 @@ be marked ready for review first.
 The CI `Verification guardrail` job runs these lightweight anti-drift checks:
 
 - `scripts/verify_kani_boundary_contract.py` — validates non-core Kani seam policy
-- `scripts/verify_tlc_matrix_contract.py` — validates TLC matrix coverage for expected `tla/*.cfg` models
+- `scripts/verify_tlc_matrix_contract.py` — validates TLC matrix coverage for expected non-coverage/non-thorough `tla/*.cfg` models
 - `scripts/verify_proptest_regressions.py` — validates persisted proptest regression-file policy and approved `failure_persistence: None` usage
 
 Run them locally:

--- a/justfile
+++ b/justfile
@@ -150,6 +150,17 @@ kani-required:
 kani-boundary:
     python3 scripts/verify_kani_boundary_contract.py
 
+# Validate that CI's TLC matrix covers expected tla/*.cfg files.
+tlc-matrix-contract:
+    python3 scripts/verify_tlc_matrix_contract.py
+
+# Validate proptest regression-file and persistence policy.
+proptest-regressions:
+    python3 scripts/verify_proptest_regressions.py
+
+# Run all lightweight verification guardrails enforced in CI.
+verification-guardrail: kani-boundary tlc-matrix-contract proptest-regressions
+
 # Download tla2tools.jar to .tools/ if missing.
 tla-setup:
     #!/usr/bin/env bash
@@ -200,7 +211,7 @@ tlc-tail:
 lint: fmt-check workspace-inheritance-guard clippy toml-check
 
 # Lint — full workspace (CI uses this)
-lint-all: fmt-check kani-boundary workspace-inheritance-guard clippy-all toml-check deny
+lint-all: fmt-check verification-guardrail clippy-all toml-check deny
 
 # Quick CI — fast lint + test (default-members, no datafusion)
 ci: lint test

--- a/scripts/verify_proptest_regressions.py
+++ b/scripts/verify_proptest_regressions.py
@@ -24,7 +24,13 @@ def iter_regression_files() -> list[Path]:
 
 
 def has_failure_persistence_none(text: str) -> bool:
-    return re.search(r"failure_persistence\s*:\s*None", text) is not None
+    return (
+        re.search(
+            r"failure_persistence\s*:\s*(?:None|(?:[A-Za-z_]\w*::)*FailurePersistence::None)",
+            text,
+        )
+        is not None
+    )
 
 
 def has_proptest_macro(text: str) -> bool:

--- a/scripts/verify_proptest_regressions.py
+++ b/scripts/verify_proptest_regressions.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Validate proptest regression-file policy."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CRATES = ROOT / "crates"
+NO_PERSISTENCE_ALLOWLIST = {
+    "crates/logfwd-io/tests/it/checkpoint_state_machine.rs",
+}
+
+
+def iter_rust_files() -> list[Path]:
+    return sorted(CRATES.rglob("*.rs"))
+
+
+def iter_regression_files() -> list[Path]:
+    return sorted(CRATES.rglob("*.proptest-regressions"))
+
+
+def has_failure_persistence_none(text: str) -> bool:
+    return re.search(r"failure_persistence\s*:\s*None", text) is not None
+
+
+def has_proptest_macro(text: str) -> bool:
+    return "proptest!" in text or "prop_state_machine!" in text
+
+
+def has_seed_entries(text: str) -> bool:
+    return any(line.startswith("cc ") for line in text.splitlines())
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+
+    no_persistence_files: set[str] = set()
+    for rust_file in iter_rust_files():
+        text = rust_file.read_text(encoding="utf-8")
+        if has_failure_persistence_none(text):
+            no_persistence_files.add(rust_file.relative_to(ROOT).as_posix())
+
+    unexpected_no_persistence = sorted(no_persistence_files - NO_PERSISTENCE_ALLOWLIST)
+    missing_allowlist_entries = sorted(NO_PERSISTENCE_ALLOWLIST - no_persistence_files)
+
+    for path in unexpected_no_persistence:
+        errors.append(
+            f"{path}: uses failure_persistence: None but is not in NO_PERSISTENCE_ALLOWLIST"
+        )
+    for path in missing_allowlist_entries:
+        errors.append(
+            f"{path}: listed in NO_PERSISTENCE_ALLOWLIST but no longer uses failure_persistence: None"
+        )
+
+    for regression_file in iter_regression_files():
+        rel = regression_file.relative_to(ROOT).as_posix()
+        text = regression_file.read_text(encoding="utf-8")
+        if not has_seed_entries(text):
+            errors.append(f"{rel}: regression file has no seed entries (lines starting with 'cc ')")
+
+        companion = regression_file.with_suffix(".rs")
+        if not companion.is_file():
+            errors.append(
+                f"{rel}: expected companion Rust test file {companion.relative_to(ROOT).as_posix()}"
+            )
+            continue
+
+        companion_rel = companion.relative_to(ROOT).as_posix()
+        companion_text = companion.read_text(encoding="utf-8")
+        if not has_proptest_macro(companion_text):
+            errors.append(
+                f"{rel}: companion test file {companion_rel} has no proptest macro"
+            )
+        if has_failure_persistence_none(companion_text):
+            errors.append(
+                f"{rel}: companion test file {companion_rel} disables failure persistence"
+            )
+
+    return errors
+
+
+def main() -> int:
+    try:
+        errors = validate()
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        print("Proptest regression policy validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("Proptest regression policy OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_tlc_matrix_contract.py
+++ b/scripts/verify_tlc_matrix_contract.py
@@ -56,39 +56,65 @@ def parse_tlc_matrix_entries(workflow_text: str) -> list[TlcMatrixEntry]:
 
     entries: list[TlcMatrixEntry] = []
     current: dict[str, str] | None = None
+    in_include = False
+    include_indent: int | None = None
+    item_indent: int | None = None
+    allowed_keys = {"spec", "tla_file", "config", "property"}
+
+    def flush_current() -> None:
+        nonlocal current
+        if current is None:
+            return
+        entries.append(
+            TlcMatrixEntry(
+                spec=current.get("spec", ""),
+                tla_file=current.get("tla_file", ""),
+                config=current.get("config", ""),
+                property=current.get("property", ""),
+            )
+        )
+        current = None
 
     for line in tlc_lines:
         stripped = line.strip()
-        if stripped.startswith("- spec:"):
-            if current is not None:
-                entries.append(
-                    TlcMatrixEntry(
-                        spec=current["spec"],
-                        tla_file=current["tla_file"],
-                        config=current["config"],
-                        property=current["property"],
-                    )
-                )
-            current = {"spec": _strip_yaml_value(stripped.split(":", 1)[1])}
+        indent = len(line) - len(line.lstrip(" "))
+
+        if not in_include:
+            if stripped == "include:":
+                in_include = True
+                include_indent = indent
             continue
 
-        if current is None or ":" not in stripped or stripped.startswith("-"):
+        if stripped and include_indent is not None and indent <= include_indent:
+            flush_current()
+            break
+
+        if not stripped:
+            continue
+
+        if stripped.startswith("- "):
+            flush_current()
+            item_indent = indent
+            current = {}
+            stripped = stripped[2:].strip()
+            if ":" not in stripped:
+                continue
+
+            key, raw_value = stripped.split(":", 1)
+            key = key.strip()
+            if key in allowed_keys:
+                current[key] = _strip_yaml_value(raw_value)
+            continue
+
+        if current is None or item_indent is None or indent <= item_indent or ":" not in stripped:
             continue
 
         key, raw_value = stripped.split(":", 1)
         key = key.strip()
-        if key in {"spec", "tla_file", "config", "property"}:
+        if key in allowed_keys:
             current[key] = _strip_yaml_value(raw_value)
 
-    if current is not None:
-        entries.append(
-            TlcMatrixEntry(
-                spec=current["spec"],
-                tla_file=current["tla_file"],
-                config=current["config"],
-                property=current["property"],
-            )
-        )
+    flush_current()
 
     if not entries:
         raise ValueError("ci.yml tlc matrix has no entries")

--- a/scripts/verify_tlc_matrix_contract.py
+++ b/scripts/verify_tlc_matrix_contract.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Validate that CI's TLC matrix covers expected TLA config files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+TLA_DIR = ROOT / "tla"
+IGNORED_CFG_SUFFIXES = (".coverage.cfg", ".thorough.cfg")
+
+
+@dataclass(frozen=True)
+class TlcMatrixEntry:
+    spec: str
+    tla_file: str
+    config: str
+    property: str
+
+
+def _strip_yaml_value(value: str) -> str:
+    value = value.strip()
+    if value and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def parse_tlc_matrix_entries(workflow_text: str) -> list[TlcMatrixEntry]:
+    lines = workflow_text.splitlines()
+    tlc_start = None
+    tlc_indent = 0
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "tlc:":
+            tlc_start = idx
+            tlc_indent = len(line) - len(line.lstrip(" "))
+            break
+    if tlc_start is None:
+        raise ValueError("ci.yml missing top-level tlc job")
+
+    tlc_lines: list[str] = []
+    for idx in range(tlc_start + 1, len(lines)):
+        line = lines[idx]
+        stripped = line.strip()
+        if stripped:
+            indent = len(line) - len(line.lstrip(" "))
+            if indent <= tlc_indent:
+                break
+        tlc_lines.append(line)
+
+    entries: list[TlcMatrixEntry] = []
+    current: dict[str, str] | None = None
+
+    for line in tlc_lines:
+        stripped = line.strip()
+        if stripped.startswith("- spec:"):
+            if current is not None:
+                entries.append(
+                    TlcMatrixEntry(
+                        spec=current["spec"],
+                        tla_file=current["tla_file"],
+                        config=current["config"],
+                        property=current["property"],
+                    )
+                )
+            current = {"spec": _strip_yaml_value(stripped.split(":", 1)[1])}
+            continue
+
+        if current is None or ":" not in stripped or stripped.startswith("-"):
+            continue
+
+        key, raw_value = stripped.split(":", 1)
+        key = key.strip()
+        if key in {"spec", "tla_file", "config", "property"}:
+            current[key] = _strip_yaml_value(raw_value)
+
+    if current is not None:
+        entries.append(
+            TlcMatrixEntry(
+                spec=current["spec"],
+                tla_file=current["tla_file"],
+                config=current["config"],
+                property=current["property"],
+            )
+        )
+
+    if not entries:
+        raise ValueError("ci.yml tlc matrix has no entries")
+
+    return entries
+
+
+def expected_ci_cfgs() -> set[str]:
+    expected: set[str] = set()
+    for cfg in TLA_DIR.glob("*.cfg"):
+        if cfg.name.endswith(IGNORED_CFG_SUFFIXES):
+            continue
+        expected.add(f"tla/{cfg.name}")
+    return expected
+
+
+def expected_mc_tla_for_cfg(config_path: str) -> str:
+    config_name = Path(config_path).name
+    match = re.match(r"^([A-Za-z0-9_]+)", config_name)
+    if not match:
+        raise ValueError(f"unable to derive spec name from config {config_path}")
+    return f"tla/MC{match.group(1)}.tla"
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+    entries = parse_tlc_matrix_entries(CI_WORKFLOW.read_text(encoding="utf-8"))
+
+    matrix_cfgs: set[str] = set()
+    seen_cfg: set[str] = set()
+
+    for entry in entries:
+        if not entry.spec:
+            errors.append("tlc matrix entry has empty spec")
+        if not entry.tla_file:
+            errors.append(f"{entry.spec}: tlc matrix entry has empty tla_file")
+            continue
+        if not entry.config:
+            errors.append(f"{entry.spec}: tlc matrix entry has empty config")
+            continue
+        if not entry.property:
+            errors.append(f"{entry.spec}: tlc matrix entry has empty property")
+
+        if entry.config in seen_cfg:
+            errors.append(f"{entry.config}: duplicated tlc matrix config entry")
+        seen_cfg.add(entry.config)
+        matrix_cfgs.add(entry.config)
+
+        cfg_path = ROOT / entry.config
+        if not cfg_path.is_file():
+            errors.append(f"{entry.config}: listed config does not exist")
+
+        tla_path = ROOT / entry.tla_file
+        if not tla_path.is_file():
+            errors.append(f"{entry.tla_file}: listed tla file does not exist")
+
+        try:
+            expected_tla = expected_mc_tla_for_cfg(entry.config)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        if entry.tla_file != expected_tla:
+            errors.append(
+                f"{entry.config}: expected tla file {expected_tla}, found {entry.tla_file}"
+            )
+
+    expected_cfg_set = expected_ci_cfgs()
+    missing = sorted(expected_cfg_set - matrix_cfgs)
+    extra = sorted(matrix_cfgs - expected_cfg_set)
+
+    for cfg in missing:
+        errors.append(
+            f"{cfg}: missing from tlc matrix (add entry or mark as ignored suffix)"
+        )
+    for cfg in extra:
+        errors.append(
+            f"{cfg}: present in tlc matrix but not in expected non-coverage/non-thorough cfg set"
+        )
+
+    return errors
+
+
+def main() -> int:
+    try:
+        errors = validate()
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        print("TLC matrix contract validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("TLC matrix contract OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/verify_tlc_matrix_contract.py` to enforce TLC matrix coverage for expected `tla/*.cfg` models (excluding `.coverage.cfg` and `.thorough.cfg`)
- add `scripts/verify_proptest_regressions.py` to enforce proptest regression-file policy and constrain `failure_persistence: None` usage to an explicit allowlist
- run both scripts in the CI `Verification guardrail` job
- add `just verification-guardrail` and document the full guardrail set in `dev-docs/VERIFICATION.md`

## Validation
- `python3 scripts/verify_kani_boundary_contract.py`
- `python3 scripts/verify_tlc_matrix_contract.py`
- `python3 scripts/verify_proptest_regressions.py`
- `just verification-guardrail`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TLC matrix and proptest regression drift guardrails to CI
> - Adds [`scripts/verify_tlc_matrix_contract.py`](https://github.com/strawgate/memagent/pull/1775/files#diff-8114ec4c2ed6097810f11d42a75b7828b8aa14f5db3a5351453c6ff7ea6b7bd3) to validate that every `.cfg` file in `tla/` has a corresponding entry in the CI TLC matrix, flagging missing entries, duplicates, bad file paths, and wrong MC TLA mappings.
> - Adds [`scripts/verify_proptest_regressions.py`](https://github.com/strawgate/memagent/pull/1775/files#diff-04fabbe767c1f75243cf1c44af4b42b3f276c7ff1b8d40e33cf08f1373eba89b) to enforce that proptest regression files have seed entries and that tests don't disable `failure_persistence` outside an allowlist.
> - Both scripts are wired into the `verification-guardrail` CI job in [`.github/workflows/ci.yml`](https://github.com/strawgate/memagent/pull/1775/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) and fail the job on any violation.
> - `just lint-all` now runs all three guardrails (kani-boundary, tlc-matrix-contract, proptest-regressions) via the new `verification-guardrail` recipe in [`justfile`](https://github.com/strawgate/memagent/pull/1775/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f629eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->