### PR TITLE
tests(net): hermetic loopback clients and deterministic wait helpers

### DIFF
--- a/crates/logfwd-diagnostics/src/diagnostics/server.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics/server.rs
@@ -1144,6 +1144,7 @@ mod tests {
     use crate::diagnostics::{ComponentHealth, ComponentStats};
     use std::io::Read;
     use std::sync::atomic::Ordering;
+    use std::time::Instant;
 
     /// Build a server with one pipeline pre-populated with known counter values.
     /// Binds to port 0 so the OS assigns a free port; call `.start()` and use
@@ -1258,6 +1259,20 @@ mod tests {
         (status, body)
     }
 
+    fn wait_until<F>(timeout: std::time::Duration, mut predicate: F, failure_message: &str)
+    where
+        F: FnMut() -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if predicate() {
+                return;
+            }
+            thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(predicate(), "{failure_message}");
+    }
+
     #[test]
     fn redact_config_yaml_masks_auth_and_endpoint_credentials() {
         let raw = r#"
@@ -1343,13 +1358,12 @@ output:
         let port = addr.port();
 
         drop(handle);
-        thread::sleep(std::time::Duration::from_millis(50));
 
         let rebound_addr = format!("127.0.0.1:{port}");
-        let result = tiny_http::Server::http(&rebound_addr);
-        assert!(
-            result.is_ok(),
-            "failed to rebind diagnostics port {port} after drop"
+        wait_until(
+            std::time::Duration::from_secs(1),
+            || tiny_http::Server::http(&rebound_addr).is_ok(),
+            &format!("failed to rebind diagnostics port {port} after drop"),
         );
     }
 

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -498,8 +498,31 @@ mod tests {
     };
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use std::sync::Arc;
+    use std::time::{Duration, Instant};
 
     use logfwd_arrow::star_schema::flat_to_star;
+
+    fn loopback_http_client() -> ureq::Agent {
+        ureq::Agent::config_builder()
+            .proxy(None)
+            .timeout_global(Some(Duration::from_secs(5)))
+            .build()
+            .into()
+    }
+
+    fn wait_until<F>(timeout: Duration, mut predicate: F, failure_message: &str)
+    where
+        F: FnMut() -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if predicate() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(predicate(), "{failure_message}");
+    }
 
     // Regression test for issue #1142: clean shutdown
     #[test]
@@ -508,19 +531,16 @@ mod tests {
         let receiver = OtapReceiver::new("test", addr).unwrap();
         let port = receiver.local_addr().port();
 
-        // Wait briefly for thread to start blocking
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
         // Drop it
         drop(receiver);
 
-        // Wait briefly for the OS to actually release the port
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
         // The port should now be free to bind to immediately
         let new_addr = format!("127.0.0.1:{}", port);
-        let result = tiny_http::Server::http(&new_addr);
-        assert!(result.is_ok(), "Failed to bind to port {} after drop", port);
+        wait_until(
+            Duration::from_secs(1),
+            || tiny_http::Server::http(&new_addr).is_ok(),
+            &format!("failed to bind to port {port} after drop"),
+        );
     }
 
     /// Build a `BatchArrowRecords` protobuf from components.
@@ -877,7 +897,8 @@ mod tests {
         );
 
         let url = format!("http://{addr}/v1/arrow_logs");
-        let response = ureq::post(&url)
+        let response = loopback_http_client()
+            .post(&url)
             .header("Content-Type", "application/x-protobuf")
             .send(&proto)
             .expect("POST should succeed");
@@ -885,7 +906,7 @@ mod tests {
 
         // Receive the flat batch.
         let received = receiver
-            .recv_timeout(std::time::Duration::from_secs(2))
+            .recv_timeout(Duration::from_secs(2))
             .expect("should receive a batch");
         assert_eq!(received.num_rows(), 2);
         assert_eq!(receiver.health(), ComponentHealth::Healthy);
@@ -898,7 +919,7 @@ mod tests {
         let addr = receiver.local_addr();
 
         let url = format!("http://{addr}/v1/logs");
-        let result = ureq::post(&url).send(b"data" as &[u8]);
+        let result = loopback_http_client().post(&url).send(b"data" as &[u8]);
         match result {
             Err(ureq::Error::StatusCode(code)) => assert_eq!(code, 404),
             other => panic!("expected 404, got {other:?}"),
@@ -912,7 +933,7 @@ mod tests {
         let addr = receiver.local_addr();
 
         let url = format!("http://{addr}/v1/arrow_logs");
-        let result = ureq::get(&url).call();
+        let result = loopback_http_client().get(&url).call();
         match result {
             Err(ureq::Error::StatusCode(code)) => assert_eq!(code, 405),
             other => panic!("expected 405, got {other:?}"),
@@ -931,7 +952,8 @@ mod tests {
         let url = format!("http://{addr}/v1/arrow_logs");
 
         // Fill the channel (capacity = 1).
-        let resp = ureq::post(&url)
+        let resp = loopback_http_client()
+            .post(&url)
             .header("Content-Type", "application/x-protobuf")
             .send(&proto)
             .expect("first POST should succeed");
@@ -939,7 +961,8 @@ mod tests {
         assert_eq!(receiver.health(), ComponentHealth::Healthy);
 
         // Next request should get 429.
-        let result = ureq::post(&url)
+        let result = loopback_http_client()
+            .post(&url)
             .header("Content-Type", "application/x-protobuf")
             .send(&proto);
         let status: u16 = match result {
@@ -956,12 +979,13 @@ mod tests {
         // Drain so the receiver is valid.
         let _ = receiver.try_recv_all();
 
-        let resp = ureq::post(&url)
+        let resp = loopback_http_client()
+            .post(&url)
             .header("Content-Type", "application/x-protobuf")
             .send(&proto)
             .expect("recovery POST should succeed");
         assert_eq!(resp.status().as_u16(), 200);
-        let _ = receiver.recv_timeout(std::time::Duration::from_secs(2));
+        let _ = receiver.recv_timeout(Duration::from_secs(2));
         assert_eq!(receiver.health(), ComponentHealth::Healthy);
     }
 

--- a/crates/logfwd-io/src/otlp_receiver/tests.rs
+++ b/crates/logfwd-io/src/otlp_receiver/tests.rs
@@ -93,6 +93,14 @@ where
     assert!(predicate(), "{failure_message}");
 }
 
+fn loopback_http_client() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .proxy(None)
+        .timeout_global(Some(Duration::from_secs(5)))
+        .build()
+        .into()
+}
+
 fn poll_receiver_until<F>(
     receiver: &mut OtlpReceiverInput,
     timeout: Duration,
@@ -985,7 +993,8 @@ fn invalid_protobuf_increments_parse_errors_when_stats_hooked() {
     .unwrap();
     let url = format!("http://{}/v1/logs", receiver.local_addr());
 
-    let status = match ureq::post(&url)
+    let status = match loopback_http_client()
+        .post(&url)
         .header("content-type", "application/x-protobuf")
         .send(b"not valid protobuf".as_slice())
     {
@@ -1316,7 +1325,8 @@ fn returns_429_when_channel_full_not_200() {
 
     // Fill the channel (capacity = 2 so two sends succeed).
     for i in 0..2 {
-        let resp = ureq::post(&url)
+        let resp = loopback_http_client()
+            .post(&url)
             .header("content-type", "application/json")
             .send(body.as_bytes())
             .unwrap_or_else(|e| panic!("request {i} failed: {e}"));
@@ -1328,7 +1338,8 @@ fn returns_429_when_channel_full_not_200() {
     }
 
     // The channel is now full; the next request must not return 200.
-    let result = ureq::post(&url)
+    let result = loopback_http_client()
+        .post(&url)
         .header("content-type", "application/json")
         .send(body.as_bytes());
 
@@ -1350,7 +1361,8 @@ fn returns_429_when_channel_full_not_200() {
     // Drain the two buffered entries so the receiver is valid.
     let _ = receiver.poll().unwrap();
 
-    let resp = ureq::post(&url)
+    let resp = loopback_http_client()
+        .post(&url)
         .header("content-type", "application/json")
         .send(body.as_bytes())
         .expect("request after drain failed");
@@ -1366,7 +1378,7 @@ fn path_prefix_variants_return_404() {
 
     for bad_path in &["/v1/logsFOO", "/v1/logs/extra", "/v1/logs2", "/v1/log"] {
         let url = format!("http://127.0.0.1:{port}{bad_path}");
-        let status = match ureq::get(&url).call() {
+        let status = match loopback_http_client().get(&url).call() {
             Ok(r) => r.status().as_u16(),
             Err(ureq::Error::StatusCode(c)) => c,
             Err(e) => panic!("unexpected error for {bad_path}: {e}"),
@@ -1391,7 +1403,8 @@ fn content_type_matching_is_case_insensitive() {
     })
     .to_string();
 
-    let resp = ureq::post(&url)
+    let resp = loopback_http_client()
+        .post(&url)
         .header("content-type", "Application/JSON")
         .send(body.as_bytes())
         .expect("request failed");
@@ -1428,7 +1441,8 @@ fn content_type_substring_match_does_not_route_json() {
     })
     .to_string();
 
-    let status = match ureq::post(&url)
+    let status = match loopback_http_client()
+        .post(&url)
         .header("content-type", "application/jsonl")
         .send(body.as_bytes())
     {
@@ -1450,8 +1464,8 @@ fn wrong_http_method_returns_405() {
     let url = format!("http://127.0.0.1:{port}/v1/logs");
 
     for (method, result) in [
-        ("GET", ureq::get(&url).call()),
-        ("DELETE", ureq::delete(&url).call()),
+        ("GET", loopback_http_client().get(&url).call()),
+        ("DELETE", loopback_http_client().delete(&url).call()),
     ] {
         let status: u16 = match result {
             Ok(resp) => resp.status().as_u16(),
@@ -1474,7 +1488,8 @@ fn missing_resource_logs_returns_400() {
 
     let bad_bodies = [r"{}", r#"{"foo":"bar"}"#, r#"{"resourceLogs":null}"#];
     for body in &bad_bodies {
-        let result = ureq::post(&url)
+        let result = loopback_http_client()
+            .post(&url)
             .header("content-type", "application/json")
             .send(body.as_bytes());
         let status: u16 = match result {
@@ -1546,7 +1561,8 @@ fn receiver_health_reports_failed_when_pipeline_disconnects() {
     let url = format!("http://127.0.0.1:{port}/v1/logs");
     receiver.rx.take();
 
-    let status = match ureq::post(&url)
+    let status = match loopback_http_client()
+        .post(&url)
         .header("content-type", "application/json")
         .send(
         br#"{"resourceLogs":[{"scopeLogs":[{"logRecords":[{"body":{"stringValue":"hello"}}]}]}]}"#,
@@ -1568,7 +1584,8 @@ fn valid_otlp_json_returns_200() {
     let url = format!("http://127.0.0.1:{port}/v1/logs");
 
     let valid_body = r#"{"resourceLogs":[{"scopeLogs":[{"logRecords":[{"severityText":"INFO","body":{"stringValue":"hello"}}]}]}]}"#;
-    let result = ureq::post(&url)
+    let result = loopback_http_client()
+        .post(&url)
         .header("content-type", "application/json")
         .send(valid_body.as_bytes());
     let status: u16 = match result {

--- a/crates/logfwd-io/tests/it/main.rs
+++ b/crates/logfwd-io/tests/it/main.rs
@@ -1,4 +1,5 @@
 mod checkpoint_state_machine;
 mod file_boundary_contract;
 mod otlp_receiver_contract;
+mod support;
 mod transport_e2e;

--- a/crates/logfwd-io/tests/it/support/http.rs
+++ b/crates/logfwd-io/tests/it/support/http.rs
@@ -1,0 +1,7 @@
+pub fn loopback_client() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .proxy(None)
+        .timeout_global(Some(std::time::Duration::from_secs(5)))
+        .build()
+        .into()
+}

--- a/crates/logfwd-io/tests/it/support/mod.rs
+++ b/crates/logfwd-io/tests/it/support/mod.rs
@@ -1,0 +1,1 @@
+pub mod http;

--- a/crates/logfwd-io/tests/it/transport_e2e.rs
+++ b/crates/logfwd-io/tests/it/transport_e2e.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
 
+use crate::support::http::loopback_client;
 use logfwd_io::{
     format::FormatDecoder,
     framed::FramedInput,
@@ -552,7 +553,8 @@ fn http_ndjson_roundtrip() {
     let addr = input.local_addr();
     let url = format!("http://{addr}/ingest");
 
-    let resp = ureq::post(&url)
+    let resp = loopback_client()
+        .post(&url)
         .header("Content-Type", "application/x-ndjson")
         .send(b"{\"seq\":1}\n{\"seq\":2}\n")
         .expect("HTTP POST should succeed");
@@ -573,7 +575,7 @@ fn http_wrong_path_rejected() {
     let addr = input.local_addr();
     let url = format!("http://{addr}/wrong");
 
-    let status = match ureq::post(&url).send(b"{\"x\":1}\n") {
+    let status = match loopback_client().post(&url).send(b"{\"x\":1}\n") {
         Ok(resp) => resp.status().as_u16(),
         Err(ureq::Error::StatusCode(code)) => code,
         Err(err) => panic!("unexpected request failure: {err}"),
@@ -625,7 +627,8 @@ fn otlp_protobuf_roundtrip() {
     let body = request.encode_to_vec();
 
     // POST the protobuf to the OTLP endpoint.
-    let resp = ureq::post(&url)
+    let resp = loopback_client()
+        .post(&url)
         .header("Content-Type", "application/x-protobuf")
         .send(&body)
         .expect("OTLP POST should succeed");
@@ -696,7 +699,8 @@ fn otlp_gzip_protobuf_roundtrip() {
     encoder.write_all(&body).expect("gzip write");
     let gzipped = encoder.finish().expect("gzip finish");
 
-    let resp = ureq::post(&url)
+    let resp = loopback_client()
+        .post(&url)
         .header("Content-Type", "application/x-protobuf")
         .header("Content-Encoding", "gzip")
         .send(&gzipped)
@@ -732,7 +736,8 @@ fn otlp_oversized_body() {
     // Build a body larger than 10 MB.
     let oversized = vec![0u8; 11 * 1024 * 1024];
 
-    let result = ureq::post(&url)
+    let result = loopback_client()
+        .post(&url)
         .header("Content-Type", "application/x-protobuf")
         .send(&oversized);
 
@@ -773,7 +778,8 @@ fn otlp_wrong_content_type() {
     let body = request.encode_to_vec();
 
     // text/plain is not JSON, so the receiver should try protobuf decode (the default).
-    let resp = ureq::post(&url)
+    let resp = loopback_client()
+        .post(&url)
         .header("Content-Type", "text/plain")
         .send(&body)
         .expect("POST should succeed");
@@ -827,7 +833,8 @@ fn otlp_concurrent_requests() {
                     }],
                 };
                 let body = request.encode_to_vec();
-                let resp = ureq::post(&url)
+                let resp = loopback_client()
+                    .post(&url)
                     .header("Content-Type", "application/x-protobuf")
                     .send(&body)
                     .expect("concurrent POST should succeed");


### PR DESCRIPTION
## Summary
- add proxy-free loopback HTTP test clients for networked `ureq` test paths
- replace fixed sleep-based shutdown/rebind checks with bounded polling helpers
- wire new `tests/it/support/http.rs` helper for integration tests

## Why
This is PR slice 1 from the network/hermetic fan-in plan:
- improves hermeticity for loopback tests
- reduces timing-flake risk from fixed sleeps
- keeps changes test-only and narrowly scoped

## Files
- `crates/logfwd-io/tests/it/transport_e2e.rs`
- `crates/logfwd-io/tests/it/main.rs`
- `crates/logfwd-io/tests/it/support/mod.rs`
- `crates/logfwd-io/tests/it/support/http.rs`
- `crates/logfwd-io/src/otlp_receiver/tests.rs`
- `crates/logfwd-io/src/otap_receiver.rs`
- `crates/logfwd-diagnostics/src/diagnostics/server.rs`

## Verification
- `cargo fmt --check`
- `cargo nextest run -p logfwd-io --profile ci --run-ignored only --lib otlp_receiver::tests::returns_429_when_channel_full_not_200 otap_receiver::tests::receiver_returns_429_when_channel_full`
- `cargo nextest run -p logfwd-diagnostics --profile ci --run-ignored only --lib diagnostics::server::tests::diagnostics_server_handle_drop_releases_port`

## Issue context
Partially advances #1311 and #1314; supports test-signal quality work adjacent to #1202/#1500.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add hermetic loopback HTTP client and deterministic wait helpers to test suites
> - Adds a `loopback_http_client()`/`loopback_client()` helper in unit and integration tests that builds a `ureq::Agent` with `proxy(None)` and a 5s global timeout, replacing bare `ureq::post`/`ureq::get` calls across [otap_receiver.rs](https://github.com/strawgate/memagent/pull/1792/files#diff-d857a8f6754a55babf2b290bc90d4dc983d53420419d6c33740dd7bab066964a), [otlp_receiver/tests.rs](https://github.com/strawgate/memagent/pull/1792/files#diff-3a088d505b0539c4ef682d152124d7693e0148297485416a91bd659b5f6b3d7b), and [transport_e2e.rs](https://github.com/strawgate/memagent/pull/1792/files#diff-cf71a61139f00e1f563b6cb5415783b9b4506739e7de16fc22813a37bf455b0a).
> - Introduces a `wait_until(timeout, predicate, failure_message)` helper in `logfwd-io` and `logfwd-diagnostics` tests that polls every 10ms up to a deadline instead of using fixed sleeps.
> - Port-release assertions in `clean_shutdown_releases_port` and `diagnostics_server_handle_drop_releases_port` now retry for up to 1s via `wait_until` rather than sleeping a fixed duration before a single bind attempt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b12ceb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->