### PR TITLE
tests(net): tighten backpressure status assertions

### DIFF
--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -971,10 +971,7 @@ mod tests {
             Err(ureq::Error::StatusCode(code)) => code,
             Err(e) => panic!("unexpected error: {e}"),
         };
-        assert!(
-            status == 429 || status == 503,
-            "expected 429 or 503, got {status}"
-        );
+        assert_eq!(status, 429, "channel-full request should return 429");
         assert_eq!(receiver.health(), ComponentHealth::Degraded);
 
         // Drain so the receiver is valid.

--- a/crates/logfwd-io/src/otlp_receiver/tests.rs
+++ b/crates/logfwd-io/src/otlp_receiver/tests.rs
@@ -1354,10 +1354,7 @@ fn returns_429_when_channel_full_not_200() {
         status, 200,
         "channel-full request must not return 200 (got {status})"
     );
-    assert!(
-        status == 429 || status == 503,
-        "expected 429 or 503 for backpressure, got {status}"
-    );
+    assert_eq!(status, 429, "channel-full request should return 429");
     assert_eq!(receiver.health(), ComponentHealth::Degraded);
 
     // Drain the two buffered entries so the receiver is valid.


### PR DESCRIPTION
## Summary
- tighten queue-full assertion to require `429` in OTLP and OTAP receiver tests
- remove permissive `429 || 503` unions that could mask regressions
- preserve explicit disconnected-path tests that validate `503`

## Why
This is PR slice 3 from the network/hermetic plan.
It makes backpressure contract checks deterministic and separates queue-full behavior from disconnect behavior.

## Files
- `crates/logfwd-io/src/otlp_receiver/tests.rs`
- `crates/logfwd-io/src/otap_receiver.rs`

## Verification
- `cargo nextest run -p logfwd-io --profile ci --run-ignored only --lib otlp_receiver::tests::returns_429_when_channel_full_not_200 otap_receiver::tests::receiver_returns_429_when_channel_full`

## Issue context
Partially advances #1311/#1314 verification quality by tightening behavioral assertions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten backpressure status assertions to require exactly 429 in receiver tests
> Updates backpressure tests in [otap_receiver.rs](https://github.com/strawgate/memagent/pull/1794/files#diff-d857a8f6754a55babf2b290bc90d4dc983d53420419d6c33740dd7bab066964a) and [otlp_receiver/tests.rs](https://github.com/strawgate/memagent/pull/1794/files#diff-3a088d505b0539c4ef682d152124d7693e0148297485416a91bd659b5f6b3d7b) to require HTTP 429 instead of accepting either 429 or 503. The looser assertions previously masked any regression where the server returned 503 instead of 429 on a full channel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2e359b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->