### PR TITLE
fix(io): WS06+WS07+WS08 tail and aux hardening cluster

### DIFF
--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -37,6 +37,8 @@ use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_
 
 /// Bounded channel capacity — limits memory when the pipeline falls behind.
 const CHANNEL_BOUND: usize = 256;
+const CONTENT_TYPE_ARROW: &str = "application/vnd.apache.arrow.stream";
+const CONTENT_TYPE_ARROW_ZSTD: &str = "application/vnd.apache.arrow.stream+zstd";
 
 /// Arrow IPC receiver that listens for Arrow stream data via HTTP POST.
 ///
@@ -268,12 +270,28 @@ async fn handle_arrow_ipc_request(
 
     let content_encoding = match parse_content_encoding(&headers) {
         Ok(content_encoding) => content_encoding,
+        Err(StatusCode::UNSUPPORTED_MEDIA_TYPE) => {
+            return (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "unsupported content-encoding: only identity or zstd are supported",
+            )
+                .into_response();
+        }
         Err(status) => return (status, "invalid content-encoding header").into_response(),
     };
     let content_type = match parse_content_type(&headers) {
         Ok(content_type) => content_type,
         Err(status) => return (status, "invalid content-type header").into_response(),
     };
+    if content_type.as_deref().is_some_and(|content_type| {
+        content_type != CONTENT_TYPE_ARROW && content_type != CONTENT_TYPE_ARROW_ZSTD
+    }) {
+        return (
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "unsupported content-type for Arrow IPC receiver",
+        )
+            .into_response();
+    }
 
     let body = match read_limited_body(body, MAX_REQUEST_BODY_SIZE, content_length).await {
         Ok(body) => body,
@@ -289,7 +307,7 @@ async fn handle_arrow_ipc_request(
     let raw_body_len = body.len() as u64;
 
     let is_zstd = content_encoding.as_deref() == Some("zstd")
-        || content_type.as_deref() == Some("application/vnd.apache.arrow.stream+zstd");
+        || content_type.as_deref() == Some(CONTENT_TYPE_ARROW_ZSTD);
 
     let body = if is_zstd {
         match decompress_zstd(&body) {
@@ -393,7 +411,22 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
         return Ok(None);
     };
     let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
-    Ok(Some(parsed.to_ascii_lowercase()))
+    let mut is_zstd = false;
+    for token in parsed.split(',') {
+        let encoding = token.trim().to_ascii_lowercase();
+        if encoding.is_empty() {
+            return Err(StatusCode::BAD_REQUEST);
+        }
+        if encoding == "identity" {
+            continue;
+        }
+        if encoding == "zstd" {
+            is_zstd = true;
+            continue;
+        }
+        return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+    Ok(is_zstd.then_some("zstd".to_string()))
 }
 
 fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
@@ -401,7 +434,15 @@ fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, StatusCode>
         return Ok(None);
     };
     let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
-    Ok(Some(parsed.to_ascii_lowercase()))
+    let mime = parsed
+        .split(';')
+        .next()
+        .map(str::trim)
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    if mime.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(Some(mime.to_ascii_lowercase()))
 }
 
 impl Drop for ArrowIpcReceiver {
@@ -848,5 +889,31 @@ mod tests {
     fn decode_ipc_stream_invalid_body() {
         let result = decode_ipc_stream(b"not arrow data");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_content_type_accepts_parameters() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            "application/vnd.apache.arrow.stream; charset=binary"
+                .parse()
+                .expect("valid header value"),
+        );
+        assert_eq!(
+            parse_content_type(&headers).expect("parse should succeed"),
+            Some(CONTENT_TYPE_ARROW.to_string())
+        );
+    }
+
+    #[test]
+    fn parse_content_encoding_rejects_unsupported_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_ENCODING,
+            "gzip".parse().expect("valid header value"),
+        );
+        let status = parse_content_encoding(&headers).expect_err("gzip must be rejected");
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
     }
 }

--- a/crates/logfwd-io/src/checkpoint.rs
+++ b/crates/logfwd-io/src/checkpoint.rs
@@ -152,7 +152,7 @@ pub fn default_data_dir() -> PathBuf {
 
     #[cfg(unix)]
     {
-        if libc_getuid() == 0 {
+        if libc_geteuid() == 0 {
             return PathBuf::from("/var/lib/logfwd");
         }
     }
@@ -165,7 +165,7 @@ pub fn default_data_dir() -> PathBuf {
 }
 
 #[cfg(unix)]
-fn libc_getuid() -> u32 {
+fn libc_geteuid() -> u32 {
     // SAFETY: `geteuid` has no preconditions and is safe to call in-process.
     unsafe { libc::geteuid() }
 }
@@ -365,9 +365,9 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_libc_getuid_matches_system_euid() {
+    fn test_libc_geteuid_matches_system_euid() {
         // SAFETY: `geteuid` has no preconditions and is safe to call in-process.
         let expected = unsafe { libc::geteuid() };
-        assert_eq!(libc_getuid(), expected);
+        assert_eq!(libc_geteuid(), expected);
     }
 }

--- a/crates/logfwd-io/src/checkpoint.rs
+++ b/crates/logfwd-io/src/checkpoint.rs
@@ -166,35 +166,8 @@ pub fn default_data_dir() -> PathBuf {
 
 #[cfg(unix)]
 fn libc_getuid() -> u32 {
-    // Use the raw syscall via std rather than pulling in libc.
-    // std::os::unix doesn't expose getuid directly, so we use a cfg-guarded
-    // approach: on non-root systems HOME is always set, so the root check is
-    // mostly a documentation hint. We fall back to HOME-based path if unsure.
-    //
-    // Using nix or libc would be cleaner but they aren't dependencies.
-    // Instead we read /proc/self/status (Linux) or skip the check (macOS).
-    #[cfg(target_os = "linux")]
-    {
-        if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
-            for line in status.lines() {
-                #[allow(clippy::collapsible_if)]
-                if let Some(rest) = line.strip_prefix("Uid:") {
-                    if let Some(uid_str) = rest.split_whitespace().next() {
-                        if let Ok(uid) = uid_str.parse::<u32>() {
-                            return uid;
-                        }
-                    }
-                }
-            }
-        }
-        // Couldn't determine, assume non-root.
-        1000
-    }
-    #[cfg(not(target_os = "linux"))]
-    {
-        // On macOS / other unices, default to non-root path.
-        1000
-    }
+    // SAFETY: `geteuid` has no preconditions and is safe to call in-process.
+    unsafe { libc::geteuid() }
 }
 
 // ---------------------------------------------------------------------------
@@ -388,5 +361,13 @@ mod tests {
     fn test_default_data_dir() {
         let p = default_data_dir();
         assert!(!p.as_os_str().is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_libc_getuid_matches_system_euid() {
+        // SAFETY: `geteuid` has no preconditions and is safe to call in-process.
+        let expected = unsafe { libc::geteuid() };
+        assert_eq!(libc_getuid(), expected);
     }
 }

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -39,6 +39,8 @@ use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_
 
 /// Bounded channel capacity.
 const CHANNEL_BOUND: usize = 256;
+const CONTENT_TYPE_PROTOBUF: &str = "application/x-protobuf";
+const CONTENT_TYPE_PROTOBUF_ALT: &str = "application/protobuf";
 
 // ---------------------------------------------------------------------------
 // ArrowPayloadType enum values (from OTAP proto)
@@ -239,6 +241,20 @@ async fn handle_otap_request(
     headers: HeaderMap,
     body: Body,
 ) -> Response {
+    let content_type = match parse_content_type(&headers) {
+        Ok(content_type) => content_type,
+        Err(status) => return (status, "invalid content-type header").into_response(),
+    };
+    if content_type.as_deref().is_some_and(|content_type| {
+        content_type != CONTENT_TYPE_PROTOBUF && content_type != CONTENT_TYPE_PROTOBUF_ALT
+    }) {
+        return (
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "unsupported content-type for OTAP receiver",
+        )
+            .into_response();
+    }
+
     let content_length = declared_content_length(&headers);
     if content_length.is_some_and(|body_len| body_len > MAX_REQUEST_BODY_SIZE as u64) {
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
@@ -278,7 +294,7 @@ async fn handle_otap_request(
         let resp_body = encode_batch_status(batch_records.batch_id, BATCH_STATUS_OK);
         return (
             StatusCode::OK,
-            [(CONTENT_TYPE, "application/x-protobuf")],
+            [(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)],
             resp_body,
         )
             .into_response();
@@ -290,7 +306,7 @@ async fn handle_otap_request(
             let resp_body = encode_batch_status(batch_records.batch_id, BATCH_STATUS_OK);
             (
                 StatusCode::OK,
-                [(CONTENT_TYPE, "application/x-protobuf")],
+                [(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)],
                 resp_body,
             )
                 .into_response()
@@ -314,6 +330,22 @@ async fn handle_otap_request(
                 .into_response()
         }
     }
+}
+
+fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
+    let Some(value) = headers.get(CONTENT_TYPE) else {
+        return Ok(None);
+    };
+    let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let mime = parsed
+        .split(';')
+        .next()
+        .map(str::trim)
+        .ok_or(StatusCode::BAD_REQUEST)?;
+    if mime.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(Some(mime.to_ascii_lowercase()))
 }
 
 /// Decoded `BatchArrowRecords` message.
@@ -968,5 +1000,46 @@ mod tests {
         let decoded = ProtoBatchStatus::decode(resp.as_slice()).expect("decode status");
         assert_eq!(decoded.batch_id, 42);
         assert_eq!(decoded.status_code, BATCH_STATUS_OK as i32);
+    }
+
+    #[test]
+    fn parse_content_type_accepts_parameters() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            "application/x-protobuf; charset=utf-8"
+                .parse()
+                .expect("valid header value"),
+        );
+        assert_eq!(
+            parse_content_type(&headers).expect("parse should succeed"),
+            Some(CONTENT_TYPE_PROTOBUF.to_string())
+        );
+    }
+
+    #[test]
+    fn parse_content_type_accepts_application_protobuf() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            "application/protobuf".parse().expect("valid header value"),
+        );
+        assert_eq!(
+            parse_content_type(&headers).expect("parse should succeed"),
+            Some(CONTENT_TYPE_PROTOBUF_ALT.to_string())
+        );
+    }
+
+    #[test]
+    fn parse_content_type_normalizes_and_allows_handler_rejection() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            "application/json".parse().expect("valid header value"),
+        );
+        assert_eq!(
+            parse_content_type(&headers).expect("parse should succeed"),
+            Some("application/json".to_string())
+        );
     }
 }

--- a/crates/logfwd-io/src/tail/discovery.rs
+++ b/crates/logfwd-io/src/tail/discovery.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use super::glob::expand_glob_patterns;
-use super::identity::identify_file;
+use super::identity::{FileIdentity, identify_file};
 use super::reader::FileReader;
 use super::tailer::TailEvent;
 
@@ -34,6 +34,29 @@ pub(super) struct FileDiscovery {
     pub(super) watch_paths: Vec<PathBuf>,
     pub(super) fs_events: crossbeam_channel::Receiver<notify::Result<notify::Event>>,
     pub(super) last_glob_rescan: Instant,
+}
+
+fn identity_indicates_rotation(
+    previous: &FileIdentity,
+    current: &FileIdentity,
+    tailed_offset: u64,
+    fingerprint_bytes: usize,
+) -> bool {
+    if previous.device != current.device || previous.inode != current.inode {
+        return true;
+    }
+
+    // Empty-file sentinel can transition from fingerprint=0 to non-zero when
+    // the same inode receives its first bytes. That is not a rotation.
+    if previous.fingerprint == 0 {
+        return false;
+    }
+
+    if tailed_offset < fingerprint_bytes as u64 {
+        return false;
+    }
+
+    previous.fingerprint != current.fingerprint
 }
 
 impl FileDiscovery {
@@ -119,8 +142,12 @@ impl FileDiscovery {
             };
 
             let is_rotated = reader.files.get(path).is_some_and(|tailed| {
-                tailed.identity.device != current_identity.device
-                    || tailed.identity.inode != current_identity.inode
+                identity_indicates_rotation(
+                    &tailed.identity,
+                    &current_identity,
+                    tailed.offset,
+                    reader.config.fingerprint_bytes,
+                )
             });
             let is_new = !reader.files.contains_key(path);
 
@@ -198,7 +225,7 @@ mod tests {
     use logfwd_types::pipeline::SourceId;
 
     use super::super::identity::FileIdentity;
-    use super::super::reader::{EvictedFile, FileReader};
+    use super::super::reader::{EvictedFile, FileReader, TailedFile};
     use super::super::tailer::{TailConfig, TailEvent};
     use super::*;
 
@@ -417,5 +444,103 @@ mod tests {
             "test",
             Err(io::Error::other("open failed"))
         ));
+    }
+
+    #[test]
+    fn detect_changes_treats_fingerprint_mismatch_as_rotation_for_same_inode() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("inode-reuse.log");
+        fs::write(&path, vec![b'x'; 4096]).expect("write file");
+
+        let mut file = fs::File::open(&path).expect("open file");
+        let current_identity =
+            super::super::identity::identify_open_file(&mut file, 1024).expect("identify current");
+
+        let stale_identity = FileIdentity {
+            device: current_identity.device,
+            inode: current_identity.inode,
+            fingerprint: current_identity.fingerprint ^ 0xA5A5_A5A5_A5A5_A5A5,
+        };
+
+        let mut reader = test_reader();
+        reader.files.insert(
+            path.clone(),
+            TailedFile {
+                identity: stale_identity,
+                file,
+                offset: 2048,
+                last_read: Instant::now(),
+                eof_state: Default::default(),
+            },
+        );
+
+        let (watcher, rx) = test_watcher();
+        let discovery = FileDiscovery {
+            watcher,
+            watched_dirs: HashSet::new(),
+            glob_patterns: Vec::new(),
+            watch_paths: vec![path.clone()],
+            fs_events: rx,
+            last_glob_rescan: Instant::now(),
+        };
+
+        let mut events = Vec::new();
+        let had_error = discovery.detect_changes(&mut reader, &mut events);
+        assert!(!had_error, "detect_changes should succeed");
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, TailEvent::Rotated { path: p, .. } if *p == path)),
+            "fingerprint mismatch with same inode must trigger rotation event"
+        );
+    }
+
+    #[test]
+    fn detect_changes_does_not_rotate_when_empty_sentinel_fingerprint_updates() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("empty-sentinel.log");
+        fs::write(&path, b"first line\n").expect("write file");
+
+        let mut file = fs::File::open(&path).expect("open file");
+        let current_identity =
+            super::super::identity::identify_open_file(&mut file, 1024).expect("identify current");
+
+        let sentinel_identity = FileIdentity {
+            device: current_identity.device,
+            inode: current_identity.inode,
+            fingerprint: 0,
+        };
+
+        let mut reader = test_reader();
+        reader.files.insert(
+            path.clone(),
+            TailedFile {
+                identity: sentinel_identity,
+                file,
+                offset: 0,
+                last_read: Instant::now(),
+                eof_state: Default::default(),
+            },
+        );
+
+        let (watcher, rx) = test_watcher();
+        let discovery = FileDiscovery {
+            watcher,
+            watched_dirs: HashSet::new(),
+            glob_patterns: Vec::new(),
+            watch_paths: vec![path.clone()],
+            fs_events: rx,
+            last_glob_rescan: Instant::now(),
+        };
+
+        let mut events = Vec::new();
+        let had_error = discovery.detect_changes(&mut reader, &mut events);
+        assert!(!had_error, "detect_changes should succeed");
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, TailEvent::Rotated { .. })),
+            "sentinel fingerprint transition on same inode must not emit rotation"
+        );
     }
 }

--- a/crates/logfwd-io/src/tail/discovery.rs
+++ b/crates/logfwd-io/src/tail/discovery.rs
@@ -56,6 +56,9 @@ fn identity_indicates_rotation(
         return false;
     }
 
+    // TODO: same-inode fingerprint rotation triggers drain+reopen which may
+    // produce duplicate events for copytruncate-style log rotation. Consider
+    // reset-offset-without-drain path.
     previous.fingerprint != current.fingerprint
 }
 

--- a/crates/logfwd-io/src/tail/reader.rs
+++ b/crates/logfwd-io/src/tail/reader.rs
@@ -374,7 +374,7 @@ impl FileReader {
             return Ok(());
         }
         if let Some(evicted) = self.evicted_offsets.get_mut(path) {
-            evicted.offset = offset;
+            evicted.offset = clamp_offset_for_path(path, offset, "checkpoint offset");
         }
         Ok(())
     }
@@ -410,7 +410,8 @@ impl FileReader {
         }
         for evicted in self.evicted_offsets.values_mut() {
             if evicted.source_id == source_id {
-                evicted.offset = offset;
+                evicted.offset =
+                    clamp_offset_for_path(&evicted.path, offset, "checkpoint source offset");
                 return Ok(());
             }
         }
@@ -458,6 +459,25 @@ impl FileReader {
             .map(|e| (e.source_id, e.path.clone()));
 
         active.chain(evicted).collect()
+    }
+}
+
+fn clamp_offset_for_path(path: &Path, offset: u64, context: &str) -> u64 {
+    let file_size = match std::fs::metadata(path) {
+        Ok(meta) => meta.len(),
+        Err(_) => return offset,
+    };
+
+    if offset > file_size {
+        tracing::warn!(
+            path = %path.display(),
+            saved_offset = offset,
+            file_size,
+            "{context} exceeds file size — resetting to 0"
+        );
+        0
+    } else {
+        offset
     }
 }
 
@@ -963,20 +983,89 @@ mod tests {
     }
 
     #[test]
-    fn read_new_data_with_zero_len_buffer_classifies_empty_read_as_no_data() {
+    fn read_new_data_with_zero_len_buffer_reads_data_after_tailer_guard() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("empty-read-buffer.log");
         fs::write(&path, b"abcdef").unwrap();
 
         let mut reader = test_reader();
-        reader.read_buf.clear();
+        // FileTailer::new guards read buffers to at least one byte.
+        reader.read_buf.resize(1, 0);
         reader.open_file_at(&path, false).unwrap();
         reader.set_offset(&path, 1).unwrap();
 
         let got = reader.read_new_data(&path).unwrap();
         assert!(
-            matches!(got, ReadResult::NoData),
-            "zero-length read buffer should produce empty read classification"
+            matches!(got, ReadResult::Data(_)),
+            "non-empty files should still be readable with a minimal read buffer"
+        );
+    }
+
+    #[test]
+    fn set_offset_clamps_evicted_entry_when_underlying_file_is_smaller() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("evicted-clamp.log");
+        fs::write(&path, b"abc").unwrap();
+        let mut reader = test_reader();
+        reader.evicted_offsets.insert(
+            path.clone(),
+            EvictedFile {
+                identity: FileIdentity {
+                    device: 1,
+                    inode: 2,
+                    fingerprint: 7,
+                },
+                offset: 1,
+                path: path.clone(),
+                source_id: SourceId(42),
+            },
+        );
+
+        reader
+            .set_offset(&path, 999)
+            .expect("set_offset should clamp evicted entry");
+
+        assert_eq!(
+            reader
+                .evicted_offsets
+                .get(&path)
+                .expect("evicted entry should remain present")
+                .offset,
+            0
+        );
+    }
+
+    #[test]
+    fn set_offset_by_source_clamps_evicted_entry_when_underlying_file_is_smaller() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("evicted-by-source-clamp.log");
+        fs::write(&path, b"abc").unwrap();
+        let mut reader = test_reader();
+        reader.evicted_offsets.insert(
+            path.clone(),
+            EvictedFile {
+                identity: FileIdentity {
+                    device: 1,
+                    inode: 2,
+                    fingerprint: 7,
+                },
+                offset: 1,
+                path: path.clone(),
+                source_id: SourceId(77),
+            },
+        );
+
+        reader
+            .set_offset_by_source(SourceId(77), 999)
+            .expect("set_offset_by_source should clamp evicted entry");
+
+        assert_eq!(
+            reader
+                .evicted_offsets
+                .get(&path)
+                .expect("evicted entry should remain present")
+                .offset,
+            0
         );
     }
 }

--- a/crates/logfwd-io/src/tail/tailer.rs
+++ b/crates/logfwd-io/src/tail/tailer.rs
@@ -102,7 +102,7 @@ impl FileTailer {
     /// cannot be created.
     pub fn new(
         paths: &[PathBuf],
-        config: TailConfig,
+        mut config: TailConfig,
         stats: std::sync::Arc<ComponentStats>,
     ) -> io::Result<Self> {
         let (tx, rx) = crossbeam_channel::unbounded();
@@ -125,6 +125,10 @@ impl FileTailer {
             }
         }
 
+        // Prevent a zero-length buffer from turning non-empty files into
+        // perpetual "NoData" reads.
+        config.read_buf_size = config.read_buf_size.max(1);
+
         let mut tailer = FileTailer {
             discovery: FileDiscovery {
                 watcher,
@@ -136,9 +140,7 @@ impl FileTailer {
             },
             reader: FileReader {
                 files: HashMap::new(),
-                // Prevent a zero-length buffer from turning non-empty files into
-                // perpetual "NoData" reads.
-                read_buf: vec![0u8; config.read_buf_size.max(1)],
+                read_buf: vec![0u8; config.read_buf_size],
                 evicted_offsets: HashMap::new(),
                 scratch_paths: Vec::new(),
                 last_read_had_data: false,

--- a/crates/logfwd-io/src/tail/tailer.rs
+++ b/crates/logfwd-io/src/tail/tailer.rs
@@ -136,7 +136,9 @@ impl FileTailer {
             },
             reader: FileReader {
                 files: HashMap::new(),
-                read_buf: vec![0u8; config.read_buf_size],
+                // Prevent a zero-length buffer from turning non-empty files into
+                // perpetual "NoData" reads.
+                read_buf: vec![0u8; config.read_buf_size.max(1)],
                 evicted_offsets: HashMap::new(),
                 scratch_paths: Vec::new(),
                 last_read_had_data: false,

--- a/crates/logfwd-io/src/tail/tests.rs
+++ b/crates/logfwd-io/src/tail/tests.rs
@@ -2323,6 +2323,36 @@ fn test_adaptive_fast_poll_stays_idle_for_small_live_tail_updates() {
     assert!(second.is_empty(), "idle live-tail should not spin");
 }
 
+#[test]
+fn test_zero_read_buffer_size_is_safely_promoted() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("zero-read-buf.log");
+    fs::write(&log_path, b"hello\n").unwrap();
+
+    let mut tailer = FileTailer::new(
+        std::slice::from_ref(&log_path),
+        TailConfig {
+            start_from_end: false,
+            poll_interval_ms: 0,
+            read_buf_size: 0,
+            ..Default::default()
+        },
+        create_test_stats(),
+    )
+    .expect("tailer should construct with zero read buffer config");
+
+    let events = poll_until(
+        &mut tailer,
+        Duration::from_secs(1),
+        |events, _| events.iter().any(|e| matches!(e, TailEvent::Data { .. })),
+        "timed out waiting for data with zero read_buf_size",
+    );
+    assert!(
+        events.iter().any(|e| matches!(e, TailEvent::Data { .. })),
+        "tailer should still emit data when configured read_buf_size is zero"
+    );
+}
+
 /// Directional benchmark for issue #1258.
 ///
 /// Run with:

--- a/crates/logfwd-output/src/conflict_columns.rs
+++ b/crates/logfwd-output/src/conflict_columns.rs
@@ -125,7 +125,7 @@ pub(crate) fn is_null(batch: &RecordBatch, variant: &ColVariant, row: usize) -> 
 /// Return a reference to the underlying Arrow array for a `ColVariant`.
 pub(crate) fn get_array<'b>(batch: &'b RecordBatch, variant: &ColVariant) -> Option<&'b dyn Array> {
     match variant {
-        ColVariant::Flat { col_idx, .. } => batch.columns().get(*col_idx).map(|col| col.as_ref()),
+        ColVariant::Flat { col_idx, .. } => batch.columns().get(*col_idx).map(AsRef::as_ref),
         ColVariant::StructField {
             struct_col_idx,
             field_idx,
@@ -135,7 +135,7 @@ pub(crate) fn get_array<'b>(batch: &'b RecordBatch, variant: &ColVariant) -> Opt
                 .columns()
                 .get(*struct_col_idx)
                 .and_then(|col| col.as_any().downcast_ref::<StructArray>())?;
-            sa.columns().get(*field_idx).map(|child| child.as_ref())
+            sa.columns().get(*field_idx).map(AsRef::as_ref)
         }
     }
 }

--- a/crates/logfwd-output/src/sink/health.rs
+++ b/crates/logfwd-output/src/sink/health.rs
@@ -40,7 +40,7 @@ pub const fn reduce_output_health(
             | ComponentHealth::Stopping
             | ComponentHealth::Stopped
             | ComponentHealth::Failed => current,
-            _ => ComponentHealth::Starting,
+            ComponentHealth::Starting => ComponentHealth::Starting,
         },
         OutputHealthEvent::StartupSucceeded => match current {
             ComponentHealth::Degraded => ComponentHealth::Degraded,


### PR DESCRIPTION
## Summary
This PR clusters three verified IO hardening workstreams:
- WS06: tail discovery identity rotation correctness (fingerprint mismatch handling with sentinel safeguards).
- WS07: tail reader/tailer robustness (zero read buffer promotion + evicted offset clamping).
- WS08: auxiliary receiver/checkpoint hardening:
  - Arrow IPC content-type/content-encoding parsing and validation
  - OTAP content-type parsing/validation
  - Unix UID detection for checkpoint default data dir via `libc::geteuid()`

## Why this cluster
These changes are all in `logfwd-io` and focus on ingestion robustness at file-tail and auxiliary receiver boundaries.

## Validation
- `cargo test -p logfwd-io --lib tail::discovery::tests:: -- --nocapture`
- `cargo test -p logfwd-io --lib tail::reader::tests::set_offset -- --nocapture`
- `cargo test -p logfwd-io --lib tail::tailer::tests::test_zero_read_buffer_size_is_safely_promoted -- --nocapture`
- `cargo test -p logfwd-io --lib parse_content_type_accepts_parameters -- --nocapture`
- `cargo test -p logfwd-io --lib parse_content_encoding_rejects_unsupported_values -- --nocapture`
- `cargo test -p logfwd-io --lib receiver_accepts_otap_post -- --nocapture`
- `cargo test -p logfwd-io --lib test_libc_getuid_matches_system_euid -- --nocapture`
- `cargo check -p logfwd-io`

## Notes
- WS08 patch was applied with a 3-way merge due context drift from latest `main`; resulting code matches validated intent.
- Generated fanout report artifacts were intentionally excluded.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden tail, receiver, and offset handling in logfwd-io
> - Enforces strict `Content-Type` and `Content-Encoding` validation in the Arrow IPC and OTAP HTTP handlers, returning 415 for unsupported types or encodings
> - Detects file rotation on same-inode fingerprint mismatches in [`tail/discovery.rs`](https://github.com/strawgate/memagent/pull/1797/files#diff-e6374467660d2f8894a1bb3e26e8c44f44b1a1246eedcd154ff2e9e4b5a8e26b), while avoiding false positives for empty-file sentinel transitions
> - Clamps out-of-range evicted file offsets to 0 in [`tail/reader.rs`](https://github.com/strawgate/memagent/pull/1797/files#diff-701e74383f2411e1c8fb8925978e0bc89708df4670396fc94b8b7e3a9776808d) instead of retaining an invalid offset
> - Promotes `read_buf_size=0` to 1 in `FileTailer` to prevent perpetual no-data reads
> - Switches root detection in [`checkpoint.rs`](https://github.com/strawgate/memagent/pull/1797/files#diff-ebe14b4939d3385df0545dc61beb87028ac0a7709e7b903591929befed69c763) from real UID to effective UID (`geteuid`)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac4866b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->