### PR TITLE
ci: enforce verification trigger contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,9 @@ jobs:
               - '.github/workflows/ci.yml'
             tla:
               - 'tla/**'
-              - 'crates/logfwd-core/src/pipeline/**'
-              - 'crates/logfwd-runtime/src/pipeline.rs'
+              - 'crates/logfwd-types/src/pipeline/**'
+              - 'crates/logfwd-runtime/src/pipeline/**'
+              - 'crates/logfwd-io/src/tail/**'
 
   # -------------------------------------------------------------------------
   # Frontend checks — format, lint, typecheck in one job (single npm install)
@@ -225,6 +226,8 @@ jobs:
         run: python3 scripts/verify_tlc_matrix_contract.py
       - name: Proptest regression policy
         run: python3 scripts/verify_proptest_regressions.py
+      - name: Verification trigger contract
+        run: python3 scripts/verify_verification_trigger_contract.py
 
   # -------------------------------------------------------------------------
   # Tests — Linux and macOS in parallel

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Link check (book + docs + README)
         uses: lycheeverse/lychee-action@v2
         with:
+          lycheeVersion: latest
           args: >-
             --no-progress
             --accept 200,429

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Link check (book + docs + README)
         uses: lycheeverse/lychee-action@v2
         with:
-          lycheeVersion: latest
+          lycheeVersion: v0.23.0
           args: >-
             --no-progress
             --accept 200,429

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -169,6 +169,7 @@ The CI `Verification guardrail` job runs these lightweight anti-drift checks:
 - `scripts/verify_kani_boundary_contract.py` — validates non-core Kani seam policy
 - `scripts/verify_tlc_matrix_contract.py` — validates TLC matrix coverage for expected non-coverage/non-thorough `tla/*.cfg` models
 - `scripts/verify_proptest_regressions.py` — validates persisted proptest regression-file policy and approved `failure_persistence: None` usage
+- `scripts/verify_verification_trigger_contract.py` — validates CI path filters, Kani crate scopes, and guardrail wiring stay aligned
 
 Run them locally:
 

--- a/justfile
+++ b/justfile
@@ -158,8 +158,12 @@ tlc-matrix-contract:
 proptest-regressions:
     python3 scripts/verify_proptest_regressions.py
 
+# Validate CI/just verification trigger contracts stay in sync.
+verification-trigger-contract:
+    python3 scripts/verify_verification_trigger_contract.py
+
 # Run all lightweight verification guardrails enforced in CI.
-verification-guardrail: kani-boundary tlc-matrix-contract proptest-regressions
+verification-guardrail: kani-boundary tlc-matrix-contract proptest-regressions verification-trigger-contract
 
 # Download tla2tools.jar to .tools/ if missing.
 tla-setup:

--- a/scripts/verify_verification_trigger_contract.py
+++ b/scripts/verify_verification_trigger_contract.py
@@ -137,13 +137,29 @@ def extract_paths_filter_entries(ci_text: str, filter_name: str) -> set[str]:
 
 def extract_job_block(ci_text: str, job_name: str) -> list[str]:
     lines = ci_text.splitlines()
+    jobs_start = None
+    jobs_indent = None
+
+    for idx, line in enumerate(lines):
+        if line.strip() == "jobs:":
+            jobs_start = idx
+            jobs_indent = len(line) - len(line.lstrip(" "))
+            break
+
+    if jobs_start is None or jobs_indent is None:
+        raise ValueError("ci.yml missing top-level 'jobs' section")
+
     start = None
     job_indent = None
 
-    for idx, line in enumerate(lines):
-        if line.strip() == f"{job_name}:":
+    for idx, line in enumerate(lines[jobs_start + 1 :], start=jobs_start + 1):
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if stripped and indent <= jobs_indent:
+            break
+        if indent == jobs_indent + 2 and stripped == f"{job_name}:":
             start = idx
-            job_indent = len(line) - len(line.lstrip(" "))
+            job_indent = indent
             break
 
     if start is None or job_indent is None:
@@ -208,6 +224,24 @@ def extract_just_recipe_deps(just_text: str, recipe: str) -> set[str]:
     return {token for token in match.group(1).split() if token}
 
 
+def extract_just_recipe_body(just_text: str, recipe: str) -> list[str]:
+    lines = just_text.splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        if re.match(rf"^{re.escape(recipe)}:\s*(.*)$", line):
+            start = idx + 1
+            break
+    if start is None:
+        raise ValueError(f"justfile missing recipe '{recipe}'")
+
+    body: list[str] = []
+    for line in lines[start:]:
+        if line and not line.startswith(" "):
+            break
+        body.append(line.strip())
+    return body
+
+
 def extract_just_kani_required_crates(just_text: str) -> set[str]:
     lines = just_text.splitlines()
     start = None
@@ -254,6 +288,7 @@ def validate() -> list[str]:
     kani_just_crates = extract_just_kani_required_crates(just_text)
     guardrail_scripts = extract_guardrail_scripts(ci_text)
     guardrail_deps = extract_just_recipe_deps(just_text, "verification-guardrail")
+    trigger_body = extract_just_recipe_body(just_text, "verification-trigger-contract")
 
     for pattern in sorted(REQUIRED_KANI_FILTER_PATTERNS):
         if pattern not in kani_filter:
@@ -286,6 +321,13 @@ def validate() -> list[str]:
     for dep in sorted(REQUIRED_JUST_GUARDRAIL_RECIPES):
         if dep not in guardrail_deps:
             errors.append(f"just verification-guardrail missing dependency: {dep}")
+
+    required_trigger_cmd = "python3 scripts/verify_verification_trigger_contract.py"
+    if not any(required_trigger_cmd in line for line in trigger_body):
+        errors.append(
+            "just verification-trigger-contract missing required command: "
+            f"{required_trigger_cmd}"
+        )
 
     return errors
 
@@ -359,6 +401,30 @@ jobs:
             -Z function-contracts
 """
         self.assertEqual(extract_kani_args_crates(ci_text), {"logfwd-core", "logfwd-io"})
+
+    def test_extract_job_block_scopes_to_jobs_section(self) -> None:
+        ci_text = """
+metadata:
+  changes:
+    note: not a job
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+"""
+        block = extract_job_block(ci_text, "changes")
+        self.assertIn("    runs-on: ubuntu-latest", block)
+
+    def test_extract_just_recipe_body(self) -> None:
+        just_text = """
+verification-trigger-contract:
+    python3 scripts/verify_verification_trigger_contract.py
+verification-guardrail: verification-trigger-contract
+"""
+        body = extract_just_recipe_body(just_text, "verification-trigger-contract")
+        self.assertIn(
+            "python3 scripts/verify_verification_trigger_contract.py",
+            body,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/verify_verification_trigger_contract.py
+++ b/scripts/verify_verification_trigger_contract.py
@@ -62,25 +62,90 @@ def _strip_yaml_value(value: str) -> str:
     return value
 
 
+def _is_required_just_command(line: str, command: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return False
+    return bool(re.match(rf"^(?:@|-)?\s*{re.escape(command)}(?:\s*(?:#.*)?)$", stripped))
+
+
+def _collect_step_lines(job_block: list[str], idx: int) -> list[str]:
+    step_start = idx
+    step_item_indent = None
+    for back_idx in range(idx, -1, -1):
+        candidate = job_block[back_idx]
+        candidate_stripped = candidate.strip()
+        candidate_indent = len(candidate) - len(candidate.lstrip(" "))
+        if candidate_stripped.startswith("- "):
+            step_start = back_idx
+            step_item_indent = candidate_indent
+            break
+
+    if step_item_indent is None:
+        step_item_indent = len(job_block[idx]) - len(job_block[idx].lstrip(" "))
+
+    step_lines = [job_block[step_start]]
+    for next_line in job_block[step_start + 1 :]:
+        next_stripped = next_line.strip()
+        next_indent = len(next_line) - len(next_line.lstrip(" "))
+        if next_stripped.startswith("- ") and next_indent == step_item_indent:
+            break
+        step_lines.append(next_line)
+    return step_lines
+
+
+def extract_job_block(ci_text: str, job_name: str) -> list[str]:
+    lines = ci_text.splitlines()
+    jobs_start = None
+    jobs_indent = None
+
+    for idx, line in enumerate(lines):
+        if line.strip() == "jobs:":
+            jobs_start = idx
+            jobs_indent = len(line) - len(line.lstrip(" "))
+            break
+
+    if jobs_start is None or jobs_indent is None:
+        raise ValueError("ci.yml missing top-level 'jobs' section")
+
+    start = None
+    job_indent = None
+    for idx, line in enumerate(lines[jobs_start + 1 :], start=jobs_start + 1):
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if stripped and indent <= jobs_indent:
+            break
+        if indent == jobs_indent + 2 and stripped == f"{job_name}:":
+            start = idx
+            job_indent = indent
+            break
+
+    if start is None or job_indent is None:
+        raise ValueError(f"ci.yml missing job '{job_name}'")
+
+    block = [lines[start]]
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if stripped and indent <= job_indent:
+            break
+        block.append(line)
+    return block
+
+
 def extract_paths_filter_entries(ci_text: str, filter_name: str) -> set[str]:
     changes_block = extract_job_block(ci_text, "changes")
     filters_block: list[str] | None = None
 
     for idx, line in enumerate(changes_block):
         stripped = line.strip()
-        if not (
-            "uses:" in stripped and "dorny/paths-filter@" in stripped
-        ):
+        if not ("uses:" in stripped and "dorny/paths-filter@" in stripped):
             continue
 
-        step_indent = len(line) - len(line.lstrip(" "))
-        step_lines = [line]
-        for next_line in changes_block[idx + 1 :]:
-            next_stripped = next_line.strip()
-            next_indent = len(next_line) - len(next_line.lstrip(" "))
-            if next_stripped and next_indent <= step_indent:
-                break
-            step_lines.append(next_line)
+        step_lines = _collect_step_lines(changes_block, idx)
+
+        if not any(step_line.strip() == "id: filter" for step_line in step_lines):
+            continue
 
         filters_start = None
         filters_indent = None
@@ -104,9 +169,7 @@ def extract_paths_filter_entries(ci_text: str, filter_name: str) -> set[str]:
         break
 
     if filters_block is None:
-        raise ValueError(
-            "ci.yml missing dorny/paths-filter filters block under the changes job"
-        )
+        raise ValueError("ci.yml missing changes.filter dorny/paths-filter filters block")
 
     entries: set[str] = set()
     in_filter = False
@@ -131,80 +194,49 @@ def extract_paths_filter_entries(ci_text: str, filter_name: str) -> set[str]:
 
     if not entries:
         raise ValueError(f"ci.yml filter '{filter_name}' missing or empty")
-
     return entries
-
-
-def extract_job_block(ci_text: str, job_name: str) -> list[str]:
-    lines = ci_text.splitlines()
-    jobs_start = None
-    jobs_indent = None
-
-    for idx, line in enumerate(lines):
-        if line.strip() == "jobs:":
-            jobs_start = idx
-            jobs_indent = len(line) - len(line.lstrip(" "))
-            break
-
-    if jobs_start is None or jobs_indent is None:
-        raise ValueError("ci.yml missing top-level 'jobs' section")
-
-    start = None
-    job_indent = None
-
-    for idx, line in enumerate(lines[jobs_start + 1 :], start=jobs_start + 1):
-        stripped = line.strip()
-        indent = len(line) - len(line.lstrip(" "))
-        if stripped and indent <= jobs_indent:
-            break
-        if indent == jobs_indent + 2 and stripped == f"{job_name}:":
-            start = idx
-            job_indent = indent
-            break
-
-    if start is None or job_indent is None:
-        raise ValueError(f"ci.yml missing job '{job_name}'")
-
-    block = [lines[start]]
-    for line in lines[start + 1 :]:
-        stripped = line.strip()
-        indent = len(line) - len(line.lstrip(" "))
-        if stripped and indent <= job_indent:
-            break
-        block.append(line)
-    return block
 
 
 def extract_kani_args_crates(ci_text: str) -> set[str]:
     kani_block = extract_job_block(ci_text, "kani")
-    args_lines: list[str] = []
-    collecting = False
-    args_indent = None
 
-    for line in kani_block:
+    for idx, line in enumerate(kani_block):
         stripped = line.strip()
-        indent = len(line) - len(line.lstrip(" "))
-        if not collecting and stripped.startswith("args:"):
-            collecting = True
-            args_indent = indent
-            after_colon = stripped.split(":", 1)[1].strip()
-            if after_colon and after_colon not in {"|", "|-", ">", ">-"}:
-                args_lines.append(after_colon)
+        if not ("uses:" in stripped and "model-checking/kani-github-action@" in stripped):
             continue
 
-        if collecting:
-            if stripped and args_indent is not None and indent <= args_indent:
-                break
-            args_lines.append(stripped)
+        step_lines = _collect_step_lines(kani_block, idx)
 
-    if not args_lines:
-        raise ValueError("ci.yml kani job missing args block")
+        args_lines: list[str] = []
+        collecting = False
+        args_indent = None
+        for step_line in step_lines:
+            step_stripped = step_line.strip()
+            indent = len(step_line) - len(step_line.lstrip(" "))
+            if not collecting and step_stripped.startswith("args:"):
+                collecting = True
+                args_indent = indent
+                after_colon = step_stripped.split(":", 1)[1].strip()
+                if after_colon and after_colon not in {"|", "|-", ">", ">-"}:
+                    args_lines.append(after_colon)
+                continue
+            if collecting:
+                if step_stripped and args_indent is not None and indent <= args_indent:
+                    break
+                args_lines.append(step_stripped)
 
-    joined = " ".join(args_lines)
-    crates = set(re.findall(r"-p\s+([A-Za-z0-9_-]+)", joined))
-    if not crates:
-        raise ValueError("ci.yml kani args missing -p crate entries")
-    return crates
+        if not args_lines:
+            raise ValueError(
+                "ci.yml kani job missing args block for model-checking/kani-github-action"
+            )
+
+        joined = " ".join(args_lines)
+        crates = set(re.findall(r"-p\s+([A-Za-z0-9_-]+)", joined))
+        if not crates:
+            raise ValueError("ci.yml kani args missing -p crate entries")
+        return crates
+
+    raise ValueError("ci.yml kani job missing model-checking/kani-github-action step")
 
 
 def extract_guardrail_scripts(ci_text: str) -> set[str]:
@@ -236,7 +268,7 @@ def extract_just_recipe_body(just_text: str, recipe: str) -> list[str]:
 
     body: list[str] = []
     for line in lines[start:]:
-        if line and not line.startswith(" "):
+        if line and not line.startswith((" ", "\t")):
             break
         body.append(line.strip())
     return body
@@ -254,7 +286,7 @@ def extract_just_kani_required_crates(just_text: str) -> set[str]:
 
     block: list[str] = []
     for line in lines[start:]:
-        if line and not line.startswith(" "):
+        if line and not line.startswith((" ", "\t")):
             break
         block.append(line)
 
@@ -323,7 +355,7 @@ def validate() -> list[str]:
             errors.append(f"just verification-guardrail missing dependency: {dep}")
 
     required_trigger_cmd = "python3 scripts/verify_verification_trigger_contract.py"
-    if not any(required_trigger_cmd in line for line in trigger_body):
+    if not any(_is_required_just_command(line, required_trigger_cmd) for line in trigger_body):
         errors.append(
             "just verification-trigger-contract missing required command: "
             f"{required_trigger_cmd}"
@@ -356,6 +388,7 @@ jobs:
   changes:
     steps:
       - uses: dorny/paths-filter@v3
+        id: filter
         with:
           filters: |
             kani_required:
@@ -380,6 +413,27 @@ jobs:
   changes:
     steps:
       - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            kani_required:
+              - 'crates/logfwd-core/**'
+"""
+        entries = extract_paths_filter_entries(ci_text, "kani_required")
+        self.assertEqual(entries, {"crates/logfwd-core/**"})
+
+    def test_extract_paths_filter_entries_uses_filter_id_step(self) -> None:
+        ci_text = """
+jobs:
+  changes:
+    steps:
+      - uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            kani_required:
+              - 'docs/**'
+      - uses: dorny/paths-filter@v3
+        id: filter
         with:
           filters: |
             kani_required:
@@ -401,6 +455,22 @@ jobs:
             -Z function-contracts
 """
         self.assertEqual(extract_kani_args_crates(ci_text), {"logfwd-core", "logfwd-io"})
+
+    def test_extract_kani_args_crates_uses_kani_action_step(self) -> None:
+        ci_text = """
+jobs:
+  kani:
+    steps:
+      - uses: some/other-action@v1
+        with:
+          args: >-
+            -p fake
+      - uses: model-checking/kani-github-action@v1
+        with:
+          args: >-
+            -p logfwd-core
+"""
+        self.assertEqual(extract_kani_args_crates(ci_text), {"logfwd-core"})
 
     def test_extract_job_block_scopes_to_jobs_section(self) -> None:
         ci_text = """
@@ -425,6 +495,25 @@ verification-guardrail: verification-trigger-contract
             "python3 scripts/verify_verification_trigger_contract.py",
             body,
         )
+
+    def test_extract_just_recipe_body_accepts_tab_indentation(self) -> None:
+        just_text = (
+            "verification-trigger-contract:\n"
+            "\tpython3 scripts/verify_verification_trigger_contract.py\n"
+            "verification-guardrail: verification-trigger-contract\n"
+        )
+        body = extract_just_recipe_body(just_text, "verification-trigger-contract")
+        self.assertIn(
+            "python3 scripts/verify_verification_trigger_contract.py",
+            body,
+        )
+
+    def test_is_required_just_command(self) -> None:
+        required = "python3 scripts/verify_verification_trigger_contract.py"
+        self.assertTrue(_is_required_just_command(required, required))
+        self.assertTrue(_is_required_just_command(f"@{required}", required))
+        self.assertFalse(_is_required_just_command(f"echo '{required}'", required))
+        self.assertFalse(_is_required_just_command(f"# {required}", required))
 
 
 if __name__ == "__main__":

--- a/scripts/verify_verification_trigger_contract.py
+++ b/scripts/verify_verification_trigger_contract.py
@@ -25,6 +25,7 @@ REQUIRED_KANI_FILTER_PATTERNS = {
     "crates/logfwd-arrow/**",
     "crates/logfwd-io/**",
     "crates/logfwd-output/**",
+    "crates/logfwd-diagnostics/**",
     "Cargo.toml",
     "Cargo.lock",
     "dev-docs/verification/kani-boundary-contract.toml",

--- a/scripts/verify_verification_trigger_contract.py
+++ b/scripts/verify_verification_trigger_contract.py
@@ -94,6 +94,10 @@ def _collect_step_lines(job_block: list[str], idx: int) -> list[str]:
     return step_lines
 
 
+def _is_yaml_block_scalar_header(line: str, key: str) -> bool:
+    return bool(re.match(rf"^{re.escape(key)}:\s*[|>][-+]?\s*$", line.strip()))
+
+
 def extract_job_block(ci_text: str, job_name: str) -> list[str]:
     lines = ci_text.splitlines()
     jobs_start = None
@@ -150,7 +154,7 @@ def extract_paths_filter_entries(ci_text: str, filter_name: str) -> set[str]:
         filters_start = None
         filters_indent = None
         for step_idx, step_line in enumerate(step_lines):
-            if step_line.strip() == "filters: |":
+            if _is_yaml_block_scalar_header(step_line, "filters"):
                 filters_start = step_idx + 1
                 filters_indent = len(step_line) - len(step_line.lstrip(" "))
                 break
@@ -278,7 +282,7 @@ def extract_just_kani_required_crates(just_text: str) -> set[str]:
     lines = just_text.splitlines()
     start = None
     for idx, line in enumerate(lines):
-        if line.strip() == "kani-required:":
+        if re.match(r"^kani-required:\s*(.*)$", line):
             start = idx + 1
             break
     if start is None:
@@ -442,6 +446,23 @@ jobs:
         entries = extract_paths_filter_entries(ci_text, "kani_required")
         self.assertEqual(entries, {"crates/logfwd-core/**"})
 
+    def test_extract_paths_filter_entries_accepts_yaml_block_scalar_variants(self) -> None:
+        for block_style in ("|", "|-", ">", ">-"):
+            with self.subTest(block_style=block_style):
+                ci_text = f"""
+jobs:
+  changes:
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: {block_style}
+            kani_required:
+              - 'crates/logfwd-core/**'
+"""
+                entries = extract_paths_filter_entries(ci_text, "kani_required")
+                self.assertEqual(entries, {"crates/logfwd-core/**"})
+
     def test_extract_kani_args_crates(self) -> None:
         ci_text = """
 jobs:
@@ -471,6 +492,17 @@ jobs:
             -p logfwd-core
 """
         self.assertEqual(extract_kani_args_crates(ci_text), {"logfwd-core"})
+
+    def test_extract_just_kani_required_crates_accepts_recipe_dependencies(self) -> None:
+        just_text = """
+kani-required: prep-cache
+    cargo kani -p logfwd-core
+    cargo kani -p logfwd-io
+"""
+        self.assertEqual(
+            extract_just_kani_required_crates(just_text),
+            {"logfwd-core", "logfwd-io"},
+        )
 
     def test_extract_job_block_scopes_to_jobs_section(self) -> None:
         ci_text = """

--- a/scripts/verify_verification_trigger_contract.py
+++ b/scripts/verify_verification_trigger_contract.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Validate CI/just verification trigger contracts stay in sync."""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+JUSTFILE = ROOT / "justfile"
+
+REQUIRED_KANI_CRATES = {
+    "logfwd-core",
+    "logfwd-arrow",
+    "logfwd-io",
+    "logfwd-output",
+}
+
+REQUIRED_KANI_FILTER_PATTERNS = {
+    "crates/logfwd-core/**",
+    "crates/logfwd-arrow/**",
+    "crates/logfwd-io/**",
+    "crates/logfwd-output/**",
+    "Cargo.toml",
+    "Cargo.lock",
+    "dev-docs/verification/kani-boundary-contract.toml",
+    "scripts/verify_kani_boundary_contract.py",
+    ".github/workflows/ci.yml",
+}
+
+REQUIRED_TLA_FILTER_PATTERNS = {
+    "tla/**",
+    "crates/logfwd-types/src/pipeline/**",
+    "crates/logfwd-runtime/src/pipeline/**",
+    "crates/logfwd-io/src/tail/**",
+}
+
+REQUIRED_GUARDRAIL_SCRIPTS = {
+    "scripts/verify_kani_boundary_contract.py",
+    "scripts/verify_tlc_matrix_contract.py",
+    "scripts/verify_proptest_regressions.py",
+    "scripts/verify_verification_trigger_contract.py",
+}
+
+REQUIRED_JUST_GUARDRAIL_RECIPES = {
+    "kani-boundary",
+    "tlc-matrix-contract",
+    "proptest-regressions",
+    "verification-trigger-contract",
+}
+
+
+def _strip_yaml_value(value: str) -> str:
+    value = value.strip()
+    if value and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1]
+    return value
+
+
+def extract_paths_filter_entries(ci_text: str, filter_name: str) -> set[str]:
+    lines = ci_text.splitlines()
+    filters_start = None
+    filters_indent = None
+
+    for idx, line in enumerate(lines):
+        if line.strip() == "filters: |":
+            filters_start = idx + 1
+            filters_indent = len(line) - len(line.lstrip(" "))
+            break
+
+    if filters_start is None or filters_indent is None:
+        raise ValueError("ci.yml missing dorny/paths-filter literal filters block")
+
+    block: list[str] = []
+    for line in lines[filters_start:]:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if stripped and indent <= filters_indent:
+            break
+        block.append(line)
+
+    entries: set[str] = set()
+    in_filter = False
+    filter_indent = None
+
+    for line in block:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if not stripped:
+            continue
+
+        if stripped == f"{filter_name}:":
+            in_filter = True
+            filter_indent = indent
+            continue
+
+        if in_filter and filter_indent is not None and indent <= filter_indent:
+            break
+
+        if in_filter and stripped.startswith("- "):
+            entries.add(_strip_yaml_value(stripped[2:]))
+
+    if not entries:
+        raise ValueError(f"ci.yml filter '{filter_name}' missing or empty")
+
+    return entries
+
+
+def extract_job_block(ci_text: str, job_name: str) -> list[str]:
+    lines = ci_text.splitlines()
+    start = None
+    job_indent = None
+
+    for idx, line in enumerate(lines):
+        if line.strip() == f"{job_name}:":
+            start = idx
+            job_indent = len(line) - len(line.lstrip(" "))
+            break
+
+    if start is None or job_indent is None:
+        raise ValueError(f"ci.yml missing job '{job_name}'")
+
+    block = [lines[start]]
+    for line in lines[start + 1 :]:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if stripped and indent <= job_indent:
+            break
+        block.append(line)
+    return block
+
+
+def extract_kani_args_crates(ci_text: str) -> set[str]:
+    kani_block = extract_job_block(ci_text, "kani")
+    args_lines: list[str] = []
+    collecting = False
+    args_indent = None
+
+    for line in kani_block:
+        stripped = line.strip()
+        indent = len(line) - len(line.lstrip(" "))
+        if not collecting and stripped.startswith("args:"):
+            collecting = True
+            args_indent = indent
+            after_colon = stripped.split(":", 1)[1].strip()
+            if after_colon and after_colon not in {"|", "|-", ">", ">-"}:
+                args_lines.append(after_colon)
+            continue
+
+        if collecting:
+            if stripped and args_indent is not None and indent <= args_indent:
+                break
+            args_lines.append(stripped)
+
+    if not args_lines:
+        raise ValueError("ci.yml kani job missing args block")
+
+    joined = " ".join(args_lines)
+    crates = set(re.findall(r"-p\s+([A-Za-z0-9_-]+)", joined))
+    if not crates:
+        raise ValueError("ci.yml kani args missing -p crate entries")
+    return crates
+
+
+def extract_guardrail_scripts(ci_text: str) -> set[str]:
+    guardrail_block = extract_job_block(ci_text, "verification-guardrail")
+    scripts = set()
+    for line in guardrail_block:
+        stripped = line.strip()
+        if stripped.startswith("run: python3 scripts/"):
+            scripts.add(stripped.removeprefix("run: python3 ").strip())
+    return scripts
+
+
+def extract_just_recipe_deps(just_text: str, recipe: str) -> set[str]:
+    match = re.search(rf"^{re.escape(recipe)}:\s*(.*)$", just_text, re.MULTILINE)
+    if not match:
+        raise ValueError(f"justfile missing recipe '{recipe}'")
+    return {token for token in match.group(1).split() if token}
+
+
+def extract_just_kani_required_crates(just_text: str) -> set[str]:
+    lines = just_text.splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        if line.strip() == "kani-required:":
+            start = idx + 1
+            break
+    if start is None:
+        raise ValueError("justfile missing 'kani-required' recipe")
+
+    block: list[str] = []
+    for line in lines[start:]:
+        if line and not line.startswith(" "):
+            break
+        block.append(line)
+
+    joined = " ".join(part.strip() for part in block)
+    crates = set(re.findall(r"cargo\s+kani\s+-p\s+([A-Za-z0-9_-]+)", joined))
+    if not crates:
+        raise ValueError("justfile 'kani-required' has no cargo kani -p entries")
+    return crates
+
+
+def pattern_base_exists(pattern: str) -> bool:
+    wildcard_idx = len(pattern)
+    for token in ("**", "*", "?"):
+        idx = pattern.find(token)
+        if idx != -1:
+            wildcard_idx = min(wildcard_idx, idx)
+    base = pattern[:wildcard_idx].rstrip("/")
+    if not base:
+        return True
+    return (ROOT / base).exists()
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+    ci_text = CI_WORKFLOW.read_text(encoding="utf-8")
+    just_text = JUSTFILE.read_text(encoding="utf-8")
+
+    kani_filter = extract_paths_filter_entries(ci_text, "kani_required")
+    tla_filter = extract_paths_filter_entries(ci_text, "tla")
+    kani_ci_crates = extract_kani_args_crates(ci_text)
+    kani_just_crates = extract_just_kani_required_crates(just_text)
+    guardrail_scripts = extract_guardrail_scripts(ci_text)
+    guardrail_deps = extract_just_recipe_deps(just_text, "verification-guardrail")
+
+    for pattern in sorted(REQUIRED_KANI_FILTER_PATTERNS):
+        if pattern not in kani_filter:
+            errors.append(f"kani_required filter missing pattern: {pattern}")
+    for pattern in sorted(REQUIRED_TLA_FILTER_PATTERNS):
+        if pattern not in tla_filter:
+            errors.append(f"tla filter missing pattern: {pattern}")
+
+    for pattern in sorted(kani_filter | tla_filter):
+        if not pattern_base_exists(pattern):
+            errors.append(f"filter pattern base path does not exist: {pattern}")
+
+    for crate in sorted(REQUIRED_KANI_CRATES):
+        if crate not in kani_ci_crates:
+            errors.append(f"ci kani args missing crate: {crate}")
+        if crate not in kani_just_crates:
+            errors.append(f"justfile kani-required missing crate: {crate}")
+
+    for crate in sorted(kani_ci_crates - kani_just_crates):
+        errors.append(f"ci kani crate not present in just kani-required: {crate}")
+    for crate in sorted(kani_just_crates - kani_ci_crates):
+        errors.append(f"just kani-required crate not present in ci kani args: {crate}")
+
+    for script in sorted(REQUIRED_GUARDRAIL_SCRIPTS):
+        if not (ROOT / script).is_file():
+            errors.append(f"guardrail script missing on disk: {script}")
+        if script not in guardrail_scripts:
+            errors.append(f"verification-guardrail job missing script: {script}")
+
+    for dep in sorted(REQUIRED_JUST_GUARDRAIL_RECIPES):
+        if dep not in guardrail_deps:
+            errors.append(f"just verification-guardrail missing dependency: {dep}")
+
+    return errors
+
+
+def main() -> int:
+    try:
+        errors = validate()
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if errors:
+        print("Verification trigger contract validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("Verification trigger contract OK")
+    return 0
+
+
+class VerificationTriggerContractTests(unittest.TestCase):
+    def test_extract_paths_filter_entries(self) -> None:
+        ci_text = """
+jobs:
+  changes:
+    steps:
+      - uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            kani_required:
+              - 'crates/logfwd-core/**'
+              - 'Cargo.toml'
+            tla:
+              - 'tla/**'
+"""
+        entries = extract_paths_filter_entries(ci_text, "kani_required")
+        self.assertEqual(entries, {"crates/logfwd-core/**", "Cargo.toml"})
+
+    def test_extract_kani_args_crates(self) -> None:
+        ci_text = """
+jobs:
+  kani:
+    steps:
+      - uses: model-checking/kani-github-action@v1
+        with:
+          args: >-
+            -p logfwd-core
+            -p logfwd-io
+            -Z function-contracts
+"""
+        self.assertEqual(extract_kani_args_crates(ci_text), {"logfwd-core", "logfwd-io"})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_verification_trigger_contract.py
+++ b/scripts/verify_verification_trigger_contract.py
@@ -63,32 +63,56 @@ def _strip_yaml_value(value: str) -> str:
 
 
 def extract_paths_filter_entries(ci_text: str, filter_name: str) -> set[str]:
-    lines = ci_text.splitlines()
-    filters_start = None
-    filters_indent = None
+    changes_block = extract_job_block(ci_text, "changes")
+    filters_block: list[str] | None = None
 
-    for idx, line in enumerate(lines):
-        if line.strip() == "filters: |":
-            filters_start = idx + 1
-            filters_indent = len(line) - len(line.lstrip(" "))
-            break
-
-    if filters_start is None or filters_indent is None:
-        raise ValueError("ci.yml missing dorny/paths-filter literal filters block")
-
-    block: list[str] = []
-    for line in lines[filters_start:]:
+    for idx, line in enumerate(changes_block):
         stripped = line.strip()
-        indent = len(line) - len(line.lstrip(" "))
-        if stripped and indent <= filters_indent:
-            break
-        block.append(line)
+        if not (
+            "uses:" in stripped and "dorny/paths-filter@" in stripped
+        ):
+            continue
+
+        step_indent = len(line) - len(line.lstrip(" "))
+        step_lines = [line]
+        for next_line in changes_block[idx + 1 :]:
+            next_stripped = next_line.strip()
+            next_indent = len(next_line) - len(next_line.lstrip(" "))
+            if next_stripped and next_indent <= step_indent:
+                break
+            step_lines.append(next_line)
+
+        filters_start = None
+        filters_indent = None
+        for step_idx, step_line in enumerate(step_lines):
+            if step_line.strip() == "filters: |":
+                filters_start = step_idx + 1
+                filters_indent = len(step_line) - len(step_line.lstrip(" "))
+                break
+
+        if filters_start is None or filters_indent is None:
+            continue
+
+        block: list[str] = []
+        for block_line in step_lines[filters_start:]:
+            block_stripped = block_line.strip()
+            block_indent = len(block_line) - len(block_line.lstrip(" "))
+            if block_stripped and block_indent <= filters_indent:
+                break
+            block.append(block_line)
+        filters_block = block
+        break
+
+    if filters_block is None:
+        raise ValueError(
+            "ci.yml missing dorny/paths-filter filters block under the changes job"
+        )
 
     entries: set[str] = set()
     in_filter = False
     filter_indent = None
 
-    for line in block:
+    for line in filters_block:
         stripped = line.strip()
         indent = len(line) - len(line.lstrip(" "))
         if not stripped:
@@ -300,6 +324,27 @@ jobs:
 """
         entries = extract_paths_filter_entries(ci_text, "kani_required")
         self.assertEqual(entries, {"crates/logfwd-core/**", "Cargo.toml"})
+
+    def test_extract_paths_filter_entries_uses_changes_job_block(self) -> None:
+        ci_text = """
+jobs:
+  unrelated:
+    steps:
+      - uses: some/other-action@v1
+        with:
+          filters: |
+            kani_required:
+              - 'docs/**'
+  changes:
+    steps:
+      - uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            kani_required:
+              - 'crates/logfwd-core/**'
+"""
+        entries = extract_paths_filter_entries(ci_text, "kani_required")
+        self.assertEqual(entries, {"crates/logfwd-core/**"})
 
     def test_extract_kani_args_crates(self) -> None:
         ci_text = """


### PR DESCRIPTION
## Summary
- add `scripts/verify_verification_trigger_contract.py` to validate verification trigger wiring across CI and just:
  - `changes` path filters for `kani_required` and `tla`
  - Kani crate list consistency between CI (`kani` job args) and `just kani-required`
  - `verification-guardrail` script wiring in both CI and justfile
  - stale path-pattern detection (base path must exist)
- fix stale TLA trigger path filters in CI:
  - replace removed `crates/logfwd-runtime/src/pipeline.rs` with `crates/logfwd-runtime/src/pipeline/**`
  - update core path to current location `crates/logfwd-types/src/pipeline/**`
  - add `crates/logfwd-io/src/tail/**` to trigger TLC on TailLifecycle-related implementation changes
- wire the new validator into CI `Verification guardrail` and `just verification-guardrail`
- document the new guardrail in `dev-docs/VERIFICATION.md`

## Validation
- `python3 scripts/verify_verification_trigger_contract.py`
- `python3 -m unittest scripts.verify_verification_trigger_contract -v`
- `just verification-guardrail`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce verification trigger contract in CI and justfile guardrail
> - Adds [verify_verification_trigger_contract.py](https://github.com/strawgate/memagent/pull/1777/files#diff-a05fa830e53d7b2dd9054e4c299411f44d67b59f27fd6dcfc7760e9ee2db689e), a script that validates alignment between CI path filters, Kani crate lists, guardrail scripts, and just recipe dependencies, exiting with status 1 on mismatches.
> - Integrates the script as a new step in the `verification-guardrail` CI job and as a new `verification-trigger-contract` dependency in the `just verification-guardrail` recipe.
> - Updates the `tla` path filter in the `changes` job to cover `crates/logfwd-types/src/pipeline/**`, `crates/logfwd-runtime/src/pipeline/**`, and `crates/logfwd-io/src/tail/**`.
> - Pins the lychee link checker to `v0.23.0` in [docs.yml](https://github.com/strawgate/memagent/pull/1777/files#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2c).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37be1de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->