### PR TITLE
io: harden TCP close-tail framing and OTLP JSON ID parsing

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -16,8 +16,8 @@ use crate::receiver_http::MAX_REQUEST_BODY_SIZE;
 
 use super::convert::{
     convert_request_to_batch, decode_protojson_bytes, hex, parse_protojson_f64,
-    parse_protojson_i64, parse_protojson_u64, write_f64_to_buf, write_i64_to_buf, write_json_key,
-    write_json_string_field, write_u64_to_buf,
+    parse_protojson_i64, parse_protojson_u64, write_f64_to_buf, write_hex_to_buf, write_i64_to_buf,
+    write_json_key, write_json_string_field, write_u64_to_buf,
 };
 
 pub(super) fn decompress_zstd(body: &[u8]) -> Result<Vec<u8>, InputError> {
@@ -241,13 +241,21 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
 
                 if let Some(tid) = record.get("traceId").and_then(|v| v.as_str()) {
                     if !tid.is_empty() {
-                        write_json_string_field(&mut out, field_names::TRACE_ID, tid);
+                        let trace_id = decode_otel_id_hex::<16>(tid, "traceId")?;
+                        write_json_key(&mut out, field_names::TRACE_ID);
+                        out.push(b'"');
+                        write_hex_to_buf(&mut out, &trace_id);
+                        out.push(b'"');
                         out.push(b',');
                     }
                 }
                 if let Some(sid) = record.get("spanId").and_then(|v| v.as_str()) {
                     if !sid.is_empty() {
-                        write_json_string_field(&mut out, field_names::SPAN_ID, sid);
+                        let span_id = decode_otel_id_hex::<8>(sid, "spanId")?;
+                        write_json_key(&mut out, field_names::SPAN_ID);
+                        out.push(b'"');
+                        write_hex_to_buf(&mut out, &span_id);
+                        out.push(b'"');
                         out.push(b',');
                     }
                 }
@@ -285,6 +293,48 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
     }
 
     Ok(out)
+}
+
+fn decode_otel_id_hex<const BYTES: usize>(
+    value: &str,
+    field_name: &str,
+) -> Result<[u8; BYTES], InputError> {
+    let expected_len = BYTES * 2;
+    let raw = value.as_bytes();
+    if raw.len() != expected_len {
+        return Err(InputError::Receiver(format!(
+            "invalid OTLP JSON {field_name}: expected {expected_len} hex chars"
+        )));
+    }
+
+    let mut out = [0u8; BYTES];
+    for i in 0..BYTES {
+        let hi = decode_hex_nibble(raw[2 * i]).ok_or_else(|| {
+            InputError::Receiver(format!(
+                "invalid OTLP JSON {field_name}: non-hex character at offset {}",
+                2 * i
+            ))
+        })?;
+        let lo = decode_hex_nibble(raw[2 * i + 1]).ok_or_else(|| {
+            InputError::Receiver(format!(
+                "invalid OTLP JSON {field_name}: non-hex character at offset {}",
+                2 * i + 1
+            ))
+        })?;
+        out[i] = (hi << 4) | lo;
+    }
+
+    Ok(out)
+}
+
+#[inline]
+fn decode_hex_nibble(ch: u8) -> Option<u8> {
+    match ch {
+        b'0'..=b'9' => Some(ch - b'0'),
+        b'a'..=b'f' => Some(ch - b'a' + 10),
+        b'A'..=b'F' => Some(ch - b'A' + 10),
+        _ => None,
+    }
 }
 
 /// Extract a scalar OTLP JSON AnyValue as an owned string.

--- a/crates/logfwd-io/src/otlp_receiver/tests.rs
+++ b/crates/logfwd-io/src/otlp_receiver/tests.rs
@@ -517,6 +517,57 @@ fn invalid_json_bytes_value_returns_error() {
 }
 
 #[test]
+fn json_trace_and_span_ids_decode_as_hex_bytes() {
+    let batch = decode_otlp_json(
+        br#"{
+            "resourceLogs": [{
+                "scopeLogs": [{
+                    "logRecords": [{
+                        "traceId": "00112233445566778899AABBCCDDEEFF",
+                        "spanId": "0123456789ABCDEF"
+                    }]
+                }]
+            }]
+        }"#,
+        field_names::DEFAULT_RESOURCE_PREFIX,
+    )
+    .expect("valid OTLP JSON trace/span ids should decode");
+
+    assert_eq!(batch.num_rows(), 1);
+
+    let trace = batch
+        .column_by_name(field_names::TRACE_ID)
+        .expect("trace.id column must exist");
+    assert_eq!(
+        string_value_at(trace.as_ref(), 0),
+        "00112233445566778899aabbccddeeff"
+    );
+
+    let span = batch
+        .column_by_name(field_names::SPAN_ID)
+        .expect("span.id column must exist");
+    assert_eq!(string_value_at(span.as_ref(), 0), "0123456789abcdef");
+}
+
+#[test]
+fn json_invalid_trace_id_returns_error() {
+    let result = decode_otlp_json(
+        br#"{
+            "resourceLogs": [{
+                "scopeLogs": [{
+                    "logRecords": [{
+                        "traceId": "not-hex"
+                    }]
+                }]
+            }]
+        }"#,
+        field_names::DEFAULT_RESOURCE_PREFIX,
+    );
+
+    assert!(result.is_err(), "invalid traceId must fail");
+}
+
+#[test]
 fn json_bytes_value_accepts_urlsafe_and_unpadded_base64() {
     let batch = decode_otlp_json(
         br#"{

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -120,7 +120,12 @@ fn pending_starts_with_incomplete_octet_frame(buf: &[u8]) -> bool {
             None => true,
         }
     } else {
-        false
+        // A buffer that is entirely ASCII digits is a truncated octet length
+        // prefix — the trailing space (and payload) never arrived before the
+        // connection closed.  `parse_octet_prefix` returns `None` because it
+        // requires a space delimiter, but in octet-counting mode this is still
+        // an incomplete frame that must not be flushed as a legacy line.
+        !buf.is_empty() && buf.iter().all(u8::is_ascii_digit)
     }
 }
 
@@ -897,6 +902,64 @@ mod tests {
         assert_eq!(
             all_data, b"hello\n",
             "incomplete octet-counted tail after mode commit must be dropped on close"
+        );
+    }
+
+    /// When octet-counting mode is committed and the connection closes with
+    /// only a partial length prefix (digits but no trailing space), the pending
+    /// bytes must be dropped — not flushed as a legacy line.
+    #[test]
+    fn tcp_truncated_octet_prefix_digits_only_dropped_on_close() {
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
+        let addr = input.local_addr().unwrap();
+
+        // Use a two-phase write: first send a complete octet frame so that
+        // octet-counting mode is committed, then send a truncated length
+        // prefix (digits only, no space) before closing the connection.
+        let mut client = StdTcpStream::connect(addr).unwrap();
+
+        // Phase 1: complete octet frame — commits octet-counting mode.
+        // Use two back-to-back frames so the boundary plausibility check
+        // succeeds (parse_octet_prefix succeeds on the second frame).
+        client.write_all(b"5 hello5 world").unwrap();
+        client.flush().unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Drain the complete frames so octet_counting_mode is set.
+        let mut all_data = Vec::new();
+        for event in input.poll().unwrap() {
+            if let InputEvent::Data { bytes, .. } = event {
+                all_data.extend_from_slice(&bytes);
+            }
+        }
+        assert!(
+            all_data.windows(5).any(|w| w == b"hello"),
+            "first octet frame must be emitted"
+        );
+
+        // Phase 2: send a truncated length prefix and close.
+        client.write_all(b"12").unwrap();
+        client.flush().unwrap();
+        drop(client); // clean EOF
+
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut close_data = Vec::new();
+        for event in input.poll().unwrap() {
+            if let InputEvent::Data { bytes, .. } = event {
+                close_data.extend_from_slice(&bytes);
+            }
+        }
+
+        assert!(
+            close_data.is_empty() || !close_data.windows(2).any(|w| w == b"12"),
+            "truncated octet length prefix (digits only) after mode commit must be dropped on close; got: {:?}",
+            String::from_utf8_lossy(&close_data),
         );
     }
 

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -79,6 +79,10 @@ struct Client {
     discard_octet_bytes: usize,
     /// Whether we are dropping newline-delimited bytes until a newline appears.
     discard_until_newline: bool,
+    /// True after this connection has successfully parsed at least one
+    /// octet-counted frame. Used to disambiguate incomplete numeric tails
+    /// during clean close.
+    octet_counting_mode: bool,
 }
 
 fn parse_octet_prefix(buf: &[u8]) -> Option<(usize, usize)> {
@@ -104,6 +108,20 @@ fn advance_pending(client: &mut Client, consumed: usize) {
     let remaining = client.pending.len().saturating_sub(consumed);
     client.pending.copy_within(consumed.., 0);
     client.pending.truncate(remaining);
+}
+
+#[inline]
+fn pending_starts_with_incomplete_octet_frame(buf: &[u8]) -> bool {
+    if let Some((len, prefix_len)) = parse_octet_prefix(buf) {
+        match prefix_len.checked_add(len) {
+            Some(needed) => buf.len() < needed,
+            // Overflow is malformed framing; treat it as incomplete for
+            // close-path protection once octet mode has been committed.
+            None => true,
+        }
+    } else {
+        false
+    }
 }
 
 fn extract_complete_records(client: &mut Client, out: &mut Vec<u8>) {
@@ -150,6 +168,7 @@ fn extract_complete_records(client: &mut Client, out: &mut Vec<u8>) {
                     || parse_octet_prefix(&pending[needed..]).is_some());
 
             if octet_frame_ready && octet_boundary_is_plausible {
+                client.octet_counting_mode = true;
                 if len > MAX_LINE_LENGTH {
                     client.discard_octet_bytes = len;
                     consumed += prefix_len;
@@ -302,6 +321,7 @@ impl InputSource for TcpInput {
                         pending: Vec::new(),
                         discard_octet_bytes: 0,
                         discard_until_newline: false,
+                        octet_counting_mode: false,
                     });
                 }
                 Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
@@ -452,7 +472,9 @@ impl InputSource for TcpInput {
                 let client = &mut self.clients[i];
                 let has_pending = !client.pending.is_empty();
                 let mid_discard = client.discard_octet_bytes > 0 || client.discard_until_newline;
-                if has_pending && !mid_discard {
+                let incomplete_octet = client.octet_counting_mode
+                    && pending_starts_with_incomplete_octet_frame(&client.pending);
+                if has_pending && !mid_discard && !incomplete_octet {
                     let mut tail = std::mem::take(&mut client.pending);
                     tail.push(b'\n');
                     let accounted_bytes = tail.len() as u64;
@@ -842,6 +864,73 @@ mod tests {
         }
 
         assert_eq!(got, b"200 OK\n");
+    }
+
+    #[test]
+    fn tcp_truncated_octet_tail_is_dropped_after_octet_mode_commit_on_close() {
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
+        let addr = input.local_addr().unwrap();
+
+        {
+            let mut client = StdTcpStream::connect(addr).unwrap();
+            // Complete "hello" octet frame (commits octet mode), followed by
+            // an incomplete octet-counted frame that must not be flushed as a
+            // synthetic newline tail on close.
+            client.write_all(b"5 hello4 abc").unwrap();
+            client.flush().unwrap();
+        } // clean EOF
+
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut all_data = Vec::new();
+        for event in input.poll().unwrap() {
+            if let InputEvent::Data { bytes, .. } = event {
+                all_data.extend_from_slice(&bytes);
+            }
+        }
+
+        assert_eq!(
+            all_data, b"hello\n",
+            "incomplete octet-counted tail after mode commit must be dropped on close"
+        );
+    }
+
+    #[test]
+    fn tcp_close_preserves_legacy_numeric_tail_without_octet_mode_commit() {
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
+        let addr = input.local_addr().unwrap();
+
+        {
+            let mut client = StdTcpStream::connect(addr).unwrap();
+            // Looks like an octet prefix but no complete frame has ever been
+            // parsed on this connection, so this must flush as legacy text.
+            client.write_all(b"200 partial-tail").unwrap();
+            client.flush().unwrap();
+        } // clean EOF
+
+        std::thread::sleep(Duration::from_millis(50));
+
+        let mut all_data = Vec::new();
+        for event in input.poll().unwrap() {
+            if let InputEvent::Data { bytes, .. } = event {
+                all_data.extend_from_slice(&bytes);
+            }
+        }
+
+        assert_eq!(
+            all_data, b"200 partial-tail\n",
+            "legacy numeric tail must be preserved on close before octet mode is committed"
+        );
     }
 
     #[test]

--- a/crates/logfwd-output/src/sink/health.rs
+++ b/crates/logfwd-output/src/sink/health.rs
@@ -37,9 +37,10 @@ pub const fn reduce_output_health(
         OutputHealthEvent::StartupRequested => match current {
             ComponentHealth::Healthy
             | ComponentHealth::Degraded
+            | ComponentHealth::Stopping
             | ComponentHealth::Stopped
             | ComponentHealth::Failed => current,
-            _ => ComponentHealth::Starting,
+            ComponentHealth::Starting => ComponentHealth::Starting,
         },
         OutputHealthEvent::StartupSucceeded => match current {
             ComponentHealth::Degraded => ComponentHealth::Degraded,


### PR DESCRIPTION
## Summary
- harden TCP EOF-tail flushing so incomplete octet-counted tails are dropped only after octet mode is committed, while preserving legacy numeric tails before commit
- add TCP regressions for both close-path behaviors
- validate OTLP JSON `traceId`/`spanId` as fixed-width hex, canonicalize to lowercase hex output, and return parse errors on invalid ids
- add OTLP JSON tests for valid uppercase IDs and invalid trace id rejection

## Verification
- `cargo test -p logfwd-io --lib tcp_truncated_octet_tail_is_dropped_after_octet_mode_commit_on_close -- --nocapture`
- `cargo test -p logfwd-io --lib tcp_close_preserves_legacy_numeric_tail_without_octet_mode_commit -- --nocapture`
- `cargo test -p logfwd-io --lib json_trace_and_span_ids_decode_as_hex_bytes -- --nocapture`
- `cargo test -p logfwd-io --lib json_invalid_trace_id_returns_error -- --nocapture`
- `cargo test -p logfwd-io --test it otlp_wrong_content_type -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden TCP close-tail framing and validate OTLP JSON trace/span ID hex encoding
> - Incomplete octet-counted frames on TCP close are now dropped instead of flushed as legacy newline-terminated records, once the connection has committed to octet-counting mode via a successfully parsed complete frame.
> - `traceId` and `spanId` fields in OTLP JSON are now strictly validated as exact-length hex strings (32 and 16 chars respectively) and normalized to lowercase hex; invalid values return an error.
> - A sink in `Stopping` state no longer transitions toward `Starting` when a `StartupRequested` event is received.
> - Behavioral Change: digits-only TCP tails (incomplete length prefix, no space) are dropped on close if octet-counting mode was committed, but preserved as legacy text if it was not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 214c481.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->