### PR TITLE
fix(output): WS09+WS12+WS14 sink correctness hardening cluster

### DIFF
--- a/crates/logfwd-output/src/conflict_columns.rs
+++ b/crates/logfwd-output/src/conflict_columns.rs
@@ -97,20 +97,27 @@ pub(crate) fn variant_dt(v: &ColVariant) -> &DataType {
 /// Returns `true` if the given `ColVariant` is null at `row` in `batch`.
 pub(crate) fn is_null(batch: &RecordBatch, variant: &ColVariant, row: usize) -> bool {
     match variant {
-        ColVariant::Flat { col_idx, .. } => batch.column(*col_idx).is_null(row),
+        ColVariant::Flat { col_idx, .. } => batch
+            .columns()
+            .get(*col_idx)
+            .is_none_or(|col| col.is_null(row)),
         ColVariant::StructField {
             struct_col_idx,
             field_idx,
             ..
         } => {
             let Some(sa) = batch
-                .column(*struct_col_idx)
-                .as_any()
-                .downcast_ref::<StructArray>()
+                .columns()
+                .get(*struct_col_idx)
+                .and_then(|col| col.as_any().downcast_ref::<StructArray>())
             else {
                 return true;
             };
-            sa.is_null(row) || sa.column(*field_idx).is_null(row)
+            sa.is_null(row)
+                || sa
+                    .columns()
+                    .get(*field_idx)
+                    .is_none_or(|child| child.is_null(row))
         }
     }
 }
@@ -118,18 +125,46 @@ pub(crate) fn is_null(batch: &RecordBatch, variant: &ColVariant, row: usize) -> 
 /// Return a reference to the underlying Arrow array for a `ColVariant`.
 pub(crate) fn get_array<'b>(batch: &'b RecordBatch, variant: &ColVariant) -> Option<&'b dyn Array> {
     match variant {
-        ColVariant::Flat { col_idx, .. } => Some(batch.column(*col_idx).as_ref()),
+        ColVariant::Flat { col_idx, .. } => batch.columns().get(*col_idx).map(|col| col.as_ref()),
         ColVariant::StructField {
             struct_col_idx,
             field_idx,
             ..
         } => {
             let sa = batch
-                .column(*struct_col_idx)
-                .as_any()
-                .downcast_ref::<StructArray>()?;
-            Some(sa.column(*field_idx).as_ref())
+                .columns()
+                .get(*struct_col_idx)
+                .and_then(|col| col.as_any().downcast_ref::<StructArray>())?;
+            sa.columns().get(*field_idx).map(|child| child.as_ref())
         }
+    }
+}
+
+fn sort_variants(info: &mut ColInfo) {
+    info.json_variants
+        .sort_by_key(|v| std::cmp::Reverse(json_priority(variant_dt(v))));
+    info.str_variants
+        .sort_by_key(|v| std::cmp::Reverse(str_priority(variant_dt(v))));
+}
+
+fn upsert_col_info(
+    infos: &mut Vec<ColInfo>,
+    field_name: &str,
+    mut json_variants: Vec<ColVariant>,
+    mut str_variants: Vec<ColVariant>,
+) {
+    if let Some(existing) = infos.iter_mut().find(|c| c.field_name == field_name) {
+        existing.json_variants.append(&mut json_variants);
+        existing.str_variants.append(&mut str_variants);
+        sort_variants(existing);
+    } else {
+        let mut info = ColInfo {
+            field_name: field_name.to_string(),
+            json_variants,
+            str_variants,
+        };
+        sort_variants(&mut info);
+        infos.push(info);
     }
 }
 
@@ -147,7 +182,7 @@ pub fn build_col_infos(batch: &RecordBatch) -> Vec<ColInfo> {
         match field.data_type() {
             DataType::Struct(child_fields) if is_conflict_struct(child_fields) => {
                 // Struct conflict column: one ColInfo, variants = child fields.
-                let mut json_variants: Vec<ColVariant> = child_fields
+                let json_variants: Vec<ColVariant> = child_fields
                     .iter()
                     .enumerate()
                     .map(|(field_idx, f)| ColVariant::StructField {
@@ -156,7 +191,7 @@ pub fn build_col_infos(batch: &RecordBatch) -> Vec<ColInfo> {
                         dt: f.data_type().clone(),
                     })
                     .collect();
-                let mut str_variants: Vec<ColVariant> = child_fields
+                let str_variants: Vec<ColVariant> = child_fields
                     .iter()
                     .enumerate()
                     .map(|(field_idx, f)| ColVariant::StructField {
@@ -166,25 +201,12 @@ pub fn build_col_infos(batch: &RecordBatch) -> Vec<ColInfo> {
                     })
                     .collect();
 
-                json_variants.sort_by_key(|v| std::cmp::Reverse(json_priority(variant_dt(v))));
-                str_variants.sort_by_key(|v| std::cmp::Reverse(str_priority(variant_dt(v))));
-                let field_name = field.name().as_str();
-                if let Some(existing) = infos.iter_mut().find(|c| c.field_name == field_name) {
-                    existing.json_variants.extend(json_variants);
-                    existing.str_variants.extend(str_variants);
-                    existing
-                        .json_variants
-                        .sort_by_key(|v| std::cmp::Reverse(json_priority(variant_dt(v))));
-                    existing
-                        .str_variants
-                        .sort_by_key(|v| std::cmp::Reverse(str_priority(variant_dt(v))));
-                } else {
-                    infos.push(ColInfo {
-                        field_name: field_name.to_string(),
-                        json_variants,
-                        str_variants,
-                    });
-                }
+                upsert_col_info(
+                    &mut infos,
+                    field.name().as_str(),
+                    json_variants,
+                    str_variants,
+                );
             }
             dt => {
                 // Plain flat column — use the column name verbatim.
@@ -193,39 +215,70 @@ pub fn build_col_infos(batch: &RecordBatch) -> Vec<ColInfo> {
                 // multi-type conflicts use StructArray.  User-defined SQL aliases
                 // (e.g. `SELECT duration_ms_int AS dur_int`) must be preserved
                 // exactly — stripping the suffix would mangle the alias (#705).
-                let field_name = field.name().as_str();
-                if let Some(existing) = infos.iter_mut().find(|c| c.field_name == field_name) {
-                    existing.json_variants.push(ColVariant::Flat {
+                upsert_col_info(
+                    &mut infos,
+                    field.name().as_str(),
+                    vec![ColVariant::Flat {
                         col_idx,
                         dt: dt.clone(),
-                    });
-                    existing.str_variants.push(ColVariant::Flat {
+                    }],
+                    vec![ColVariant::Flat {
                         col_idx,
                         dt: dt.clone(),
-                    });
-                    // Re-sort both lists.
-                    existing
-                        .json_variants
-                        .sort_by_key(|v| std::cmp::Reverse(json_priority(variant_dt(v))));
-                    existing
-                        .str_variants
-                        .sort_by_key(|v| std::cmp::Reverse(str_priority(variant_dt(v))));
-                } else {
-                    infos.push(ColInfo {
-                        field_name: field_name.to_string(),
-                        json_variants: vec![ColVariant::Flat {
-                            col_idx,
-                            dt: dt.clone(),
-                        }],
-                        str_variants: vec![ColVariant::Flat {
-                            col_idx,
-                            dt: dt.clone(),
-                        }],
-                    });
-                }
+                    }],
+                );
             }
         }
     }
 
     infos
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Int64Array, StructArray};
+    use arrow::datatypes::{Field, Fields, Schema};
+    use std::sync::Arc;
+
+    #[test]
+    fn struct_variant_out_of_bounds_is_treated_as_null_and_missing() {
+        let struct_fields = Fields::from(vec![Field::new("int", DataType::Int64, true)]);
+        let struct_array = StructArray::new(
+            struct_fields.clone(),
+            vec![Arc::new(Int64Array::from(vec![Some(1)]))],
+            None,
+        );
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "status",
+            DataType::Struct(struct_fields),
+            true,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(struct_array)]).expect("valid batch");
+
+        let bad_child = ColVariant::StructField {
+            struct_col_idx: 0,
+            field_idx: 99,
+            dt: DataType::Int64,
+        };
+
+        assert!(is_null(&batch, &bad_child, 0));
+        assert!(get_array(&batch, &bad_child).is_none());
+    }
+
+    #[test]
+    fn flat_variant_out_of_bounds_is_treated_as_null_and_missing() {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int64, true)]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![Some(10)]))])
+            .expect("valid batch");
+
+        let bad_flat = ColVariant::Flat {
+            col_idx: 42,
+            dt: DataType::Int64,
+        };
+
+        assert!(is_null(&batch, &bad_flat, 0));
+        assert!(get_array(&batch, &bad_flat).is_none());
+    }
 }

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -100,9 +100,10 @@ pub fn build_sink_factory(
             })?;
             let compression = match cfg.compression.as_deref() {
                 Some("zstd") => Compression::Zstd,
+                Some("none") => Compression::None,
                 Some(other) => {
                     return Err(OutputError::Construction(format!(
-                        "output '{name}': arrow_ipc does not support '{other}' compression (use 'zstd' or omit)"
+                        "output '{name}': arrow_ipc does not support '{other}' compression (use 'zstd', 'none', or omit)"
                     )));
                 }
                 None => Compression::None,
@@ -254,5 +255,30 @@ pub fn build_sink_factory(
             "output '{name}': type {:?} not yet supported",
             cfg.output_type
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_sink_factory;
+    use std::sync::Arc;
+
+    use logfwd_config::{OutputConfig, OutputType};
+    use logfwd_types::diagnostics::ComponentStats;
+
+    #[test]
+    fn build_sink_factory_arrow_ipc_accepts_none_compression() {
+        let cfg = OutputConfig {
+            output_type: OutputType::ArrowIpc,
+            endpoint: Some("http://localhost:4318/v1/logs".to_string()),
+            compression: Some("none".to_string()),
+            ..Default::default()
+        };
+
+        let result = build_sink_factory("arrow", &cfg, None, Arc::new(ComponentStats::new()));
+        assert!(
+            result.is_ok(),
+            "arrow_ipc should accept explicit 'none' compression"
+        );
     }
 }

--- a/crates/logfwd-output/src/otap_sink.rs
+++ b/crates/logfwd-output/src/otap_sink.rs
@@ -42,12 +42,15 @@
 
 use std::future::Future;
 use std::io;
+use std::io::Write as _;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
 use arrow::record_batch::RecordBatch;
+use flate2::Compression as GzipLevel;
+use flate2::write::GzEncoder;
 use logfwd_otap_proto::otap::{
     ArrowPayload as ProtoArrowPayload, ArrowPayloadType as ProtoArrowPayloadType,
     BatchArrowRecords as ProtoBatchArrowRecords, BatchStatus as ProtoBatchStatus,
@@ -62,7 +65,7 @@ use logfwd_types::diagnostics::ComponentStats;
 use super::arrow_ipc_sink::serialize_ipc;
 use super::sink::{SendResult, Sink, SinkFactory};
 use super::{BatchMetadata, Compression};
-use crate::http_classify::DEFAULT_RETRY_AFTER_SECS;
+use crate::http_classify::{self, DEFAULT_RETRY_AFTER_SECS};
 
 mod generated_fast {
     include!("generated/otap_fast_v1.rs");
@@ -357,7 +360,12 @@ impl OtapSink {
     fn maybe_compress(&self) -> io::Result<Vec<u8>> {
         match self.config.compression {
             Compression::Zstd => zstd::bulk::compress(&self.proto_buf, 1).map_err(io::Error::other),
-            Compression::None | Compression::Gzip => Ok(self.proto_buf.clone()),
+            Compression::Gzip => {
+                let mut encoder = GzEncoder::new(Vec::new(), GzipLevel::fast());
+                encoder.write_all(&self.proto_buf)?;
+                encoder.finish()
+            }
+            Compression::None => Ok(self.proto_buf.clone()),
         }
     }
 
@@ -368,8 +376,10 @@ impl OtapSink {
             .post(&self.config.endpoint)
             .header("Content-Type", CONTENT_TYPE_PROTOBUF);
 
-        if self.config.compression == Compression::Zstd {
-            req = req.header("Content-Encoding", "zstd");
+        match self.config.compression {
+            Compression::Zstd => req = req.header("Content-Encoding", "zstd"),
+            Compression::Gzip => req = req.header("Content-Encoding", "gzip"),
+            Compression::None => {}
         }
 
         for (k, v) in &self.config.headers {
@@ -379,26 +389,19 @@ impl OtapSink {
         let response = req.body(payload).send().await.map_err(io::Error::other)?;
         let status = response.status();
 
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            let retry_after = response
-                .headers()
-                .get("Retry-After")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(DEFAULT_RETRY_AFTER_SECS);
-            return Ok(SendResult::RetryAfter(Duration::from_secs(retry_after)));
-        }
-
-        if status.is_server_error() {
-            let _body = response.text().await.unwrap_or_default();
-            return Ok(SendResult::RetryAfter(Duration::from_secs(
-                DEFAULT_RETRY_AFTER_SECS,
-            )));
-        }
-
         if !status.is_success() {
+            let retry_after = response.headers().get("Retry-After").cloned();
             let body = response.text().await.unwrap_or_default();
-            return Ok(SendResult::Rejected(format!("HTTP {status}: {body}")));
+            if let Some(send_result) = http_classify::classify_http_status(
+                status.as_u16(),
+                retry_after.as_ref(),
+                &format!("OTAP: {body}"),
+            ) {
+                return Ok(send_result);
+            }
+            return Err(io::Error::other(format!(
+                "OTAP request failed with status {status}: {body}"
+            )));
         }
 
         // Parse BatchStatus from the response body.
@@ -559,6 +562,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use logfwd_arrow::star_schema::{flat_to_star, star_to_flat};
     use logfwd_core::otlp::encode_varint_field;
+    use reqwest::header::{CONTENT_ENCODING, RETRY_AFTER};
 
     use super::super::arrow_ipc_sink::deserialize_ipc;
 
@@ -1123,5 +1127,119 @@ mod tests {
             status_vals.contains(&"200") && status_vals.contains(&"OK"),
             "expected both coalesced status values (200 and OK), got: {status_vals:?}"
         );
+    }
+
+    #[test]
+    fn maybe_compress_gzip_produces_valid_gzip_stream() {
+        use std::io::Read as _;
+
+        let config = Arc::new(OtapSinkConfig {
+            endpoint: "http://localhost:4318/v1/otap".to_string(),
+            compression: Compression::Gzip,
+            headers: vec![],
+        });
+        let mut sink = OtapSink::new(
+            "test".to_string(),
+            config,
+            reqwest::Client::new(),
+            Arc::new(AtomicI64::new(0)),
+            Arc::new(ComponentStats::new()),
+        );
+        sink.proto_buf = b"sample-otap-payload".to_vec();
+
+        let compressed = sink
+            .maybe_compress()
+            .expect("gzip compression should succeed");
+        assert_ne!(compressed, sink.proto_buf, "payload should be compressed");
+
+        let mut decoded = Vec::new();
+        flate2::read::GzDecoder::new(compressed.as_slice())
+            .read_to_end(&mut decoded)
+            .expect("gzip payload should decompress");
+        assert_eq!(
+            decoded, sink.proto_buf,
+            "gzip roundtrip should preserve protobuf bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn otap_send_gzip_sets_content_encoding_header() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/v1/otap")
+            .match_header(CONTENT_ENCODING.as_str(), "gzip")
+            .with_status(200)
+            .create_async()
+            .await;
+
+        let config = Arc::new(OtapSinkConfig {
+            endpoint: format!("{}/v1/otap", server.url()),
+            compression: Compression::Gzip,
+            headers: vec![],
+        });
+        let sink = OtapSink::new(
+            "test".to_string(),
+            config,
+            reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("client"),
+            Arc::new(AtomicI64::new(0)),
+            Arc::new(ComponentStats::new()),
+        );
+
+        let payload = b"sample-otap-payload".to_vec();
+        let send_result = sink
+            .do_send(payload, 1)
+            .await
+            .expect("do_send should succeed");
+        assert!(matches!(send_result, SendResult::Ok));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn otap_send_retry_after_http_date_is_honored() {
+        let retry_after_http_date =
+            httpdate::fmt_http_date(std::time::SystemTime::now() + Duration::from_secs(60));
+
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/v1/otap")
+            .with_status(429)
+            .with_header(RETRY_AFTER.as_str(), &retry_after_http_date)
+            .create_async()
+            .await;
+
+        let config = Arc::new(OtapSinkConfig {
+            endpoint: format!("{}/v1/otap", server.url()),
+            compression: Compression::None,
+            headers: vec![],
+        });
+        let sink = OtapSink::new(
+            "test".to_string(),
+            config,
+            reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("client"),
+            Arc::new(AtomicI64::new(0)),
+            Arc::new(ComponentStats::new()),
+        );
+
+        let result = sink
+            .do_send(vec![0x01], 10)
+            .await
+            .expect("do_send should classify 429");
+
+        match result {
+            SendResult::RetryAfter(duration) => {
+                assert!(
+                    (58..=60).contains(&duration.as_secs()),
+                    "HTTP-date Retry-After should parse to ~60s, got {}s",
+                    duration.as_secs()
+                );
+            }
+            other => panic!("expected RetryAfter, got {other:?}"),
+        }
     }
 }

--- a/crates/logfwd-output/src/sink/health.rs
+++ b/crates/logfwd-output/src/sink/health.rs
@@ -37,6 +37,7 @@ pub const fn reduce_output_health(
         OutputHealthEvent::StartupRequested => match current {
             ComponentHealth::Healthy
             | ComponentHealth::Degraded
+            | ComponentHealth::Stopping
             | ComponentHealth::Stopped
             | ComponentHealth::Failed => current,
             _ => ComponentHealth::Starting,
@@ -145,6 +146,13 @@ mod tests {
                 OutputHealthEvent::StartupRequested
             ),
             ComponentHealth::Degraded
+        );
+        assert_eq!(
+            reduce_output_health(
+                ComponentHealth::Stopping,
+                OutputHealthEvent::StartupRequested
+            ),
+            ComponentHealth::Stopping
         );
     }
 

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -9,6 +9,8 @@ use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use tokio::io::AsyncWriteExt;
 
+use memchr::memchr_iter;
+
 use logfwd_types::diagnostics::ComponentStats;
 use logfwd_types::field_names;
 
@@ -456,7 +458,8 @@ impl Sink for StdoutSink {
                 return SendResult::IoError(e);
             }
 
-            self.stats.inc_lines(batch.num_rows() as u64);
+            let lines_written = memchr_iter(b'\n', &self.output_buf).count() as u64;
+            self.stats.inc_lines(lines_written);
             self.stats.inc_bytes(bytes_written);
             SendResult::Ok
         })
@@ -924,6 +927,35 @@ mod tests {
         assert!(
             rendered.contains("canonical-body"),
             "console output should render canonical body first: {rendered:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_batch_counts_emitted_lines_for_text_mode() {
+        use std::sync::atomic::Ordering;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::Utf8, true)]));
+        let body = StringArray::from(vec![Some("printed"), None]);
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(body)]).unwrap();
+
+        let stats = Arc::new(ComponentStats::new());
+        let mut sink = StdoutSink::new(
+            "test-lines".to_string(),
+            StdoutFormat::Text,
+            Arc::clone(&stats),
+        );
+        let meta = make_metadata();
+
+        let mut expected = Vec::new();
+        sink.write_batch_to(&batch, &meta, &mut expected).unwrap();
+        let expected_lines = expected.iter().filter(|b| **b == b'\n').count() as u64;
+
+        let _ = sink.send_batch(&batch, &meta).await.unwrap();
+
+        assert_eq!(
+            stats.lines_total.load(Ordering::Relaxed),
+            expected_lines,
+            "lines_total should reflect emitted lines, not raw row count"
         );
     }
 }


### PR DESCRIPTION
## Summary
This PR clusters three verified output-surface fixes:
- WS09: `arrow_ipc` factory accepts explicit `compression: none`; sink health keeps `Stopping` sticky during startup transitions.
- WS12: OTAP sink correctness for gzip compression and `Retry-After` HTTP-date handling.
- WS14: stdout line metrics count only emitted text lines; conflict-column extraction hardened against out-of-bounds/stale variants.

## Why this cluster
All changes are in `logfwd-output` and are low-overlap correctness/observability fixes across sink behavior, transport handling, and output diagnostics.

## Validation
- `cargo test -p logfwd-output build_sink_factory_arrow_ipc_accepts_none_compression -- --nocapture`
- `cargo test -p logfwd-output sink::health::tests -- --nocapture`
- `cargo test -p logfwd-output maybe_compress_gzip_produces_valid_gzip_stream -- --nocapture`
- `cargo test -p logfwd-output otap_send_gzip_sets_content_encoding_header -- --nocapture`
- `cargo test -p logfwd-output otap_send_retry_after_http_date_is_honored -- --nocapture`
- `cargo test -p logfwd-output send_batch_counts_emitted_lines_for_text_mode -- --nocapture`
- `cargo test -p logfwd-output out_of_bounds_is_treated_as_null_and_missing -- --nocapture`
- `cargo test -p logfwd-output --lib`

## Notes
- WS12 was merged with context drift from latest `main`; conflict was resolved in `otap_sink.rs` and validated with full `logfwd-output --lib` tests.
- Generated fanout report artifacts were intentionally excluded.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix correctness bugs in output sinks for compression, metrics, and panic-safety
> - Fixes panics in [`conflict_columns.rs`](https://github.com/strawgate/memagent/pull/1798/files#diff-2b252e115c85e392197a8bfea4d32b875468336e340c5c76a59d6d8ca069f637) by replacing direct index access with safe lookups; out-of-bounds or missing columns are now treated as null instead of panicking.
> - Implements real gzip compression in [`otap_sink.rs`](https://github.com/strawgate/memagent/pull/1798/files#diff-5315ee02bf5eb3064a09f568f785e7a96c849ec26d45af9413f6bdd1211eb55f) via `flate2`; previously, gzip-configured payloads were sent uncompressed. HTTP error handling is now delegated to `http_classify`, with correct `Content-Encoding` headers set.
> - Fixes `lines_total` metric in [`stdout.rs`](https://github.com/strawgate/memagent/pull/1798/files#diff-367abe982e9af5da76298a1b865bc7161a9123e70ee2bee1b32c4af4d879c9a3) to count actual newlines written rather than input row count.
> - Fixes `reduce_output_health` in [`sink/health.rs`](https://github.com/strawgate/memagent/pull/1798/files#diff-4e4ac2e3c981a7e16d2ed338a0b4b4b6921893c530ebc3d0ee7984255c20bff9) so a sink in `Stopping` state stays `Stopping` on `StartupRequested` instead of transitioning to `Starting`.
> - Adds explicit `"none"` compression support in [`factory.rs`](https://github.com/strawgate/memagent/pull/1798/files#diff-38138875bb6a160b3328cc8507d27d322ae4c2f810e755490e66ce6088078fac) for Arrow IPC outputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f9b3df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->