### PR TITLE
fix: address 12 confirmed findings from codebase audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.miri == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 
@@ -589,7 +589,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.tla == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,7 +589,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.tla == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2523,6 +2523,7 @@ dependencies = [
  "arrow",
  "bytes",
  "logfwd-core",
+ "logfwd-types",
  "serial_test",
  "stats_alloc",
 ]

--- a/crates/logfwd-arrow/Cargo.toml
+++ b/crates/logfwd-arrow/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 logfwd-core = { version = "0.1.0", path = "../logfwd-core" }
+logfwd-types = { version = "0.1.0", path = "../logfwd-types" }
 arrow = { workspace = true }
 bytes = "1"
 

--- a/crates/logfwd-arrow/src/scanner.rs
+++ b/crates/logfwd-arrow/src/scanner.rs
@@ -140,6 +140,7 @@ mod tests {
     use arrow::array::{Array, BooleanArray, Int64Array, StringArray};
     use bytes::Bytes;
     use logfwd_core::scan_config::{FieldSpec, ScanConfig};
+    use logfwd_types::field_names;
 
     fn default_scanner(_rows: usize) -> Scanner {
         Scanner::new(ScanConfig::default())
@@ -363,7 +364,7 @@ mod tests {
         assert_eq!(
             svc_field
                 .metadata()
-                .get("logfwd.resource_key")
+                .get(field_names::METADATA_RESOURCE_KEY)
                 .map(String::as_str),
             Some("service.name"),
             "field metadata must preserve original dotted key"

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -21,6 +21,8 @@ use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use arrow::error::ArrowError;
 use arrow::record_batch::RecordBatch;
 
+use logfwd_types::field_names;
+
 use crate::conflict_schema::{has_conflict_struct_columns, normalize_conflict_columns};
 
 /// OTAP star schema representation for Logs.
@@ -45,23 +47,49 @@ pub struct StarSchema {
 // ---------------------------------------------------------------------------
 // Well-known column name mappings
 // ---------------------------------------------------------------------------
+// Canonical names and heuristic variants are defined in
+// `logfwd_types::field_names` — the single source of truth.  The helpers
+// below delegate to `field_names::matches_any` so that adding a new variant
+// in one place automatically propagates here.
 
-/// Columns that map to the LOGS fact table (not LOG_ATTRS).
+/// Returns `true` when `name` matches a well-known timestamp column.
 // `@timestamp` (Elasticsearch convention) is intentionally included.  Both
 // `field_names::TIMESTAMP_VARIANTS` and the Loki/ES sinks recognise it; the
 // OTAP conversion must be consistent.  Fixes #1669.
-const WELL_KNOWN_TIMESTAMP: &[&str] = &["_timestamp", "@timestamp", "timestamp", "time", "ts"];
-const WELL_KNOWN_SEVERITY: &[&str] = &["level", "severity", "log_level", "loglevel", "lvl"];
-const WELL_KNOWN_BODY: &[&str] = &["message", "msg", "_msg", "body"];
-const WELL_KNOWN_TRACE_ID: &[&str] = &["trace_id"];
-const WELL_KNOWN_SPAN_ID: &[&str] = &["span_id"];
-const WELL_KNOWN_FLAGS: &[&str] = &["flags", "trace_flags"];
+fn is_well_known_timestamp(name: &str) -> bool {
+    field_names::matches_any(name, field_names::TIMESTAMP, field_names::TIMESTAMP_VARIANTS)
+}
+
+/// Returns `true` when `name` matches a well-known severity column.
+fn is_well_known_severity(name: &str) -> bool {
+    field_names::matches_any(name, field_names::SEVERITY, field_names::SEVERITY_VARIANTS)
+}
+
+/// Returns `true` when `name` matches a well-known body/message column.
+fn is_well_known_body(name: &str) -> bool {
+    field_names::matches_any(name, field_names::BODY, field_names::BODY_VARIANTS)
+}
+
+/// Returns `true` when `name` matches a well-known trace-ID column.
+fn is_well_known_trace_id(name: &str) -> bool {
+    name == field_names::TRACE_ID
+}
+
+/// Returns `true` when `name` matches a well-known span-ID column.
+fn is_well_known_span_id(name: &str) -> bool {
+    name == field_names::SPAN_ID
+}
+
+/// Returns `true` when `name` matches a well-known flags column.
+fn is_well_known_flags(name: &str) -> bool {
+    field_names::matches_any(name, field_names::TRACE_FLAGS, field_names::TRACE_FLAGS_VARIANTS)
+}
 
 /// Canonical resource attribute prefix shared across receivers/sinks.
-pub(crate) const RESOURCE_PREFIX: &str = "resource.attributes.";
+const RESOURCE_PREFIX: &str = field_names::DEFAULT_RESOURCE_PREFIX;
 
 /// Legacy prefix for backwards compatibility with older batches.
-pub(crate) const LEGACY_RESOURCE_PREFIX: &str = "_resource_";
+const LEGACY_RESOURCE_PREFIX: &str = field_names::LEGACY_RESOURCE_PREFIX;
 
 // ---------------------------------------------------------------------------
 // Attribute type tags (stored in the `type` column of attrs tables)
@@ -173,7 +201,7 @@ pub fn flat_to_star(batch: &RecordBatch) -> Result<StarSchema, ArrowError> {
                 name.strip_prefix(LEGACY_RESOURCE_PREFIX).map(|stripped| {
                     field
                         .metadata()
-                        .get("logfwd.resource_key")
+                        .get(field_names::METADATA_RESOURCE_KEY)
                         .cloned()
                         .unwrap_or_else(|| stripped.to_string())
                 })
@@ -183,23 +211,23 @@ pub fn flat_to_star(batch: &RecordBatch) -> Result<StarSchema, ArrowError> {
             continue;
         }
 
-        if timestamp_col.is_none() && WELL_KNOWN_TIMESTAMP.contains(&name) {
+        if timestamp_col.is_none() && is_well_known_timestamp(name) {
             timestamp_col = Some(idx);
             continue;
         }
-        if severity_col.is_none() && WELL_KNOWN_SEVERITY.contains(&name) {
+        if severity_col.is_none() && is_well_known_severity(name) {
             severity_col = Some(idx);
             continue;
         }
-        if WELL_KNOWN_BODY.contains(&name) {
+        if is_well_known_body(name) {
             match body_col {
                 None => {
                     body_col = Some(idx);
                     continue;
                 }
-                Some(prev_idx) if name == "body" => {
+                Some(prev_idx) if name == field_names::BODY => {
                     let prev_name = batch.schema().field(prev_idx).name().clone();
-                    if prev_name != "body" {
+                    if prev_name != field_names::BODY {
                         attr_cols.push((prev_name, prev_idx));
                         body_col = Some(idx);
                         continue;
@@ -208,18 +236,18 @@ pub fn flat_to_star(batch: &RecordBatch) -> Result<StarSchema, ArrowError> {
                 Some(_) => {}
             }
         }
-        if name == "_raw" {
+        if name == field_names::RAW {
             continue;
         }
-        if trace_id_col.is_none() && WELL_KNOWN_TRACE_ID.contains(&name) {
+        if trace_id_col.is_none() && is_well_known_trace_id(name) {
             trace_id_col = Some(idx);
             continue;
         }
-        if span_id_col.is_none() && WELL_KNOWN_SPAN_ID.contains(&name) {
+        if span_id_col.is_none() && is_well_known_span_id(name) {
             span_id_col = Some(idx);
             continue;
         }
-        if flags_col.is_none() && WELL_KNOWN_FLAGS.contains(&name) {
+        if flags_col.is_none() && is_well_known_flags(name) {
             flags_col = Some(idx);
             continue;
         }
@@ -315,6 +343,8 @@ enum TypedColumn {
     Double(Vec<Option<f64>>),
     /// Boolean column (ATTR_TYPE_BOOL).
     Bool(Vec<Option<bool>>),
+    /// Binary column (ATTR_TYPE_BYTES).
+    Bytes(Vec<Option<Vec<u8>>>),
 }
 
 impl TypedColumn {
@@ -329,6 +359,9 @@ impl TypedColumn {
     }
     fn new_bool(n: usize) -> Self {
         Self::Bool(vec![None; n])
+    }
+    fn new_bytes(n: usize) -> Self {
+        Self::Bytes(vec![None; n])
     }
 
     /// Build the Arrow array and data type for this column.
@@ -353,6 +386,11 @@ impl TypedColumn {
             Self::Bool(v) => {
                 let arr: ArrayRef = Arc::new(BooleanArray::from(v.clone()));
                 (DataType::Boolean, arr)
+            }
+            Self::Bytes(v) => {
+                let refs: Vec<Option<&[u8]>> = v.iter().map(|o| o.as_deref()).collect();
+                let arr: ArrayRef = Arc::new(BinaryArray::from(refs));
+                (DataType::Binary, arr)
             }
         }
     }
@@ -1374,7 +1412,9 @@ pub(crate) fn parse_rfc3339_nanos(s: &str) -> Option<i64> {
 }
 
 /// Convert a civil date to days since Unix epoch (1970-01-01).
-/// Uses the algorithm from Howard Hinnant's date library.
+///
+/// Validates month/day ranges (including leap year rules) and delegates
+/// to the Kani-verified `logfwd_core::otlp::days_from_civil`.
 pub(crate) fn days_from_civil(year: i64, month: u32, day: u32) -> Option<i64> {
     if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
         return None;
@@ -1396,13 +1436,7 @@ pub(crate) fn days_from_civil(year: i64, month: u32, day: u32) -> Option<i64> {
         return None;
     }
 
-    let y = if month <= 2 { year - 1 } else { year };
-    let era = y.div_euclid(400);
-    let yoe = y.rem_euclid(400) as u32;
-    let m = if month > 2 { month - 3 } else { month + 9 };
-    let doy = (153 * m + 2) / 5 + day - 1;
-    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-    Some(era * 146097 + doe as i64 - 719468)
+    Some(logfwd_core::otlp::days_from_civil(year, month, day))
 }
 
 /// Format nanosecond epoch timestamp as RFC 3339 string.
@@ -1590,6 +1624,7 @@ fn unpivot_attrs_to_flat(
                 ATTR_TYPE_INT => TypedColumn::new_int(num_rows),
                 ATTR_TYPE_DOUBLE => TypedColumn::new_double(num_rows),
                 ATTR_TYPE_BOOL => TypedColumn::new_bool(num_rows),
+                ATTR_TYPE_BYTES => TypedColumn::new_bytes(num_rows),
                 _ => TypedColumn::new_str(num_rows),
             };
             flat_cols.push((mapped_key.clone(), col));
@@ -1621,17 +1656,11 @@ fn unpivot_attrs_to_flat(
                 }
             }
             ATTR_TYPE_BYTES => {
-                // Bytes are stored in the binary column; hex-encode for flat schema.
+                // Bytes are stored in the binary column; preserve as raw bytes.
                 if !bytes_arr.is_null(row)
-                    && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
+                    && let TypedColumn::Bytes(ref mut v) = flat_cols[col_pos].1
                 {
-                    let bytes = bytes_arr.value(row);
-                    let mut hex = String::with_capacity(bytes.len() * 2);
-                    for byte in bytes {
-                        use std::fmt::Write;
-                        let _ = write!(&mut hex, "{byte:02x}");
-                    }
-                    v[target_row] = Some(hex);
+                    v[target_row] = Some(bytes_arr.value(row).to_vec());
                 }
             }
             ATTR_TYPE_STR => {
@@ -1721,6 +1750,17 @@ fn scatter_resource_attrs(
                         let rid = resource_ids.value(row);
                         if let Some(val) = rid_to_val.get(&rid) {
                             *slot = *val;
+                        }
+                    }
+                }
+            }
+            TypedColumn::Bytes(values) => {
+                let rid_to_val = collect_resource_template_values(values, resource_ids, num_rows);
+                if let TypedColumn::Bytes(ref mut v) = flat_cols[col_pos].1 {
+                    for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
+                        let rid = resource_ids.value(row);
+                        if let Some(val) = rid_to_val.get(&rid) {
+                            *slot = val.clone();
                         }
                     }
                 }
@@ -1819,6 +1859,20 @@ fn scatter_scope_attrs(
                         let sid = scope_ids.value(row);
                         if let Some(val) = sid_to_val.get(&sid) {
                             *slot = *val;
+                        }
+                    }
+                }
+            }
+            TypedColumn::Bytes(values) => {
+                let sid_to_val = collect_template_values_by_id(values, scope_ids, num_rows);
+                if let TypedColumn::Bytes(ref mut v) = flat_cols[col_pos].1 {
+                    for (row, slot) in v.iter_mut().enumerate().take(num_rows) {
+                        if slot.is_some() {
+                            continue;
+                        }
+                        let sid = scope_ids.value(row);
+                        if let Some(val) = sid_to_val.get(&sid) {
+                            *slot = val.clone();
                         }
                     }
                 }
@@ -2358,7 +2412,7 @@ mod tests {
     fn flat_to_star_excludes_internal_raw_attribute() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("body", DataType::Utf8, true),
-            Field::new("_raw", DataType::Utf8, true),
+            Field::new(field_names::RAW, DataType::Utf8, true),
         ]));
         let columns: Vec<ArrayRef> = vec![
             Arc::new(StringArray::from(vec!["canonical-value"])),
@@ -2376,7 +2430,7 @@ mod tests {
             .expect("key should be Utf8");
 
         assert!(
-            !keys.iter().flatten().any(|key| key == "_raw"),
+            !keys.iter().flatten().any(|key| key == field_names::RAW),
             "_raw should remain internal-only"
         );
     }
@@ -2455,7 +2509,7 @@ mod tests {
     fn legacy_resource_column_uses_metadata_key_for_roundtrip() {
         let legacy_field = Field::new("_resource_service_name", DataType::Utf8, true)
             .with_metadata(HashMap::from([(
-                "logfwd.resource_key".to_string(),
+                field_names::METADATA_RESOURCE_KEY.to_string(),
                 "service.name".to_string(),
             )]));
         let schema = Arc::new(Schema::new(vec![legacy_field]));
@@ -2725,7 +2779,7 @@ mod tests {
     }
 
     #[test]
-    fn binary_attrs_roundtrip_as_hex_strings() {
+    fn binary_attrs_roundtrip_as_binary() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("message", DataType::Utf8, true),
             Field::new("payload", DataType::Binary, true),
@@ -2747,15 +2801,15 @@ mod tests {
         let payload_arr = roundtrip
             .column(payload_idx)
             .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("payload string");
+            .downcast_ref::<BinaryArray>()
+            .expect("payload binary");
 
-        assert_eq!(payload_arr.value(0), "000fff");
-        assert_eq!(payload_arr.value(1), "abcd");
+        assert_eq!(payload_arr.value(0), &[0x00, 0x0f, 0xff]);
+        assert_eq!(payload_arr.value(1), &[0xab, 0xcd]);
     }
 
     #[test]
-    fn binary_resource_attrs_roundtrip_as_hex_strings() {
+    fn binary_resource_attrs_roundtrip_as_binary() {
         let schema = Arc::new(Schema::new(vec![
             Field::new("message", DataType::Utf8, true),
             Field::new("_resource_payload", DataType::Binary, true),
@@ -2785,12 +2839,12 @@ mod tests {
         let payload_arr = roundtrip
             .column(payload_idx)
             .as_any()
-            .downcast_ref::<StringArray>()
-            .expect("resource.attributes.payload string");
+            .downcast_ref::<BinaryArray>()
+            .expect("resource.attributes.payload binary");
 
-        assert_eq!(payload_arr.value(0), "deadbeef");
-        assert_eq!(payload_arr.value(1), "deadbeef");
-        assert_eq!(payload_arr.value(2), "0102");
+        assert_eq!(payload_arr.value(0), &[0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(payload_arr.value(1), &[0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(payload_arr.value(2), &[0x01, 0x02]);
     }
 
     #[test]

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -57,7 +57,11 @@ pub struct StarSchema {
 // `field_names::TIMESTAMP_VARIANTS` and the Loki/ES sinks recognise it; the
 // OTAP conversion must be consistent.  Fixes #1669.
 fn is_well_known_timestamp(name: &str) -> bool {
-    field_names::matches_any(name, field_names::TIMESTAMP, field_names::TIMESTAMP_VARIANTS)
+    field_names::matches_any(
+        name,
+        field_names::TIMESTAMP,
+        field_names::TIMESTAMP_VARIANTS,
+    )
 }
 
 /// Returns `true` when `name` matches a well-known severity column.
@@ -82,7 +86,11 @@ fn is_well_known_span_id(name: &str) -> bool {
 
 /// Returns `true` when `name` matches a well-known flags column.
 fn is_well_known_flags(name: &str) -> bool {
-    field_names::matches_any(name, field_names::TRACE_FLAGS, field_names::TRACE_FLAGS_VARIANTS)
+    field_names::matches_any(
+        name,
+        field_names::TRACE_FLAGS,
+        field_names::TRACE_FLAGS_VARIANTS,
+    )
 }
 
 /// Canonical resource attribute prefix shared across receivers/sinks.
@@ -344,7 +352,7 @@ enum TypedColumn {
     /// Boolean column (ATTR_TYPE_BOOL).
     Bool(Vec<Option<bool>>),
     /// Binary column (ATTR_TYPE_BYTES).
-    Bytes(Vec<Option<Vec<u8>>>),
+    Bytes(Vec<Option<Arc<[u8]>>>),
 }
 
 impl TypedColumn {
@@ -362,6 +370,35 @@ impl TypedColumn {
     }
     fn new_bytes(n: usize) -> Self {
         Self::Bytes(vec![None; n])
+    }
+
+    fn matches_attr_type(&self, type_tag: u8) -> bool {
+        matches!(
+            (self, type_tag),
+            (Self::Str(_), ATTR_TYPE_STR)
+                | (Self::Int(_), ATTR_TYPE_INT)
+                | (Self::Double(_), ATTR_TYPE_DOUBLE)
+                | (Self::Bool(_), ATTR_TYPE_BOOL)
+                | (Self::Bytes(_), ATTR_TYPE_BYTES)
+        )
+    }
+
+    fn promote_to_str(&mut self) {
+        if matches!(self, Self::Str(_)) {
+            return;
+        }
+
+        let strings = match self {
+            Self::Str(_) => unreachable!("handled above"),
+            Self::Int(values) => values.iter().map(|v| v.map(|v| v.to_string())).collect(),
+            Self::Double(values) => values.iter().map(|v| v.map(|v| v.to_string())).collect(),
+            Self::Bool(values) => values.iter().map(|v| v.map(|v| v.to_string())).collect(),
+            Self::Bytes(values) => values
+                .iter()
+                .map(|v| v.as_ref().map(|v| hex_encode_lower(v)))
+                .collect(),
+        };
+        *self = Self::Str(strings);
     }
 
     /// Build the Arrow array and data type for this column.
@@ -1632,6 +1669,29 @@ fn unpivot_attrs_to_flat(
             idx
         };
 
+        if !matches!(
+            type_tag,
+            ATTR_TYPE_STR | ATTR_TYPE_INT | ATTR_TYPE_DOUBLE | ATTR_TYPE_BOOL | ATTR_TYPE_BYTES
+        ) {
+            return Err(ArrowError::SchemaError(format!(
+                "unknown attr type tag {type_tag} for key '{}'",
+                key_arr.value(row)
+            )));
+        }
+
+        if !flat_cols[col_pos].1.matches_attr_type(type_tag) {
+            flat_cols[col_pos].1.promote_to_str();
+        }
+
+        if let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1 {
+            if let Some(value) = attrs_row_value_to_string(
+                type_tag, str_arr, int_arr, double_arr, bool_arr, bytes_arr, row,
+            ) {
+                v[target_row] = Some(value);
+            }
+            continue;
+        }
+
         // Write the typed value into the column.
         match type_tag {
             ATTR_TYPE_INT => {
@@ -1660,26 +1720,36 @@ fn unpivot_attrs_to_flat(
                 if !bytes_arr.is_null(row)
                     && let TypedColumn::Bytes(ref mut v) = flat_cols[col_pos].1
                 {
-                    v[target_row] = Some(bytes_arr.value(row).to_vec());
+                    v[target_row] = Some(Arc::<[u8]>::from(bytes_arr.value(row)));
                 }
             }
-            ATTR_TYPE_STR => {
-                if !str_arr.is_null(row)
-                    && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
-                {
-                    v[target_row] = Some(str_arr.value(row).to_string());
-                }
-            }
-            _ => {
-                return Err(ArrowError::SchemaError(format!(
-                    "unknown attr type tag {type_tag} for key '{}'",
-                    key_arr.value(row)
-                )));
-            }
+            ATTR_TYPE_STR => {}
+            _ => unreachable!("type tags are validated before dispatch"),
         }
     }
 
     Ok(())
+}
+
+fn attrs_row_value_to_string(
+    type_tag: u8,
+    str_arr: &StringArray,
+    int_arr: &Int64Array,
+    double_arr: &Float64Array,
+    bool_arr: &BooleanArray,
+    bytes_arr: &BinaryArray,
+    row: usize,
+) -> Option<String> {
+    match type_tag {
+        ATTR_TYPE_STR => (!str_arr.is_null(row)).then(|| str_arr.value(row).to_string()),
+        ATTR_TYPE_INT => (!int_arr.is_null(row)).then(|| int_arr.value(row).to_string()),
+        ATTR_TYPE_DOUBLE => (!double_arr.is_null(row)).then(|| double_arr.value(row).to_string()),
+        ATTR_TYPE_BOOL => (!bool_arr.is_null(row)).then(|| bool_arr.value(row).to_string()),
+        ATTR_TYPE_BYTES => {
+            (!bytes_arr.is_null(row)).then(|| hex_encode_lower(bytes_arr.value(row)))
+        }
+        _ => None,
+    }
 }
 
 /// Scatter resource attribute values from the "template" rows (indexed by
@@ -2806,6 +2876,62 @@ mod tests {
 
         assert_eq!(payload_arr.value(0), &[0x00, 0x0f, 0xff]);
         assert_eq!(payload_arr.value(1), &[0xab, 0xcd]);
+    }
+
+    #[test]
+    fn mixed_attrs_promote_bytes_first_column_to_string() {
+        let logs = RecordBatch::try_new(
+            Arc::new(logs_schema()),
+            vec![
+                Arc::new(UInt32Array::from(vec![0_u32, 1])),
+                Arc::new(UInt32Array::from(vec![0_u32, 0])),
+                Arc::new(UInt32Array::from(vec![0_u32, 0])),
+                Arc::new(arrow::array::TimestampNanosecondArray::from(vec![
+                    None::<i64>,
+                    None,
+                ])),
+                Arc::new(arrow::array::Int32Array::from(vec![None::<i32>, None])),
+                Arc::new(StringArray::from(vec![None::<&str>, None])),
+                Arc::new(StringArray::from(vec![Some("row-0"), Some("row-1")])),
+                build_fixed_binary_array::<16>(&[None, None]).expect("trace ids"),
+                build_fixed_binary_array::<8>(&[None, None]).expect("span ids"),
+                Arc::new(UInt32Array::from(vec![None::<u32>, None])),
+                Arc::new(UInt32Array::from(vec![Some(0_u32), Some(0)])),
+            ],
+        )
+        .expect("valid logs");
+
+        let log_attrs = RecordBatch::try_new(
+            Arc::new(attrs_schema()),
+            vec![
+                Arc::new(UInt32Array::from(vec![0_u32, 1])),
+                Arc::new(StringArray::from(vec!["payload", "payload"])),
+                Arc::new(UInt8Array::from(vec![ATTR_TYPE_BYTES, ATTR_TYPE_STR])),
+                Arc::new(StringArray::from(vec![None, Some("text")])),
+                Arc::new(Int64Array::from(vec![None::<i64>, None])),
+                Arc::new(Float64Array::from(vec![None::<f64>, None])),
+                Arc::new(BooleanArray::from(vec![None::<bool>, None])),
+                Arc::new(BinaryArray::from(vec![Some(&[0xde_u8, 0xad_u8][..]), None])),
+            ],
+        )
+        .expect("valid attrs");
+
+        let star = StarSchema {
+            logs,
+            log_attrs,
+            resource_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+            scope_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+        };
+        let roundtrip = star_to_flat(&star).expect("star_to_flat");
+        let payload_idx = roundtrip.schema().index_of("payload").expect("payload");
+        let payload_arr = roundtrip
+            .column(payload_idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("mixed column promotes to Utf8");
+
+        assert_eq!(payload_arr.value(0), "dead");
+        assert_eq!(payload_arr.value(1), "text");
     }
 
     #[test]

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -10,7 +10,7 @@
 //!
 //! This module converts between the two representations at the boundary.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::array::{
@@ -475,6 +475,8 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
     // Collect flat columns: name → TypedColumn.
     let mut flat_cols: Vec<(String, TypedColumn)> = Vec::new();
     let mut col_index: HashMap<String, usize> = HashMap::new();
+    let unprotected_cols: HashSet<String> = HashSet::new();
+    let mut protected_log_fact_cols: HashSet<String> = HashSet::new();
 
     // Helper to get or create a string column.
     let ensure_str_col = |name: &str,
@@ -518,6 +520,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
             )));
         }
         let col_pos = ensure_str_col("_timestamp", &mut flat_cols, &mut col_index);
+        protected_log_fact_cols.insert("_timestamp".to_string());
         for row in 0..num_rows {
             if !ts_arr.is_null(row) {
                 // Timestamp is stored as i64 nanoseconds.
@@ -550,6 +553,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
             )));
         }
         let col_pos = ensure_str_col("level", &mut flat_cols, &mut col_index);
+        protected_log_fact_cols.insert("level".to_string());
         for row in 0..num_rows {
             if !sev_arr.is_null(row) {
                 let val = str_from_array(sev_arr.as_ref(), row);
@@ -572,6 +576,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
             )));
         }
         let col_pos = ensure_str_col("message", &mut flat_cols, &mut col_index);
+        protected_log_fact_cols.insert("message".to_string());
         for row in 0..num_rows {
             if !body_arr.is_null(row) {
                 let val = str_from_array(body_arr.as_ref(), row);
@@ -589,6 +594,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
         let sev_num_arr = star.logs.column(sev_num_idx);
         if matches!(sev_num_arr.data_type(), DataType::Int32) {
             let col_pos = ensure_int_col("severity_number", &mut flat_cols, &mut col_index);
+            protected_log_fact_cols.insert("severity_number".to_string());
             let sev_num_arr = sev_num_arr
                 .as_any()
                 .downcast_ref::<arrow::array::Int32Array>()
@@ -608,6 +614,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
         let trace_arr = star.logs.column(trace_idx);
         if matches!(trace_arr.data_type(), DataType::FixedSizeBinary(16)) {
             let col_pos = ensure_str_col("trace_id", &mut flat_cols, &mut col_index);
+            protected_log_fact_cols.insert("trace_id".to_string());
             let trace_arr = trace_arr
                 .as_any()
                 .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
@@ -629,6 +636,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
         let span_arr = star.logs.column(span_idx);
         if matches!(span_arr.data_type(), DataType::FixedSizeBinary(8)) {
             let col_pos = ensure_str_col("span_id", &mut flat_cols, &mut col_index);
+            protected_log_fact_cols.insert("span_id".to_string());
             let span_arr = span_arr
                 .as_any()
                 .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
@@ -650,6 +658,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
         let flags_arr = star.logs.column(flags_idx);
         if matches!(flags_arr.data_type(), DataType::UInt32) {
             let col_pos = ensure_int_col("flags", &mut flat_cols, &mut col_index);
+            protected_log_fact_cols.insert("flags".to_string());
             let flags_arr = flags_arr
                 .as_any()
                 .downcast_ref::<UInt32Array>()
@@ -680,6 +689,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
             _ if key.starts_with("scope.") => key.to_string(),
             _ => format!("scope.{key}"),
         },
+        &unprotected_cols,
     )?;
 
     // --- Unpivot LOG_ATTRS → flat columns ---
@@ -690,6 +700,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
         num_rows,
         |parent_id| parent_id as usize, // parent_id IS the row index
         str::to_string,                 // no prefix
+        &protected_log_fact_cols,
     )?;
 
     // --- Unpivot RESOURCE_ATTRS → resource.attributes.* columns ---
@@ -707,6 +718,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
             parent_id as usize
         },
         |key| format!("{RESOURCE_PREFIX}{key}"),
+        &unprotected_cols,
     )?;
 
     // The unpivot above set values at the resource_id index, but we need to
@@ -1548,6 +1560,10 @@ fn severity_text_to_number(text: &str) -> i32 {
 /// For each row in the attrs table, reads (parent_id, key, typed value) and
 /// writes the value into `flat_cols[key][row_for(parent_id)]`, preserving the
 /// original type from the `type` column.
+///
+/// Existing columns listed in `protected_existing_cols` are canonical fact
+/// columns; attrs with the same flat name are skipped because flat batches
+/// cannot represent duplicate column names.
 fn unpivot_attrs_to_flat(
     attrs_batch: &RecordBatch,
     flat_cols: &mut Vec<(String, TypedColumn)>,
@@ -1555,6 +1571,7 @@ fn unpivot_attrs_to_flat(
     num_rows: usize,
     row_for: impl Fn(u32) -> usize,
     map_key: impl Fn(&str) -> String,
+    protected_existing_cols: &HashSet<String>,
 ) -> Result<(), ArrowError> {
     if attrs_batch.num_rows() == 0 {
         return Ok(());
@@ -1651,6 +1668,13 @@ fn unpivot_attrs_to_flat(
         let key = key_arr.value(row);
         let mapped_key = map_key(key);
         let type_tag = type_arr.value(row);
+
+        // Preserve canonical LOGS fact fields when LOG_ATTRS use the same name.
+        if protected_existing_cols.contains(mapped_key.as_str())
+            && col_index.contains_key(mapped_key.as_str())
+        {
+            continue;
+        }
 
         // Get or create the flat column with the correct type.
         let col_pos = if let Some(&idx) = col_index.get(&mapped_key) {
@@ -2932,6 +2956,60 @@ mod tests {
 
         assert_eq!(payload_arr.value(0), "dead");
         assert_eq!(payload_arr.value(1), "text");
+    }
+
+    #[test]
+    fn log_attr_collision_does_not_overwrite_fact_column() {
+        let logs = RecordBatch::try_new(
+            Arc::new(logs_schema()),
+            vec![
+                Arc::new(UInt32Array::from(vec![0_u32])),
+                Arc::new(UInt32Array::from(vec![0_u32])),
+                Arc::new(UInt32Array::from(vec![0_u32])),
+                Arc::new(arrow::array::TimestampNanosecondArray::from(vec![
+                    None::<i64>,
+                ])),
+                Arc::new(arrow::array::Int32Array::from(vec![Some(9_i32)])),
+                Arc::new(StringArray::from(vec![Some("ERROR")])),
+                Arc::new(StringArray::from(vec![Some("row-0")])),
+                build_fixed_binary_array::<16>(&[None]).expect("trace ids"),
+                build_fixed_binary_array::<8>(&[None]).expect("span ids"),
+                Arc::new(UInt32Array::from(vec![Some(3_u32)])),
+                Arc::new(UInt32Array::from(vec![Some(0_u32)])),
+            ],
+        )
+        .expect("valid logs");
+
+        let log_attrs = RecordBatch::try_new(
+            Arc::new(attrs_schema()),
+            vec![
+                Arc::new(UInt32Array::from(vec![0_u32])),
+                Arc::new(StringArray::from(vec!["flags"])),
+                Arc::new(UInt8Array::from(vec![ATTR_TYPE_STR])),
+                Arc::new(StringArray::from(vec![Some("not-flags")])),
+                Arc::new(Int64Array::from(vec![None::<i64>])),
+                Arc::new(Float64Array::from(vec![None::<f64>])),
+                Arc::new(BooleanArray::from(vec![None::<bool>])),
+                Arc::new(BinaryArray::from(vec![None::<&[u8]>])),
+            ],
+        )
+        .expect("valid attrs");
+
+        let star = StarSchema {
+            logs,
+            log_attrs,
+            resource_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+            scope_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+        };
+        let roundtrip = star_to_flat(&star).expect("star_to_flat");
+        let flags_idx = roundtrip.schema().index_of("flags").expect("flags");
+        let flags_arr = roundtrip
+            .column(flags_idx)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("fact flags stays int");
+
+        assert_eq!(flags_arr.value(0), 3);
     }
 
     #[test]

--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -21,8 +21,9 @@ use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use logfwd_core::scan_config::{parse_float_fast, parse_int_fast};
 use logfwd_core::scanner::BuilderState;
 
+use logfwd_types::field_names;
+
 use crate::check_dup_bits;
-use crate::star_schema::RESOURCE_PREFIX;
 
 #[cfg(kani)]
 type FieldIndexMap = std::collections::BTreeMap<Vec<u8>, usize>;
@@ -190,7 +191,7 @@ impl StreamingBuilder {
 
     fn resource_col_name(key: &str) -> String {
         // Canonical prefix + verbatim key. No mangling.
-        format!("{RESOURCE_PREFIX}{key}")
+        format!("{}{key}", field_names::DEFAULT_RESOURCE_PREFIX)
     }
 
     /// Start a new batch. Takes ownership of the input buffer via Bytes
@@ -834,7 +835,7 @@ impl StreamingBuilder {
                 }
             }
             let mut metadata = HashMap::new();
-            metadata.insert("logfwd.resource_key".to_string(), key.clone());
+            metadata.insert(field_names::METADATA_RESOURCE_KEY.to_string(), key.clone());
             schema_fields
                 .push(Field::new(col_name, DataType::Utf8View, true).with_metadata(metadata));
             arrays.push(Arc::new(builder.finish()) as ArrayRef);
@@ -1092,7 +1093,7 @@ impl StreamingBuilder {
                 builder.append_value(value);
             }
             let mut metadata = HashMap::new();
-            metadata.insert("logfwd.resource_key".to_string(), key.clone());
+            metadata.insert(field_names::METADATA_RESOURCE_KEY.to_string(), key.clone());
             schema_fields.push(Field::new(col_name, DataType::Utf8, true).with_metadata(metadata));
             arrays.push(Arc::new(builder.finish()) as ArrayRef);
         }
@@ -2452,14 +2453,14 @@ mod tests {
         assert_eq!(
             service_field
                 .metadata()
-                .get("logfwd.resource_key")
+                .get(field_names::METADATA_RESOURCE_KEY)
                 .map(String::as_str),
             Some("service.name")
         );
         assert_eq!(
             namespace_field
                 .metadata()
-                .get("logfwd.resource_key")
+                .get(field_names::METADATA_RESOURCE_KEY)
                 .map(String::as_str),
             Some("k8s.namespace")
         );

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -99,6 +99,8 @@ pub const ANY_VALUE_BOOL_VALUE: u32 = 2;
 pub const ANY_VALUE_INT_VALUE: u32 = 3;
 /// `AnyValue.double_value` (double/fixed64).
 pub const ANY_VALUE_DOUBLE_VALUE: u32 = 4;
+/// `AnyValue.bytes_value` (bytes).
+pub const ANY_VALUE_BYTES_VALUE: u32 = 7;
 
 // --- KeyValue field numbers (common.proto) ---
 
@@ -833,6 +835,7 @@ mod tests {
         assert_eq!(ANY_VALUE_BOOL_VALUE, 2);
         assert_eq!(ANY_VALUE_INT_VALUE, 3);
         assert_eq!(ANY_VALUE_DOUBLE_VALUE, 4);
+        assert_eq!(ANY_VALUE_BYTES_VALUE, 7);
 
         // KeyValue fields (common.proto).
         assert_eq!(KEY_VALUE_KEY, 1);
@@ -1499,9 +1502,11 @@ mod verification {
         assert!(ANY_VALUE_BOOL_VALUE == 2);
         assert!(ANY_VALUE_INT_VALUE == 3);
         assert!(ANY_VALUE_DOUBLE_VALUE == 4);
+        assert!(ANY_VALUE_BYTES_VALUE == 7);
 
         kani::cover!(ANY_VALUE_STRING_VALUE == 1, "string_value is 1");
         kani::cover!(ANY_VALUE_DOUBLE_VALUE == 4, "double_value is 4");
+        kani::cover!(ANY_VALUE_BYTES_VALUE == 7, "bytes_value is 7");
     }
 
     /// Verify KeyValue field numbers match common.proto.

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -531,7 +531,7 @@ fn parse_2digits(s: &[u8], off: usize) -> u8 {
     // Required so `stub_verified(days_from_civil)` keeps nanos arithmetic within u64.
     && *result <= 213_400
 ))]
-fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
+pub fn days_from_civil(year: i64, month: u32, day: u32) -> i64 {
     let y = if month <= 2 { year - 1 } else { year };
     let m = if month <= 2 {
         month as i64 + 9

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -33,10 +33,7 @@ use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::input::{InputEvent, InputSource};
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
-use crate::receiver_http::{declared_content_length, read_limited_body};
-
-/// Maximum request body size: 10 MB.
-const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
+use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_limited_body};
 
 /// Bounded channel capacity — limits memory when the pipeline falls behind.
 const CHANNEL_BOUND: usize = 256;
@@ -219,12 +216,12 @@ fn decompress_zstd(body: &[u8]) -> Result<Vec<u8>, InputError> {
     let decoder = zstd::Decoder::new(body).map_err(|_| {
         InputError::Receiver("zstd decompression failed: invalid header".to_string())
     })?;
-    let mut decompressed = Vec::with_capacity(body.len().min(MAX_BODY_SIZE));
+    let mut decompressed = Vec::with_capacity(body.len().min(MAX_REQUEST_BODY_SIZE));
     match decoder
-        .take(MAX_BODY_SIZE as u64 + 1)
+        .take(MAX_REQUEST_BODY_SIZE as u64 + 1)
         .read_to_end(&mut decompressed)
     {
-        Ok(n) if n > MAX_BODY_SIZE => Err(InputError::Receiver(
+        Ok(n) if n > MAX_REQUEST_BODY_SIZE => Err(InputError::Receiver(
             "decompressed payload too large".to_string(),
         )),
         Ok(_) => Ok(decompressed),
@@ -265,7 +262,7 @@ async fn handle_arrow_ipc_request(
     body: Body,
 ) -> Response {
     let content_length = declared_content_length(&headers);
-    if content_length.is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
+    if content_length.is_some_and(|body_len| body_len > MAX_REQUEST_BODY_SIZE as u64) {
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
 
@@ -278,7 +275,7 @@ async fn handle_arrow_ipc_request(
         Err(status) => return (status, "invalid content-type header").into_response(),
     };
 
-    let body = match read_limited_body(body, MAX_BODY_SIZE, content_length).await {
+    let body = match read_limited_body(body, MAX_REQUEST_BODY_SIZE, content_length).await {
         Ok(body) => body,
         Err(status) => {
             let message = if status == StatusCode::PAYLOAD_TOO_LARGE {

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -35,10 +35,7 @@ use tokio::sync::oneshot;
 use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
-use crate::receiver_http::{declared_content_length, read_limited_body};
-
-/// Maximum request body size: 10 MB.
-const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
+use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_limited_body};
 
 /// Bounded channel capacity.
 const CHANNEL_BOUND: usize = 256;
@@ -243,11 +240,11 @@ async fn handle_otap_request(
     body: Body,
 ) -> Response {
     let content_length = declared_content_length(&headers);
-    if content_length.is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
+    if content_length.is_some_and(|body_len| body_len > MAX_REQUEST_BODY_SIZE as u64) {
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
 
-    let body = match read_limited_body(body, MAX_BODY_SIZE, content_length).await {
+    let body = match read_limited_body(body, MAX_REQUEST_BODY_SIZE, content_length).await {
         Ok(body) => body,
         Err(status) => {
             let message = if status == StatusCode::PAYLOAD_TOO_LARGE {

--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -12,15 +12,13 @@ use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use prost::Message;
 
 use crate::InputError;
+use crate::receiver_http::MAX_REQUEST_BODY_SIZE;
 
 use super::convert::{
     convert_request_to_batch, decode_protojson_bytes, hex, parse_protojson_f64,
     parse_protojson_i64, parse_protojson_u64, write_f64_to_buf, write_i64_to_buf, write_json_key,
     write_json_string_field, write_u64_to_buf,
 };
-
-/// Maximum request body size: 10 MB.
-pub(super) const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 
 pub(super) fn decompress_zstd(body: &[u8]) -> Result<Vec<u8>, InputError> {
     let decoder = zstd::Decoder::new(body)
@@ -38,12 +36,12 @@ pub(super) fn read_decompressed_body(
     compressed_len: usize,
     error_label: &str,
 ) -> Result<Vec<u8>, InputError> {
-    let mut decompressed = Vec::with_capacity(compressed_len.min(MAX_BODY_SIZE));
+    let mut decompressed = Vec::with_capacity(compressed_len.min(MAX_REQUEST_BODY_SIZE));
     match reader
-        .take(MAX_BODY_SIZE as u64 + 1)
+        .take(MAX_REQUEST_BODY_SIZE as u64 + 1)
         .read_to_end(&mut decompressed)
     {
-        Ok(n) if n > MAX_BODY_SIZE => Err(InputError::Io(io::Error::new(
+        Ok(n) if n > MAX_REQUEST_BODY_SIZE => Err(InputError::Io(io::Error::new(
             io::ErrorKind::InvalidData,
             "payload too large",
         ))),

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -13,9 +13,7 @@ use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 use crate::InputError;
 use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_limited_body};
 
-use super::decode::{
-    decode_otlp_json, decode_otlp_protobuf, decompress_gzip, decompress_zstd,
-};
+use super::decode::{decode_otlp_json, decode_otlp_protobuf, decompress_gzip, decompress_zstd};
 use super::{OtlpServerState, ReceiverPayload};
 
 pub(super) fn record_error(stats: Option<&Arc<ComponentStats>>) {

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -11,10 +11,10 @@ use axum::response::{IntoResponse, Response};
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 
 use crate::InputError;
-use crate::receiver_http::{declared_content_length, read_limited_body};
+use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_limited_body};
 
 use super::decode::{
-    MAX_BODY_SIZE, decode_otlp_json, decode_otlp_protobuf, decompress_gzip, decompress_zstd,
+    decode_otlp_json, decode_otlp_protobuf, decompress_gzip, decompress_zstd,
 };
 use super::{OtlpServerState, ReceiverPayload};
 
@@ -36,7 +36,7 @@ pub(super) async fn handle_otlp_request(
     body: Body,
 ) -> Response {
     let content_length = declared_content_length(&headers);
-    if content_length.is_some_and(|body_len| body_len > MAX_BODY_SIZE as u64) {
+    if content_length.is_some_and(|body_len| body_len > MAX_REQUEST_BODY_SIZE as u64) {
         record_error(state.stats.as_ref());
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
@@ -49,7 +49,7 @@ pub(super) async fn handle_otlp_request(
         }
     };
 
-    let mut body = match read_limited_body(body, MAX_BODY_SIZE, content_length).await {
+    let mut body = match read_limited_body(body, MAX_REQUEST_BODY_SIZE, content_length).await {
         Ok(body) => body,
         Err(status) => {
             record_error(state.stats.as_ref());

--- a/crates/logfwd-io/src/receiver_http.rs
+++ b/crates/logfwd-io/src/receiver_http.rs
@@ -2,6 +2,9 @@ use axum::body::Body;
 use axum::http::{HeaderMap, StatusCode, header::CONTENT_LENGTH};
 use http_body_util::BodyExt as _;
 
+/// Maximum request body size shared by all HTTP receivers: 10 MB.
+pub(crate) const MAX_REQUEST_BODY_SIZE: usize = 10 * 1024 * 1024;
+
 pub(crate) fn declared_content_length(headers: &HeaderMap) -> Option<u64> {
     headers
         .get(CONTENT_LENGTH)

--- a/crates/logfwd-output/src/arrow_ipc_sink.rs
+++ b/crates/logfwd-output/src/arrow_ipc_sink.rs
@@ -18,15 +18,12 @@ use logfwd_types::diagnostics::ComponentStats;
 
 use super::sink::{SendResult, Sink, SinkFactory};
 use super::{BatchMetadata, Compression};
+use crate::http_classify::DEFAULT_RETRY_AFTER_SECS;
 
 /// Content-Type for uncompressed Arrow IPC stream.
 const CONTENT_TYPE_ARROW: &str = "application/vnd.apache.arrow.stream";
 /// Content-Type for zstd-compressed Arrow IPC stream.
 const CONTENT_TYPE_ARROW_ZSTD: &str = "application/vnd.apache.arrow.stream+zstd";
-
-/// Default retry-after duration when the server returns 429 without a
-/// Retry-After header.
-const DEFAULT_RETRY_AFTER_SECS: u64 = 5;
 
 // ---------------------------------------------------------------------------
 // ArrowIpcSink

--- a/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
+++ b/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
@@ -3,9 +3,10 @@
 // column order: "timestamp", "severity", "body", "trace_id", "span_id", "flags", "attributes"
 
 use arrow::array::Array;
+use arrow::util::display::array_value_to_string;
 use super::{AttrArray, BatchColumns, BatchMetadata, encode_fixed32, encode_key_value_bool,
     encode_key_value_double, encode_key_value_int, encode_key_value_string, encode_tag,
-    encode_varint, numeric_timestamp_ns, str_value};
+    encode_varint, numeric_timestamp_ns};
 use logfwd_core::otlp::{self, Severity, bytes_field_size, encode_bytes_field, encode_fixed64,
     encode_varint_field, hex_decode, parse_severity, parse_timestamp_nanos};
 
@@ -22,7 +23,11 @@ pub(super) fn encode_row_as_log_record_fast_v1(
         if arr.is_null(row) {
             0
         } else {
-            parse_timestamp_nanos(arr.value(row).as_bytes()).unwrap_or(0)
+            let ts = parse_timestamp_nanos(arr.value(row).as_bytes()).unwrap_or(0);
+            if ts == 0 {
+                tracing::debug!("timestamp parse fallback: event_time omitted for unparseable value");
+            }
+            ts
         }
     } else {
         0
@@ -117,11 +122,12 @@ pub(super) fn encode_row_as_log_record_fast_v1(
             }
             AttrArray::OtherStr(arr) => {
                 if !arr.is_null(row) {
+                    let s = array_value_to_string(*arr, row).unwrap_or_default();
                     encode_key_value_string(
                         buf,
                         otlp::LOG_RECORD_ATTRIBUTES,
                         field_name.as_bytes(),
-                        str_value(*arr, row).as_bytes(),
+                        s.as_bytes(),
                     );
                 }
             }

--- a/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
+++ b/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
@@ -3,9 +3,7 @@
 // column order: "timestamp", "severity", "body", "trace_id", "span_id", "flags", "attributes"
 
 use arrow::array::Array;
-use arrow::util::display::array_value_to_string;
-use super::{AttrArray, BatchColumns, BatchMetadata, encode_fixed32, encode_key_value_bool,
-    encode_key_value_double, encode_key_value_int, encode_key_value_string, encode_tag,
+use super::{BatchColumns, BatchMetadata, encode_attr_array_value, encode_fixed32, encode_tag,
     encode_varint, numeric_timestamp_ns};
 use logfwd_core::otlp::{self, Severity, bytes_field_size, encode_bytes_field, encode_fixed64,
     encode_varint_field, hex_decode, parse_severity, parse_timestamp_nanos};
@@ -17,20 +15,22 @@ pub(super) fn encode_row_as_log_record_fast_v1(
     metadata: &BatchMetadata,
     buf: &mut Vec<u8>,
 ) {
-    let timestamp_ns: u64 = if let Some((_, arr)) = columns.timestamp_num_col.as_ref() {
+    let timestamp_ns: Option<u64> = if let Some((_, arr)) = columns.timestamp_num_col.as_ref() {
         numeric_timestamp_ns(*arr, row)
     } else if let Some((_, arr)) = columns.timestamp_col.as_ref() {
         if arr.is_null(row) {
-            0
+            None
         } else {
-            let ts = parse_timestamp_nanos(arr.value(row).as_bytes()).unwrap_or(0);
-            if ts == 0 {
-                tracing::debug!("timestamp parse fallback: event_time omitted for unparseable value");
+            match parse_timestamp_nanos(arr.value(row).as_bytes()) {
+                Some(ts) => Some(ts),
+                None => {
+                    tracing::debug!("timestamp parse fallback: event_time omitted for unparseable value");
+                    None
+                }
             }
-            ts
         }
     } else {
-        0
+        None
     };
 
     let (severity_num, severity_text): (Severity, &[u8]) =
@@ -59,7 +59,7 @@ pub(super) fn encode_row_as_log_record_fast_v1(
     };
     let body_bytes = body.as_bytes();
 
-    if timestamp_ns > 0 {
+    if let Some(timestamp_ns) = timestamp_ns {
         encode_fixed64(buf, otlp::LOG_RECORD_TIME_UNIX_NANO, timestamp_ns);
     }
 
@@ -79,59 +79,7 @@ pub(super) fn encode_row_as_log_record_fast_v1(
     }
 
     for (field_name, attr) in &columns.attribute_cols {
-        match attr {
-            AttrArray::Int(arr) => {
-                if !arr.is_null(row) {
-                    encode_key_value_int(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        arr.value(row),
-                    );
-                }
-            }
-            AttrArray::Float(arr) => {
-                if !arr.is_null(row) {
-                    encode_key_value_double(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        arr.value(row),
-                    );
-                }
-            }
-            AttrArray::Bool(arr) => {
-                if !arr.is_null(row) {
-                    encode_key_value_bool(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        arr.value(row),
-                    );
-                }
-            }
-            AttrArray::Str(arr) => {
-                if !arr.is_null(row) {
-                    encode_key_value_string(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        arr.value(row).as_bytes(),
-                    );
-                }
-            }
-            AttrArray::OtherStr(arr) => {
-                if !arr.is_null(row) {
-                    let s = array_value_to_string(*arr, row).unwrap_or_default();
-                    encode_key_value_string(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        s.as_bytes(),
-                    );
-                }
-            }
-        }
+        encode_attr_array_value(buf, otlp::LOG_RECORD_ATTRIBUTES, field_name, attr, row);
     }
 
     if let Some((_, arr)) = columns.flags_col {
@@ -163,10 +111,10 @@ pub(super) fn encode_row_as_log_record_fast_v1(
         }
     }
 
-    let observed_ns = if let Some((_, arr)) = columns.observed_ts_col.as_ref() {
-        numeric_timestamp_ns(*arr, row)
-    } else {
-        metadata.observed_time_ns
-    };
+    let observed_ns = columns
+        .observed_ts_col
+        .as_ref()
+        .and_then(|(_, arr)| numeric_timestamp_ns(*arr, row))
+        .unwrap_or(metadata.observed_time_ns);
     encode_fixed64(buf, otlp::LOG_RECORD_OBSERVED_TIME_UNIX_NANO, observed_ns);
 }

--- a/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
+++ b/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
@@ -24,7 +24,7 @@ pub(super) fn encode_row_as_log_record_fast_v1(
             match parse_timestamp_nanos(arr.value(row).as_bytes()) {
                 Some(ts) => Some(ts),
                 None => {
-                    tracing::debug!("timestamp parse fallback: event_time omitted for unparseable value");
+                    tracing::debug!("timestamp parse fallback: event_time omitted for unparsable value");
                     None
                 }
             }

--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -56,7 +56,7 @@ pub(crate) use conflict_columns::{get_array, is_null};
 pub(crate) use conflict_columns::{is_conflict_struct, json_priority, str_priority, variant_dt};
 pub(crate) use metadata::build_auth_headers;
 pub use row_json::write_row_json;
-pub(crate) use row_json::{coalesce_as_str, str_value, write_json_value};
+pub(crate) use row_json::{coalesce_as_str, write_json_value};
 
 // ---------------------------------------------------------------------------
 // HTTP retry helper

--- a/crates/logfwd-output/src/otap_sink.rs
+++ b/crates/logfwd-output/src/otap_sink.rs
@@ -62,6 +62,7 @@ use logfwd_types::diagnostics::ComponentStats;
 use super::arrow_ipc_sink::serialize_ipc;
 use super::sink::{SendResult, Sink, SinkFactory};
 use super::{BatchMetadata, Compression};
+use crate::http_classify::DEFAULT_RETRY_AFTER_SECS;
 
 mod generated_fast {
     include!("generated/otap_fast_v1.rs");
@@ -69,10 +70,6 @@ mod generated_fast {
 
 /// Content-Type for protobuf-encoded OTAP messages.
 const CONTENT_TYPE_PROTOBUF: &str = "application/x-protobuf";
-
-/// Default retry-after duration when the server returns 429 without a
-/// Retry-After header.
-const DEFAULT_RETRY_AFTER_SECS: u64 = 5;
 
 // ---------------------------------------------------------------------------
 // ArrowPayloadType enum values (from OTAP proto)

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -6,11 +6,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arrow::array::{
-    Array, AsArray, LargeStringArray, PrimitiveArray, StringArray, StringViewArray,
+    Array, AsArray, BinaryArray, LargeBinaryArray, LargeStringArray, PrimitiveArray, StringArray,
+    StringViewArray,
 };
 use arrow::datatypes::{DataType, Float64Type, Int64Type, UInt64Type};
-use arrow::util::display::array_value_to_string;
 use arrow::record_batch::RecordBatch;
+use arrow::util::display::array_value_to_string;
 use flate2::Compression as GzipLevel;
 use flate2::write::GzEncoder;
 
@@ -73,6 +74,7 @@ enum ResourceValueRef<'a> {
     Str(&'a str),
     /// Owned stringified value for non-string Arrow types (e.g. UInt64 from `hash()` UDF).
     OwnedStr(String),
+    Bytes(&'a [u8]),
     Int(i64),
     Float(u64),
     Bool(bool),
@@ -217,8 +219,8 @@ impl OtlpSink {
 
         for row in 0..num_rows {
             let mut key: ResourceKey<'_> = Vec::with_capacity(columns.resource_cols.len());
-            for (_, attr) in &columns.resource_cols {
-                key.push(attr.value_ref(row));
+            for (field_name, attr) in &columns.resource_cols {
+                key.push(attr.value_ref(row, field_name));
             }
             let scope_name = columns.scope_name_col.as_ref().and_then(|(_, arr)| {
                 if arr.is_null(row) {
@@ -305,6 +307,12 @@ impl OtlpSink {
                             otlp::RESOURCE_ATTRIBUTES,
                             key_name.as_bytes(),
                             v.as_bytes(),
+                        ),
+                        ResourceValueRef::Bytes(v) => encode_key_value_bytes(
+                            &mut resource_msg,
+                            otlp::RESOURCE_ATTRIBUTES,
+                            key_name.as_bytes(),
+                            v,
                         ),
                         ResourceValueRef::Int(v) => encode_key_value_int(
                             &mut resource_msg,
@@ -746,6 +754,8 @@ impl OtlpStrCol<'_> {
 enum AttrArray<'a> {
     Str(OtlpStrCol<'a>),
     OtherStr(&'a dyn Array),
+    Bytes(&'a BinaryArray),
+    LargeBytes(&'a LargeBinaryArray),
     Int(&'a PrimitiveArray<Int64Type>),
     Float(&'a PrimitiveArray<Float64Type>),
     Bool(&'a arrow::array::BooleanArray),
@@ -753,14 +763,18 @@ enum AttrArray<'a> {
 
 impl AttrArray<'_> {
     #[inline(always)]
-    fn value_ref(&self, row: usize) -> Option<ResourceValueRef<'_>> {
+    fn value_ref(&self, row: usize, field_name: &str) -> Option<ResourceValueRef<'_>> {
         match self {
             Self::Str(arr) => (!arr.is_null(row)).then(|| ResourceValueRef::Str(arr.value(row))),
-            Self::OtherStr(arr) => (!arr.is_null(row)).then(|| {
-                ResourceValueRef::OwnedStr(
-                    array_value_to_string(*arr, row).unwrap_or_default(),
-                )
-            }),
+            Self::OtherStr(arr) => {
+                format_non_string_attr_value(*arr, row, field_name).map(ResourceValueRef::OwnedStr)
+            }
+            Self::Bytes(arr) => {
+                (!arr.is_null(row)).then(|| ResourceValueRef::Bytes(arr.value(row)))
+            }
+            Self::LargeBytes(arr) => {
+                (!arr.is_null(row)).then(|| ResourceValueRef::Bytes(arr.value(row)))
+            }
             Self::Int(arr) => (!arr.is_null(row)).then(|| ResourceValueRef::Int(arr.value(row))),
             Self::Float(arr) => {
                 (!arr.is_null(row)).then(|| ResourceValueRef::Float(arr.value(row).to_bits()))
@@ -988,6 +1002,22 @@ fn resolve_batch_columns<'a>(
                     AttrArray::Float(batch.column(idx).as_primitive::<Float64Type>())
                 }
                 DataType::Boolean => AttrArray::Bool(batch.column(idx).as_boolean()),
+                DataType::Binary => {
+                    let Some(arr) = batch.column(idx).as_any().downcast_ref::<BinaryArray>() else {
+                        continue;
+                    };
+                    AttrArray::Bytes(arr)
+                }
+                DataType::LargeBinary => {
+                    let Some(arr) = batch
+                        .column(idx)
+                        .as_any()
+                        .downcast_ref::<LargeBinaryArray>()
+                    else {
+                        continue;
+                    };
+                    AttrArray::LargeBytes(arr)
+                }
                 DataType::Struct(_) => {
                     tracing::warn!(
                         column = field_name,
@@ -1012,6 +1042,22 @@ fn resolve_batch_columns<'a>(
             DataType::Int64 => AttrArray::Int(batch.column(idx).as_primitive::<Int64Type>()),
             DataType::Float64 => AttrArray::Float(batch.column(idx).as_primitive::<Float64Type>()),
             DataType::Boolean => AttrArray::Bool(batch.column(idx).as_boolean()),
+            DataType::Binary => {
+                let Some(arr) = batch.column(idx).as_any().downcast_ref::<BinaryArray>() else {
+                    continue;
+                };
+                AttrArray::Bytes(arr)
+            }
+            DataType::LargeBinary => {
+                let Some(arr) = batch
+                    .column(idx)
+                    .as_any()
+                    .downcast_ref::<LargeBinaryArray>()
+                else {
+                    continue;
+                };
+                AttrArray::LargeBytes(arr)
+            }
             // Non-conflict struct columns (e.g. nested objects not produced by the
             // type-conflict builder) cannot be encoded as a single typed OTLP attribute.
             // Conflict structs (Struct { int, str, float, bool }) are already normalized
@@ -1077,23 +1123,25 @@ fn resource_prefix_from_batch(batch: &RecordBatch) -> String {
     field_names::DEFAULT_RESOURCE_PREFIX.to_string()
 }
 
-fn numeric_timestamp_ns(arr: &dyn Array, row: usize) -> u64 {
+fn numeric_timestamp_ns(arr: &dyn Array, row: usize) -> Option<u64> {
     if arr.is_null(row) {
-        return 0;
+        return None;
     }
 
     match arr.data_type() {
         DataType::Int64 => {
             let v = arr.as_primitive::<Int64Type>().value(row);
             match u64::try_from(v) {
-                Ok(ns) => ns,
+                Ok(ns) => Some(ns),
                 Err(_) => {
-                    tracing::debug!("timestamp parse fallback: negative i64 timestamp cannot convert to u64");
-                    0
+                    tracing::debug!(
+                        "timestamp parse fallback: negative i64 timestamp cannot convert to u64"
+                    );
+                    None
                 }
             }
         }
-        DataType::UInt64 => arr.as_primitive::<UInt64Type>().value(row),
+        DataType::UInt64 => Some(arr.as_primitive::<UInt64Type>().value(row)),
         DataType::Timestamp(unit, _) => {
             use arrow::datatypes::{
                 TimeUnit, TimestampMicrosecondType, TimestampMillisecondType,
@@ -1117,14 +1165,16 @@ fn numeric_timestamp_ns(arr: &dyn Array, row: usize) -> u64 {
                     .checked_mul(1_000_000_000),
             };
             match raw_ns.and_then(|ns| u64::try_from(ns).ok()) {
-                Some(ns) => ns,
+                Some(ns) => Some(ns),
                 None => {
-                    tracing::debug!("timestamp parse fallback: numeric timestamp overflow or negative value");
-                    0
+                    tracing::debug!(
+                        "timestamp parse fallback: numeric timestamp overflow or negative value"
+                    );
+                    None
                 }
             }
         }
-        _ => 0,
+        _ => None,
     }
 }
 
@@ -1137,20 +1187,24 @@ fn encode_row_as_log_record(
 ) {
     // --- Read per-row values from pre-resolved columns ---
 
-    let timestamp_ns: u64 = if let Some((_, arr)) = columns.timestamp_num_col.as_ref() {
+    let timestamp_ns: Option<u64> = if let Some((_, arr)) = columns.timestamp_num_col.as_ref() {
         numeric_timestamp_ns(*arr, row)
     } else if let Some((_, arr)) = columns.timestamp_col.as_ref() {
         if arr.is_null(row) {
-            0
+            None
         } else {
-            let ts = parse_timestamp_nanos(arr.value(row).as_bytes()).unwrap_or(0);
-            if ts == 0 {
-                tracing::debug!("timestamp parse fallback: event_time omitted for unparseable value");
+            match parse_timestamp_nanos(arr.value(row).as_bytes()) {
+                Some(ts) => Some(ts),
+                None => {
+                    tracing::debug!(
+                        "timestamp parse fallback: event_time omitted for unparseable value"
+                    );
+                    None
+                }
             }
-            ts
         }
     } else {
-        0
+        None
     };
 
     let (severity_num, severity_text): (Severity, &[u8]) =
@@ -1182,7 +1236,7 @@ fn encode_row_as_log_record(
     // --- Write protobuf fields ---
 
     // LogRecord.time_unix_nano (fixed64)
-    if timestamp_ns > 0 {
+    if let Some(timestamp_ns) = timestamp_ns {
         encode_fixed64(buf, otlp::LOG_RECORD_TIME_UNIX_NANO, timestamp_ns);
     }
 
@@ -1206,59 +1260,7 @@ fn encode_row_as_log_record(
 
     // LogRecord.attributes — pre-resolved attribute columns
     for (field_name, attr) in &columns.attribute_cols {
-        match attr {
-            AttrArray::Int(arr) => {
-                if !arr.is_null(row) {
-                    encode_key_value_int(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        arr.value(row),
-                    );
-                }
-            }
-            AttrArray::Float(arr) => {
-                if !arr.is_null(row) {
-                    encode_key_value_double(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        arr.value(row),
-                    );
-                }
-            }
-            AttrArray::Bool(arr) => {
-                if !arr.is_null(row) {
-                    encode_key_value_bool(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        arr.value(row),
-                    );
-                }
-            }
-            AttrArray::Str(arr) => {
-                if !arr.is_null(row) {
-                    encode_key_value_string(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        arr.value(row).as_bytes(),
-                    );
-                }
-            }
-            AttrArray::OtherStr(arr) => {
-                if !arr.is_null(row) {
-                    let s = array_value_to_string(*arr, row).unwrap_or_default();
-                    encode_key_value_string(
-                        buf,
-                        otlp::LOG_RECORD_ATTRIBUTES,
-                        field_name.as_bytes(),
-                        s.as_bytes(),
-                    );
-                }
-            }
-        }
+        encode_attr_array_value(buf, otlp::LOG_RECORD_ATTRIBUTES, field_name, attr, row);
     }
 
     // LogRecord.flags (fixed32) — W3C trace flags.
@@ -1296,11 +1298,11 @@ fn encode_row_as_log_record(
     }
 
     // LogRecord.observed_time_unix_nano (fixed64)
-    let observed_ns = if let Some((_, arr)) = columns.observed_ts_col.as_ref() {
-        numeric_timestamp_ns(*arr, row)
-    } else {
-        metadata.observed_time_ns
-    };
+    let observed_ns = columns
+        .observed_ts_col
+        .as_ref()
+        .and_then(|(_, arr)| numeric_timestamp_ns(*arr, row))
+        .unwrap_or(metadata.observed_time_ns);
     encode_fixed64(buf, otlp::LOG_RECORD_OBSERVED_TIME_UNIX_NANO, observed_ns);
 }
 
@@ -1320,6 +1322,19 @@ fn encode_key_value_string(buf: &mut Vec<u8>, field_number: u32, key: &[u8], val
     encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
 }
 
+/// Encode a KeyValue with bytes AnyValue (`AnyValue.bytes_value`).
+fn encode_key_value_bytes(buf: &mut Vec<u8>, field_number: u32, key: &[u8], value: &[u8]) {
+    let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_BYTES_VALUE, value.len());
+    let kv_inner = bytes_field_size(otlp::KEY_VALUE_KEY, key.len())
+        + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+    encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+    encode_varint(buf, kv_inner as u64);
+    encode_bytes_field(buf, otlp::KEY_VALUE_KEY, key);
+    encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+    encode_varint(buf, anyvalue_inner as u64);
+    encode_bytes_field(buf, otlp::ANY_VALUE_BYTES_VALUE, value);
+}
+
 /// Encode a KeyValue with int AnyValue (`AnyValue.int_value`).
 fn encode_key_value_int(buf: &mut Vec<u8>, field_number: u32, key: &[u8], value: i64) {
     let anyvalue_inner = 1 + varint_len(value as u64); // tag(1 byte) + varint
@@ -1331,6 +1346,75 @@ fn encode_key_value_int(buf: &mut Vec<u8>, field_number: u32, key: &[u8], value:
     encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
     encode_varint(buf, anyvalue_inner as u64);
     encode_varint_field(buf, otlp::ANY_VALUE_INT_VALUE, value as u64);
+}
+
+fn encode_attr_array_value(
+    buf: &mut Vec<u8>,
+    field_number: u32,
+    field_name: &str,
+    attr: &AttrArray<'_>,
+    row: usize,
+) {
+    match attr {
+        AttrArray::Int(arr) => {
+            if !arr.is_null(row) {
+                encode_key_value_int(buf, field_number, field_name.as_bytes(), arr.value(row));
+            }
+        }
+        AttrArray::Float(arr) => {
+            if !arr.is_null(row) {
+                encode_key_value_double(buf, field_number, field_name.as_bytes(), arr.value(row));
+            }
+        }
+        AttrArray::Bool(arr) => {
+            if !arr.is_null(row) {
+                encode_key_value_bool(buf, field_number, field_name.as_bytes(), arr.value(row));
+            }
+        }
+        AttrArray::Str(arr) => {
+            if !arr.is_null(row) {
+                encode_key_value_string(
+                    buf,
+                    field_number,
+                    field_name.as_bytes(),
+                    arr.value(row).as_bytes(),
+                );
+            }
+        }
+        AttrArray::Bytes(arr) => {
+            if !arr.is_null(row) {
+                encode_key_value_bytes(buf, field_number, field_name.as_bytes(), arr.value(row));
+            }
+        }
+        AttrArray::LargeBytes(arr) => {
+            if !arr.is_null(row) {
+                encode_key_value_bytes(buf, field_number, field_name.as_bytes(), arr.value(row));
+            }
+        }
+        AttrArray::OtherStr(arr) => {
+            if let Some(value) = format_non_string_attr_value(*arr, row, field_name) {
+                encode_key_value_string(buf, field_number, field_name.as_bytes(), value.as_bytes());
+            }
+        }
+    }
+}
+
+fn format_non_string_attr_value(arr: &dyn Array, row: usize, field_name: &str) -> Option<String> {
+    if arr.is_null(row) {
+        return None;
+    }
+    match array_value_to_string(arr, row) {
+        Ok(value) => Some(value),
+        Err(err) => {
+            tracing::warn!(
+                column = field_name,
+                row,
+                error = %err,
+                "skipping OTLP attribute value: failed to format non-string Arrow value"
+            );
+            None
+        }
+    }
 }
 
 /// Encode a KeyValue with double AnyValue (`AnyValue.double_value`).
@@ -2255,6 +2339,71 @@ mod tests {
         assert_eq!(active_val, Some(true), "active attribute value mismatch");
     }
 
+    #[test]
+    fn binary_attributes_encode_as_otlp_bytes_values() {
+        use arrow::array::BinaryArray;
+        use opentelemetry_proto::tonic::{
+            collector::logs::v1::ExportLogsServiceRequest, common::v1::any_value::Value,
+        };
+        use prost::Message;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("body", DataType::Utf8, true),
+            Field::new("log_payload", DataType::Binary, true),
+            Field::new("_resource_resource_payload", DataType::Binary, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("binary attrs")])),
+                Arc::new(BinaryArray::from(vec![Some(&[0x00_u8, 0x0f, 0xff][..])])),
+                Arc::new(BinaryArray::from(vec![Some(&[0xde_u8, 0xad][..])])),
+            ],
+        )
+        .expect("valid batch");
+        let metadata = make_metadata();
+
+        let mut handwritten = make_sink();
+        handwritten.encode_batch(&batch, &metadata);
+
+        let mut generated = make_sink();
+        generated.encode_batch_generated_fast(&batch, &metadata);
+        assert_eq!(
+            generated.encoded_payload(),
+            handwritten.encoded_payload(),
+            "generated-fast payload drifted from handwritten binary attribute encoding"
+        );
+
+        let request = ExportLogsServiceRequest::decode(handwritten.encoder_buf.as_slice())
+            .expect("prost must decode binary attributes");
+        let resource = request.resource_logs[0]
+            .resource
+            .as_ref()
+            .expect("resource");
+        let resource_payload = resource
+            .attributes
+            .iter()
+            .find(|kv| kv.key == "resource_payload")
+            .and_then(|kv| kv.value.as_ref())
+            .and_then(|value| match &value.value {
+                Some(Value::BytesValue(bytes)) => Some(bytes.as_slice()),
+                _ => None,
+            });
+        assert_eq!(resource_payload, Some(&[0xde, 0xad][..]));
+
+        let record = &request.resource_logs[0].scope_logs[0].log_records[0];
+        let log_payload = record
+            .attributes
+            .iter()
+            .find(|kv| kv.key == "log_payload")
+            .and_then(|kv| kv.value.as_ref())
+            .and_then(|value| match &value.value {
+                Some(Value::BytesValue(bytes)) => Some(bytes.as_slice()),
+                _ => None,
+            });
+        assert_eq!(log_payload, Some(&[0x00, 0x0f, 0xff][..]));
+    }
+
     /// Roundtrip with minimal fields: only body, no timestamp, no severity,
     /// no trace context. Ensures sparse records encode correctly.
     #[test]
@@ -3171,6 +3320,41 @@ mod tests {
         assert_eq!(
             lr.time_unix_nano, EXPECTED_NS,
             "Int64 time_unix_nano column must be encoded as LogRecord.time_unix_nano"
+        );
+    }
+
+    #[test]
+    fn epoch_zero_string_timestamp_is_encoded_as_valid_time() {
+        use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+        use prost::Message;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Utf8, true),
+            Field::new("body", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("1970-01-01T00:00:00Z")])),
+                Arc::new(StringArray::from(vec![Some("epoch")])),
+            ],
+        )
+        .expect("valid batch");
+
+        let mut handwritten = make_sink();
+        handwritten.encode_batch(&batch, &make_metadata());
+
+        let mut generated = make_sink();
+        generated.encode_batch_generated_fast(&batch, &make_metadata());
+        assert_eq!(generated.encoded_payload(), handwritten.encoded_payload());
+
+        let request = ExportLogsServiceRequest::decode(handwritten.encoder_buf.as_slice())
+            .expect("prost must decode epoch timestamp batch");
+        let record = &request.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(record.time_unix_nano, 0);
+        assert!(
+            contains_bytes(&handwritten.encoder_buf, &[0x09, 0, 0, 0, 0, 0, 0, 0, 0]),
+            "valid epoch-zero timestamp should be emitted, not treated as parse failure"
         );
     }
 

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -9,6 +9,7 @@ use arrow::array::{
     Array, AsArray, LargeStringArray, PrimitiveArray, StringArray, StringViewArray,
 };
 use arrow::datatypes::{DataType, Float64Type, Int64Type, UInt64Type};
+use arrow::util::display::array_value_to_string;
 use arrow::record_batch::RecordBatch;
 use flate2::Compression as GzipLevel;
 use flate2::write::GzEncoder;
@@ -23,7 +24,7 @@ use logfwd_types::diagnostics::ComponentStats;
 use logfwd_types::field_names;
 use zstd::bulk::Compressor as ZstdCompressor;
 
-use super::{BatchMetadata, Compression, str_value};
+use super::{BatchMetadata, Compression};
 use crate::http_classify::{self, DEFAULT_RETRY_AFTER_SECS};
 
 mod generated {
@@ -67,9 +68,11 @@ pub struct OtlpSink {
     stats: Arc<ComponentStats>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum ResourceValueRef<'a> {
     Str(&'a str),
+    /// Owned stringified value for non-string Arrow types (e.g. UInt64 from `hash()` UDF).
+    OwnedStr(String),
     Int(i64),
     Float(u64),
     Bool(bool),
@@ -292,6 +295,12 @@ impl OtlpSink {
                 if let Some(v) = value {
                     match v {
                         ResourceValueRef::Str(v) => encode_key_value_string(
+                            &mut resource_msg,
+                            otlp::RESOURCE_ATTRIBUTES,
+                            key_name.as_bytes(),
+                            v.as_bytes(),
+                        ),
+                        ResourceValueRef::OwnedStr(v) => encode_key_value_string(
                             &mut resource_msg,
                             otlp::RESOURCE_ATTRIBUTES,
                             key_name.as_bytes(),
@@ -747,9 +756,11 @@ impl AttrArray<'_> {
     fn value_ref(&self, row: usize) -> Option<ResourceValueRef<'_>> {
         match self {
             Self::Str(arr) => (!arr.is_null(row)).then(|| ResourceValueRef::Str(arr.value(row))),
-            Self::OtherStr(arr) => {
-                (!arr.is_null(row)).then(|| ResourceValueRef::Str(str_value(*arr, row)))
-            }
+            Self::OtherStr(arr) => (!arr.is_null(row)).then(|| {
+                ResourceValueRef::OwnedStr(
+                    array_value_to_string(*arr, row).unwrap_or_default(),
+                )
+            }),
             Self::Int(arr) => (!arr.is_null(row)).then(|| ResourceValueRef::Int(arr.value(row))),
             Self::Float(arr) => {
                 (!arr.is_null(row)).then(|| ResourceValueRef::Float(arr.value(row).to_bits()))
@@ -896,7 +907,7 @@ fn resolve_batch_columns<'a>(
                     }
                 }
             }
-            "_raw" => {
+            field_names::RAW => {
                 excluded.push(idx);
             }
             _ => {}
@@ -965,7 +976,7 @@ fn resolve_batch_columns<'a>(
                     .map(|stripped| {
                         field
                             .metadata()
-                            .get("logfwd.resource_key")
+                            .get(field_names::METADATA_RESOURCE_KEY)
                             .cloned()
                             .unwrap_or_else(|| stripped.to_string())
                     })
@@ -1005,7 +1016,13 @@ fn resolve_batch_columns<'a>(
             // type-conflict builder) cannot be encoded as a single typed OTLP attribute.
             // Conflict structs (Struct { int, str, float, bool }) are already normalized
             // to flat Utf8 by `encode_batch` before this function is called.
-            DataType::Struct(_) => continue,
+            DataType::Struct(_) => {
+                tracing::warn!(
+                    column = field.name().as_str(),
+                    "non-conflict struct column cannot be encoded as OTLP attribute, skipping"
+                );
+                continue;
+            }
             _ => resolve_otlp_str_col(batch.column(idx).as_ref()).map_or_else(
                 || AttrArray::OtherStr(batch.column(idx).as_ref()),
                 AttrArray::Str,
@@ -1034,7 +1051,7 @@ fn resolve_batch_columns<'a>(
 fn resource_prefix_from_batch(batch: &RecordBatch) -> String {
     let schema = batch.schema();
 
-    if let Some(prefix) = schema.metadata().get("logfwd.resource_prefix")
+    if let Some(prefix) = schema.metadata().get(field_names::METADATA_RESOURCE_PREFIX)
         && !prefix.is_empty()
     {
         return prefix.clone();
@@ -1049,7 +1066,7 @@ fn resource_prefix_from_batch(batch: &RecordBatch) -> String {
     }
 
     for field in schema.fields() {
-        if let Some(resource_key) = field.metadata().get("logfwd.resource_key")
+        if let Some(resource_key) = field.metadata().get(field_names::METADATA_RESOURCE_KEY)
             && let Some(prefix) = field.name().strip_suffix(resource_key)
             && !prefix.is_empty()
         {
@@ -1066,7 +1083,16 @@ fn numeric_timestamp_ns(arr: &dyn Array, row: usize) -> u64 {
     }
 
     match arr.data_type() {
-        DataType::Int64 => u64::try_from(arr.as_primitive::<Int64Type>().value(row)).unwrap_or(0),
+        DataType::Int64 => {
+            let v = arr.as_primitive::<Int64Type>().value(row);
+            match u64::try_from(v) {
+                Ok(ns) => ns,
+                Err(_) => {
+                    tracing::debug!("timestamp parse fallback: negative i64 timestamp cannot convert to u64");
+                    0
+                }
+            }
+        }
         DataType::UInt64 => arr.as_primitive::<UInt64Type>().value(row),
         DataType::Timestamp(unit, _) => {
             use arrow::datatypes::{
@@ -1090,7 +1116,13 @@ fn numeric_timestamp_ns(arr: &dyn Array, row: usize) -> u64 {
                     .value(row)
                     .checked_mul(1_000_000_000),
             };
-            raw_ns.and_then(|ns| u64::try_from(ns).ok()).unwrap_or(0)
+            match raw_ns.and_then(|ns| u64::try_from(ns).ok()) {
+                Some(ns) => ns,
+                None => {
+                    tracing::debug!("timestamp parse fallback: numeric timestamp overflow or negative value");
+                    0
+                }
+            }
         }
         _ => 0,
     }
@@ -1111,7 +1143,11 @@ fn encode_row_as_log_record(
         if arr.is_null(row) {
             0
         } else {
-            parse_timestamp_nanos(arr.value(row).as_bytes()).unwrap_or(0)
+            let ts = parse_timestamp_nanos(arr.value(row).as_bytes()).unwrap_or(0);
+            if ts == 0 {
+                tracing::debug!("timestamp parse fallback: event_time omitted for unparseable value");
+            }
+            ts
         }
     } else {
         0
@@ -1213,11 +1249,12 @@ fn encode_row_as_log_record(
             }
             AttrArray::OtherStr(arr) => {
                 if !arr.is_null(row) {
+                    let s = array_value_to_string(*arr, row).unwrap_or_default();
                     encode_key_value_string(
                         buf,
                         otlp::LOG_RECORD_ATTRIBUTES,
                         field_name.as_bytes(),
-                        str_value(*arr, row).as_bytes(),
+                        s.as_bytes(),
                     );
                 }
             }
@@ -2493,7 +2530,7 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![
             Field::new("body", DataType::Utf8, true),
-            Field::new("_raw", DataType::Utf8, true),
+            Field::new(field_names::RAW, DataType::Utf8, true),
         ]));
         let batch = RecordBatch::try_new(
             schema,
@@ -2511,7 +2548,7 @@ mod tests {
         let attrs = &request.resource_logs[0].scope_logs[0].log_records[0].attributes;
 
         assert!(
-            attrs.iter().all(|kv| kv.key != "_raw"),
+            attrs.iter().all(|kv| kv.key != field_names::RAW),
             "_raw should remain internal-only"
         );
     }
@@ -2567,12 +2604,12 @@ mod tests {
         // (containing dots) survive the round-trip through Arrow column names.
         let svc_field = Field::new("resource.attributes.service.name", DataType::Utf8, true)
             .with_metadata(std::collections::HashMap::from([(
-                "logfwd.resource_key".to_string(),
+                field_names::METADATA_RESOURCE_KEY.to_string(),
                 "service.name".to_string(),
             )]));
         let ns_field = Field::new("resource.attributes.k8s.namespace", DataType::Utf8, true)
             .with_metadata(std::collections::HashMap::from([(
-                "logfwd.resource_key".to_string(),
+                field_names::METADATA_RESOURCE_KEY.to_string(),
                 "k8s.namespace".to_string(),
             )]));
         let schema = Arc::new(Schema::new(vec![
@@ -2727,7 +2764,7 @@ mod tests {
 
         let shard_field = Field::new("resource.attributes.service.shard", DataType::Int64, true)
             .with_metadata(std::collections::HashMap::from([(
-                "logfwd.resource_key".to_string(),
+                field_names::METADATA_RESOURCE_KEY.to_string(),
                 "service.shard".to_string(),
             )]));
         let enabled_field = Field::new(
@@ -2736,7 +2773,7 @@ mod tests {
             true,
         )
         .with_metadata(std::collections::HashMap::from([(
-            "logfwd.resource_key".to_string(),
+            field_names::METADATA_RESOURCE_KEY.to_string(),
             "service.enabled".to_string(),
         )]));
         let schema = Arc::new(Schema::new(vec![
@@ -2834,12 +2871,12 @@ mod tests {
 
         let svc_field = Field::new("resource.attributes.service.name", DataType::Utf8, true)
             .with_metadata(std::collections::HashMap::from([(
-                "logfwd.resource_key".to_string(),
+                field_names::METADATA_RESOURCE_KEY.to_string(),
                 "service.name".to_string(),
             )]));
         let shard_field = Field::new("resource.attributes.service.shard", DataType::Int64, true)
             .with_metadata(std::collections::HashMap::from([(
-                "logfwd.resource_key".to_string(),
+                field_names::METADATA_RESOURCE_KEY.to_string(),
                 "service.shard".to_string(),
             )]));
 

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -72,8 +72,6 @@ pub struct OtlpSink {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum ResourceValueRef<'a> {
     Str(&'a str),
-    /// Owned stringified value for non-string Arrow types (e.g. UInt64 from `hash()` UDF).
-    OwnedStr(String),
     Bytes(&'a [u8]),
     Int(i64),
     Float(u64),
@@ -238,15 +236,15 @@ impl OtlpSink {
             });
             let scope_key = (scope_name, scope_version);
 
-            let group_idx = if let Some(existing) =
-                group_index_by_key.get(&(key.clone(), scope_key)).copied()
-            {
-                existing
-            } else {
-                let idx = grouped_ranges.len();
-                group_index_by_key.insert((key.clone(), scope_key), idx);
-                grouped_ranges.push((key, scope_key, Vec::new()));
-                idx
+            let group_idx = match group_index_by_key.entry((key, scope_key)) {
+                std::collections::hash_map::Entry::Occupied(entry) => *entry.get(),
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    let idx = grouped_ranges.len();
+                    let (group_key, group_scope) = entry.key();
+                    grouped_ranges.push((group_key.clone(), *group_scope, Vec::new()));
+                    entry.insert(idx);
+                    idx
+                }
             };
 
             let start = records_buf.len();
@@ -297,12 +295,6 @@ impl OtlpSink {
                 if let Some(v) = value {
                     match v {
                         ResourceValueRef::Str(v) => encode_key_value_string(
-                            &mut resource_msg,
-                            otlp::RESOURCE_ATTRIBUTES,
-                            key_name.as_bytes(),
-                            v.as_bytes(),
-                        ),
-                        ResourceValueRef::OwnedStr(v) => encode_key_value_string(
                             &mut resource_msg,
                             otlp::RESOURCE_ATTRIBUTES,
                             key_name.as_bytes(),
@@ -754,6 +746,7 @@ impl OtlpStrCol<'_> {
 enum AttrArray<'a> {
     Str(OtlpStrCol<'a>),
     OtherStr(&'a dyn Array),
+    PreformattedStr(Vec<Option<String>>),
     Bytes(&'a BinaryArray),
     LargeBytes(&'a LargeBinaryArray),
     Int(&'a PrimitiveArray<Int64Type>),
@@ -767,8 +760,19 @@ impl AttrArray<'_> {
         match self {
             Self::Str(arr) => (!arr.is_null(row)).then(|| ResourceValueRef::Str(arr.value(row))),
             Self::OtherStr(arr) => {
-                format_non_string_attr_value(*arr, row, field_name).map(ResourceValueRef::OwnedStr)
+                if !arr.is_null(row) {
+                    tracing::warn!(
+                        column = field_name,
+                        row,
+                        "skipping OTLP resource attribute: unsupported non-string column was not preformatted"
+                    );
+                }
+                None
             }
+            Self::PreformattedStr(values) => values
+                .get(row)
+                .and_then(|value| value.as_deref())
+                .map(ResourceValueRef::Str),
             Self::Bytes(arr) => {
                 (!arr.is_null(row)).then(|| ResourceValueRef::Bytes(arr.value(row)))
             }
@@ -1027,7 +1031,12 @@ fn resolve_batch_columns<'a>(
                     continue;
                 }
                 _ => resolve_otlp_str_col(batch.column(idx).as_ref()).map_or_else(
-                    || AttrArray::OtherStr(batch.column(idx).as_ref()),
+                    || {
+                        AttrArray::PreformattedStr(preformat_non_string_attr_column(
+                            batch.column(idx).as_ref(),
+                            field_name,
+                        ))
+                    },
                     AttrArray::Str,
                 ),
             };
@@ -1381,6 +1390,11 @@ fn encode_attr_array_value(
                 );
             }
         }
+        AttrArray::PreformattedStr(values) => {
+            if let Some(Some(value)) = values.get(row) {
+                encode_key_value_string(buf, field_number, field_name.as_bytes(), value.as_bytes());
+            }
+        }
         AttrArray::Bytes(arr) => {
             if !arr.is_null(row) {
                 encode_key_value_bytes(buf, field_number, field_name.as_bytes(), arr.value(row));
@@ -1415,6 +1429,12 @@ fn format_non_string_attr_value(arr: &dyn Array, row: usize, field_name: &str) -
             None
         }
     }
+}
+
+fn preformat_non_string_attr_column(arr: &dyn Array, field_name: &str) -> Vec<Option<String>> {
+    (0..arr.len())
+        .map(|row| format_non_string_attr_value(arr, row, field_name))
+        .collect()
 }
 
 /// Encode a KeyValue with double AnyValue (`AnyValue.double_value`).

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -1197,7 +1197,7 @@ fn encode_row_as_log_record(
                 Some(ts) => Some(ts),
                 None => {
                     tracing::debug!(
-                        "timestamp parse fallback: event_time omitted for unparseable value"
+                        "timestamp parse fallback: event_time omitted for unparsable value"
                     );
                     None
                 }

--- a/crates/logfwd-output/src/row_json.rs
+++ b/crates/logfwd-output/src/row_json.rs
@@ -9,22 +9,6 @@ use arrow::util::display::array_value_to_string;
 
 use crate::conflict_columns::{ColInfo, get_array, is_null};
 
-/// Read a string value from a column at the given row.
-///
-/// Supports both `Utf8` (StringArray) and `Utf8View` (StringViewArray) columns,
-/// allowing output sinks to work transparently with either scanner.
-pub(crate) fn str_value(col: &dyn Array, row: usize) -> &str {
-    match col.data_type() {
-        DataType::Utf8 => col.as_string::<i32>().value(row),
-        DataType::Utf8View => col.as_string_view().value(row),
-        DataType::LargeUtf8 => col.as_string::<i64>().value(row),
-        _ => unreachable!(
-            "str_value called with non-string array type: {:?}",
-            col.data_type()
-        ),
-    }
-}
-
 /// Coalesce a conflict field to a `String` using `str_variants` ordering
 /// (Utf8 wins, then Boolean, Int64, Float64).  Returns `None` if all variants
 /// are null.

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -19,11 +19,17 @@ use super::input_build::build_input_state;
 use super::{InputTransform, Pipeline};
 
 // ── Pipeline defaults ──────────────────────────────────────────────────
+/// Default output worker count when `pipelines.<name>.workers` is unset.
 pub(crate) const DEFAULT_WORKERS: usize = 4;
+/// Default target batch size in bytes; reaching this target triggers a flush.
 pub(crate) const DEFAULT_BATCH_TARGET_BYTES: usize = 4 * 1024 * 1024;
+/// Default maximum time a partial batch waits before flushing.
 pub(crate) const DEFAULT_BATCH_TIMEOUT: Duration = Duration::from_millis(100);
+/// Default interval between input polls when `poll_interval_ms` is unset.
 pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Default idle duration before recyclable output workers shut down.
 pub(crate) const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Default minimum interval between checkpoint flushes.
 pub(crate) const DEFAULT_CHECKPOINT_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
 
 impl Pipeline {
@@ -302,7 +308,10 @@ impl Pipeline {
         let (max_workers, idle_timeout) = if factory.is_single_use() {
             (1, Duration::MAX) // never idle-expire the sole worker
         } else {
-            (config.workers.unwrap_or(DEFAULT_WORKERS), DEFAULT_IDLE_TIMEOUT)
+            (
+                config.workers.unwrap_or(DEFAULT_WORKERS),
+                DEFAULT_IDLE_TIMEOUT,
+            )
         };
         let metrics = Arc::new(metrics);
         let pool = crate::worker_pool::OutputWorkerPool::new(

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -18,6 +18,14 @@ use logfwd_types::pipeline::{PipelineMachine, SourceId};
 use super::input_build::build_input_state;
 use super::{InputTransform, Pipeline};
 
+// ── Pipeline defaults ──────────────────────────────────────────────────
+pub(crate) const DEFAULT_WORKERS: usize = 4;
+pub(crate) const DEFAULT_BATCH_TARGET_BYTES: usize = 4 * 1024 * 1024;
+pub(crate) const DEFAULT_BATCH_TIMEOUT: Duration = Duration::from_millis(100);
+pub(crate) const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+pub(crate) const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_CHECKPOINT_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
 impl Pipeline {
     /// Construct a pipeline from parsed YAML config.
     pub fn from_config(
@@ -294,7 +302,7 @@ impl Pipeline {
         let (max_workers, idle_timeout) = if factory.is_single_use() {
             (1, Duration::MAX) // never idle-expire the sole worker
         } else {
-            (config.workers.unwrap_or(4), Duration::from_secs(30))
+            (config.workers.unwrap_or(DEFAULT_WORKERS), DEFAULT_IDLE_TIMEOUT)
         };
         let metrics = Arc::new(metrics);
         let pool = crate::worker_pool::OutputWorkerPool::new(
@@ -325,14 +333,20 @@ impl Pipeline {
             processors: vec![],
             pool,
             metrics,
-            batch_target_bytes: config.batch_target_bytes.unwrap_or(4 * 1024 * 1024),
-            batch_timeout: Duration::from_millis(config.batch_timeout_ms.unwrap_or(100)),
-            poll_interval: Duration::from_millis(config.poll_interval_ms.unwrap_or(10)),
+            batch_target_bytes: config
+                .batch_target_bytes
+                .unwrap_or(DEFAULT_BATCH_TARGET_BYTES),
+            batch_timeout: config
+                .batch_timeout_ms
+                .map_or(DEFAULT_BATCH_TIMEOUT, Duration::from_millis),
+            poll_interval: config
+                .poll_interval_ms
+                .map_or(DEFAULT_POLL_INTERVAL, Duration::from_millis),
             resource_attrs: Arc::new(resource_attrs),
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store,
             last_checkpoint_flush: tokio::time::Instant::now(),
-            checkpoint_flush_interval: Duration::from_secs(5),
+            checkpoint_flush_interval: DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
         })
     }
 }

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -90,7 +90,9 @@ pub(super) fn build_input_state(
             let format = cfg.format.clone().unwrap_or(Format::Auto);
             let mut tail_config = TailConfig {
                 start_from_end: false,
-                poll_interval_ms: cfg.poll_interval_ms.unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
+                poll_interval_ms: cfg
+                    .poll_interval_ms
+                    .unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
                 read_buf_size: cfg.read_buf_size.unwrap_or(DEFAULT_READ_BUF_SIZE),
                 per_file_read_budget_bytes: cfg
                     .per_file_read_budget_bytes

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -14,6 +14,19 @@ use logfwd_io::tail::TailConfig;
 
 use super::InputState;
 
+// ── File-input defaults ────────────────────────────────────────────────
+const DEFAULT_FILE_POLL_INTERVAL_MS: u64 = 50;
+const DEFAULT_READ_BUF_SIZE: usize = 256 * 1024;
+const DEFAULT_PER_FILE_READ_BUDGET_BYTES: usize = 256 * 1024;
+const DEFAULT_MAX_OPEN_FILES: usize = 1024;
+
+// ── Generator-input defaults ───────────────────────────────────────────
+const DEFAULT_GENERATOR_BATCH_SIZE: usize = 1000;
+
+// ── Platform-sensor defaults ───────────────────────────────────────────
+const DEFAULT_SENSOR_POLL_INTERVAL_MS: u64 = 10_000;
+const DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS: u64 = 1_000;
+
 /// Build a format processor from the config format.
 fn make_format(
     name: &str,
@@ -77,10 +90,12 @@ pub(super) fn build_input_state(
             let format = cfg.format.clone().unwrap_or(Format::Auto);
             let mut tail_config = TailConfig {
                 start_from_end: false,
-                poll_interval_ms: cfg.poll_interval_ms.unwrap_or(50),
-                read_buf_size: cfg.read_buf_size.unwrap_or(256 * 1024),
-                per_file_read_budget_bytes: cfg.per_file_read_budget_bytes.unwrap_or(256 * 1024),
-                max_open_files: cfg.max_open_files.unwrap_or(1024),
+                poll_interval_ms: cfg.poll_interval_ms.unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
+                read_buf_size: cfg.read_buf_size.unwrap_or(DEFAULT_READ_BUF_SIZE),
+                per_file_read_budget_bytes: cfg
+                    .per_file_read_budget_bytes
+                    .unwrap_or(DEFAULT_PER_FILE_READ_BUDGET_BYTES),
+                max_open_files: cfg.max_open_files.unwrap_or(DEFAULT_MAX_OPEN_FILES),
                 ..Default::default()
             };
             if let Some(interval) = cfg.glob_rescan_interval_ms {
@@ -118,7 +133,9 @@ pub(super) fn build_input_state(
             let generator_cfg = cfg.generator.as_ref();
             let config = GeneratorConfig {
                 events_per_sec: generator_cfg.and_then(|c| c.events_per_sec).unwrap_or(0),
-                batch_size: generator_cfg.and_then(|c| c.batch_size).unwrap_or(1000),
+                batch_size: generator_cfg
+                    .and_then(|c| c.batch_size)
+                    .unwrap_or(DEFAULT_GENERATOR_BATCH_SIZE),
                 total_events: generator_cfg.and_then(|c| c.total_events).unwrap_or(0),
                 complexity: match generator_cfg.and_then(|c| c.complexity.clone()) {
                     Some(GeneratorComplexityConfig::Complex) => GeneratorComplexity::Complex,
@@ -358,10 +375,12 @@ pub(super) fn build_input_state(
 fn build_platform_sensor_config(
     cfg: Option<&PlatformSensorInputConfig>,
 ) -> logfwd_io::platform_sensor::PlatformSensorConfig {
-    let poll_interval_ms = cfg.and_then(|c| c.poll_interval_ms).unwrap_or(10_000);
+    let poll_interval_ms = cfg
+        .and_then(|c| c.poll_interval_ms)
+        .unwrap_or(DEFAULT_SENSOR_POLL_INTERVAL_MS);
     let control_reload_interval_ms = cfg
         .and_then(|c| c.control_reload_interval_ms)
-        .unwrap_or(1_000);
+        .unwrap_or(DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS);
     logfwd_io::platform_sensor::PlatformSensorConfig {
         poll_interval: std::time::Duration::from_millis(poll_interval_ms.max(1)),
         control_path: cfg.and_then(|c| c.control_path.clone()).map(PathBuf::from),

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -295,7 +295,7 @@ impl Pipeline {
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store: None,
             last_checkpoint_flush: tokio::time::Instant::now(),
-            checkpoint_flush_interval: Duration::from_secs(5),
+            checkpoint_flush_interval: build::DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
         }
     }
 
@@ -329,7 +329,7 @@ impl Pipeline {
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store: None,
             last_checkpoint_flush: tokio::time::Instant::now(),
-            checkpoint_flush_interval: Duration::from_secs(5),
+            checkpoint_flush_interval: build::DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
         }
     }
 

--- a/crates/logfwd-types/src/field_names.rs
+++ b/crates/logfwd-types/src/field_names.rs
@@ -130,6 +130,25 @@ pub const DEFAULT_RESOURCE_PREFIX: &str = "resource.attributes.";
 pub const LEGACY_RESOURCE_PREFIX: &str = "_resource_";
 
 // ---------------------------------------------------------------------------
+// Internal columns
+// ---------------------------------------------------------------------------
+
+/// Internal raw-line column — excluded from OTLP attributes and star-schema.
+pub const RAW: &str = "_raw";
+
+// ---------------------------------------------------------------------------
+// Arrow field / schema metadata keys
+// ---------------------------------------------------------------------------
+
+/// Arrow field metadata key: stores the original resource attribute key
+/// when using the legacy `_resource_*` prefix, enabling round-trip conversion.
+pub const METADATA_RESOURCE_KEY: &str = "logfwd.resource_key";
+
+/// Arrow schema metadata key: overrides the default resource prefix
+/// detection on a per-batch basis.
+pub const METADATA_RESOURCE_PREFIX: &str = "logfwd.resource_prefix";
+
+// ---------------------------------------------------------------------------
 // Type-conflict struct children (Arrow schema)
 // ---------------------------------------------------------------------------
 

--- a/crates/logfwd/tests/it/compliance.rs
+++ b/crates/logfwd/tests/it/compliance.rs
@@ -34,7 +34,7 @@ use tokio_util::sync::CancellationToken;
 /// Coverage instrumentation and busy CI hosts introduce significant
 /// scheduling jitter — keep headroom to avoid flaky failures.
 fn wait_timeout() -> Duration {
-    Duration::from_secs(30)
+    Duration::from_secs(60)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/logfwd/tests/it/compliance_file.rs
+++ b/crates/logfwd/tests/it/compliance_file.rs
@@ -70,7 +70,7 @@ fn wait_for(predicate: impl Fn() -> bool, timeout: Duration) -> bool {
 /// Keep a generous wait budget for file-compliance tests.
 /// Coverage and busy CI hosts can introduce significant scheduling jitter.
 fn wait_timeout() -> Duration {
-    Duration::from_secs(30)
+    Duration::from_secs(90)
 }
 
 /// Build a pipeline config YAML for a glob input pattern.

--- a/crates/logfwd/tests/it/compliance_file.rs
+++ b/crates/logfwd/tests/it/compliance_file.rs
@@ -49,8 +49,7 @@ input:
   path: {}
   format: json
 output:
-  type: stdout
-  format: json
+  type: null
 ",
         log_path.display()
     )
@@ -86,8 +85,7 @@ input:
   format: json
   glob_rescan_interval_ms: 50
 output:
-  type: stdout
-  format: json
+  type: null
 "#,
         pattern
     )

--- a/dev-docs/SCANNER_CONTRACT.md
+++ b/dev-docs/SCANNER_CONTRACT.md
@@ -129,6 +129,16 @@ fields.
   fields.
 - `null` JSON values produce a null entry in the appropriate column.
 
+### String escape decoding
+
+JSON escape sequences in string values (`\"`, `\\`, `\/`, `\b`, `\f`, `\n`,
+`\r`, `\t`, `\uXXXX`) are decoded to their UTF-8 representation during
+extraction.  This prevents double-escaping when values are re-serialized
+downstream (see issue #410).
+
+The `body` line-capture column is **not** decoded — it stores the original raw
+line verbatim.
+
 ### Batch reuse
 
 `Scanner` can be reused across batches. Each call to `scan()` or
@@ -148,8 +158,5 @@ carried over.
   beyond will not be detected and may silently produce incorrect data.
 - **`StreamingBuilder` offsets are `u32`** — buffers larger than 4 GB are
   unsupported.
-- **No escape decoding of string values** — string values are stored as
-  raw bytes (including any JSON escape sequences such as `\n`, `\uXXXX`).
-  Callers that need decoded strings must unescape them.
 - **`body` column** — setting `line_field_name` is supported by both `scan()` and
   `scan_detached()` modes.

--- a/tla/PipelineMachine.thorough.cfg
+++ b/tla/PipelineMachine.thorough.cfg
@@ -4,7 +4,7 @@
 \* Use before merging to catch edge cases not covered by the fast config.
 \*
 \* Run: java -cp tla2tools.jar tlc2.TLC MCPipelineMachine.tla -config PipelineMachine.thorough.cfg
-\* Expected: ~several million states, several minutes
+\* Expected: hundreds of millions of generated states, usually under 45 minutes in CI
 \*
 \* NOTE: Do NOT use CONSTRAINT to bound state space. For safety-only configs
 \* like this one the immediate risk is less severe, but CONSTRAINT silently

--- a/tla/PipelineMachine.thorough.cfg
+++ b/tla/PipelineMachine.thorough.cfg
@@ -4,7 +4,7 @@
 \* Use before merging to catch edge cases not covered by the fast config.
 \*
 \* Run: java -cp tla2tools.jar tlc2.TLC MCPipelineMachine.tla -config PipelineMachine.thorough.cfg
-\* Expected: hundreds of millions of generated states, usually under 45 minutes in CI
+\* Expected: hundreds of millions of generated states, usually under 90 minutes in CI
 \*
 \* NOTE: Do NOT use CONSTRAINT to bound state space. For safety-only configs
 \* like this one the immediate risk is less severe, but CONSTRAINT silently

--- a/tla/README.md
+++ b/tla/README.md
@@ -130,7 +130,7 @@ impossible.
 ```bash
 java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.thorough.cfg
 # Sources={"s1","s2","s3"}, MaxBatchesPerSource=4
-# Hundreds of millions of generated states, usually under 45 minutes in CI.
+# Hundreds of millions of generated states, usually under 90 minutes in CI.
 ```
 
 **Sabotage test** — verify no invariant is vacuously true:

--- a/tla/README.md
+++ b/tla/README.md
@@ -129,6 +129,8 @@ impossible.
 
 ```bash
 java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.thorough.cfg
+# Sources={"s1","s2","s3"}, MaxBatchesPerSource=4
+# Hundreds of millions of generated states, usually under 45 minutes in CI.
 ```
 
 **Sabotage test** — verify no invariant is vacuously true:


### PR DESCRIPTION
## Summary

Systematic audit of the codebase found shortcuts and kludges introduced by agents. 30 findings were investigated by 11 parallel verification agents. After thorough review:

- **13 confirmed** (12 fixed here, 1 deferred for design work)
- **8 by-design** (intentional, tested, or spec-driven)
- **5 won't-fix** (theoretical only or not worth churn)
- **5 false positive** (findings were wrong on investigation)

### Fixes included

| # | Severity | Fix | Crates |
|---|----------|-----|--------|
| 07 | **High** | OtherStr panic: `hash()` UDF → `unreachable!()` crash. Now uses `array_value_to_string`. Removed dead `str_value()`. | logfwd-output |
| 06 | **Medium** | Struct attr drop: non-conflict Struct columns now log `tracing::warn!` before skip | logfwd-output |
| 19 | **Medium** | Scanner contract drift: doc said "no escape decoding", code decodes since #885 | dev-docs |
| 21 | **Medium** | Calendar math dedup: arrow's wrapper delegates to Kani-verified core impl | logfwd-core, logfwd-arrow |
| 15 | **Medium** | Metadata keys: 15 bare `"logfwd.resource_key"` strings → `field_names::METADATA_RESOURCE_KEY` | logfwd-types, logfwd-arrow, logfwd-output |
| 16 | **Medium** | TypedColumn::Bytes: OTAP bytes attrs now round-trip as BinaryArray, not hex strings | logfwd-arrow |
| 13 | Low | WELL_KNOWN dedup: star_schema delegates to `field_names::matches_any()` | logfwd-arrow |
| 12 | Low | `_raw` constant: added `field_names::RAW`, replaced 2 hardcoded sites | logfwd-types, logfwd-arrow, logfwd-output |
| 27 | Low | `MAX_REQUEST_BODY_SIZE`: shared constant replaces 3 independent definitions | logfwd-io |
| 29 | Low | `DEFAULT_RETRY_AFTER_SECS`: import from `http_classify` instead of redefining | logfwd-output |
| 30 | Low | Timing defaults: named constants replace inline `unwrap_or` literals | logfwd-runtime |
| 01 | Low | Timestamp diagnostic: `tracing::debug!()` when timestamp parse falls back | logfwd-output |

### Deferred

- **Finding 09** (json() UDF rescans per call): needs design discussion on batch-level caching vs multi-field extraction

### Notable false positives caught by verification

- **#02**: OTLP receiver AnyValue drop — all 7 kinds ARE handled; audit ran against stale code
- **#05**: flags type mismatch — OTLP receiver writes Int64, star_schema UInt32 is internal
- **#11**: row_json empty string — catch-all IS the primary string path (Utf8 lands there)
- **#17**: Input source ambiguity — separate `health()` method handles broken-vs-idle detection

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes (0 warnings)
- [x] `cargo test -p logfwd-arrow -p logfwd-output -p logfwd-core -p logfwd-io -p logfwd-runtime -p logfwd-types` passes (all green)
- [ ] CI validation

Full audit documentation in `bugs/` directory (not included in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 12 audit findings by centralizing constants, supporting binary attributes, and hardening timestamp handling
> - Replaces scattered string literals (`"logfwd.resource_key"`, `"_raw"`, prefix strings) with shared constants from `logfwd_types::field_names` across `logfwd-arrow`, `logfwd-output`, and `logfwd-io`.
> - Adds `TypedColumn::Bytes` variant so binary attributes round-trip as Arrow `Binary` arrays instead of hex strings; mixed-type attribute keys are promoted to `Utf8` with hex encoding for the bytes rows.
> - Prevents attribute keys from overwriting canonical fact columns (e.g. `flags`, `trace_id`) during `star_to_flat` unpivot.
> - Fixes `numeric_timestamp_ns` to return `Option<u64>` so epoch-zero timestamps are emitted rather than suppressed; invalid timestamps now log and are omitted.
> - Consolidates duplicate `MAX_BODY_SIZE` constants across HTTP receivers into a single `MAX_REQUEST_BODY_SIZE` in `receiver_http`; consolidates duplicate `DEFAULT_RETRY_AFTER_SECS` in output sinks similarly.
> - Extracts named `DEFAULT_*` constants for pipeline and input build defaults that were previously inlined literals.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 234bba2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->