### PR TITLE
output: harden network/file sink retry and UDP send semantics

### DIFF
--- a/crates/logfwd-output/src/arrow_ipc_sink.rs
+++ b/crates/logfwd-output/src/arrow_ipc_sink.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
@@ -105,25 +105,6 @@ impl ArrowIpcSink {
         }
     }
 
-    fn parse_retry_after(headers: &reqwest::header::HeaderMap, now: SystemTime) -> Duration {
-        let Some(value) = headers.get(reqwest::header::RETRY_AFTER) else {
-            return Duration::from_secs(DEFAULT_RETRY_AFTER_SECS);
-        };
-        let Ok(value_str) = value.to_str() else {
-            return Duration::from_secs(DEFAULT_RETRY_AFTER_SECS);
-        };
-
-        if let Ok(seconds) = value_str.parse::<u64>() {
-            return Duration::from_secs(seconds);
-        }
-
-        if let Ok(when) = httpdate::parse_http_date(value_str) {
-            return when.duration_since(now).unwrap_or_default();
-        }
-
-        Duration::from_secs(DEFAULT_RETRY_AFTER_SECS)
-    }
-
     /// POST the payload to the configured endpoint.
     ///
     /// Returns `SendResult::RetryAfter` for 429 / 5xx so the worker pool can
@@ -155,14 +136,18 @@ impl ArrowIpcSink {
         }
 
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            return Ok(SendResult::RetryAfter(Self::parse_retry_after(
-                response.headers(),
-                SystemTime::now(),
-            )));
+            let retry_after =
+                crate::http_classify::parse_retry_after(response.headers().get(reqwest::header::RETRY_AFTER))
+                    .unwrap_or(Duration::from_secs(DEFAULT_RETRY_AFTER_SECS));
+            // Consume the response body to free the connection for reuse.
+            let _ = response.text().await;
+            return Ok(SendResult::RetryAfter(retry_after));
         }
 
         if status.is_server_error() {
-            let retry_after = Self::parse_retry_after(response.headers(), SystemTime::now());
+            let retry_after =
+                crate::http_classify::parse_retry_after(response.headers().get(reqwest::header::RETRY_AFTER))
+                    .unwrap_or(Duration::from_secs(DEFAULT_RETRY_AFTER_SECS));
             // Consume the response body to free the connection.
             let _body = response.text().await.unwrap_or_default();
             return Ok(SendResult::RetryAfter(retry_after));
@@ -351,7 +336,7 @@ mod tests {
     use super::*;
     use arrow::array::{Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
-    use std::time::{Duration, SystemTime};
+    use std::time::Duration;
 
     fn make_test_batch() -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
@@ -448,37 +433,21 @@ mod tests {
 
     #[test]
     fn retry_after_parses_delta_seconds() {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(reqwest::header::RETRY_AFTER, "12".parse().unwrap());
-
-        let parsed = ArrowIpcSink::parse_retry_after(&headers, SystemTime::UNIX_EPOCH);
-        assert_eq!(parsed, Duration::from_secs(12));
-    }
-
-    #[test]
-    fn retry_after_parses_http_date() {
-        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
-        let later = now + Duration::from_secs(9);
-        let http_date = httpdate::fmt_http_date(later);
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            reqwest::header::RETRY_AFTER,
-            http_date.parse().expect("http-date header value is valid"),
-        );
-
-        let parsed = ArrowIpcSink::parse_retry_after(&headers, now);
-        assert_eq!(parsed, Duration::from_secs(9));
+        let hv = reqwest::header::HeaderValue::from_static("12");
+        let parsed = crate::http_classify::parse_retry_after(Some(&hv));
+        assert_eq!(parsed, Some(Duration::from_secs(12)));
     }
 
     #[test]
     fn retry_after_defaults_on_invalid_header() {
-        let mut headers = reqwest::header::HeaderMap::new();
-        headers.insert(
-            reqwest::header::RETRY_AFTER,
-            "definitely-not-valid".parse().unwrap(),
-        );
+        let hv = reqwest::header::HeaderValue::from_static("definitely-not-valid");
+        let parsed = crate::http_classify::parse_retry_after(Some(&hv));
+        assert_eq!(parsed, None);
+    }
 
-        let parsed = ArrowIpcSink::parse_retry_after(&headers, SystemTime::UNIX_EPOCH);
-        assert_eq!(parsed, Duration::from_secs(DEFAULT_RETRY_AFTER_SECS));
+    #[test]
+    fn retry_after_none_when_absent() {
+        let parsed = crate::http_classify::parse_retry_after(None);
+        assert_eq!(parsed, None);
     }
 }

--- a/crates/logfwd-output/src/arrow_ipc_sink.rs
+++ b/crates/logfwd-output/src/arrow_ipc_sink.rs
@@ -456,8 +456,7 @@ mod tests {
     #[test]
     fn retry_after_parses_http_date() {
         // Use a far-future HTTP-date so the parsed duration is always positive.
-        let hv =
-            reqwest::header::HeaderValue::from_static("Thu, 01 Jan 2099 00:00:00 GMT");
+        let hv = reqwest::header::HeaderValue::from_static("Thu, 01 Jan 2099 00:00:00 GMT");
         let parsed = crate::http_classify::parse_retry_after(Some(&hv));
         let duration = parsed.expect("should parse a far-future HTTP-date");
         // The duration should be large (decades away) but finite.

--- a/crates/logfwd-output/src/arrow_ipc_sink.rs
+++ b/crates/logfwd-output/src/arrow_ipc_sink.rs
@@ -452,4 +452,18 @@ mod tests {
         let parsed = crate::http_classify::parse_retry_after(None);
         assert_eq!(parsed, None);
     }
+
+    #[test]
+    fn retry_after_parses_http_date() {
+        // Use a far-future HTTP-date so the parsed duration is always positive.
+        let hv =
+            reqwest::header::HeaderValue::from_static("Thu, 01 Jan 2099 00:00:00 GMT");
+        let parsed = crate::http_classify::parse_retry_after(Some(&hv));
+        let duration = parsed.expect("should parse a far-future HTTP-date");
+        // The duration should be large (decades away) but finite.
+        assert!(
+            duration.as_secs() > 3600,
+            "expected duration > 1 hour for a far-future date, got {duration:?}"
+        );
+    }
 }

--- a/crates/logfwd-output/src/arrow_ipc_sink.rs
+++ b/crates/logfwd-output/src/arrow_ipc_sink.rs
@@ -136,18 +136,20 @@ impl ArrowIpcSink {
         }
 
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            let retry_after =
-                crate::http_classify::parse_retry_after(response.headers().get(reqwest::header::RETRY_AFTER))
-                    .unwrap_or(Duration::from_secs(DEFAULT_RETRY_AFTER_SECS));
+            let retry_after = crate::http_classify::parse_retry_after(
+                response.headers().get(reqwest::header::RETRY_AFTER),
+            )
+            .unwrap_or(Duration::from_secs(DEFAULT_RETRY_AFTER_SECS));
             // Consume the response body to free the connection for reuse.
             let _ = response.text().await;
             return Ok(SendResult::RetryAfter(retry_after));
         }
 
         if status.is_server_error() {
-            let retry_after =
-                crate::http_classify::parse_retry_after(response.headers().get(reqwest::header::RETRY_AFTER))
-                    .unwrap_or(Duration::from_secs(DEFAULT_RETRY_AFTER_SECS));
+            let retry_after = crate::http_classify::parse_retry_after(
+                response.headers().get(reqwest::header::RETRY_AFTER),
+            )
+            .unwrap_or(Duration::from_secs(DEFAULT_RETRY_AFTER_SECS));
             // Consume the response body to free the connection.
             let _body = response.text().await.unwrap_or_default();
             return Ok(SendResult::RetryAfter(retry_after));

--- a/crates/logfwd-output/src/arrow_ipc_sink.rs
+++ b/crates/logfwd-output/src/arrow_ipc_sink.rs
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
@@ -105,6 +105,25 @@ impl ArrowIpcSink {
         }
     }
 
+    fn parse_retry_after(headers: &reqwest::header::HeaderMap, now: SystemTime) -> Duration {
+        let Some(value) = headers.get(reqwest::header::RETRY_AFTER) else {
+            return Duration::from_secs(DEFAULT_RETRY_AFTER_SECS);
+        };
+        let Ok(value_str) = value.to_str() else {
+            return Duration::from_secs(DEFAULT_RETRY_AFTER_SECS);
+        };
+
+        if let Ok(seconds) = value_str.parse::<u64>() {
+            return Duration::from_secs(seconds);
+        }
+
+        if let Ok(when) = httpdate::parse_http_date(value_str) {
+            return when.duration_since(now).unwrap_or_default();
+        }
+
+        Duration::from_secs(DEFAULT_RETRY_AFTER_SECS)
+    }
+
     /// POST the payload to the configured endpoint.
     ///
     /// Returns `SendResult::RetryAfter` for 429 / 5xx so the worker pool can
@@ -136,21 +155,17 @@ impl ArrowIpcSink {
         }
 
         if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            let retry_after = response
-                .headers()
-                .get("Retry-After")
-                .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.parse::<u64>().ok())
-                .unwrap_or(DEFAULT_RETRY_AFTER_SECS);
-            return Ok(SendResult::RetryAfter(Duration::from_secs(retry_after)));
+            return Ok(SendResult::RetryAfter(Self::parse_retry_after(
+                response.headers(),
+                SystemTime::now(),
+            )));
         }
 
         if status.is_server_error() {
+            let retry_after = Self::parse_retry_after(response.headers(), SystemTime::now());
             // Consume the response body to free the connection.
             let _body = response.text().await.unwrap_or_default();
-            return Ok(SendResult::RetryAfter(Duration::from_secs(
-                DEFAULT_RETRY_AFTER_SECS,
-            )));
+            return Ok(SendResult::RetryAfter(retry_after));
         }
 
         // 4xx client error — not retryable.
@@ -336,6 +351,7 @@ mod tests {
     use super::*;
     use arrow::array::{Float64Array, Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
+    use std::time::{Duration, SystemTime};
 
     fn make_test_batch() -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
@@ -428,5 +444,41 @@ mod tests {
     fn deserialize_invalid_bytes_returns_error() {
         let result = deserialize_ipc(b"not arrow ipc data");
         assert!(result.is_err(), "invalid bytes should produce an error");
+    }
+
+    #[test]
+    fn retry_after_parses_delta_seconds() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::RETRY_AFTER, "12".parse().unwrap());
+
+        let parsed = ArrowIpcSink::parse_retry_after(&headers, SystemTime::UNIX_EPOCH);
+        assert_eq!(parsed, Duration::from_secs(12));
+    }
+
+    #[test]
+    fn retry_after_parses_http_date() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        let later = now + Duration::from_secs(9);
+        let http_date = httpdate::fmt_http_date(later);
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            http_date.parse().expect("http-date header value is valid"),
+        );
+
+        let parsed = ArrowIpcSink::parse_retry_after(&headers, now);
+        assert_eq!(parsed, Duration::from_secs(9));
+    }
+
+    #[test]
+    fn retry_after_defaults_on_invalid_header() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            "definitely-not-valid".parse().unwrap(),
+        );
+
+        let parsed = ArrowIpcSink::parse_retry_after(&headers, SystemTime::UNIX_EPOCH);
+        assert_eq!(parsed, Duration::from_secs(DEFAULT_RETRY_AFTER_SECS));
     }
 }

--- a/crates/logfwd-output/src/file_sink.rs
+++ b/crates/logfwd-output/src/file_sink.rs
@@ -73,14 +73,14 @@ impl Sink for FileSink {
                 .serializer
                 .write_batch_to(batch, metadata, &mut self.output_buf)
             {
-                return SendResult::IoError(e);
+                return SendResult::from_io_error(e);
             }
 
             let bytes_written = self.output_buf.len() as u64;
             let lines_written = memchr::memchr_iter(b'\n', &self.output_buf).count() as u64;
             let mut file = self.file.lock().await;
             if let Err(e) = file.write_all(&self.output_buf).await {
-                return SendResult::IoError(e);
+                return SendResult::from_io_error(e);
             }
 
             self.stats.inc_lines(lines_written);

--- a/crates/logfwd-output/src/sink/health.rs
+++ b/crates/logfwd-output/src/sink/health.rs
@@ -37,9 +37,10 @@ pub const fn reduce_output_health(
         OutputHealthEvent::StartupRequested => match current {
             ComponentHealth::Healthy
             | ComponentHealth::Degraded
+            | ComponentHealth::Stopping
             | ComponentHealth::Stopped
             | ComponentHealth::Failed => current,
-            _ => ComponentHealth::Starting,
+            ComponentHealth::Starting => ComponentHealth::Starting,
         },
         OutputHealthEvent::StartupSucceeded => match current {
             ComponentHealth::Degraded => ComponentHealth::Degraded,

--- a/crates/logfwd-output/src/udp_sink.rs
+++ b/crates/logfwd-output/src/udp_sink.rs
@@ -27,6 +27,10 @@ const MAX_DATAGRAM_PAYLOAD: usize = 1400;
 pub struct UdpSink {
     name: String,
     socket: UdpSocket,
+    /// The target address string (host:port). DNS resolution is deferred to
+    /// each `send_to` call so the sink tolerates DNS being temporarily
+    /// unavailable at startup and picks up address changes over time.
+    target: String,
     /// Scratch buffer for serializing a single row before deciding whether
     /// it fits in the current datagram.
     row_buf: Vec<u8>,
@@ -39,33 +43,51 @@ impl UdpSink {
     /// Create a new UDP sink.
     ///
     /// Binds a UDP socket to an ephemeral port (`0.0.0.0:0`) for outbound-only
-    /// traffic. The socket is set to non-blocking mode and converted to a
-    /// `tokio::net::UdpSocket`.
+    /// traffic. DNS resolution of `target` is deferred to the first
+    /// [`send_batch`](Sink::send_batch) call, avoiding synchronous DNS on the
+    /// async runtime thread and allowing the sink to be constructed even when
+    /// DNS is temporarily unavailable.
     pub fn new(
         name: impl Into<String>,
         target: impl Into<String>,
         stats: Arc<ComponentStats>,
     ) -> io::Result<Self> {
-        let target = target.into();
         let std_socket = std::net::UdpSocket::bind("0.0.0.0:0")?;
-        std_socket.connect(&target)?;
         std_socket.set_nonblocking(true)?;
         let socket = UdpSocket::from_std(std_socket)?;
         Ok(Self {
             name: name.into(),
             socket,
+            target: target.into(),
             row_buf: Vec::with_capacity(2048),
             dgram_buf: Vec::with_capacity(MAX_DATAGRAM_PAYLOAD),
             stats,
         })
     }
 
+    /// Resolve the target address asynchronously and return the first
+    /// `SocketAddr`. Uses `tokio::net::lookup_host` so DNS happens on the
+    /// async runtime without blocking an OS thread.
+    async fn resolve_target(&self) -> io::Result<std::net::SocketAddr> {
+        tokio::net::lookup_host(&self.target)
+            .await?
+            .next()
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    format!("DNS lookup returned no addresses for {}", self.target),
+                )
+            })
+    }
+
     /// Send one UDP datagram to the configured peer.
     ///
-    /// Because the socket is connected in `new`, this uses `send` rather than
-    /// `send_to`, avoiding repeat address resolution work on every packet.
+    /// Resolves the target address on each call via async DNS, then uses
+    /// `send_to` on the unconnected socket. This defers and repeats
+    /// resolution so DNS changes are picked up automatically.
     async fn send_packet(&self, buf: &[u8]) -> io::Result<()> {
-        match self.socket.send(buf).await {
+        let addr = self.resolve_target().await?;
+        match self.socket.send_to(buf, addr).await {
             Ok(n) if n == buf.len() => Ok(()),
             Ok(_) => Err(io::Error::new(
                 io::ErrorKind::WriteZero,

--- a/crates/logfwd-output/src/udp_sink.rs
+++ b/crates/logfwd-output/src/udp_sink.rs
@@ -65,17 +65,21 @@ impl UdpSink {
         })
     }
 
-    /// Resolve the target address asynchronously and return the first
+    /// Resolve the target address asynchronously and return the first IPv4
     /// `SocketAddr`. Uses `tokio::net::lookup_host` so DNS happens on the
     /// async runtime without blocking an OS thread.
+    ///
+    /// The socket is bound to `0.0.0.0:0` (IPv4), so we filter for IPv4
+    /// addresses to avoid address-family mismatches on dual-stack systems
+    /// where `lookup_host` may return IPv6 addresses first.
     async fn resolve_target(&self) -> io::Result<std::net::SocketAddr> {
         tokio::net::lookup_host(&self.target)
             .await?
-            .next()
+            .find(std::net::SocketAddr::is_ipv4)
             .ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::AddrNotAvailable,
-                    format!("DNS lookup returned no addresses for {}", self.target),
+                    format!("DNS lookup returned no IPv4 addresses for {}", self.target),
                 )
             })
     }

--- a/crates/logfwd-output/src/udp_sink.rs
+++ b/crates/logfwd-output/src/udp_sink.rs
@@ -27,7 +27,6 @@ const MAX_DATAGRAM_PAYLOAD: usize = 1400;
 pub struct UdpSink {
     name: String,
     socket: UdpSocket,
-    target: String,
     /// Scratch buffer for serializing a single row before deciding whether
     /// it fits in the current datagram.
     row_buf: Vec<u8>,
@@ -47,17 +46,37 @@ impl UdpSink {
         target: impl Into<String>,
         stats: Arc<ComponentStats>,
     ) -> io::Result<Self> {
+        let target = target.into();
         let std_socket = std::net::UdpSocket::bind("0.0.0.0:0")?;
+        std_socket.connect(&target)?;
         std_socket.set_nonblocking(true)?;
         let socket = UdpSocket::from_std(std_socket)?;
         Ok(Self {
             name: name.into(),
-            target: target.into(),
             socket,
             row_buf: Vec::with_capacity(2048),
             dgram_buf: Vec::with_capacity(MAX_DATAGRAM_PAYLOAD),
             stats,
         })
+    }
+
+    /// Send one UDP datagram to the configured peer.
+    ///
+    /// Because the socket is connected in `new`, this uses `send` rather than
+    /// `send_to`, avoiding repeat address resolution work on every packet.
+    async fn send_packet(&self, buf: &[u8]) -> io::Result<()> {
+        match self.socket.send(buf).await {
+            Ok(n) if n == buf.len() => Ok(()),
+            Ok(_) => Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "UDP datagram was only partially sent",
+            )),
+            Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
+                // Silently drop — UDP is best-effort.
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
     }
 
     /// Send the current datagram buffer if non-empty, then clear it.
@@ -67,13 +86,7 @@ impl UdpSink {
         if self.dgram_buf.is_empty() {
             return Ok(());
         }
-        match self.socket.send_to(&self.dgram_buf, &self.target).await {
-            Ok(_) => {}
-            Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {
-                // Silently drop — UDP is best-effort.
-            }
-            Err(e) => return Err(e),
-        }
+        self.send_packet(&self.dgram_buf).await?;
         self.dgram_buf.clear();
         Ok(())
     }
@@ -101,11 +114,7 @@ impl UdpSink {
             // but that is better than silently dropping data.
             if row_len > MAX_DATAGRAM_PAYLOAD {
                 self.flush_dgram().await?;
-                match self.socket.send_to(&self.row_buf, &self.target).await {
-                    Ok(_) => {}
-                    Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => {}
-                    Err(e) => return Err(e),
-                }
+                self.send_packet(&self.row_buf).await?;
                 continue;
             }
 
@@ -134,7 +143,7 @@ impl Sink for UdpSink {
         Box::pin(async move {
             match self.do_send_batch(batch).await {
                 Ok(()) => SendResult::Ok,
-                Err(e) => SendResult::IoError(e),
+                Err(e) => SendResult::from_io_error(e),
             }
         })
     }


### PR DESCRIPTION
## Summary
- improve Arrow IPC sink retry handling by parsing `Retry-After` as either delta-seconds or HTTP-date and reusing it for 429 and 5xx responses
- normalize `FileSink` and `UdpSink` error classification to `SendResult::from_io_error` so permanent serialization/input errors are rejected instead of retried forever
- switch UDP sink to a connected socket send path with explicit short-write handling while preserving best-effort `ConnectionRefused` behavior
- add Arrow IPC retry-after unit tests for delta-seconds, HTTP-date, and invalid header fallback

## Verification
- `cargo test -p logfwd-output udp_sink::tests:: -- --nocapture`
- `cargo test -p logfwd-output file_sink::tests:: -- --nocapture`
- `cargo test -p logfwd-output arrow_ipc_sink::tests::retry_after_parses_delta_seconds -- --nocapture`
- `cargo test -p logfwd-output arrow_ipc_sink::tests::retry_after_parses_http_date -- --nocapture`
- `cargo test -p logfwd-output arrow_ipc_sink::tests::retry_after_defaults_on_invalid_header -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden retry logic, UDP send semantics, and DNS resolution in network/file sinks
> - [arrow_ipc_sink.rs](https://github.com/strawgate/memagent/pull/1803/files#diff-2a04098124b0d9ce8f3fdf8c46bb58320a9e1994c82a8cee9795d01015659d77): HTTP 429 and 5xx responses now parse the `Retry-After` header (delta-seconds or HTTP-date) to compute retry delay; 429 response bodies are consumed to allow connection reuse.
> - [udp_sink.rs](https://github.com/strawgate/memagent/pull/1803/files#diff-9e3b3ad35ddc18d4aa752faef209856a84b98d4b63cdfe8f7a6f5fe7da528c80): UDP sends now resolve the target hostname per-send via async DNS lookup, restricted to IPv4; partial sends are treated as errors and `ECONNREFUSED` is silently ignored.
> - [file_sink.rs](https://github.com/strawgate/memagent/pull/1803/files#diff-2dd2ae9a24ba18b09457e817228d3bb69e1c715182a0e78dc3bb6488bac55c1a): IO errors in `FileSink` now use `SendResult::from_io_error` for consistent error mapping.
> - Behavioral Change: UDP target resolution now fails with `AddrNotAvailable` if no IPv4 address is found; previously resolution may have succeeded with an IPv6 address.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f916b04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->