### PR TITLE
feat: integrate best-of fault/verification wave2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
  "arrow-select",
  "arrow-string",
  "half",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -979,7 +979,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand",
+ "rand 0.9.2",
  "regex",
  "sqlparser",
  "tempfile",
@@ -1094,7 +1094,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
- "rand",
+ "rand 0.9.2",
  "tokio",
  "url",
 ]
@@ -1169,7 +1169,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand",
+ "rand 0.9.2",
  "tempfile",
  "url",
 ]
@@ -1227,7 +1227,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "rand",
+ "rand 0.9.2",
  "regex",
  "unicode-segmentation",
  "uuid",
@@ -1549,6 +1549,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fail"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2733,6 +2744,7 @@ dependencies = [
  "backon",
  "bytes",
  "dhat",
+ "fail",
  "futures-util",
  "libc",
  "logfwd-arrow",
@@ -2929,7 +2941,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand",
+ "rand 0.9.2",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -3216,7 +3228,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3422,8 +3434,8 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -3629,7 +3641,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -3687,12 +3699,33 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3702,7 +3735,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -3721,7 +3763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -3730,7 +3772,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4838,7 +4880,7 @@ checksum = "f5384da930ba6d7e467030c421a7332726755d548ba38058aed30c2c30d991d2"
 dependencies = [
  "bytes",
  "indexmap",
- "rand",
+ "rand 0.9.2",
  "rand_distr",
  "scoped-tls",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ datafusion = { version = "48", default-features = false, features = [
     "regex_expressions",
     "recursive_protection",
 ] }
+fail = "0.5"
 globset = "0.4"
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ needless_pass_by_ref_mut = "warn"
 undocumented_unsafe_blocks = "warn"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)', 'cfg(feature, values("turmoil"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)', 'cfg(feature, values("turmoil", "internal-failpoints"))'] }
 unused_qualifications = "warn"
 
 [profile.dev]

--- a/crates/logfwd-runtime/Cargo.toml
+++ b/crates/logfwd-runtime/Cargo.toml
@@ -44,7 +44,7 @@ thiserror = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "time", "sync"] }
 tokio-util = { version = "0.7" }
 futures-util = "0.3"
-fail = { version = "0.5", optional = true }
+fail = { workspace = true, optional = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/logfwd-runtime/Cargo.toml
+++ b/crates/logfwd-runtime/Cargo.toml
@@ -15,6 +15,7 @@ ignored = ["turmoil"]
 default = ["datafusion"]
 turmoil = []
 loom-tests = []
+internal-failpoints = ["dep:fail", "fail/failpoints"]
 datafusion = ["dep:logfwd-transform"]
 dhat-heap = ["dep:dhat"]
 cpu-profiling = ["dep:pprof"]
@@ -43,6 +44,7 @@ thiserror = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "time", "sync"] }
 tokio-util = { version = "0.7" }
 futures-util = "0.3"
+fail = { version = "0.5", optional = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
+++ b/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 use logfwd_io::checkpoint::CheckpointStore;
 
+use super::internal_faults;
+
 #[must_use]
 const fn should_retry_flush(attempt: u32, max_attempts: u32) -> bool {
     attempt < max_attempts.saturating_sub(1)
@@ -21,6 +23,22 @@ pub(super) async fn flush_checkpoint_with_retry(store: &mut dyn CheckpointStore)
     const RETRY_DELAY: Duration = Duration::from_millis(100);
 
     for attempt in 0..MAX_ATTEMPTS {
+        if internal_faults::checkpoint_flush_should_fail() {
+            if should_retry_flush(attempt, MAX_ATTEMPTS) {
+                tracing::warn!(
+                    attempt,
+                    "pipeline: checkpoint flush failpoint fired, retrying"
+                );
+                tokio::time::sleep(RETRY_DELAY).await;
+            } else {
+                tracing::error!(
+                    attempts = MAX_ATTEMPTS,
+                    "pipeline: checkpoint flush failpoint fired on final attempt"
+                );
+            }
+            continue;
+        }
+
         match store.flush() {
             Ok(()) => {
                 if attempt > 0 {
@@ -59,6 +77,41 @@ mod tests {
     use proptest::prelude::*;
 
     use super::{flush_checkpoint_with_retry, should_retry_flush};
+
+    trait RetryFaultHook {
+        fn fail_flush_attempt(&self, attempt: u32) -> bool;
+    }
+
+    struct NeverFailHook;
+
+    impl RetryFaultHook for NeverFailHook {
+        fn fail_flush_attempt(&self, _attempt: u32) -> bool {
+            false
+        }
+    }
+
+    struct FailFirstAttemptHook;
+
+    impl RetryFaultHook for FailFirstAttemptHook {
+        fn fail_flush_attempt(&self, attempt: u32) -> bool {
+            attempt == 0
+        }
+    }
+
+    async fn flush_checkpoint_with_retry_hooked(
+        store: &mut dyn CheckpointStore,
+        hook: &dyn RetryFaultHook,
+    ) {
+        const MAX_ATTEMPTS: u32 = 3;
+        for attempt in 0..MAX_ATTEMPTS {
+            if hook.fail_flush_attempt(attempt) {
+                continue;
+            }
+            if store.flush().is_ok() {
+                return;
+            }
+        }
+    }
 
     struct SequenceCheckpointStore {
         outcomes: Vec<io::Result<()>>,
@@ -171,6 +224,43 @@ mod tests {
             3,
             "flush should execute exactly three attempts"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn trait_hook_prototype_can_inject_first_attempt_failure() {
+        let mut store = SequenceCheckpointStore::new(vec![Ok(()), Ok(())]);
+        let hook = FailFirstAttemptHook;
+
+        flush_checkpoint_with_retry_hooked(&mut store, &hook).await;
+        assert_eq!(store.calls, 1, "first real store.flush call should succeed");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn trait_hook_prototype_noop_matches_normal_path() {
+        let mut store = SequenceCheckpointStore::new(vec![Ok(())]);
+        let hook = NeverFailHook;
+
+        flush_checkpoint_with_retry_hooked(&mut store, &hook).await;
+        assert_eq!(store.calls, 1, "noop hook must preserve baseline behavior");
+    }
+
+    #[cfg(feature = "internal-failpoints")]
+    #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial]
+    async fn failpoint_checkpoint_flush_retries_then_succeeds() {
+        let scenario = fail::FailScenario::setup();
+        fail::cfg(
+            "runtime::pipeline::checkpoint_flush::before_flush",
+            "1*return->off",
+        )
+        .expect("configure failpoint");
+
+        let mut store = SequenceCheckpointStore::new(vec![Ok(()), Ok(())]);
+        flush_checkpoint_with_retry(&mut store).await;
+        assert_eq!(store.calls, 1, "one injected failure + one real success");
+
+        fail::remove("runtime::pipeline::checkpoint_flush::before_flush");
+        scenario.teardown();
     }
 }
 

--- a/crates/logfwd-runtime/src/pipeline/input_poll.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_poll.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 #[cfg(feature = "turmoil")]
-use logfwd_io::diagnostics::PipelineMetrics;
+use logfwd_diagnostics::diagnostics::PipelineMetrics;
 #[cfg(feature = "turmoil")]
 use logfwd_io::input::InputEvent;
 #[cfg(feature = "turmoil")]

--- a/crates/logfwd-runtime/src/pipeline/internal_faults.rs
+++ b/crates/logfwd-runtime/src/pipeline/internal_faults.rs
@@ -1,0 +1,36 @@
+//! Internal fault injection hooks for runtime seam testing.
+//!
+//! Approach A (adopted): failpoint-backed hooks gated by
+//! `internal-failpoints`. When disabled, all hooks compile to zero-cost no-ops.
+
+/// Return `true` when checkpoint flush should fail before calling store I/O.
+#[inline]
+pub(super) fn checkpoint_flush_should_fail() -> bool {
+    #[cfg(feature = "internal-failpoints")]
+    {
+        fail::fail_point!("runtime::pipeline::checkpoint_flush::before_flush", |_| {
+            true
+        });
+    }
+    false
+}
+
+/// Return `true` when the pipeline should short-circuit before pool submit.
+#[inline]
+pub(super) fn submit_before_pool_should_hold_and_shutdown() -> bool {
+    #[cfg(feature = "internal-failpoints")]
+    {
+        fail::fail_point!("runtime::pipeline::submit::before_pool_submit", |_| true);
+    }
+    false
+}
+
+/// Return `true` when shutdown should skip draining channel messages.
+#[inline]
+pub(super) fn shutdown_skip_channel_drain() -> bool {
+    #[cfg(feature = "internal-failpoints")]
+    {
+        fail::fail_point!("runtime::pipeline::run_async::skip_channel_drain", |_| true);
+    }
+    false
+}

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -11,6 +11,7 @@ mod health;
 mod input_build;
 pub(crate) mod input_pipeline;
 mod input_poll;
+mod internal_faults;
 mod processor_stage;
 mod submit;
 
@@ -40,7 +41,7 @@ use logfwd_io::checkpoint::FileCheckpointStore;
 use logfwd_io::checkpoint::{CheckpointStore, SourceCheckpoint};
 #[cfg(test)]
 use logfwd_io::format::FormatDecoder;
-#[cfg(any(test, feature = "turmoil"))]
+#[cfg(test)]
 use logfwd_io::input::InputEvent;
 use logfwd_io::input::InputSource;
 use logfwd_io::tail::ByteOffset;
@@ -512,7 +513,7 @@ impl Pipeline {
             }
         }
 
-        if should_drain_input_channel {
+        if should_drain_input_channel && !internal_faults::shutdown_skip_channel_drain() {
             // Drain channel messages before joining input threads.
             // This prevents deadlock during shutdown if a producer is blocked in
             // `blocking_send` while the bounded channel is full.
@@ -2460,6 +2461,71 @@ output:
             0,
             "inflight counter must not underflow on stray ack"
         );
+    }
+
+    #[cfg(feature = "internal-failpoints")]
+    #[test]
+    #[serial]
+    fn test_failpoint_submit_before_pool_triggers_hold_and_shutdown() {
+        let scenario = fail::FailScenario::setup();
+        fail::cfg(
+            "runtime::pipeline::submit::before_pool_submit",
+            "1*return->off",
+        )
+        .expect("configure failpoint");
+
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("submit-failpoint.log");
+        logfwd_test_utils::generate_json_lines(&log_path, 20, "submit-failpoint");
+
+        let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        pipeline.set_batch_timeout(Duration::from_millis(10));
+
+        let shutdown = CancellationToken::new();
+        let result = pipeline.run(&shutdown);
+        assert!(
+            result.is_ok(),
+            "submit failpoint should trigger graceful shutdown without panic"
+        );
+        assert!(
+            pipeline.machine.is_none(),
+            "pipeline machine should still reach drained terminal state"
+        );
+
+        fail::remove("runtime::pipeline::submit::before_pool_submit");
+        scenario.teardown();
+    }
+
+    #[cfg(feature = "internal-failpoints")]
+    #[test]
+    #[serial]
+    fn test_failpoint_shutdown_skip_channel_drain_remains_safe() {
+        let scenario = fail::FailScenario::setup();
+        fail::cfg("runtime::pipeline::run_async::skip_channel_drain", "return")
+            .expect("configure failpoint");
+
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("shutdown-skip-drain.log");
+        logfwd_test_utils::generate_json_lines(&log_path, 100, "skip-drain");
+
+        let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        pipeline.set_batch_timeout(Duration::from_millis(10));
+
+        let shutdown = CancellationToken::new();
+        let sd = shutdown.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(100));
+            sd.cancel();
+        });
+
+        let result = pipeline.run(&shutdown);
+        assert!(
+            result.is_ok(),
+            "skip-drain failpoint must not deadlock or crash shutdown"
+        );
+
+        fail::remove("runtime::pipeline::run_async::skip_channel_drain");
+        scenario.teardown();
     }
 
     #[test]

--- a/crates/logfwd-runtime/src/pipeline/submit.rs
+++ b/crates/logfwd-runtime/src/pipeline/submit.rs
@@ -133,7 +133,9 @@ impl Pipeline {
             self.ack_all_tickets(sending, super::checkpoint_policy::TicketDisposition::Hold);
             self.metrics.finish_active_batch(batch_id);
             shutdown.cancel();
-            return true;
+            // Keep the select-loop on the normal shutdown path so run_async can
+            // still drain the input channel and avoid producer-side deadlocks.
+            return false;
         }
 
         let batch_span = tracing::info_span!(

--- a/crates/logfwd-runtime/src/pipeline/submit.rs
+++ b/crates/logfwd-runtime/src/pipeline/submit.rs
@@ -13,6 +13,7 @@ use logfwd_output::BatchMetadata;
 use logfwd_types::pipeline::SourceId;
 use tokio_util::sync::CancellationToken;
 
+use super::internal_faults;
 use super::processor_stage::{ProcessorStageResult, run_processor_stage};
 #[cfg(feature = "turmoil")]
 use super::scan_maybe_blocking;
@@ -126,6 +127,14 @@ impl Pipeline {
         let input_rows = num_rows as u64;
         let out_rows = result.num_rows() as u64;
         let submitted_at = tokio::time::Instant::now();
+
+        if internal_faults::submit_before_pool_should_hold_and_shutdown() {
+            tracing::warn!("internal failpoint: submit pre-pool hold+shutdown");
+            self.ack_all_tickets(sending, super::checkpoint_policy::TicketDisposition::Hold);
+            self.metrics.finish_active_batch(batch_id);
+            shutdown.cancel();
+            return true;
+        }
 
         let batch_span = tracing::info_span!(
             "batch",

--- a/crates/logfwd-runtime/src/worker_pool/pool.rs
+++ b/crates/logfwd-runtime/src/worker_pool/pool.rs
@@ -1895,4 +1895,69 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    fn deterministic_worker_removal_late_event_orders_match_expected_health() {
+        #[derive(Clone, Copy)]
+        enum Step {
+            Observe,
+            Remove,
+            Apply,
+        }
+
+        struct DeterministicState {
+            worker_present: bool,
+            slot_gen: u64,
+            slot_health: ComponentHealth,
+            observed_gen: Option<u64>,
+        }
+
+        fn run_order(order: [Step; 3]) -> (bool, ComponentHealth) {
+            let mut state = DeterministicState {
+                worker_present: true,
+                slot_gen: 0,
+                slot_health: ComponentHealth::Starting,
+                observed_gen: None,
+            };
+            let mut event_applied = false;
+
+            for step in order {
+                match step {
+                    Step::Observe => {
+                        state.observed_gen = Some(state.slot_gen);
+                    }
+                    Step::Remove => {
+                        state.slot_gen = state.slot_gen.saturating_add(1);
+                        state.worker_present = false;
+                    }
+                    Step::Apply => {
+                        if state.worker_present && state.observed_gen == Some(state.slot_gen) {
+                            state.slot_health = reduce_worker_slot_health(
+                                state.slot_health,
+                                OutputHealthEvent::FatalFailure,
+                            );
+                            event_applied = true;
+                        }
+                    }
+                }
+            }
+
+            (event_applied, state.slot_health)
+        }
+
+        let expected_degraded =
+            reduce_worker_slot_health(ComponentHealth::Starting, OutputHealthEvent::FatalFailure);
+
+        // Order 1: event fully completes before removal. Health can degrade.
+        let (event_applied_before_removal, health_before_removal) =
+            run_order([Step::Observe, Step::Apply, Step::Remove]);
+        assert!(event_applied_before_removal);
+        assert_eq!(health_before_removal, expected_degraded);
+
+        // Order 2: remove happens before event apply. Stale event must be ignored.
+        let (event_applied_after_removal, health_after_removal) =
+            run_order([Step::Observe, Step::Remove, Step::Apply]);
+        assert!(!event_applied_after_removal);
+        assert_eq!(health_after_removal, ComponentHealth::Starting);
+    }
 }

--- a/crates/logfwd-runtime/src/worker_pool/worker.rs
+++ b/crates/logfwd-runtime/src/worker_pool/worker.rs
@@ -341,6 +341,7 @@ pub(super) async fn process_item(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::Arc;
@@ -361,6 +362,38 @@ mod tests {
     use super::super::pool::WorkerConfig;
     use super::super::types::{DeliveryOutcome, WorkItem, WorkerMsg};
     use super::{process_item, worker_task};
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum TerminalizationAction {
+        AckDelivered,
+        AckChannelClosed,
+    }
+
+    #[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+    struct TerminalizationState {
+        terminalizations: u8,
+        held_for_replay: bool,
+        cancel_requested: bool,
+    }
+
+    fn reduce_terminalization(
+        mut state: TerminalizationState,
+        action: TerminalizationAction,
+    ) -> TerminalizationState {
+        if state.terminalizations == 0 {
+            state.terminalizations = 1;
+            match action {
+                TerminalizationAction::AckDelivered => {
+                    state.held_for_replay = false;
+                }
+                TerminalizationAction::AckChannelClosed => {
+                    state.held_for_replay = true;
+                    state.cancel_requested = true;
+                }
+            }
+        }
+        state
+    }
 
     struct OkSink;
 
@@ -489,5 +522,99 @@ mod tests {
 
         assert_eq!(outcome, DeliveryOutcome::PoolClosed);
         assert_eq!(retries, 0);
+    }
+
+    #[test]
+    fn terminalization_reducer_is_idempotent_for_any_two_step_schedule() {
+        let actions = [
+            TerminalizationAction::AckDelivered,
+            TerminalizationAction::AckChannelClosed,
+        ];
+        let mut outcomes = BTreeSet::new();
+
+        for first in actions {
+            for second in actions {
+                let state = reduce_terminalization(
+                    reduce_terminalization(TerminalizationState::default(), first),
+                    second,
+                );
+                assert!(
+                    state.terminalizations <= 1,
+                    "terminalization must occur at most once"
+                );
+                outcomes.insert(state);
+            }
+        }
+
+        assert!(
+            outcomes.contains(&TerminalizationState {
+                terminalizations: 1,
+                held_for_replay: false,
+                cancel_requested: false,
+            }),
+            "delivered schedule should be reachable"
+        );
+        assert!(
+            outcomes.contains(&TerminalizationState {
+                terminalizations: 1,
+                held_for_replay: true,
+                cancel_requested: true,
+            }),
+            "ack-channel-closed schedule should be reachable"
+        );
+    }
+
+    #[cfg(feature = "loom-tests")]
+    #[test]
+    fn loom_terminalization_race_resolves_once() {
+        loom::model(|| {
+            let state =
+                loom::sync::Arc::new(loom::sync::Mutex::new(TerminalizationState::default()));
+
+            let state_ack = loom::sync::Arc::clone(&state);
+            let ack = loom::thread::spawn(move || {
+                let mut guard = state_ack
+                    .lock()
+                    .expect("loom mutex poisoned during ack path");
+                *guard = reduce_terminalization(*guard, TerminalizationAction::AckDelivered);
+            });
+
+            let state_closed = loom::sync::Arc::clone(&state);
+            let closed = loom::thread::spawn(move || {
+                let mut guard = state_closed
+                    .lock()
+                    .expect("loom mutex poisoned during ack-closed path");
+                *guard = reduce_terminalization(*guard, TerminalizationAction::AckChannelClosed);
+            });
+
+            ack.join().expect("ack thread should not panic");
+            closed
+                .join()
+                .expect("ack-channel-closed thread should not panic");
+
+            let final_state = *state
+                .lock()
+                .expect("loom mutex poisoned while validating terminalization state");
+
+            assert_eq!(
+                final_state.terminalizations, 1,
+                "checkpoint seam must resolve each ticket exactly once"
+            );
+            assert!(
+                final_state
+                    == TerminalizationState {
+                        terminalizations: 1,
+                        held_for_replay: false,
+                        cancel_requested: false,
+                    }
+                    || final_state
+                        == TerminalizationState {
+                            terminalizations: 1,
+                            held_for_replay: true,
+                            cancel_requested: true,
+                        },
+                "terminalization outcome must be either delivered or held-for-replay"
+            );
+        });
     }
 }

--- a/crates/logfwd/tests/turmoil_sim/fault_harness.rs
+++ b/crates/logfwd/tests/turmoil_sim/fault_harness.rs
@@ -287,10 +287,10 @@ impl FaultScenario {
                     });
 
                     let run_result = pipeline.run_async(&shutdown).await;
+                    run_result?;
                     trace_for_pipeline.record(TraceEvent::Phase {
                         phase: TracePhase::Stopped,
                     });
-                    run_result?;
                     Ok(())
                 });
             }
@@ -350,10 +350,10 @@ impl FaultScenario {
                     });
 
                     let run_result = pipeline.run_async(&shutdown).await;
+                    run_result?;
                     trace_for_pipeline.record(TraceEvent::Phase {
                         phase: TracePhase::Stopped,
                     });
-                    run_result?;
                     Ok(())
                 });
             }
@@ -410,10 +410,10 @@ impl FaultScenario {
                     });
 
                     let run_result = pipeline.run_async(&shutdown).await;
+                    run_result?;
                     trace_for_pipeline.record(TraceEvent::Phase {
                         phase: TracePhase::Stopped,
                     });
-                    run_result?;
                     Ok(())
                 });
             }
@@ -460,7 +460,12 @@ impl FaultScenario {
             Ok(Err(err)) => (false, Some(err.to_string())),
             Err(_) => (true, None),
         };
-        let trace_events = load_trace(&trace_path).unwrap_or_default();
+        let trace_events = load_trace(&trace_path).unwrap_or_else(|err| {
+            panic!(
+                "failed to load turmoil trace from {}: {err}",
+                trace_path.display()
+            )
+        });
         let trace_validation_error = TransitionValidator::default().validate(&trace_events).err();
         let normalized_trace = normalized_contract_trace(&trace_events);
 

--- a/crates/logfwd/tests/turmoil_sim/fault_harness.rs
+++ b/crates/logfwd/tests/turmoil_sim/fault_harness.rs
@@ -12,12 +12,17 @@ use std::time::Duration;
 use logfwd::pipeline::Pipeline;
 use logfwd_test_utils::sinks::CountingSink;
 use logfwd_types::pipeline::SourceId;
+use tempfile::NamedTempFile;
 use tokio_util::sync::CancellationToken;
 
 use super::channel_input::ChannelInputSource;
 use super::instrumented_sink::{FailureAction, InstrumentedSink};
 use super::observable_checkpoint::{CheckpointHandle, ObservableCheckpointStore};
 use super::tcp_server::{TcpServerHandle, run_tcp_server};
+use super::trace_bridge::{
+    TraceEvent, TracePhase, TraceRecorder, TransitionValidator, load_trace,
+    normalized_contract_trace,
+};
 use super::turmoil_tcp_sink::TurmoilTcpSink;
 
 const DEFAULT_SIM_DURATION_SECS: u64 = 60;
@@ -36,6 +41,10 @@ pub enum NetworkFaultAction {
     Partition,
     /// Repair the pipeline and server hosts.
     Repair,
+    /// Hold all in-flight messages between the hosts.
+    Hold,
+    /// Release held in-flight messages between the hosts.
+    Release,
 }
 
 /// A network fault scheduled for a particular turmoil simulation step.
@@ -93,6 +102,7 @@ pub struct FaultScenario {
     arm_checkpoint_crash_after: Option<Duration>,
     network_faults: Vec<NetworkFault>,
     fail_rate: Option<f64>,
+    typed_contract: Option<TypedInvariantBundle>,
 }
 
 impl FaultScenario {
@@ -112,6 +122,7 @@ impl FaultScenario {
             arm_checkpoint_crash_after: None,
             network_faults: Vec::new(),
             fail_rate: None,
+            typed_contract: None,
         }
     }
 
@@ -181,6 +192,12 @@ impl FaultScenario {
         self
     }
 
+    /// Prototype Shape A lane: attach a typed invariant bundle.
+    pub fn with_typed_contract(mut self, typed_contract: TypedInvariantBundle) -> Self {
+        self.typed_contract = Some(typed_contract);
+        self
+    }
+
     /// Execute the scenario and return the captured outcome.
     pub fn run(self) -> TestOutcome {
         let scenario_name = self.name.clone();
@@ -200,9 +217,14 @@ impl FaultScenario {
         let mut call_counter = Arc::new(AtomicU64::new(0));
         let mut checkpoint_handle: Option<CheckpointHandle> = None;
         let mut tcp_server_handle: Option<TcpServerHandle> = None;
+        let trace_path = NamedTempFile::new()
+            .expect("create temp trace")
+            .into_temp_path();
+        let trace = TraceRecorder::new(&trace_path).expect("create trace recorder");
 
         match &self.sink_mode {
             SinkMode::TurmoilTcp => {
+                let trace_for_pipeline = trace.clone();
                 let server = TcpServerHandle::new();
                 let sh = server.clone();
                 sim.host("server", move || {
@@ -220,6 +242,7 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                 {
                     let (store, handle) = ObservableCheckpointStore::new();
+                    let store = store.with_trace_recorder(trace_for_pipeline.clone());
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -227,6 +250,9 @@ impl FaultScenario {
                 };
 
                 sim.client("pipeline", async move {
+                    trace_for_pipeline.record(TraceEvent::Phase {
+                        phase: TracePhase::Running,
+                    });
                     let lines = generate_json_lines(scenario.lines);
                     let input = ChannelInputSource::new("scenario", scenario.source_id, lines);
 
@@ -251,17 +277,27 @@ impl FaultScenario {
 
                     let shutdown = CancellationToken::new();
                     let sd = shutdown.clone();
+                    let trace_for_shutdown = trace_for_pipeline.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(scenario.shutdown_after).await;
+                        trace_for_shutdown.record(TraceEvent::Phase {
+                            phase: TracePhase::Draining,
+                        });
                         sd.cancel();
                     });
 
-                    pipeline.run_async(&shutdown).await?;
+                    let run_result = pipeline.run_async(&shutdown).await;
+                    trace_for_pipeline.record(TraceEvent::Phase {
+                        phase: TracePhase::Stopped,
+                    });
+                    run_result?;
                     Ok(())
                 });
             }
             SinkMode::Instrumented { script } => {
-                let sink = InstrumentedSink::new(script.clone());
+                let trace_for_pipeline = trace.clone();
+                let sink = InstrumentedSink::new(script.clone())
+                    .with_trace_recorder(trace_for_pipeline.clone());
                 delivered_counter = sink.delivered_counter();
                 call_counter = sink.call_counter();
 
@@ -270,6 +306,7 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                 {
                     let (store, handle) = ObservableCheckpointStore::new();
+                    let store = store.with_trace_recorder(trace_for_pipeline.clone());
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -277,6 +314,9 @@ impl FaultScenario {
                 };
 
                 sim.client("pipeline", async move {
+                    trace_for_pipeline.record(TraceEvent::Phase {
+                        phase: TracePhase::Running,
+                    });
                     let lines = generate_json_lines(scenario.lines);
                     let input = ChannelInputSource::new("scenario", scenario.source_id, lines);
                     let mut pipeline = Pipeline::for_simulation("sim", Box::new(sink));
@@ -300,16 +340,25 @@ impl FaultScenario {
 
                     let shutdown = CancellationToken::new();
                     let sd = shutdown.clone();
+                    let trace_for_shutdown = trace_for_pipeline.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(scenario.shutdown_after).await;
+                        trace_for_shutdown.record(TraceEvent::Phase {
+                            phase: TracePhase::Draining,
+                        });
                         sd.cancel();
                     });
 
-                    pipeline.run_async(&shutdown).await?;
+                    let run_result = pipeline.run_async(&shutdown).await;
+                    trace_for_pipeline.record(TraceEvent::Phase {
+                        phase: TracePhase::Stopped,
+                    });
+                    run_result?;
                     Ok(())
                 });
             }
             SinkMode::Counting => {
+                let trace_for_pipeline = trace.clone();
                 let sink = CountingSink::new(delivered_counter.clone());
                 let scenario = self.clone();
 
@@ -317,6 +366,7 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                 {
                     let (store, handle) = ObservableCheckpointStore::new();
+                    let store = store.with_trace_recorder(trace_for_pipeline.clone());
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -324,6 +374,9 @@ impl FaultScenario {
                 };
 
                 sim.client("pipeline", async move {
+                    trace_for_pipeline.record(TraceEvent::Phase {
+                        phase: TracePhase::Running,
+                    });
                     let lines = generate_json_lines(scenario.lines);
                     let input = ChannelInputSource::new("scenario", scenario.source_id, lines);
                     let mut pipeline = Pipeline::for_simulation("sim", Box::new(sink));
@@ -347,12 +400,20 @@ impl FaultScenario {
 
                     let shutdown = CancellationToken::new();
                     let sd = shutdown.clone();
+                    let trace_for_shutdown = trace_for_pipeline.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(scenario.shutdown_after).await;
+                        trace_for_shutdown.record(TraceEvent::Phase {
+                            phase: TracePhase::Draining,
+                        });
                         sd.cancel();
                     });
 
-                    pipeline.run_async(&shutdown).await?;
+                    let run_result = pipeline.run_async(&shutdown).await;
+                    trace_for_pipeline.record(TraceEvent::Phase {
+                        phase: TracePhase::Stopped,
+                    });
+                    run_result?;
                     Ok(())
                 });
             }
@@ -399,8 +460,11 @@ impl FaultScenario {
             Ok(Err(err)) => (false, Some(err.to_string())),
             Err(_) => (true, None),
         };
+        let trace_events = load_trace(&trace_path).unwrap_or_default();
+        let trace_validation_error = TransitionValidator::default().validate(&trace_events).err();
+        let normalized_trace = normalized_contract_trace(&trace_events);
 
-        TestOutcome {
+        let outcome = TestOutcome {
             scenario_name,
             seed,
             delivered_rows: delivered_counter.load(Ordering::Relaxed),
@@ -410,7 +474,14 @@ impl FaultScenario {
             applied_network_fault_steps,
             checkpoint: checkpoint_handle,
             tcp_server: tcp_server_handle,
+            trace_events,
+            trace_validation_error,
+            normalized_trace,
+        };
+        if let Some(typed_contract) = self.typed_contract {
+            typed_contract.verify(&outcome);
         }
+        outcome
     }
 }
 
@@ -418,6 +489,8 @@ fn apply_network_fault(sim: &mut turmoil::Sim<'_>, fault: &NetworkFault) {
     match fault.action {
         NetworkFaultAction::Partition => sim.partition("pipeline", "server"),
         NetworkFaultAction::Repair => sim.repair("pipeline", "server"),
+        NetworkFaultAction::Hold => sim.hold("pipeline", "server"),
+        NetworkFaultAction::Release => sim.release("pipeline", "server"),
     }
 }
 
@@ -442,6 +515,9 @@ pub struct TestOutcome {
     applied_network_fault_steps: Vec<usize>,
     checkpoint: Option<CheckpointHandle>,
     tcp_server: Option<TcpServerHandle>,
+    trace_events: Vec<TraceEvent>,
+    trace_validation_error: Option<String>,
+    normalized_trace: Vec<String>,
 }
 
 impl TestOutcome {
@@ -491,6 +567,16 @@ impl TestOutcome {
             self.seed
         )
     }
+
+    /// Normalized deterministic contract trace for replay comparison.
+    pub fn normalized_contract_trace(&self) -> &[String] {
+        &self.normalized_trace
+    }
+
+    /// Raw trace events captured during the scenario run.
+    pub fn trace_events(&self) -> &[TraceEvent] {
+        &self.trace_events
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -498,11 +584,21 @@ enum Invariant {
     NoSimError,
     DeliveredEq(u64),
     CallsGe(u64),
-    CheckpointMonotonic { source_id: u64 },
+    CheckpointMonotonic {
+        source_id: u64,
+    },
     CheckpointCrashCountGe(u64),
-    CheckpointUpdatesGe { source_id: u64, min: usize },
+    CheckpointUpdatesGe {
+        source_id: u64,
+        min: usize,
+    },
     ServerReceivedGe(u64),
     ServerConnectionsGe(u64),
+    CheckpointDurableEq {
+        source_id: u64,
+        expected: Option<u64>,
+    },
+    TraceContractValid,
 }
 
 /// Builder-style collection of invariants to assert against a `TestOutcome`.
@@ -569,6 +665,21 @@ impl InvariantSet {
     pub fn server_connections_ge(mut self, minimum: u64) -> Self {
         self.invariants
             .push(Invariant::ServerConnectionsGe(minimum));
+        self
+    }
+
+    /// Require an exact durable checkpoint value (or no checkpoint).
+    pub fn checkpoint_durable_eq(mut self, source_id: u64, expected: Option<u64>) -> Self {
+        self.invariants.push(Invariant::CheckpointDurableEq {
+            source_id,
+            expected,
+        });
+        self
+    }
+
+    /// Require the transition-contract validator to accept trace output.
+    pub fn trace_contract_valid(mut self) -> Self {
+        self.invariants.push(Invariant::TraceContractValid);
         self
     }
 
@@ -669,7 +780,61 @@ impl InvariantSet {
                         outcome.replay_hint()
                     );
                 }
+                Invariant::CheckpointDurableEq {
+                    source_id,
+                    expected,
+                } => {
+                    let checkpoint = outcome
+                        .checkpoint()
+                        .expect("checkpoint invariant requested without checkpoint handle");
+                    let durable = checkpoint.durable_offset(*source_id);
+                    assert_eq!(
+                        durable,
+                        *expected,
+                        "scenario '{}' expected durable checkpoint {:?} for source {}, got {:?} ({})",
+                        outcome.scenario_name,
+                        expected,
+                        source_id,
+                        durable,
+                        outcome.replay_hint()
+                    );
+                }
+                Invariant::TraceContractValid => {
+                    if let Some(err) = &outcome.trace_validation_error {
+                        panic!(
+                            "scenario '{}' produced invalid transition trace: {err} ({})",
+                            outcome.scenario_name,
+                            outcome.replay_hint()
+                        );
+                    }
+                }
             }
+        }
+    }
+}
+
+/// Prototype for Shape A: typed phase + invariant bundle contract.
+#[derive(Clone, Debug)]
+pub struct TypedInvariantBundle {
+    requires_trace_contract: bool,
+}
+
+impl TypedInvariantBundle {
+    /// Build a minimal typed contract prototype that requires valid traces.
+    pub fn trace_contract() -> Self {
+        Self {
+            requires_trace_contract: true,
+        }
+    }
+
+    fn verify(&self, outcome: &TestOutcome) {
+        if self.requires_trace_contract {
+            assert!(
+                outcome.trace_validation_error.is_none(),
+                "typed invariant bundle rejected outcome '{}': {:?}",
+                outcome.scenario_name,
+                outcome.trace_validation_error
+            );
         }
     }
 }

--- a/crates/logfwd/tests/turmoil_sim/fault_scenario_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/fault_scenario_sim.rs
@@ -3,8 +3,11 @@
 use std::io;
 use std::time::Duration;
 
-use super::fault_harness::{FaultScenario, InvariantSet, NetworkFault, NetworkFaultAction};
+use super::fault_harness::{
+    FaultScenario, InvariantSet, NetworkFault, NetworkFaultAction, TypedInvariantBundle,
+};
 use super::instrumented_sink::FailureAction;
+use super::trace_bridge::{SinkOutcome, TraceEvent};
 
 #[test]
 fn checkpoint_crash_scenario_keeps_delivery_and_monotonic_updates() {
@@ -141,4 +144,125 @@ fn seed_replay_produces_stable_outcome_for_fail_rate_scenario() {
         replay.server_received(),
         "same seed should reproduce same delivery count"
     );
+}
+
+#[test]
+fn panic_unwind_scenario_reports_panic_contract() {
+    let outcome = FaultScenario::builder("panic-unwind")
+        .with_seed(20260420)
+        .with_line_count(4)
+        .with_sink_script(vec![FailureAction::Panic])
+        .with_shutdown_after(Duration::from_millis(250))
+        .run();
+
+    InvariantSet::new()
+        .no_sim_error()
+        .trace_contract_valid()
+        .verify(&outcome);
+    assert!(
+        outcome.trace_events().iter().any(|event| matches!(
+            event,
+            TraceEvent::SinkResult {
+                outcome: SinkOutcome::Panic,
+                ..
+            }
+        )),
+        "panic scenario must emit a sink panic outcome event"
+    );
+}
+
+#[test]
+fn checkpoint_flush_crash_can_hold_durable_checkpoint_progress() {
+    let outcome = FaultScenario::builder("checkpoint-hold-no-advance")
+        .with_seed(20260421)
+        .with_line_count(20)
+        .with_counting_sink()
+        .with_batch_timeout(Duration::from_millis(10))
+        .with_checkpoint_flush_interval(Duration::from_millis(50))
+        .with_checkpoint_crash_after(Duration::from_millis(1))
+        .with_shutdown_after(Duration::from_millis(70))
+        .run();
+
+    InvariantSet::new()
+        .no_sim_error()
+        .checkpoint_crash_count_ge(1)
+        .checkpoint_updates_ge(1, 1)
+        .checkpoint_durable_eq(1, None)
+        .verify(&outcome);
+}
+
+#[test]
+fn post_stop_trace_contract_disallows_further_side_effects() {
+    let outcome = FaultScenario::builder("post-stop-contract")
+        .with_seed(20260422)
+        .with_line_count(15)
+        .with_sink_script(vec![FailureAction::Succeed])
+        .with_batch_timeout(Duration::from_millis(10))
+        .with_shutdown_after(Duration::from_secs(2))
+        .run();
+
+    InvariantSet::new()
+        .no_sim_error()
+        .trace_contract_valid()
+        .verify(&outcome);
+}
+
+#[test]
+fn replay_equivalence_same_seed_produces_same_normalized_contract_trace() {
+    let seed = 20260423;
+    let baseline = FaultScenario::builder("replay-equivalence-a")
+        .with_seed(seed)
+        .with_line_count(12)
+        .with_sink_script(vec![
+            FailureAction::RetryAfter(Duration::from_millis(10)),
+            FailureAction::Succeed,
+        ])
+        .with_checkpoint_flush_interval(Duration::from_millis(40))
+        .with_shutdown_after(Duration::from_secs(3))
+        .with_typed_contract(TypedInvariantBundle::trace_contract())
+        .run();
+    let replay = FaultScenario::builder("replay-equivalence-b")
+        .with_seed(seed)
+        .with_line_count(12)
+        .with_sink_script(vec![
+            FailureAction::RetryAfter(Duration::from_millis(10)),
+            FailureAction::Succeed,
+        ])
+        .with_checkpoint_flush_interval(Duration::from_millis(40))
+        .with_shutdown_after(Duration::from_secs(3))
+        .with_typed_contract(TypedInvariantBundle::trace_contract())
+        .run();
+
+    InvariantSet::new()
+        .no_sim_error()
+        .trace_contract_valid()
+        .verify(&baseline);
+    InvariantSet::new()
+        .no_sim_error()
+        .trace_contract_valid()
+        .verify(&replay);
+    assert_eq!(
+        baseline.normalized_contract_trace(),
+        replay.normalized_contract_trace(),
+        "same seed should produce same normalized contract trace"
+    );
+}
+
+#[test]
+fn hold_release_schedule_restores_delivery() {
+    let outcome = FaultScenario::builder("hold-release")
+        .with_seed(20260424)
+        .with_turmoil_tcp_sink()
+        .with_line_count(50)
+        .with_batch_timeout(Duration::from_millis(20))
+        .with_shutdown_after(Duration::from_secs(10))
+        .with_network_fault(NetworkFault::at_step(80, NetworkFaultAction::Hold))
+        .with_network_fault(NetworkFault::at_step(160, NetworkFaultAction::Release))
+        .run();
+
+    InvariantSet::new()
+        .no_sim_error()
+        .server_connections_ge(1)
+        .server_received_ge(1)
+        .verify(&outcome);
 }

--- a/crates/logfwd/tests/turmoil_sim/instrumented_sink.rs
+++ b/crates/logfwd/tests/turmoil_sim/instrumented_sink.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
@@ -41,6 +42,7 @@ pub struct InstrumentedSink {
     call_index: usize,
     delivered_rows: Arc<AtomicU64>,
     call_count: Arc<AtomicU64>,
+    outcomes: Arc<Mutex<Vec<SinkOutcome>>>,
     trace: Option<TraceRecorder>,
 }
 
@@ -53,6 +55,7 @@ impl InstrumentedSink {
             call_index: 0,
             delivered_rows: Arc::new(AtomicU64::new(0)),
             call_count: Arc::new(AtomicU64::new(0)),
+            outcomes: Arc::new(Mutex::new(Vec::new())),
             trace: None,
         }
     }
@@ -70,6 +73,11 @@ impl InstrumentedSink {
     /// Get the shared counter for total calls.
     pub fn call_counter(&self) -> Arc<AtomicU64> {
         self.call_count.clone()
+    }
+
+    /// Get the shared sink outcome log in observed call order.
+    pub fn outcome_log(&self) -> Arc<Mutex<Vec<SinkOutcome>>> {
+        self.outcomes.clone()
     }
 
     /// Attach a trace recorder that receives sink result events.
@@ -98,9 +106,10 @@ impl InstrumentedSink {
 /// the same delivery and call counters. The factory pops scripts from a queue;
 /// when exhausted, new workers get an always-succeed sink.
 pub struct InstrumentedSinkFactory {
-    scripts: std::sync::Mutex<Vec<Vec<FailureAction>>>,
+    scripts: Mutex<Vec<Vec<FailureAction>>>,
     delivered_rows: Arc<AtomicU64>,
     call_count: Arc<AtomicU64>,
+    outcomes: Arc<Mutex<Vec<SinkOutcome>>>,
     trace: Option<TraceRecorder>,
 }
 
@@ -111,9 +120,10 @@ impl InstrumentedSinkFactory {
         let delivered_rows = Arc::new(AtomicU64::new(0));
         let call_count = Arc::new(AtomicU64::new(0));
         Self {
-            scripts: std::sync::Mutex::new(per_worker_scripts),
+            scripts: Mutex::new(per_worker_scripts),
             delivered_rows,
             call_count,
+            outcomes: Arc::new(Mutex::new(Vec::new())),
             trace: None,
         }
     }
@@ -126,6 +136,11 @@ impl InstrumentedSinkFactory {
     /// Get the shared counter for total calls.
     pub fn call_counter(&self) -> Arc<AtomicU64> {
         self.call_count.clone()
+    }
+
+    /// Get the shared outcome log across all sinks created by this factory.
+    pub fn outcome_log(&self) -> Arc<Mutex<Vec<SinkOutcome>>> {
+        self.outcomes.clone()
     }
 
     /// Attach a trace recorder that receives sink result events.
@@ -144,6 +159,7 @@ impl logfwd_output::SinkFactory for InstrumentedSinkFactory {
         let mut sink = InstrumentedSink::new(script);
         sink.delivered_rows = self.delivered_rows.clone();
         sink.call_count = self.call_count.clone();
+        sink.outcomes = self.outcomes.clone();
         sink.trace = self.trace.clone();
         Ok(Box::new(sink))
     }
@@ -167,11 +183,16 @@ impl Sink for InstrumentedSink {
         let action = self.next_action();
         let rows = batch.num_rows() as u64;
         let delivered = self.delivered_rows.clone();
+        let outcomes = self.outcomes.clone();
         let trace = self.trace.clone();
 
         Box::pin(async move {
             match action {
                 FailureAction::Succeed => {
+                    outcomes
+                        .lock()
+                        .expect("outcomes mutex poisoned")
+                        .push(SinkOutcome::Ok);
                     delivered.fetch_add(rows, Ordering::Relaxed);
                     if let Some(trace) = &trace {
                         trace.record(TraceEvent::SinkResult {
@@ -182,6 +203,10 @@ impl Sink for InstrumentedSink {
                     SendResult::Ok
                 }
                 FailureAction::RetryAfter(dur) => {
+                    outcomes
+                        .lock()
+                        .expect("outcomes mutex poisoned")
+                        .push(SinkOutcome::RetryAfter);
                     if let Some(trace) = &trace {
                         trace.record(TraceEvent::SinkResult {
                             outcome: SinkOutcome::RetryAfter,
@@ -191,6 +216,10 @@ impl Sink for InstrumentedSink {
                     SendResult::RetryAfter(dur)
                 }
                 FailureAction::IoError(kind) => {
+                    outcomes
+                        .lock()
+                        .expect("outcomes mutex poisoned")
+                        .push(SinkOutcome::IoError);
                     if let Some(trace) = &trace {
                         trace.record(TraceEvent::SinkResult {
                             outcome: SinkOutcome::IoError,
@@ -200,6 +229,10 @@ impl Sink for InstrumentedSink {
                     SendResult::IoError(io::Error::new(kind, "simulated failure"))
                 }
                 FailureAction::Reject(reason) => {
+                    outcomes
+                        .lock()
+                        .expect("outcomes mutex poisoned")
+                        .push(SinkOutcome::Rejected);
                     if let Some(trace) = &trace {
                         trace.record(TraceEvent::SinkResult {
                             outcome: SinkOutcome::Rejected,
@@ -210,6 +243,10 @@ impl Sink for InstrumentedSink {
                 }
                 FailureAction::Delay(dur) => {
                     tokio::time::sleep(dur).await;
+                    outcomes
+                        .lock()
+                        .expect("outcomes mutex poisoned")
+                        .push(SinkOutcome::Ok);
                     delivered.fetch_add(rows, Ordering::Relaxed);
                     if let Some(trace) = &trace {
                         trace.record(TraceEvent::SinkResult {
@@ -220,6 +257,10 @@ impl Sink for InstrumentedSink {
                     SendResult::Ok
                 }
                 FailureAction::Panic => {
+                    outcomes
+                        .lock()
+                        .expect("outcomes mutex poisoned")
+                        .push(SinkOutcome::Panic);
                     if let Some(trace) = &trace {
                         trace.record(TraceEvent::SinkResult {
                             outcome: SinkOutcome::Panic,

--- a/crates/logfwd/tests/turmoil_sim/trace_bridge.rs
+++ b/crates/logfwd/tests/turmoil_sim/trace_bridge.rs
@@ -260,6 +260,10 @@ impl PhaseState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Structured validator failure for a single trace event position.
+///
+/// This is returned by `TransitionValidator::validate_detailed` so callers can
+/// inspect stable machine-readable fields without parsing formatted text.
 pub struct ValidationError {
     index: usize,
     code: &'static str,
@@ -291,6 +295,31 @@ impl ValidationError {
             previous_event_summary,
         }
     }
+
+    /// Index of the failing event in the trace.
+    pub fn index(&self) -> usize {
+        self.index
+    }
+
+    /// Stable short code for programmatic matching.
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+
+    /// Human-readable explanation of the violated condition.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// Summary of the event at `index`.
+    pub fn event_summary(&self) -> &str {
+        &self.event_summary
+    }
+
+    /// Summary of the event immediately before `index`, when present.
+    pub fn previous_event_summary(&self) -> Option<&str> {
+        self.previous_event_summary.as_deref()
+    }
 }
 
 impl fmt::Display for ValidationError {
@@ -320,6 +349,7 @@ pub struct NormalizedTrace {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Normalized event record used by pluggable validators.
 pub struct NormalizedTraceEvent {
     pub index: usize,
     pub kind: &'static str,
@@ -360,10 +390,12 @@ impl NormalizedTrace {
     }
 }
 
+/// Validator plug-in interface for normalized trace analysis.
 pub trait EventValidator {
     fn validate(&self, trace: &NormalizedTrace) -> Result<(), String>;
 }
 
+/// Minimal validator that enforces `running -> draining -> stopped` order.
 pub struct PhaseOrderValidator;
 
 impl EventValidator for PhaseOrderValidator {
@@ -412,6 +444,10 @@ impl TransitionValidator {
             .map_err(|err| err.to_string())
     }
 
+    /// Validate transition rules and return structured failure context.
+    ///
+    /// On success returns `Ok(())`. On failure returns `ValidationError`
+    /// with a stable code, failing event index, and neighboring summaries.
     pub fn validate_detailed(&self, events: &[TraceEvent]) -> Result<(), ValidationError> {
         if events.is_empty() {
             return Err(ValidationError::at(

--- a/crates/logfwd/tests/turmoil_sim/trace_bridge.rs
+++ b/crates/logfwd/tests/turmoil_sim/trace_bridge.rs
@@ -3,6 +3,7 @@
 //! This stays test-only (`turmoil_sim`) and emits JSONL for easy human inspection.
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
@@ -17,6 +18,30 @@ pub enum TraceEvent {
     SinkResult { outcome: SinkOutcome, rows: u64 },
     CheckpointUpdate { source_id: u64, offset: u64 },
     CheckpointFlush { success: bool },
+}
+
+impl TraceEvent {
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Phase { .. } => "phase",
+            Self::SinkResult { .. } => "sink_result",
+            Self::CheckpointUpdate { .. } => "checkpoint_update",
+            Self::CheckpointFlush { .. } => "checkpoint_flush",
+        }
+    }
+
+    fn summary(&self) -> String {
+        match self {
+            Self::Phase { phase } => format!("phase={}", phase.as_str()),
+            Self::SinkResult { outcome, rows } => {
+                format!("sink_result outcome={} rows={rows}", outcome.as_str())
+            }
+            Self::CheckpointUpdate { source_id, offset } => {
+                format!("checkpoint_update source_id={source_id} offset={offset}")
+            }
+            Self::CheckpointFlush { success } => format!("checkpoint_flush success={success}"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -197,11 +222,182 @@ pub fn load_trace(path: impl AsRef<Path>) -> io::Result<Vec<TraceEvent>> {
     Ok(events)
 }
 
+/// Build a deterministic, human-readable contract trace.
+///
+/// This normalizes events into stable strings so replay tests can compare
+/// outcomes across runs with the same seed.
+pub fn normalized_contract_trace(events: &[TraceEvent]) -> Vec<String> {
+    events
+        .iter()
+        .map(|event| match event {
+            TraceEvent::Phase { phase } => format!("phase:{}", phase.as_str()),
+            TraceEvent::SinkResult { outcome, rows } => {
+                format!("sink:{}:{rows}", outcome.as_str())
+            }
+            TraceEvent::CheckpointUpdate { source_id, offset } => {
+                format!("ckpt_update:{source_id}:{offset}")
+            }
+            TraceEvent::CheckpointFlush { success } => format!("ckpt_flush:{success}"),
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PhaseState {
     Running,
     Draining,
     Stopped,
+}
+
+impl PhaseState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Draining => "draining",
+            Self::Stopped => "stopped",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationError {
+    index: usize,
+    code: &'static str,
+    message: String,
+    event_summary: String,
+    previous_event_summary: Option<String>,
+}
+
+impl ValidationError {
+    fn at(
+        events: &[TraceEvent],
+        index: usize,
+        code: &'static str,
+        message: impl Into<String>,
+    ) -> Self {
+        let event_summary = events
+            .get(index)
+            .map(TraceEvent::summary)
+            .unwrap_or_else(|| "<missing>".to_string());
+        let previous_event_summary = index
+            .checked_sub(1)
+            .and_then(|idx| events.get(idx))
+            .map(TraceEvent::summary);
+        Self {
+            index,
+            code,
+            message: message.into(),
+            event_summary,
+            previous_event_summary,
+        }
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.previous_event_summary {
+            Some(prev) => write!(
+                f,
+                "[{}] event #{}: {}; event={}; previous={}",
+                self.code, self.index, self.message, self.event_summary, prev
+            ),
+            None => write!(
+                f,
+                "[{}] event #{}: {}; event={}",
+                self.code, self.index, self.message, self.event_summary
+            ),
+        }
+    }
+}
+
+/// Strategy-B prototype: normalized event-log IR with validator plug-ins.
+///
+/// This is intentionally partial (no source-offset state), and exists as a
+/// contrast point for testing extension ergonomics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedTrace {
+    pub entries: Vec<NormalizedTraceEvent>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedTraceEvent {
+    pub index: usize,
+    pub kind: &'static str,
+    pub attributes: BTreeMap<&'static str, String>,
+}
+
+impl NormalizedTrace {
+    pub fn from_events(events: &[TraceEvent]) -> Self {
+        let entries = events
+            .iter()
+            .enumerate()
+            .map(|(index, event)| {
+                let mut attributes: BTreeMap<&'static str, String> = BTreeMap::new();
+                match event {
+                    TraceEvent::Phase { phase } => {
+                        attributes.insert("phase", phase.as_str().to_string());
+                    }
+                    TraceEvent::SinkResult { outcome, rows } => {
+                        attributes.insert("outcome", outcome.as_str().to_string());
+                        attributes.insert("rows", rows.to_string());
+                    }
+                    TraceEvent::CheckpointUpdate { source_id, offset } => {
+                        attributes.insert("source_id", source_id.to_string());
+                        attributes.insert("offset", offset.to_string());
+                    }
+                    TraceEvent::CheckpointFlush { success } => {
+                        attributes.insert("success", success.to_string());
+                    }
+                }
+                NormalizedTraceEvent {
+                    index,
+                    kind: event.kind(),
+                    attributes,
+                }
+            })
+            .collect();
+        Self { entries }
+    }
+}
+
+pub trait EventValidator {
+    fn validate(&self, trace: &NormalizedTrace) -> Result<(), String>;
+}
+
+pub struct PhaseOrderValidator;
+
+impl EventValidator for PhaseOrderValidator {
+    fn validate(&self, trace: &NormalizedTrace) -> Result<(), String> {
+        let mut expected = "running";
+        for entry in &trace.entries {
+            if entry.kind != "phase" {
+                continue;
+            }
+            let Some(phase) = entry.attributes.get("phase") else {
+                return Err(format!(
+                    "phase event missing normalized 'phase' at index {}",
+                    entry.index
+                ));
+            };
+            match (expected, phase.as_str()) {
+                ("running", "running") => expected = "draining",
+                ("draining", "draining") => expected = "stopped",
+                ("stopped", "stopped") => expected = "done",
+                (want, got) => {
+                    return Err(format!(
+                        "phase order mismatch at index {}: expected {want}, got {got}",
+                        entry.index
+                    ));
+                }
+            }
+        }
+        if expected != "done" {
+            return Err(format!(
+                "phase order incomplete in normalized trace: next_expected={expected}"
+            ));
+        }
+        Ok(())
+    }
 }
 
 /// Declared transition contract for replay validation.
@@ -212,8 +408,18 @@ pub struct TransitionValidator {
 
 impl TransitionValidator {
     pub fn validate(&self, events: &[TraceEvent]) -> Result<(), String> {
+        self.validate_detailed(events)
+            .map_err(|err| err.to_string())
+    }
+
+    pub fn validate_detailed(&self, events: &[TraceEvent]) -> Result<(), ValidationError> {
         if events.is_empty() {
-            return Err("trace is empty".to_string());
+            return Err(ValidationError::at(
+                events,
+                0,
+                "empty_trace",
+                "trace is empty",
+            ));
         }
         if !matches!(
             events.first(),
@@ -221,7 +427,12 @@ impl TransitionValidator {
                 phase: TracePhase::Running
             })
         ) {
-            return Err("trace must start with running phase marker".to_string());
+            return Err(ValidationError::at(
+                events,
+                0,
+                "missing_running_start",
+                "trace must start with running phase marker",
+            ));
         }
 
         let mut phase = PhaseState::Running;
@@ -235,8 +446,11 @@ impl TransitionValidator {
                     if idx == 0 {
                         phase = PhaseState::Running;
                     } else {
-                        return Err(format!(
-                            "event {idx}: running phase marker may only appear first"
+                        return Err(ValidationError::at(
+                            events,
+                            idx,
+                            "duplicate_running",
+                            "running phase marker may only appear first",
                         ));
                     }
                 }
@@ -244,8 +458,11 @@ impl TransitionValidator {
                     phase: TracePhase::Draining,
                 } => {
                     if phase != PhaseState::Running {
-                        return Err(format!(
-                            "event {idx}: invalid phase transition {phase:?} -> Draining"
+                        return Err(ValidationError::at(
+                            events,
+                            idx,
+                            "invalid_phase_transition",
+                            format!("invalid phase transition {} -> draining", phase.as_str()),
                         ));
                     }
                     phase = PhaseState::Draining;
@@ -254,42 +471,71 @@ impl TransitionValidator {
                     phase: TracePhase::Stopped,
                 } => {
                     if phase != PhaseState::Draining {
-                        return Err(format!(
-                            "event {idx}: invalid phase transition {phase:?} -> Stopped"
+                        return Err(ValidationError::at(
+                            events,
+                            idx,
+                            "invalid_phase_transition",
+                            format!("invalid phase transition {} -> stopped", phase.as_str()),
                         ));
                     }
                     phase = PhaseState::Stopped;
                 }
                 TraceEvent::CheckpointUpdate { source_id, offset } => {
                     if phase == PhaseState::Stopped {
-                        return Err(format!(
-                            "event {idx}: checkpoint update after Stopped (source_id={source_id}, offset={offset})"
+                        return Err(ValidationError::at(
+                            events,
+                            idx,
+                            "event_after_stopped",
+                            format!(
+                                "checkpoint update after stopped (source_id={source_id}, offset={offset})"
+                            ),
                         ));
                     }
                     let last = source_offsets.get(source_id).copied().unwrap_or(0);
                     if *offset < last {
-                        return Err(format!(
-                            "event {idx}: checkpoint regression for source {source_id}: {offset} < {last}"
+                        return Err(ValidationError::at(
+                            events,
+                            idx,
+                            "checkpoint_regression",
+                            format!(
+                                "checkpoint regression for source {source_id}: {offset} < {last}"
+                            ),
                         ));
                     }
                     source_offsets.insert(*source_id, *offset);
                 }
                 TraceEvent::CheckpointFlush { .. } => {
                     if phase == PhaseState::Stopped {
-                        return Err(format!("event {idx}: flush after Stopped"));
+                        return Err(ValidationError::at(
+                            events,
+                            idx,
+                            "event_after_stopped",
+                            "checkpoint flush after stopped",
+                        ));
                     }
                 }
                 TraceEvent::SinkResult { .. } => {
                     if phase == PhaseState::Stopped {
-                        return Err(format!("event {idx}: sink activity after Stopped"));
+                        return Err(ValidationError::at(
+                            events,
+                            idx,
+                            "event_after_stopped",
+                            "sink activity after stopped",
+                        ));
                     }
                 }
             }
         }
 
         if phase != PhaseState::Stopped {
-            return Err(format!(
-                "trace ended before stopped transition (last phase: {phase:?})"
+            return Err(ValidationError::at(
+                events,
+                events.len().saturating_sub(1),
+                "terminal_phase_missing",
+                format!(
+                    "trace ended before stopped transition (last phase: {})",
+                    phase.as_str()
+                ),
             ));
         }
         Ok(())
@@ -309,5 +555,47 @@ mod tests {
         let value = event.to_json();
         let decoded = TraceEvent::from_json(&value).expect("decode should work");
         assert_eq!(event, decoded);
+    }
+
+    #[test]
+    fn strategy_b_normalized_trace_builds_event_entries() {
+        let events = vec![
+            TraceEvent::Phase {
+                phase: TracePhase::Running,
+            },
+            TraceEvent::SinkResult {
+                outcome: SinkOutcome::Ok,
+                rows: 2,
+            },
+        ];
+        let normalized = NormalizedTrace::from_events(&events);
+        assert_eq!(normalized.entries.len(), 2);
+        assert_eq!(normalized.entries[0].kind, "phase");
+        assert_eq!(
+            normalized.entries[0]
+                .attributes
+                .get("phase")
+                .expect("phase key present"),
+            "running"
+        );
+    }
+
+    #[test]
+    fn strategy_b_phase_validator_detects_order_mismatch() {
+        let normalized = NormalizedTrace::from_events(&[
+            TraceEvent::Phase {
+                phase: TracePhase::Running,
+            },
+            TraceEvent::Phase {
+                phase: TracePhase::Stopped,
+            },
+        ]);
+        let err = PhaseOrderValidator
+            .validate(&normalized)
+            .expect_err("phase mismatch should fail");
+        assert!(
+            err.contains("phase order mismatch"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/logfwd/tests/turmoil_sim/trace_validation.rs
+++ b/crates/logfwd/tests/turmoil_sim/trace_validation.rs
@@ -277,19 +277,36 @@ fn trace_validator_detailed_error_contains_operator_context() {
     let validator = TransitionValidator::default();
     let err = validator
         .validate_detailed(&events)
-        .expect_err("checkpoint regression must fail with detailed diagnostics")
-        .to_string();
+        .expect_err("checkpoint regression must fail with detailed diagnostics");
+
+    assert_eq!(err.code(), "checkpoint_regression");
+    assert_eq!(err.index(), 2);
+    assert!(
+        err.message().contains("checkpoint regression"),
+        "unexpected detailed message: {}",
+        err.message()
+    );
+    assert_eq!(
+        err.event_summary(),
+        "checkpoint_update source_id=12 offset=3"
+    );
+    assert_eq!(
+        err.previous_event_summary(),
+        Some("checkpoint_update source_id=12 offset=42")
+    );
+
+    let rendered = err.to_string();
 
     assert!(
-        err.contains("[checkpoint_regression]"),
-        "expected stable machine-readable code: {err}"
+        rendered.contains("[checkpoint_regression]"),
+        "expected stable machine-readable code: {rendered}"
     );
     assert!(
-        err.contains("event #2"),
-        "expected failing index context: {err}"
+        rendered.contains("event #2"),
+        "expected failing index context: {rendered}"
     );
     assert!(
-        err.contains("previous=checkpoint_update source_id=12 offset=42"),
-        "expected previous event context for operator debugging: {err}"
+        rendered.contains("previous=checkpoint_update source_id=12 offset=42"),
+        "expected previous event context for operator debugging: {rendered}"
     );
 }

--- a/crates/logfwd/tests/turmoil_sim/trace_validation.rs
+++ b/crates/logfwd/tests/turmoil_sim/trace_validation.rs
@@ -198,7 +198,98 @@ fn trace_validator_rejects_sink_activity_after_stopped() {
         .validate(&events)
         .expect_err("sink activity after stopped must be rejected");
     assert!(
-        err.contains("after Stopped"),
+        err.contains("sink activity after stopped"),
         "unexpected validator error: {err}"
+    );
+}
+
+#[test]
+fn trace_validator_rejects_checkpoint_flush_after_stopped() {
+    let events = vec![
+        TraceEvent::Phase {
+            phase: TracePhase::Running,
+        },
+        TraceEvent::Phase {
+            phase: TracePhase::Draining,
+        },
+        TraceEvent::Phase {
+            phase: TracePhase::Stopped,
+        },
+        TraceEvent::CheckpointFlush { success: true },
+    ];
+
+    let validator = TransitionValidator::default();
+    let err = validator
+        .validate(&events)
+        .expect_err("flush activity after stopped must be rejected");
+    assert!(
+        err.contains("checkpoint flush after stopped"),
+        "unexpected validator error: {err}"
+    );
+}
+
+#[test]
+fn trace_validator_rejects_trace_without_stopped_terminalization() {
+    let events = vec![
+        TraceEvent::Phase {
+            phase: TracePhase::Running,
+        },
+        TraceEvent::SinkResult {
+            outcome: super::trace_bridge::SinkOutcome::Ok,
+            rows: 4,
+        },
+        TraceEvent::Phase {
+            phase: TracePhase::Draining,
+        },
+    ];
+
+    let validator = TransitionValidator::default();
+    let err = validator
+        .validate(&events)
+        .expect_err("missing stopped phase must be rejected");
+    assert!(
+        err.contains("terminal_phase_missing") && err.contains("last phase: draining"),
+        "unexpected validator error: {err}"
+    );
+}
+
+#[test]
+fn trace_validator_detailed_error_contains_operator_context() {
+    let events = vec![
+        TraceEvent::Phase {
+            phase: TracePhase::Running,
+        },
+        TraceEvent::CheckpointUpdate {
+            source_id: 12,
+            offset: 42,
+        },
+        TraceEvent::CheckpointUpdate {
+            source_id: 12,
+            offset: 3,
+        },
+        TraceEvent::Phase {
+            phase: TracePhase::Draining,
+        },
+        TraceEvent::Phase {
+            phase: TracePhase::Stopped,
+        },
+    ];
+    let validator = TransitionValidator::default();
+    let err = validator
+        .validate_detailed(&events)
+        .expect_err("checkpoint regression must fail with detailed diagnostics")
+        .to_string();
+
+    assert!(
+        err.contains("[checkpoint_regression]"),
+        "expected stable machine-readable code: {err}"
+    );
+    assert!(
+        err.contains("event #2"),
+        "expected failing index context: {err}"
+    );
+    assert!(
+        err.contains("previous=checkpoint_update source_id=12 offset=42"),
+        "expected previous event context for operator debugging: {err}"
     );
 }

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -51,9 +51,11 @@ Update existing TLA+ specs when:
 | `DrainCompleteness` | Safety | `stop()` only reachable when all in-flight batches are resolved |
 | `QuiescenceHasNoSilentStrandedWork` | Safety | `Stopped` never leaves sent batches without a terminal `acked`/`rejected`/`abandoned` outcome |
 | `NoUnresolvedSentAtQuiescence` | Safety | `Stopped` implies `sent \ terminal = {}` for every source (no stranded sent work) |
+| `StopMetadataConsistent` | Safety | `forced` and `stop_reason` stay phase-consistent (`Stopped` iff reason is non-`none`) |
 | `CheckpointOrderingInvariant` | Safety | `committed[s]=n` implies every sent batch `<= n` is terminalized via `acked`/`rejected`/`abandoned` and none are in-flight |
 | `CommittedMonotonic` | Safety | Checkpoint never goes backwards |
 | `FailureTerminalizationPreservesCheckpoint` | Safety | Force/crash terminalization cannot advance checkpoints |
+| `FailureClassMustTerminalizePrototype` | Safety | Force/crash transitions must leave no sent-but-unterminalized batches |
 | `NoCreateAfterDrain` | Safety | No new batches after `begin_drain` |
 | `NoDoubleComplete` | Safety | In-flight batches are disjoint from `acked`, `rejected`, and `abandoned` terminal sets |
 | `EventualDrain` | Liveness | Every started drain eventually reaches Stopped |

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -50,8 +50,10 @@ Update existing TLA+ specs when:
 |----------|------|-------------|
 | `DrainCompleteness` | Safety | `stop()` only reachable when all in-flight batches are resolved |
 | `QuiescenceHasNoSilentStrandedWork` | Safety | `Stopped` never leaves sent batches without a terminal `acked`/`rejected`/`abandoned` outcome |
+| `NoUnresolvedSentAtQuiescence` | Safety | `Stopped` implies `sent \ terminal = {}` for every source (no stranded sent work) |
 | `CheckpointOrderingInvariant` | Safety | `committed[s]=n` implies every sent batch `<= n` is terminalized via `acked`/`rejected`/`abandoned` and none are in-flight |
 | `CommittedMonotonic` | Safety | Checkpoint never goes backwards |
+| `FailureTerminalizationPreservesCheckpoint` | Safety | Force/crash terminalization cannot advance checkpoints |
 | `NoCreateAfterDrain` | Safety | No new batches after `begin_drain` |
 | `NoDoubleComplete` | Safety | In-flight batches are disjoint from `acked`, `rejected`, and `abandoned` terminal sets |
 | `EventualDrain` | Liveness | Every started drain eventually reaches Stopped |

--- a/tla/PipelineMachine.cfg
+++ b/tla/PipelineMachine.cfg
@@ -20,6 +20,7 @@ CONSTANTS
 \* Safety invariants
 INVARIANTS
     TypeOK
+    StopMetadataConsistent
     NoDoubleComplete
     DrainCompleteness
     QuiescenceHasNoSilentStrandedWork

--- a/tla/PipelineMachine.cfg
+++ b/tla/PipelineMachine.cfg
@@ -23,6 +23,7 @@ INVARIANTS
     NoDoubleComplete
     DrainCompleteness
     QuiescenceHasNoSilentStrandedWork
+    NoUnresolvedSentAtQuiescence
     CheckpointOrderingInvariant
     CommittedNeverAheadOfCreated
     SentImpliesCreated
@@ -40,3 +41,5 @@ PROPERTIES
     NoCreateAfterDrain
     CommittedMonotonic
     DrainMeansNoNewSending
+    FailureTerminalizationPreservesCheckpoint
+    FailureClassMustTerminalizePrototype

--- a/tla/PipelineMachine.coverage.cfg
+++ b/tla/PipelineMachine.coverage.cfg
@@ -27,4 +27,5 @@ INVARIANTS
     CheckpointAdvances
     ForcedReachable
     AbandonOccurs
+    CrashReachable
     CreateOccurs

--- a/tla/PipelineMachine.tla
+++ b/tla/PipelineMachine.tla
@@ -120,6 +120,10 @@ TypeOK ==
         /\ rejected[s] \cap abandoned[s] = {}
         /\ committed[s] \in 0..MaxBatchesPerSource
 
+StopMetadataConsistent ==
+    /\ (forced <=> stop_reason = "force")
+    /\ ((phase = "Stopped") <=> (stop_reason # "none"))
+
 (* ---------------------------------------------------------------------------
  * Initial state
  * ---------------------------------------------------------------------------*)

--- a/tla/PipelineMachine.tla
+++ b/tla/PipelineMachine.tla
@@ -63,9 +63,10 @@ VARIABLES
     rejected,    \* [Sources -> SUBSET BatchIds] — terminal permanent-reject outcome
     abandoned,   \* [Sources -> SUBSET BatchIds] — terminal crash/force-stop outcome
     committed,   \* [Sources -> Nat]  — highest committed batch sequence (0 = none)
-    forced       \* BOOLEAN — TRUE if ForceStop was used (data loss accepted)
+    forced,      \* BOOLEAN — TRUE if ForceStop was used (data loss accepted)
+    stop_reason  \* "none" | "graceful" | "force" | "crash"
 
-vars == <<phase, created, sent, in_flight, acked, rejected, abandoned, committed, forced>>
+vars == <<phase, created, sent, in_flight, acked, rejected, abandoned, committed, forced, stop_reason>>
 
 (* ---------------------------------------------------------------------------
  * Helper operators
@@ -101,6 +102,7 @@ NewCommitted(new_acked_s, new_rejected_s, new_in_flight_s) ==
 TypeOK ==
     /\ phase \in {"Running", "Draining", "Stopped"}
     /\ forced \in BOOLEAN
+    /\ stop_reason \in {"none", "graceful", "force", "crash"}
     /\ \A s \in Sources :
         /\ created[s]   \subseteq BatchIds
         /\ sent[s]      \subseteq created[s]
@@ -132,6 +134,7 @@ Init ==
     /\ abandoned  = [s \in Sources |-> {}]
     /\ committed  = [s \in Sources |-> 0]
     /\ forced     = FALSE
+    /\ stop_reason = "none"
 
 (* ---------------------------------------------------------------------------
  * Actions
@@ -144,7 +147,7 @@ CreateBatch(s) ==
     /\ phase = "Running"
     /\ next_id \in BatchIds
     /\ created'   = [created   EXCEPT ![s] = created[s] \cup {next_id}]
-    /\ UNCHANGED <<phase, sent, in_flight, acked, rejected, abandoned, committed, forced>>
+    /\ UNCHANGED <<phase, sent, in_flight, acked, rejected, abandoned, committed, forced, stop_reason>>
 
 \* begin_send: machine takes ownership of batch b for source s.
 \* A Queued ticket dropped before begin_send has no machine state — safe.
@@ -167,7 +170,7 @@ BeginSend(s, b) ==
     /\ \A other \in (in_flight[s] \cup acked[s] \cup rejected[s] \cup abandoned[s]) : b >= other
     /\ sent'      = [sent      EXCEPT ![s] = sent[s] \cup {b}]
     /\ in_flight' = [in_flight EXCEPT ![s] = in_flight[s] \cup {b}]
-    /\ UNCHANGED <<phase, created, acked, rejected, abandoned, committed, forced>>
+    /\ UNCHANGED <<phase, created, acked, rejected, abandoned, committed, forced, stop_reason>>
 
 \* apply_ack / apply_reject: batch leaves in_flight, checkpoint may advance.
 \*
@@ -192,7 +195,7 @@ AckBatch(s, b) ==
        /\ in_flight' = [in_flight EXCEPT ![s] = new_in_flight_s]
        /\ acked'     = [acked     EXCEPT ![s] = new_acked_s]
        /\ committed' = [committed EXCEPT ![s] = NewCommitted(new_acked_s, new_rejected_s, new_in_flight_s)]
-    /\ UNCHANGED <<phase, created, sent, rejected, abandoned, forced>>
+    /\ UNCHANGED <<phase, created, sent, rejected, abandoned, forced, stop_reason>>
 
 RejectBatch(s, b) ==
     /\ b \in in_flight[s]
@@ -203,13 +206,13 @@ RejectBatch(s, b) ==
        /\ in_flight' = [in_flight EXCEPT ![s] = new_in_flight_s]
        /\ rejected'  = [rejected  EXCEPT ![s] = new_rejected_s]
        /\ committed' = [committed EXCEPT ![s] = NewCommitted(new_acked_s, new_rejected_s, new_in_flight_s)]
-    /\ UNCHANGED <<phase, created, sent, acked, abandoned, forced>>
+    /\ UNCHANGED <<phase, created, sent, acked, abandoned, forced, stop_reason>>
 
 \* begin_drain: closes pipeline to new batches.
 BeginDrain ==
     /\ phase = "Running"
     /\ phase' = "Draining"
-    /\ UNCHANGED <<created, sent, in_flight, acked, rejected, abandoned, committed, forced>>
+    /\ UNCHANGED <<created, sent, in_flight, acked, rejected, abandoned, committed, forced, stop_reason>>
 
 \* stop: THE DRAIN GUARANTEE.
 \* Rust: PipelineMachine<Draining, C>::stop() returns Err(self) if not drained.
@@ -228,6 +231,7 @@ Stop ==
     /\ phase = "Draining"
     /\ \A s \in Sources : in_flight[s] = {}    \* THE DRAIN GUARD (≡ is_drained())
     /\ phase' = "Stopped"
+    /\ stop_reason' = "graceful"
     /\ UNCHANGED <<created, sent, in_flight, acked, rejected, abandoned, committed, forced>>
 
 \* force_stop: emergency shutdown when grace period expires.
@@ -248,7 +252,23 @@ ForceStop ==
     /\ phase = "Draining"
     /\ phase' = "Stopped"
     /\ forced' = TRUE
+    /\ stop_reason' = "force"
     /\ abandoned' = [s \in Sources |-> abandoned[s] \cup in_flight[s]]
+    /\ in_flight' = [s \in Sources |-> {}]
+    /\ UNCHANGED <<created, sent, acked, rejected, committed>>
+
+\* crash_stop: panic/unwind-equivalent terminalization.
+\* Models runtime abort/failure completion obligations without encoding Rust stack unwind.
+\* Any sent-but-not-terminalized batch must become abandoned before terminal state.
+CrashStop ==
+    /\ phase \in {"Running", "Draining"}
+    /\ phase' = "Stopped"
+    /\ forced' = FALSE
+    /\ stop_reason' = "crash"
+    /\ abandoned' =
+        [s \in Sources |->
+            LET unresolved_s == sent[s] \ (acked[s] \cup rejected[s] \cup abandoned[s])
+            IN abandoned[s] \cup unresolved_s]
     /\ in_flight' = [s \in Sources |-> {}]
     /\ UNCHANGED <<created, sent, acked, rejected, committed>>
 
@@ -267,6 +287,7 @@ Next ==
     \/ BeginDrain
     \/ Stop
     \/ ForceStop
+    \/ CrashStop
     \* Terminal state: Stopped is final, nothing more can happen.
     \* Explicit stuttering prevents TLC from reporting a false deadlock.
     \/ (phase = "Stopped" /\ UNCHANGED vars)
@@ -328,6 +349,12 @@ QuiescenceHasNoSilentStrandedWork ==
             LET terminal_s == acked[s] \cup rejected[s] \cup abandoned[s]
             IN sent[s] = terminal_s
 
+\* No unresolved sent work may remain once Stopped, regardless of terminal path.
+NoUnresolvedSentAtQuiescence ==
+    phase = "Stopped" =>
+        \A s \in Sources :
+            sent[s] \ (acked[s] \cup rejected[s] \cup abandoned[s]) = {}
+
 \* in_flight cannot grow once drain begins.
 \* This is what makes WF(Stop) sufficient — once in_flight[s] = {} is reached
 \* during Draining it stays empty, so Stop's enabledness is stable (doesn't
@@ -349,6 +376,15 @@ NoCreateAfterDrain ==
 \* committed[s] is monotonically non-decreasing.
 CommittedMonotonic ==
     [][\A s \in Sources : committed[s]' >= committed[s]]_vars
+
+\* Failure-terminalization steps must not advance checkpoints.
+\* Checkpoint progression remains tied to ack/reject ordering only.
+FailureTerminalizationPreservesCheckpoint ==
+    [][
+        ((phase = "Draining" /\ phase' = "Stopped" /\ stop_reason' = "force")
+          \/ (phase \in {"Running", "Draining"} /\ phase' = "Stopped" /\ stop_reason' = "crash"))
+        => (\A s \in Sources : committed'[s] = committed[s])
+    ]_vars
 
 \* THE CHECKPOINT ORDERING INVARIANT:
 \* committed[s] = n implies every SENT batch with ID ≤ n is acked and none
@@ -447,6 +483,21 @@ AllCreatedBatchesEventuallyAccountedFor ==
                  \/ committed[s] >= b
                  \/ phase = "Stopped")
 
+(* ---------------------------------------------------------------------------
+ * Approach B prototype (minimal/runnable only):
+ * transition-class decomposition for failure transitions.
+ * ---------------------------------------------------------------------------*)
+FailureTransitionClass ==
+    \/ ForceStop
+    \/ CrashStop
+
+FailureClassMustTerminalizePrototype ==
+    [][
+        FailureTransitionClass =>
+        \A s \in Sources :
+            sent'[s] \ (acked'[s] \cup rejected'[s] \cup abandoned'[s]) = {}
+    ]_vars
+
 (* ===========================================================================
  * REACHABILITY ASSERTIONS  (vacuity guards — kani::cover!() equivalent)
  *
@@ -486,6 +537,9 @@ ForcedReachable == ~(forced = TRUE)
 
 \* At least one in-flight batch is explicitly abandoned by ForceStop.
 AbandonOccurs == ~(\E s \in Sources : abandoned[s] /= {})
+
+\* Crash-stop path is reachable.
+CrashReachable == ~(stop_reason = "crash")
 
 \* At least one batch is created (CreateBatch fires).
 \* Covers NoBatchLeftBehind and AllCreatedBatchesEventuallyAccountedFor

--- a/tla/README.md
+++ b/tla/README.md
@@ -29,6 +29,7 @@ Models `PipelineMachine<S, C>` from
 | `DrainCompleteness` | Safety | `stop()` only reachable when all in_flight batches are resolved |
 | `QuiescenceHasNoSilentStrandedWork` | Safety | At `Stopped`, no in-flight batch is left without explicit terminal outcome |
 | `NoUnresolvedSentAtQuiescence` | Safety | At `Stopped`, every sent batch is terminalized (`acked`/`rejected`/`abandoned`) |
+| `StopMetadataConsistent` | Safety | `forced`/`stop_reason` remain phase-consistent (`Stopped` iff reason is not `none`) |
 | `CheckpointOrderingInvariant` | Safety | committed[s]=n implies all sent batches `<= n` are terminalized for commit (`acked` or `rejected`), none in_flight |
 | `CommittedNeverAheadOfCreated` | Safety | committed[s] never exceeds highest created batch ID |
 | `NoDoubleComplete` | Safety | batch cannot be both in_flight and any terminal set |
@@ -38,6 +39,7 @@ Models `PipelineMachine<S, C>` from
 | `NoCreateAfterDrain` | Safety (temporal) | no new batches after begin_drain |
 | `DrainMeansNoNewSending` | Safety (temporal) | in_flight cannot grow once phase ≠ Running |
 | `FailureTerminalizationPreservesCheckpoint` | Safety (temporal) | force/crash terminalization does not advance checkpoints |
+| `FailureClassMustTerminalizePrototype` | Safety (temporal) | force/crash transition class preserves terminalization completeness |
 | `EventualDrain` | Liveness | every started drain eventually reaches Stopped |
 | `NoBatchLeftBehind` | Liveness | every in_flight batch eventually terminalizes (ack/reject/abandon) |
 | `StoppedIsStable` | Liveness | once Stopped, stays Stopped |

--- a/tla/README.md
+++ b/tla/README.md
@@ -28,6 +28,7 @@ Models `PipelineMachine<S, C>` from
 |----------|------|-------------|
 | `DrainCompleteness` | Safety | `stop()` only reachable when all in_flight batches are resolved |
 | `QuiescenceHasNoSilentStrandedWork` | Safety | At `Stopped`, no in-flight batch is left without explicit terminal outcome |
+| `NoUnresolvedSentAtQuiescence` | Safety | At `Stopped`, every sent batch is terminalized (`acked`/`rejected`/`abandoned`) |
 | `CheckpointOrderingInvariant` | Safety | committed[s]=n implies all sent batches `<= n` are terminalized for commit (`acked` or `rejected`), none in_flight |
 | `CommittedNeverAheadOfCreated` | Safety | committed[s] never exceeds highest created batch ID |
 | `NoDoubleComplete` | Safety | batch cannot be both in_flight and any terminal set |
@@ -36,6 +37,7 @@ Models `PipelineMachine<S, C>` from
 | `CommittedMonotonic` | Safety (temporal) | checkpoint never goes backwards |
 | `NoCreateAfterDrain` | Safety (temporal) | no new batches after begin_drain |
 | `DrainMeansNoNewSending` | Safety (temporal) | in_flight cannot grow once phase ≠ Running |
+| `FailureTerminalizationPreservesCheckpoint` | Safety (temporal) | force/crash terminalization does not advance checkpoints |
 | `EventualDrain` | Liveness | every started drain eventually reaches Stopped |
 | `NoBatchLeftBehind` | Liveness | every in_flight batch eventually terminalizes (ack/reject/abandon) |
 | `StoppedIsStable` | Liveness | once Stopped, stays Stopped |
@@ -47,6 +49,7 @@ Models `PipelineMachine<S, C>` from
 | `ForcedReachable` | Reachability (invariant ~P) | ForceStop path is reachable (vacuity guard) |
 | `RejectOccurs` | Reachability (invariant ~P) | Reject path is reachable |
 | `AbandonOccurs` | Reachability (invariant ~P) | ForceStop abandonment path is reachable |
+| `CrashReachable` | Reachability (invariant ~P) | panic/unwind-equivalent crash-stop path is reachable |
 
 ### File structure (two-file pattern)
 


### PR DESCRIPTION
## Summary
This PR integrates the best-of fanout/fan-in outputs across fault-injection and verification lanes into one coherent implementation.

### Included lanes
- **WS02 (TLA/TLC):** crash/abandon terminalization model expansion and property docs updates.
- **WS03 (trace validation):** richer transition validator diagnostics, normalized trace prototype seam, and additional drift tests.
- **WS05 (concurrency):** deterministic worker-slot interleaving test plus Loom terminalization race coverage.
- **WS01 (turmoil harness):** stronger scenario harness contracts, normalized trace replay checks, and additional deterministic fault scenarios.
- **WS04 (internal failpoints):** feature-gated runtime failpoint seams with deterministic tests and policy-aligned naming.

## Key implementation changes
- Added runtime-internal fault injection seam module:
  - `crates/logfwd-runtime/src/pipeline/internal_faults.rs`
- Extended pipeline + checkpoint + submit paths for gated failpoint hooks.
- Strengthened turmoil trace bridge/validator:
  - `ValidationError` with structured context
  - detailed validator entrypoint
  - normalized trace/event validator prototypes
- Expanded turmoil scenario harness and tests for panic/failure/checkpoint/replay behavior.
- Added deterministic + Loom race tests in worker pool seams.
- Updated TLA model/config/docs and verification docs for failure terminalization obligations.

## Verification run
- `cargo test -p logfwd-runtime`
- `cargo test -p logfwd --features turmoil --test turmoil_sim`
- `cargo test -p logfwd-runtime --features internal-failpoints`
- `cargo test -p logfwd-runtime --features loom-tests loom_ -- --nocapture`
- `just tlc MCPipelineMachine.tla PipelineMachine.cfg`
- `just tlc MCPipelineMachine.tla PipelineMachine.liveness.cfg`
- `just ci`

Note:
- `just tlc MCPipelineMachine.tla PipelineMachine.coverage.cfg` returns expected witness violation exit for coverage mode.
- `scripts/verify_tla_coverage.py` failed in this local shell due Java runtime discovery in script environment, while `just tlc ...` checks succeeded.

## Risk controls
- New failpoints are strictly feature-gated (`internal-failpoints`).
- Turmoil changes are test/simulation scoped.
- Loom tests remain feature-gated (`loom-tests`).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fault injection, trace validation, and TLA+ crash properties to the pipeline simulation
> - Introduces an `internal-failpoints` feature (via the `fail` crate) with hooks in checkpoint flush, submit, and shutdown paths to short-circuit behavior under test, enabling deterministic fault simulation.
> - Extends the turmoil fault harness to record phase transition traces per run, validate them via `TransitionValidator`, and expose `normalized_contract_trace` and `trace_events` on `TestOutcome`.
> - Adds `TypedInvariantBundle` and new `Invariant` variants (`CheckpointDurableEq`, `TraceContractValid`) so scenarios can assert trace contract validity and durable checkpoint state after a run.
> - Adds `Hold`/`Release` network fault actions to suspend and resume in-flight messages between simulation hosts.
> - Extends the TLA+ model in [PipelineMachine.tla](https://github.com/strawgate/memagent/pull/1795/files#diff-4914d1315b61c062fe754fab3998fb6e9b313688c204f62128dadbca331efdf3) with a `CrashStop` action, `stop_reason` variable, and four new checked properties (`NoUnresolvedSentAtQuiescence`, `StopMetadataConsistent`, `FailureTerminalizationPreservesCheckpoint`, `FailureClassMustTerminalizePrototype`).
> - Adds `ValidationError` with stable error codes and structured summaries to `TransitionValidator`, and introduces `NormalizedTrace`/`EventValidator` as a pluggable validator extension point.
> - Risk: `FaultScenario::run` now panics if the trace file cannot be loaded from disk, and validation errors from attached `TypedInvariantBundle` will panic the test.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4916363.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->