### PR TITLE
output: tighten Loki/ES delivery semantics and sink accounting

### DIFF
--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -226,6 +226,10 @@ impl ElasticsearchSink {
                 .and_then(|obj| obj.values().next())
                 .and_then(serde_json::Value::as_object);
             if let Some(action_obj) = action {
+                let status = action_obj
+                    .get("status")
+                    .and_then(serde_json::Value::as_u64)
+                    .map(|s| s as u16);
                 if let Some(error) = action_obj.get("error") {
                     let error_type = error
                         .get("type")
@@ -235,11 +239,33 @@ impl ElasticsearchSink {
                         .get("reason")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("no reason provided");
+                    if let Some(status) = status {
+                        if status == 429 || status >= 500 {
+                            return Err(io::Error::other(format!(
+                                "ES bulk transient item failure (status {status}): {error_type}: {reason}"
+                            )));
+                        }
+                    }
                     // InvalidData: document-level rejection — permanent, do not retry.
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidData,
                         format!("ES bulk error: {error_type}: {reason}"),
                     ));
+                }
+                if let Some(status) = status {
+                    if status >= 400 {
+                        if status == 429 || status >= 500 {
+                            return Err(io::Error::other(format!(
+                                "ES bulk transient item failure (status {status})"
+                            )));
+                        }
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "ES bulk item failed with HTTP status {status} (no error details)"
+                            ),
+                        ));
+                    }
                 }
             }
         }
@@ -1331,6 +1357,59 @@ mod tests {
         let err = ElasticsearchSink::parse_bulk_response(response)
             .expect_err("should error on bulk failure");
         assert!(err.to_string().contains("mapper_parsing_exception"));
+    }
+
+    #[test]
+    fn parse_bulk_response_transient_item_error_is_io_error() {
+        let response = br#"{
+            "took":3,
+            "errors":true,
+            "items":[
+                {"index":{"error":{"type":"es_rejected_execution_exception","reason":"queue is full"},"status":429}}
+            ]
+        }"#;
+        let err = ElasticsearchSink::parse_bulk_response(response)
+            .expect_err("transient bulk item errors must return Err");
+        assert_eq!(
+            err.kind(),
+            io::ErrorKind::Other,
+            "429 should be surfaced as transient to allow retry"
+        );
+        assert!(err.to_string().contains("status 429"));
+    }
+
+    #[test]
+    fn parse_bulk_response_status_only_transient_is_io_error() {
+        let response = br#"{
+            "took":3,
+            "errors":true,
+            "items":[
+                {"index":{"status":503}}
+            ]
+        }"#;
+        let err = ElasticsearchSink::parse_bulk_response(response)
+            .expect_err("status-only transient failure should return Err");
+        assert_eq!(
+            err.kind(),
+            io::ErrorKind::Other,
+            "5xx status-only failures should remain retriable"
+        );
+        assert!(err.to_string().contains("status 503"));
+    }
+
+    #[test]
+    fn parse_bulk_response_status_only_client_error_is_invalid_data() {
+        let response = br#"{
+            "took":3,
+            "errors":true,
+            "items":[
+                {"index":{"status":400}}
+            ]
+        }"#;
+        let err = ElasticsearchSink::parse_bulk_response(response)
+            .expect_err("status-only 4xx should be permanent");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("HTTP status 400"));
     }
 
     /// Regression test for issue #1675.

--- a/crates/logfwd-output/src/http_classify.rs
+++ b/crates/logfwd-output/src/http_classify.rs
@@ -22,8 +22,9 @@ pub const DEFAULT_RETRY_AFTER_SECS: u64 = 5;
 /// Returns `None` if the value is absent, unparsable, or in the past.
 pub fn parse_retry_after(header: Option<&reqwest::header::HeaderValue>) -> Option<Duration> {
     let value = header.and_then(|v| v.to_str().ok())?;
+    let value = value.trim();
     // delta-seconds first (most common for APIs)
-    if let Ok(secs) = value.trim().parse::<u64>() {
+    if let Ok(secs) = value.parse::<u64>() {
         return Some(Duration::from_secs(secs));
     }
     // HTTP-date fallback
@@ -193,5 +194,16 @@ mod tests {
     fn parse_retry_after_invalid() {
         let hv = reqwest::header::HeaderValue::from_static("not-a-number");
         assert_eq!(parse_retry_after(Some(&hv)), None);
+    }
+
+    #[test]
+    fn parse_retry_after_http_date_with_whitespace() {
+        let future = std::time::SystemTime::now() + Duration::from_secs(120);
+        let value = format!(" {}\t", httpdate::fmt_http_date(future));
+        let hv = reqwest::header::HeaderValue::from_str(&value).expect("valid header value");
+        assert!(
+            parse_retry_after(Some(&hv)).is_some(),
+            "whitespace-padded HTTP-date Retry-After should parse"
+        );
     }
 }

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -57,7 +57,10 @@ use super::{BatchMetadata, build_col_infos, coalesce_as_str, write_row_json};
 type LokiEntry = (u64, String);
 
 /// Collect entries per stream label set.
-type StreamMap = HashMap<String, Vec<LokiEntry>>;
+type StreamKey = Vec<(String, String)>;
+
+/// Collect entries per stream label set.
+type StreamMap = HashMap<StreamKey, Vec<LokiEntry>>;
 
 fn sanitize_loki_label_name(name: &str) -> String {
     let mut out = String::with_capacity(name.len().max(1));
@@ -340,16 +343,9 @@ impl LokiSink {
             }
             labels.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
-            // Build stream key as a JSON array of [key, value] pairs.
-            // This is unambiguous even when label values contain commas or `=`,
-            // which the previous `k=v,...` encoding could not represent losslessly.
-            let stream_key = {
-                let pairs: Vec<String> = labels
-                    .iter()
-                    .map(|(k, v)| format!("[\"{}\",\"{}\"]", escape_json(k), escape_json(v)))
-                    .collect();
-                format!("[{}]", pairs.join(","))
-            };
+            // Stream key is the sorted label vector itself.
+            // This avoids per-row string formatting and per-stream JSON parsing.
+            let stream_key = labels;
 
             // --- Log line ---
             let mut log_line = Vec::new();
@@ -375,20 +371,17 @@ impl LokiSink {
         let mut streams_json = Vec::new();
         let mut retained: u64 = 0;
 
-        for (stream_key, entries) in stream_map.iter_mut() {
+        let mut ordered_keys: Vec<StreamKey> = stream_map.keys().cloned().collect();
+        ordered_keys.sort_unstable();
+
+        for labels in ordered_keys {
+            let Some(entries) = stream_map.get_mut(&labels) else {
+                continue;
+            };
             retained += sort_and_dedup_timestamps(entries) as u64;
 
-            // Parse stream_key (JSON array of [key, value] pairs) back into label map.
-            // The stream key already includes sanitized static and dynamic labels.
-            let mut labels_map: HashMap<String, String> = HashMap::new();
-            if let Ok(pairs) = serde_json::from_str::<Vec<[String; 2]>>(stream_key.as_str()) {
-                for [k, v] in pairs {
-                    labels_map.entry(k).or_insert(v);
-                }
-            }
-
-            // Build stream JSON.
-            let labels_str = labels_map
+            // Build stream JSON from the deterministic sorted labels vector.
+            let labels_str = labels
                 .iter()
                 .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
                 .collect::<Vec<_>>()
@@ -1040,10 +1033,9 @@ mod tests {
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
         let key = stream_map.keys().next().unwrap();
-        let parsed: Vec<[String; 2]> = serde_json::from_str(key).unwrap();
         assert_eq!(
-            parsed,
-            vec![["service_name".to_string(), "checkout".to_string()]]
+            key.as_slice(),
+            &[("service_name".to_string(), "checkout".to_string())]
         );
     }
 
@@ -1325,8 +1317,8 @@ mod tests {
         assert_eq!(stream_map.len(), 1);
         let key = stream_map.keys().next().unwrap();
         assert!(
-            !key.contains("namespace"),
-            "empty label value must be excluded from stream key; key: {key}"
+            !key.iter().any(|(k, _)| k == "namespace"),
+            "empty label value must be excluded from stream key; key: {key:?}"
         );
     }
 
@@ -1596,6 +1588,35 @@ mod tests {
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].0, metadata.observed_time_ns);
         assert_eq!(entries[1].0, metadata.observed_time_ns);
+    }
+
+    #[test]
+    fn serialize_loki_json_is_deterministic_across_stream_insertion_order() {
+        let mut map_a: StreamMap = HashMap::new();
+        let mut map_b: StreamMap = HashMap::new();
+
+        let stream_a = vec![
+            ("app".to_string(), "api".to_string()),
+            ("env".to_string(), "prod".to_string()),
+        ];
+        let stream_b = vec![
+            ("app".to_string(), "worker".to_string()),
+            ("env".to_string(), "prod".to_string()),
+        ];
+
+        map_a.insert(stream_a.clone(), vec![(2, "a".to_string())]);
+        map_a.insert(stream_b.clone(), vec![(1, "b".to_string())]);
+        map_b.insert(stream_b, vec![(1, "b".to_string())]);
+        map_b.insert(stream_a, vec![(2, "a".to_string())]);
+
+        let (payload_a, retained_a) = LokiSink::serialize_loki_json(&mut map_a);
+        let (payload_b, retained_b) = LokiSink::serialize_loki_json(&mut map_b);
+        assert_eq!(retained_a, 2);
+        assert_eq!(retained_b, 2);
+        assert_eq!(
+            payload_a, payload_b,
+            "Loki payload serialization must be deterministic"
+        );
     }
 }
 

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -845,8 +845,8 @@ fn resolve_batch_columns<'a>(
     let mut trace_id_col: Option<(usize, OtlpStrCol<'_>)> = None;
     let mut span_id_col: Option<(usize, OtlpStrCol<'_>)> = None;
     let mut flags_col: Option<(usize, &PrimitiveArray<Int64Type>)> = None;
-    // Indices of columns to exclude from attributes.
-    let mut excluded: Vec<usize> = Vec::with_capacity(4);
+    // Column indices to exclude from attributes.
+    let mut excluded = vec![false; schema.fields().len()];
 
     for (idx, field) in schema.fields().iter().enumerate() {
         let col_name = field.name().as_str();
@@ -861,13 +861,13 @@ fn resolve_batch_columns<'a>(
                 if timestamp_col.is_none() && timestamp_num_col.is_none() {
                     if let Some(arr) = resolve_otlp_str_col(batch.column(idx).as_ref()) {
                         timestamp_col = Some((idx, arr));
-                        excluded.push(idx);
+                        excluded[idx] = true;
                     } else if matches!(
                         field.data_type(),
                         DataType::Int64 | DataType::UInt64 | DataType::Timestamp(_, _)
                     ) {
                         timestamp_num_col = Some((idx, batch.column(idx).as_ref()));
-                        excluded.push(idx);
+                        excluded[idx] = true;
                     }
                 }
             }
@@ -881,7 +881,7 @@ fn resolve_batch_columns<'a>(
                     && let Some(arr) = resolve_otlp_str_col(batch.column(idx).as_ref())
                 {
                     level_col = Some((idx, arr));
-                    excluded.push(idx);
+                    excluded[idx] = true;
                 }
             }
             field_names::TRACE_ID => {
@@ -889,7 +889,7 @@ fn resolve_batch_columns<'a>(
                     && let Some(arr) = resolve_otlp_str_col(batch.column(idx).as_ref())
                 {
                     trace_id_col = Some((idx, arr));
-                    excluded.push(idx);
+                    excluded[idx] = true;
                 }
             }
             field_names::SPAN_ID => {
@@ -897,7 +897,7 @@ fn resolve_batch_columns<'a>(
                     && let Some(arr) = resolve_otlp_str_col(batch.column(idx).as_ref())
                 {
                     span_id_col = Some((idx, arr));
-                    excluded.push(idx);
+                    excluded[idx] = true;
                 }
             }
             name if field_names::matches_any(
@@ -908,7 +908,7 @@ fn resolve_batch_columns<'a>(
             {
                 if flags_col.is_none() && matches!(field.data_type(), DataType::Int64) {
                     flags_col = Some((idx, batch.column(idx).as_primitive::<Int64Type>()));
-                    excluded.push(idx);
+                    excluded[idx] = true;
                 }
             }
             name if name == message_field
@@ -926,13 +926,13 @@ fn resolve_batch_columns<'a>(
                 }
             }
             field_names::RAW => {
-                excluded.push(idx);
+                excluded[idx] = true;
             }
             _ => {}
         }
     }
     if let Some((idx, _)) = body_col {
-        excluded.push(idx);
+        excluded[idx] = true;
     }
 
     // --- Second pass: new well-known columns and attribute/resource classification ---
@@ -943,7 +943,7 @@ fn resolve_batch_columns<'a>(
     let mut attribute_cols: Vec<(String, AttrArray<'_>)> = Vec::new();
     let mut resource_cols: Vec<(String, AttrArray<'_>)> = Vec::new();
     for (idx, field) in schema.fields().iter().enumerate() {
-        if excluded.contains(&idx) {
+        if excluded[idx] {
             continue;
         }
         let field_name = field.name().as_str();

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use arrow::array::{Array, AsArray};
 use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
+use memchr::memchr_iter;
 use tokio::io::AsyncWriteExt;
-
 
 use logfwd_types::diagnostics::ComponentStats;
 use logfwd_types::field_names;
@@ -447,7 +447,7 @@ impl Sink for StdoutSink {
             }
 
             let bytes_written = self.output_buf.len() as u64;
-            let rendered_lines = self.output_buf.iter().filter(|&&b| b == b'\n').count() as u64;
+            let rendered_lines = memchr_iter(b'\n', &self.output_buf).count() as u64;
 
             // Write the pre-rendered buffer to async stdout in one shot.
             let mut stdout = tokio::io::stdout();

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -9,7 +9,6 @@ use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use tokio::io::AsyncWriteExt;
 
-use memchr::memchr_iter;
 
 use logfwd_types::diagnostics::ComponentStats;
 use logfwd_types::field_names;
@@ -448,6 +447,7 @@ impl Sink for StdoutSink {
             }
 
             let bytes_written = self.output_buf.len() as u64;
+            let rendered_lines = self.output_buf.iter().filter(|&&b| b == b'\n').count() as u64;
 
             // Write the pre-rendered buffer to async stdout in one shot.
             let mut stdout = tokio::io::stdout();
@@ -458,8 +458,7 @@ impl Sink for StdoutSink {
                 return SendResult::IoError(e);
             }
 
-            let lines_written = memchr_iter(b'\n', &self.output_buf).count() as u64;
-            self.stats.inc_lines(lines_written);
+            self.stats.inc_lines(rendered_lines);
             self.stats.inc_bytes(bytes_written);
             SendResult::Ok
         })


### PR DESCRIPTION
## Summary
- Elasticsearch bulk-response parsing now classifies item-level transient failures (`429`/`5xx`) as retryable `io::ErrorKind::Other`, including status-only item failures
- `parse_retry_after` now trims whitespace so HTTP-date `Retry-After` values with surrounding whitespace parse correctly
- Loki stream key handling was moved to typed sorted label vectors, and payload serialization is now deterministic across stream insertion order
- `StdoutSink` line accounting now increments by rendered line count (newline count), not raw input row count
- OTLP sink column exclusion bookkeeping in `resolve_batch_columns` is normalized to fixed-size boolean indexing (`field_names::RAW` included), avoiding dynamic push-on-index logic drift

## Verification
- `cargo test -p logfwd-output loki::tests::serialize_loki_json_is_deterministic_across_stream_insertion_order -- --nocapture`
- `cargo test -p logfwd-output stdout::tests::send_batch_counts_only_rendered_text_lines -- --nocapture`
- `cargo test -p logfwd-output http_classify::tests::parse_retry_after_http_date_with_whitespace -- --nocapture`
- `cargo test -p logfwd-output elasticsearch::tests::parse_bulk_response_transient_item_error_is_io_error -- --nocapture`
- `cargo test -p logfwd-output elasticsearch::tests::parse_bulk_response_status_only_transient_is_io_error -- --nocapture`
- `cargo test -p logfwd-output elasticsearch::tests::parse_bulk_response_status_only_client_error_is_invalid_data -- --nocapture`
- `cargo test -p logfwd-output otlp_sink::tests:: -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten Loki and Elasticsearch delivery semantics and sink accounting
> - Elasticsearch bulk response parsing now treats item-level 429 and >=500 errors as transient (`io::ErrorKind::Other`) so callers can retry; other 4xx errors remain `InvalidData` with an explicit HTTP status message.
> - Loki stream map keys change from JSON strings to structured `Vec<(String, String)>` vectors, and `serialize_loki_json` now emits streams in deterministic order regardless of `HashMap` insertion order.
> - `parse_retry_after` in [http_classify.rs](https://github.com/strawgate/memagent/pull/1804/files#diff-43e150ae9c0e7c4e9750fe9aa153a2a3b46730a86ff7c879a05bf3447ce7ff1c) trims whitespace before both numeric and HTTP-date parsing, fixing silent failures on padded header values.
> - Stdout sink moves rendered-line counting to before the async write so stats reflect serialized output accurately.
> - Behavioral Change: Elasticsearch callers that previously saw permanent errors on 429/5xx bulk items will now receive transient errors and may retry those records.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 571ef9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->