### PR TITLE
ci: stabilize miri proptests and raise verification timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.kani_required == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 
@@ -543,7 +543,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.tla == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/crates/logfwd-core/src/reassembler.rs
+++ b/crates/logfwd-core/src/reassembler.rs
@@ -265,8 +265,13 @@ mod tests {
 mod proptests {
     use super::*;
     use proptest::prelude::*;
+    use proptest::test_runner::Config as ProptestConfig;
 
     proptest! {
+        #![proptest_config(ProptestConfig {
+            failure_persistence: None,
+            .. ProptestConfig::default()
+        })]
         /// Output never exceeds max_message_size for any sequence of P and F feeds.
         ///
         /// Extends the Kani proofs (fixed depth P+F, P+P+F) to arbitrary-length

--- a/crates/logfwd-core/src/scanner.rs
+++ b/crates/logfwd-core/src/scanner.rs
@@ -614,6 +614,7 @@ mod kani_proofs {
 mod proptest_builder_state {
     use super::BuilderState;
     use proptest::prelude::*;
+    use proptest::test_runner::Config as ProptestConfig;
 
     /// Simulate a state transition (same logic as Kani proofs).
     fn transition(state: BuilderState, op: u8) -> Option<BuilderState> {
@@ -631,6 +632,10 @@ mod proptest_builder_state {
     // Generate a random valid operation sequence that ends with
     // `finish_batch`, then verify the final state is `Idle`.
     proptest! {
+        #![proptest_config(ProptestConfig {
+            failure_persistence: None,
+            .. ProptestConfig::default()
+        })]
         #[test]
         fn random_valid_sequence_ends_idle(ops in prop::collection::vec(0u8..6, 1..50)) {
             let mut state = BuilderState::Idle;

--- a/crates/logfwd-core/src/structural.rs
+++ b/crates/logfwd-core/src/structural.rs
@@ -505,8 +505,13 @@ pub fn find_structural_chars(block: &[u8; 64]) -> RawBlockMasks {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use proptest::test_runner::Config as ProptestConfig;
 
     proptest! {
+        #![proptest_config(ProptestConfig {
+            failure_persistence: None,
+            .. ProptestConfig::default()
+        })]
         #[test]
         fn simd_eq_scalar(
             block in (any::<[u8; 32]>(), any::<[u8; 32]>()).prop_map(|(a, b)| {

--- a/crates/logfwd-types/src/pipeline/lifecycle.rs
+++ b/crates/logfwd-types/src/pipeline/lifecycle.rs
@@ -1311,6 +1311,7 @@ mod verification {
 mod proptests {
     use super::*;
     use proptest::prelude::*;
+    use proptest::test_runner::Config as ProptestConfig;
 
     #[derive(Debug, Clone)]
     enum Action {
@@ -1330,6 +1331,10 @@ mod proptests {
     }
 
     proptest! {
+        #![proptest_config(ProptestConfig {
+            failure_persistence: None,
+            .. ProptestConfig::default()
+        })]
         /// Random event sequences: in-flight count is always consistent.
         #[test]
         fn in_flight_consistent(actions in proptest::collection::vec(action_strategy(), 1..50)) {

--- a/scripts/verify_proptest_regressions.py
+++ b/scripts/verify_proptest_regressions.py
@@ -11,8 +11,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CRATES = ROOT / "crates"
 NO_PERSISTENCE_ALLOWLIST = {
+    "crates/logfwd-core/src/reassembler.rs",
+    "crates/logfwd-core/src/scanner.rs",
+    "crates/logfwd-core/src/structural.rs",
     "crates/logfwd-core/src/cri.rs",
     "crates/logfwd-core/src/json_scanner.rs",
+    "crates/logfwd-types/src/pipeline/lifecycle.rs",
     "crates/logfwd-io/tests/it/checkpoint_state_machine.rs",
 }
 


### PR DESCRIPTION
## Summary
- disable proptest failure persistence in remaining Miri-exercised property modules to avoid `getcwd` isolation failures under Miri
- update proptest regression allowlist to include the newly no-persistence modules
- increase CI timeouts for long-running verification lanes (`Kani proofs` and `TLA+ PipelineMachine (thorough)`) to match observed runtime

## Validation
- `just verification-guardrail`
- `python3 scripts/verify_proptest_regressions.py`
- `cargo test -p logfwd-core reassembler_output_never_exceeds_max_size`
- `cargo test -p logfwd-core random_valid_sequence_ends_idle`
- `cargo test -p logfwd-core simd_eq_scalar`
- `cargo test -p logfwd-types in_flight_consistent`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stabilize miri proptests and raise CI verification timeouts
> - Disables proptest failure persistence (`failure_persistence: None`) in four test modules across `logfwd-core` and `logfwd-types` to prevent flaky miri runs caused by filesystem access during persistence.
> - Updates [`verify_proptest_regressions.py`](https://github.com/strawgate/memagent/pull/1790/files#diff-04fabbe767c1f75243cf1c44af4b42b3f276c7ff1b8d40e33cf08f1373eba89b) to allowlist these four files so the script does not flag them as missing persistence.
> - Raises the `kani` job timeout from 60 to 90 minutes and the `tlc-coverage` job timeout from 20 to 30 minutes in [`ci.yml`](https://github.com/strawgate/memagent/pull/1790/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0ecf1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->