### PR TITLE
dev: add local miri just targets

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,6 +19,7 @@ Optional but recommended:
 | [Docker](https://www.docker.com) | Local services (`docker-compose.dev.yml`) | docker.com |
 | [sccache](https://github.com/mozilla/sccache) | Compile caching | `cargo install sccache --locked` |
 | [OpenJDK](https://openjdk.org) | Run TLC model checks (`just tlc-tail`) | `brew install openjdk` (macOS) |
+| Miri nightly components | Local UB checks (`just miri`) | `just miri-setup` |
 
 All tool versions are declared in `mise.toml`. If you have [mise](https://mise.jdx.dev) installed, `mise install` sets everything up automatically. Otherwise, install the tools listed above manually.
 
@@ -74,6 +75,8 @@ just test                    # tests (default-members only, ~30s)
 just test-all                # tests (full workspace, ~3min)
 just lint                    # fmt + clippy + toml
 just lint-all                # full: fmt + clippy + toml + deny + kani-boundary
+just miri-setup              # install nightly Miri components locally
+just miri                    # Miri checks for logfwd-core and logfwd-types
 just tlc-tail                # run TailLifecycle TLA+ model check
 just build                   # release logfwd binary (includes DataFusion SQL)
 just build-dev-lite          # dev-only fast binary (no DataFusion SQL)

--- a/justfile
+++ b/justfile
@@ -139,7 +139,7 @@ test-all:
 kani:
     just kani-required
 
-# Run the Miri suite used by CI for proof-heavy pure crates.
+# Run local Miri checks for proof-heavy pure crates.
 # Requires:
 #   rustup component add --toolchain nightly miri rust-src
 miri-setup:
@@ -147,17 +147,14 @@ miri-setup:
 
 miri:
     just miri-setup
+    RUSTC_WRAPPER="" cargo +nightly miri setup
     just miri-core
     just miri-types
 
 miri-core:
-    just miri-setup
-    RUSTC_WRAPPER="" cargo +nightly miri setup
     RUSTC_WRAPPER="" MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-core --lib
 
 miri-types:
-    just miri-setup
-    RUSTC_WRAPPER="" cargo +nightly miri setup
     RUSTC_WRAPPER="" MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-types --lib
 
 # Run the required Kani crate set enforced by CI guardrails.

--- a/justfile
+++ b/justfile
@@ -139,6 +139,27 @@ test-all:
 kani:
     just kani-required
 
+# Run the Miri suite used by CI for proof-heavy pure crates.
+# Requires:
+#   rustup component add --toolchain nightly miri rust-src
+miri-setup:
+    rustup component add --toolchain nightly miri rust-src
+
+miri:
+    just miri-setup
+    just miri-core
+    just miri-types
+
+miri-core:
+    just miri-setup
+    RUSTC_WRAPPER="" cargo +nightly miri setup
+    RUSTC_WRAPPER="" MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-core --lib
+
+miri-types:
+    just miri-setup
+    RUSTC_WRAPPER="" cargo +nightly miri setup
+    RUSTC_WRAPPER="" MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-types --lib
+
 # Run the required Kani crate set enforced by CI guardrails.
 kani-required:
     RUSTC_WRAPPER="" cargo kani -p logfwd-core -Z function-contracts -Z mem-predicates -Z stubbing


### PR DESCRIPTION
## Summary
- add `just miri-setup`, `just miri`, `just miri-core`, and `just miri-types`
- align local Miri commands with the CI lane using nightly and strict provenance
- document the new local Miri workflow in `DEVELOPING.md`

## Validation
- `just --list`
- `just -n miri-setup`
- `just -n miri`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local Miri just targets for `logfwd-core` and `logfwd-types`
> Adds four new recipes to the [justfile](https://github.com/strawgate/memagent/pull/1779/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1): `miri-setup` (installs nightly Miri and `rust-src` via rustup), `miri` (runs full Miri test suite), `miri-core`, and `miri-types` (run Miri tests for each crate with strict provenance enabled and `RUSTC_WRAPPER` unset). Updates [DEVELOPING.md](https://github.com/strawgate/memagent/pull/1779/files#diff-8822179a8da757fde968cf80a9162e1c1d6f8cc170509cfbdea10be03b7e7d20) to document Miri and the new commands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 936a868.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->