### PR TITLE
runtime: harden checkpoint retry policy and worker-pool edge cases

### DIFF
--- a/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
+++ b/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
@@ -9,6 +9,23 @@ const fn should_retry_flush(attempt: u32, max_attempts: u32) -> bool {
     attempt < max_attempts.saturating_sub(1)
 }
 
+#[must_use]
+const fn is_retryable_flush_error(kind: std::io::ErrorKind) -> bool {
+    match kind {
+        std::io::ErrorKind::Interrupted
+        | std::io::ErrorKind::WouldBlock
+        | std::io::ErrorKind::TimedOut
+        | std::io::ErrorKind::WriteZero
+        | std::io::ErrorKind::UnexpectedEof
+        | std::io::ErrorKind::ConnectionReset
+        | std::io::ErrorKind::ConnectionAborted
+        | std::io::ErrorKind::ConnectionRefused
+        | std::io::ErrorKind::NotConnected
+        | std::io::ErrorKind::BrokenPipe => true,
+        _ => false,
+    }
+}
+
 /// Flush checkpoint store with bounded retry (3 attempts, 100ms between).
 ///
 /// The final shutdown flush is the last chance to persist checkpoint progress.
@@ -70,7 +87,8 @@ pub(super) async fn flush_checkpoint_with_retry(store: &mut dyn CheckpointStore)
                     },
                 )
                 .await;
-                if should_retry_flush(attempt, MAX_ATTEMPTS) {
+                let retryable = is_retryable_flush_error(e.kind());
+                if retryable && should_retry_flush(attempt, MAX_ATTEMPTS) {
                     tracing::warn!(
                         attempt,
                         error = %e,
@@ -80,10 +98,12 @@ pub(super) async fn flush_checkpoint_with_retry(store: &mut dyn CheckpointStore)
                 } else {
                     tracing::error!(
                         attempts = MAX_ATTEMPTS,
+                        retryable,
                         error = %e,
                         "pipeline: checkpoint flush failed after all retries — \
                          checkpoint progress from this run may be lost"
                     );
+                    return;
                 }
             }
         }
@@ -99,7 +119,7 @@ mod tests {
     use logfwd_io::checkpoint::{CheckpointStore, SourceCheckpoint};
     use proptest::prelude::*;
 
-    use super::{flush_checkpoint_with_retry, should_retry_flush};
+    use super::{flush_checkpoint_with_retry, is_retryable_flush_error, should_retry_flush};
 
     trait RetryFaultHook {
         fn fail_flush_attempt(&self, attempt: u32) -> bool;
@@ -190,7 +210,7 @@ mod tests {
 
         fn flush(&mut self) -> io::Result<()> {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            Err(io::Error::other("flush failed"))
+            Err(io::Error::new(io::ErrorKind::TimedOut, "flush failed"))
         }
 
         fn load(&self, _source_id: u64) -> Option<SourceCheckpoint> {
@@ -214,6 +234,15 @@ mod tests {
         assert!(!should_retry_flush(0, 0));
     }
 
+    #[test]
+    fn retryable_error_kind_classification_matches_policy() {
+        assert!(is_retryable_flush_error(io::ErrorKind::Interrupted));
+        assert!(is_retryable_flush_error(io::ErrorKind::TimedOut));
+        assert!(is_retryable_flush_error(io::ErrorKind::WriteZero));
+        assert!(!is_retryable_flush_error(io::ErrorKind::InvalidInput));
+        assert!(!is_retryable_flush_error(io::ErrorKind::PermissionDenied));
+    }
+
     proptest! {
         #[test]
         fn retry_decision_equivalent_to_next_attempt_check(
@@ -223,12 +252,30 @@ mod tests {
             let expected = max_attempts > 0 && attempt.saturating_add(1) < max_attempts;
             prop_assert_eq!(should_retry_flush(attempt, max_attempts), expected);
         }
+
+        #[test]
+        fn retryable_error_kind_only_for_transient_kinds(kind in any::<io::ErrorKind>()) {
+            let expected = matches!(
+                kind,
+                io::ErrorKind::Interrupted
+                    | io::ErrorKind::WouldBlock
+                    | io::ErrorKind::TimedOut
+                    | io::ErrorKind::WriteZero
+                    | io::ErrorKind::UnexpectedEof
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::ConnectionAborted
+                    | io::ErrorKind::ConnectionRefused
+                    | io::ErrorKind::NotConnected
+                    | io::ErrorKind::BrokenPipe
+            );
+            prop_assert_eq!(is_retryable_flush_error(kind), expected);
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn flush_stops_after_first_success() {
         let mut store = SequenceCheckpointStore::new(vec![
-            Err(io::Error::other("first failure")),
+            Err(io::Error::new(io::ErrorKind::TimedOut, "first failure")),
             Ok(()),
             Err(io::Error::other("must not be observed")),
         ]);
@@ -285,11 +332,28 @@ mod tests {
         fail::remove("runtime::pipeline::checkpoint_flush::before_flush");
         scenario.teardown();
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn flush_does_not_retry_non_retryable_failures() {
+        let mut store = SequenceCheckpointStore::new(vec![
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "permission denied",
+            )),
+            Ok(()),
+        ]);
+
+        flush_checkpoint_with_retry(&mut store).await;
+        assert_eq!(
+            store.calls, 1,
+            "flush should stop immediately for non-retryable failures"
+        );
+    }
 }
 
 #[cfg(kani)]
 mod verification {
-    use super::should_retry_flush;
+    use super::{is_retryable_flush_error, should_retry_flush};
 
     #[kani::proof]
     fn verify_zero_or_one_attempt_never_retries() {
@@ -314,5 +378,24 @@ mod verification {
         assert_eq!(should_retry_flush(attempt, max_attempts), expected);
         kani::cover!(should_retry_flush(0, 2), "retry path reachable");
         kani::cover!(!should_retry_flush(1, 2), "terminal-attempt path reachable");
+    }
+
+    #[kani::proof]
+    fn verify_retryable_flush_error_classification() {
+        let kind = kani::any::<std::io::ErrorKind>();
+        let expected = matches!(
+            kind,
+            std::io::ErrorKind::Interrupted
+                | std::io::ErrorKind::WouldBlock
+                | std::io::ErrorKind::TimedOut
+                | std::io::ErrorKind::WriteZero
+                | std::io::ErrorKind::UnexpectedEof
+                | std::io::ErrorKind::ConnectionReset
+                | std::io::ErrorKind::ConnectionAborted
+                | std::io::ErrorKind::ConnectionRefused
+                | std::io::ErrorKind::NotConnected
+                | std::io::ErrorKind::BrokenPipe
+        );
+        assert_eq!(is_retryable_flush_error(kind), expected);
     }
 }

--- a/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
+++ b/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
@@ -11,19 +11,19 @@ const fn should_retry_flush(attempt: u32, max_attempts: u32) -> bool {
 
 #[must_use]
 const fn is_retryable_flush_error(kind: std::io::ErrorKind) -> bool {
-    match kind {
+    matches!(
+        kind,
         std::io::ErrorKind::Interrupted
-        | std::io::ErrorKind::WouldBlock
-        | std::io::ErrorKind::TimedOut
-        | std::io::ErrorKind::WriteZero
-        | std::io::ErrorKind::UnexpectedEof
-        | std::io::ErrorKind::ConnectionReset
-        | std::io::ErrorKind::ConnectionAborted
-        | std::io::ErrorKind::ConnectionRefused
-        | std::io::ErrorKind::NotConnected
-        | std::io::ErrorKind::BrokenPipe => true,
-        _ => false,
-    }
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::TimedOut
+            | std::io::ErrorKind::WriteZero
+            | std::io::ErrorKind::UnexpectedEof
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::NotConnected
+            | std::io::ErrorKind::BrokenPipe
+    )
 }
 
 /// Flush checkpoint store with bounded retry (3 attempts, 100ms between).

--- a/crates/logfwd-runtime/src/pipeline/health.rs
+++ b/crates/logfwd-runtime/src/pipeline/health.rs
@@ -169,6 +169,17 @@ mod tests {
         }
 
         #[test]
+        fn stopping_state_never_recovers_to_healthy_or_starting(
+            events in proptest::collection::vec(arb_event(), 0..16)
+        ) {
+            let out = apply_events(ComponentHealth::Stopping, &events);
+            prop_assert!(matches!(
+                out,
+                ComponentHealth::Stopping | ComponentHealth::Stopped | ComponentHealth::Failed
+            ));
+        }
+
+        #[test]
         fn shutdown_requested_never_recovers_to_ready_without_full_restart(
             events in proptest::collection::vec(arb_event(), 0..16)
         ) {

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -120,6 +120,16 @@ struct InputState {
     stats: Arc<ComponentStats>,
 }
 
+const DEFAULT_PASSTHROUGH_SQL: &str = "SELECT * FROM logs";
+
+fn assert_stateless_processor(processor: &dyn Processor) {
+    assert!(
+        !processor.is_stateful(),
+        "stateful processors are not yet supported: checkpointing path is incomplete \
+         (see #1404). Register only stateless processors."
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Pipeline
 // ---------------------------------------------------------------------------
@@ -180,8 +190,8 @@ impl Pipeline {
         });
         // Keep input_transforms in sync: one transform per input.
         while self.input_transforms.len() < self.inputs.len() {
-            let transform =
-                SqlTransform::new("SELECT * FROM logs").expect("default passthrough SQL");
+            let transform = SqlTransform::new(DEFAULT_PASSTHROUGH_SQL)
+                .expect("default passthrough SQL must compile");
             let scanner = Scanner::new(transform.scan_config());
             self.input_transforms.push(InputTransform {
                 scanner,
@@ -206,11 +216,7 @@ impl Pipeline {
     /// require deferred-ACK checkpointing support that is not yet implemented
     /// (tracked in #1404). Register only stateless processors until then.
     pub fn with_processor(mut self, processor: Box<dyn Processor>) -> Self {
-        assert!(
-            !processor.is_stateful(),
-            "stateful processors are not yet supported: checkpointing path is incomplete \
-             (see #1404). Register only stateless processors."
-        );
+        assert_stateless_processor(processor.as_ref());
         self.processors.push(processor);
         self
     }
@@ -225,11 +231,7 @@ impl Pipeline {
     /// See [`with_processor`](Self::with_processor) for details.
     pub fn with_processors(mut self, processors: Vec<Box<dyn Processor>>) -> Self {
         for p in &processors {
-            assert!(
-                !p.is_stateful(),
-                "stateful processors are not yet supported: checkpointing path is incomplete \
-                 (see #1404). Register only stateless processors."
-            );
+            assert_stateless_processor(p.as_ref());
         }
         self.processors.extend(processors);
         self
@@ -349,11 +351,16 @@ impl Pipeline {
     }
 
     /// Run the pipeline until `shutdown` is cancelled. Blocks the calling thread.
-    /// Run the pipeline until `shutdown` is cancelled. Blocks the calling thread.
     ///
     /// Delegates to `run_async` on a tokio runtime. The sync interface exists
     /// for test convenience; production uses `run_async` directly.
     pub fn run(&mut self, shutdown: &CancellationToken) -> io::Result<()> {
+        if self.batch_timeout.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "batch_timeout must be greater than zero",
+            ));
+        }
         let mut builder = tokio::runtime::Builder::new_multi_thread();
         builder.enable_all();
         if let Ok(threads_raw) = std::env::var("TOKIO_WORKER_THREADS")
@@ -382,6 +389,12 @@ impl Pipeline {
     ///   when ureq is replaced with an async HTTP client.
     /// - self.inputs.drain(..) makes this method non-reentrant.
     pub async fn run_async(&mut self, shutdown: &CancellationToken) -> io::Result<()> {
+        if self.batch_timeout.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "batch_timeout must be greater than zero",
+            ));
+        }
         assert_eq!(
             self.inputs.len(),
             self.input_transforms.len(),
@@ -451,6 +464,7 @@ impl Pipeline {
 
         let mut heartbeat_interval = tokio::time::interval(self.batch_timeout);
         heartbeat_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let has_stateful_processors = self.processors.iter().any(|p| p.is_stateful());
 
         let mut should_drain_input_channel = true;
         loop {
@@ -487,9 +501,7 @@ impl Pipeline {
                     // Heartbeat for stateful processors: send an empty batch through
                     // the chain so stateful processors can check their internal timers
                     // and emit timed-out data.
-                    if !self.processors.is_empty()
-                        && self.processors.iter().any(|p| p.is_stateful())
-                    {
+                    if has_stateful_processors {
                         let empty = RecordBatch::new_empty(
                             Arc::new(arrow::datatypes::Schema::empty()),
                         );
@@ -544,7 +556,7 @@ impl Pipeline {
 
         // Cascading flush: drain all buffered state from stateful processors.
         // Each processor's flushed output is fed through downstream processors.
-        if !self.processors.is_empty() {
+        if has_stateful_processors {
             let meta = BatchMetadata {
                 resource_attrs: Arc::clone(&self.resource_attrs),
                 observed_time_ns: now_nanos(),
@@ -1189,6 +1201,42 @@ output:
     }
 
     #[test]
+    #[should_panic(expected = "stateful processors are not yet supported")]
+    fn test_with_processor_rejects_stateful_processors() {
+        #[derive(Debug)]
+        struct StatefulProcessor;
+
+        impl Processor for StatefulProcessor {
+            fn process(
+                &mut self,
+                batch: RecordBatch,
+                _meta: &BatchMetadata,
+            ) -> Result<smallvec::SmallVec<[RecordBatch; 1]>, crate::processor::ProcessorError>
+            {
+                Ok(smallvec::smallvec![batch])
+            }
+
+            fn flush(&mut self) -> smallvec::SmallVec<[RecordBatch; 1]> {
+                smallvec::SmallVec::new()
+            }
+
+            fn name(&self) -> &'static str {
+                "stateful"
+            }
+
+            fn is_stateful(&self) -> bool {
+                true
+            }
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("stateful.log");
+        std::fs::write(&log_path, b"{\"ok\":true}\n").unwrap();
+        let pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        let _ = pipeline.with_processor(Box::new(StatefulProcessor));
+    }
+
+    #[test]
     fn test_pipeline_run_one_batch() {
         use std::sync::atomic::Ordering;
 
@@ -1444,6 +1492,27 @@ output:
         assert!(
             lines_in >= 100,
             "expected at least 100 lines through transform, got {lines_in}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_async_zero_batch_timeout_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("zero_timeout.log");
+        std::fs::write(&log_path, b"{\"msg\":\"x\"}\n").unwrap();
+
+        let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        pipeline.set_batch_timeout(Duration::ZERO);
+
+        let shutdown = CancellationToken::new();
+        let err = pipeline
+            .run_async(&shutdown)
+            .await
+            .expect_err("zero batch_timeout must be rejected");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains("batch_timeout"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/logfwd-runtime/src/worker_pool/dispatch.rs
+++ b/crates/logfwd-runtime/src/worker_pool/dispatch.rs
@@ -62,6 +62,35 @@ pub(crate) fn dispatch_step(states: &[ChannelState], max_workers: usize) -> Disp
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{ChannelState, DispatchOutcome, dispatch_step};
+
+    #[test]
+    fn dispatch_step_prefers_first_available_worker() {
+        let states = [
+            ChannelState::Full,
+            ChannelState::HasSpace,
+            ChannelState::HasSpace,
+        ];
+        assert_eq!(dispatch_step(&states, 3), DispatchOutcome::SentToIndex(1));
+    }
+
+    #[test]
+    fn dispatch_step_ignores_closed_workers_when_counting_capacity() {
+        let states = [ChannelState::Closed, ChannelState::Full];
+        // Active workers = 1 (< max), so we should spawn instead of waiting.
+        assert_eq!(dispatch_step(&states, 2), DispatchOutcome::SpawnNew);
+    }
+
+    #[test]
+    fn dispatch_step_waits_when_every_active_worker_is_full_at_capacity() {
+        let states = [ChannelState::Full, ChannelState::Closed, ChannelState::Full];
+        // Closed workers do not count toward active capacity, so active=2 == max.
+        assert_eq!(dispatch_step(&states, 2), DispatchOutcome::WaitOnFront);
+    }
+}
+
 #[cfg(kani)]
 mod kani_proofs {
     use super::*;

--- a/crates/logfwd-runtime/src/worker_pool/dispatch.rs
+++ b/crates/logfwd-runtime/src/worker_pool/dispatch.rs
@@ -85,8 +85,10 @@ mod tests {
 
     #[test]
     fn dispatch_step_waits_when_every_active_worker_is_full_at_capacity() {
-        let states = [ChannelState::Full, ChannelState::Closed, ChannelState::Full];
-        // Closed workers do not count toward active capacity, so active=2 == max.
+        // Both workers are Full and active == max_workers == 2, so backpressure
+        // must kick in. states.len() <= max_workers satisfies the Kani-proven
+        // precondition.
+        let states = [ChannelState::Full, ChannelState::Full];
         assert_eq!(dispatch_step(&states, 2), DispatchOutcome::WaitOnFront);
     }
 }

--- a/crates/logfwd-runtime/src/worker_pool/pool.rs
+++ b/crates/logfwd-runtime/src/worker_pool/pool.rs
@@ -198,7 +198,7 @@ pub struct OutputWorkerPool {
     cancel: CancellationToken,
     /// Tracks all spawned worker tasks for clean drain.
     join_set: JoinSet<()>,
-    /// Per-worker channel capacity. Capacity 2 allows one item buffered
+    /// Per-worker channel capacity. Capacity 1 allows one item buffered
     /// while the worker is processing another — keeps throughput high while
     /// preserving work consolidation (worker "appears full" quickly).
     channel_capacity: usize,
@@ -243,6 +243,9 @@ impl OutputWorkerPool {
             ack_tx,
             cancel: CancellationToken::new(),
             join_set: JoinSet::new(),
+            // Capacity 1 means a worker can process one item while one extra
+            // item is queued, which keeps throughput high without overfilling
+            // a single worker queue.
             channel_capacity: 1,
             max_workers,
             idle_timeout,
@@ -272,29 +275,7 @@ impl OutputWorkerPool {
             // silently losing it. This keeps the at-least-once invariant intact
             // even for callers that mistakenly submit after drain.
             tracing::warn!("worker_pool: submit after drain, rejecting batch immediately");
-            let ticket_count = item.tickets.len();
-            if self
-                .ack_tx
-                .send(AckItem {
-                    tickets: item.tickets,
-                    outcome: DeliveryOutcome::PoolClosed,
-                    num_rows: item.num_rows,
-                    submitted_at: item.submitted_at,
-                    scan_ns: item.scan_ns,
-                    transform_ns: item.transform_ns,
-                    output_ns: 0,
-                    queue_wait_ns: 0,
-                    send_latency_ns: 0,
-                    batch_id: item.batch_id,
-                    output_name: self.factory.name().to_string(),
-                })
-                .is_err()
-            {
-                tracing::error!(
-                    ticket_count,
-                    "worker_pool: ack channel closed, batch lost permanently"
-                );
-            }
+            self.reject_work_item(item, DeliveryOutcome::PoolClosed);
             return;
         }
 
@@ -326,10 +307,30 @@ impl OutputWorkerPool {
         // --- Step 2: spawn a new worker if under limit ---
         if self.workers.len() < self.max_workers {
             if let Ok(handle) = self.spawn_worker() {
-                // New channel: guaranteed to have space.
-                let _ = handle.tx.try_send(msg);
-                self.workers.push_front(handle);
-                return;
+                match handle.tx.try_send(msg) {
+                    Ok(()) => {
+                        self.workers.push_front(handle);
+                        return;
+                    }
+                    Err(mpsc::error::TrySendError::Full(returned)) => {
+                        // A freshly created channel should never be full, but
+                        // if this invariant is violated preserve correctness by
+                        // falling back to the existing back-pressure path.
+                        tracing::warn!(
+                            "worker_pool: newly spawned worker channel reported full; falling back to wait path"
+                        );
+                        msg = returned;
+                    }
+                    Err(mpsc::error::TrySendError::Closed(returned)) => {
+                        tracing::warn!(
+                            "worker_pool: newly spawned worker channel closed before first send"
+                        );
+                        if let WorkerMsg::Work(item) = returned {
+                            self.reject_work_item(item, DeliveryOutcome::WorkerChannelClosed);
+                        }
+                        return;
+                    }
+                }
             }
             // Sink factory failed — fall through to back-pressure path.
         }
@@ -342,29 +343,7 @@ impl OutputWorkerPool {
             if let Err(mpsc::error::SendError(WorkerMsg::Work(item))) = tx.send(msg).await {
                 // Rare race: worker closed its channel between clone and send.
                 // Reject explicitly rather than silently dropping.
-                let ticket_count = item.tickets.len();
-                if self
-                    .ack_tx
-                    .send(AckItem {
-                        tickets: item.tickets,
-                        outcome: DeliveryOutcome::WorkerChannelClosed,
-                        num_rows: item.num_rows,
-                        submitted_at: item.submitted_at,
-                        scan_ns: item.scan_ns,
-                        transform_ns: item.transform_ns,
-                        output_ns: 0,
-                        queue_wait_ns: 0,
-                        send_latency_ns: 0,
-                        batch_id: item.batch_id,
-                        output_name: self.factory.name().to_string(),
-                    })
-                    .is_err()
-                {
-                    tracing::error!(
-                        ticket_count,
-                        "worker_pool: ack channel closed, batch lost permanently"
-                    );
-                }
+                self.reject_work_item(item, DeliveryOutcome::WorkerChannelClosed);
             }
             return;
         }
@@ -374,29 +353,33 @@ impl OutputWorkerPool {
         // after its first worker exits). Silently dropping would lose the ack.
         if let WorkerMsg::Work(item) = msg {
             tracing::error!("worker_pool: no workers available, rejecting batch");
-            let ticket_count = item.tickets.len();
-            if self
-                .ack_tx
-                .send(AckItem {
-                    tickets: item.tickets,
-                    outcome: DeliveryOutcome::NoWorkersAvailable,
-                    num_rows: item.num_rows,
-                    submitted_at: item.submitted_at,
-                    scan_ns: item.scan_ns,
-                    transform_ns: item.transform_ns,
-                    output_ns: 0,
-                    queue_wait_ns: 0,
-                    send_latency_ns: 0,
-                    batch_id: item.batch_id,
-                    output_name: self.factory.name().to_string(),
-                })
-                .is_err()
-            {
-                tracing::error!(
-                    ticket_count,
-                    "worker_pool: ack channel closed, batch lost permanently"
-                );
-            }
+            self.reject_work_item(item, DeliveryOutcome::NoWorkersAvailable);
+        }
+    }
+
+    fn reject_work_item(&self, item: WorkItem, outcome: DeliveryOutcome) {
+        let ticket_count = item.tickets.len();
+        if self
+            .ack_tx
+            .send(AckItem {
+                tickets: item.tickets,
+                outcome,
+                num_rows: item.num_rows,
+                submitted_at: item.submitted_at,
+                scan_ns: item.scan_ns,
+                transform_ns: item.transform_ns,
+                output_ns: 0,
+                queue_wait_ns: 0,
+                send_latency_ns: 0,
+                batch_id: item.batch_id,
+                output_name: self.factory.name().to_string(),
+            })
+            .is_err()
+        {
+            tracing::error!(
+                ticket_count,
+                "worker_pool: ack channel closed, batch lost permanently"
+            );
         }
     }
 
@@ -1508,6 +1491,25 @@ mod tests {
             capture.contains_event_field("error", "503"),
             "expected logged error to include HTTP 503 detail"
         );
+    }
+
+    #[tokio::test]
+    async fn reject_work_item_emits_expected_ack() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let factory = Arc::new(CountingSinkFactory {
+            calls,
+            fail: false,
+            fail_shutdown: false,
+        });
+        let mut pool = OutputWorkerPool::new(factory, 1, Duration::from_secs(60), test_metrics());
+
+        pool.reject_work_item(empty_work_item(), DeliveryOutcome::WorkerChannelClosed);
+
+        let ack = pool
+            .ack_rx
+            .try_recv()
+            .expect("expected ack from reject_work_item");
+        assert_eq!(ack.outcome, DeliveryOutcome::WorkerChannelClosed);
     }
 
     #[tokio::test]

--- a/crates/logfwd-runtime/src/worker_pool/pool.rs
+++ b/crates/logfwd-runtime/src/worker_pool/pool.rs
@@ -316,6 +316,8 @@ impl OutputWorkerPool {
                         // A freshly created channel should never be full, but
                         // if this invariant is violated preserve correctness by
                         // falling back to the existing back-pressure path.
+                        // Push the handle back so the spawned worker task is not leaked.
+                        self.workers.push_front(handle);
                         tracing::warn!(
                             "worker_pool: newly spawned worker channel reported full; falling back to wait path"
                         );

--- a/crates/logfwd-runtime/src/worker_pool/types.rs
+++ b/crates/logfwd-runtime/src/worker_pool/types.rs
@@ -65,17 +65,25 @@ impl DeliveryOutcome {
 }
 
 pub(super) fn bound_rejection_reason(mut reason: String) -> String {
-    if reason.len() <= MAX_REJECTION_REASON_BYTES {
-        return reason;
+    bound_reason_to_limit(&mut reason, MAX_REJECTION_REASON_BYTES);
+    reason
+}
+
+fn bound_reason_to_limit(reason: &mut String, max_bytes: usize) {
+    if reason.len() <= max_bytes {
+        return;
     }
-    let suffix = "...";
-    let mut boundary = MAX_REJECTION_REASON_BYTES.saturating_sub(suffix.len());
+    const SUFFIX: &str = "...";
+    if max_bytes <= SUFFIX.len() {
+        reason.truncate(max_bytes);
+        return;
+    }
+    let mut boundary = max_bytes - SUFFIX.len();
     while boundary > 0 && !reason.is_char_boundary(boundary) {
         boundary -= 1;
     }
     reason.truncate(boundary);
-    reason.push_str(suffix);
-    reason
+    reason.push_str(SUFFIX);
 }
 
 pub struct AckItem {
@@ -113,3 +121,40 @@ pub(super) enum WorkerMsg {
 }
 
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_REJECTION_REASON_BYTES, bound_reason_to_limit, bound_rejection_reason};
+
+    #[test]
+    fn bound_rejection_reason_keeps_short_reason_unchanged() {
+        let reason = "transient backend error".to_string();
+        assert_eq!(bound_rejection_reason(reason.clone()), reason);
+    }
+
+    #[test]
+    fn bound_rejection_reason_respects_global_limit_and_appends_suffix() {
+        let reason = "x".repeat(MAX_REJECTION_REASON_BYTES + 64);
+        let bounded = bound_rejection_reason(reason);
+        assert_eq!(bounded.len(), MAX_REJECTION_REASON_BYTES);
+        assert!(bounded.ends_with("..."));
+    }
+
+    #[test]
+    fn bound_reason_to_limit_preserves_utf8_boundaries() {
+        let mut reason = "é".repeat(8);
+        // 8 * 2 bytes = 16 bytes; bounding to 7 bytes should become 4 bytes
+        // ("éé") plus suffix.
+        bound_reason_to_limit(&mut reason, 7);
+        assert_eq!(reason, "éé...");
+        assert_eq!(reason.len(), 7);
+    }
+
+    #[test]
+    fn bound_reason_to_limit_handles_tiny_limits_without_overflowing() {
+        let mut reason = "abcdef".to_string();
+        bound_reason_to_limit(&mut reason, 2);
+        assert_eq!(reason, "ab");
+        assert_eq!(reason.len(), 2);
+    }
+}

--- a/crates/logfwd-runtime/src/worker_pool/types.rs
+++ b/crates/logfwd-runtime/src/worker_pool/types.rs
@@ -75,7 +75,11 @@ fn bound_reason_to_limit(reason: &mut String, max_bytes: usize) {
     }
     const SUFFIX: &str = "...";
     if max_bytes <= SUFFIX.len() {
-        reason.truncate(max_bytes);
+        let mut end = max_bytes;
+        while end > 0 && !reason.is_char_boundary(end) {
+            end -= 1;
+        }
+        reason.truncate(end);
         return;
     }
     let mut boundary = max_bytes - SUFFIX.len();
@@ -156,5 +160,15 @@ mod tests {
         bound_reason_to_limit(&mut reason, 2);
         assert_eq!(reason, "ab");
         assert_eq!(reason.len(), 2);
+    }
+
+    #[test]
+    fn bound_reason_to_limit_tiny_limit_with_multibyte_does_not_panic() {
+        // "é" is 2 bytes (0xC3 0xA9). With max_bytes=1 (< SUFFIX.len()),
+        // truncating at byte 1 would split the char and panic without the
+        // char-boundary walk-back.
+        let mut reason = "é".to_string();
+        bound_reason_to_limit(&mut reason, 1);
+        assert!(reason.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- checkpoint flush retry logic now retries only retryable `io::ErrorKind`s and bails immediately on permanent failures; added retryability classifier tests and proofs
- pipeline runtime now rejects zero `batch_timeout` in both sync and async entrypoints, deduplicates stateless-processor assertions, and caches `has_stateful_processors` for heartbeat/flush gates
- worker-pool dispatch/type coverage improved with direct unit tests and stricter UTF-8-safe bounded rejection-reason helper behavior
- worker-pool rejection ack creation is centralized via `reject_work_item`, removing repeated fallback blocks and preserving explicit ack outcomes on post-drain/closed-channel/no-worker paths
- added targeted regression tests across checkpoint/pipeline/dispatch/types/pool for the new behaviors

## Verification
- `cargo test -p logfwd-runtime pipeline::checkpoint_io::tests:: -- --nocapture`
- `cargo test -p logfwd-runtime test_with_processor_rejects_stateful_processors -- --nocapture`
- `cargo test -p logfwd-runtime test_async_zero_batch_timeout_returns_error -- --nocapture`
- `cargo test -p logfwd-runtime dispatch_step_prefers_first_available_worker -- --nocapture`
- `cargo test -p logfwd-runtime bound_rejection_reason_respects_global_limit_and_appends_suffix -- --nocapture`
- `cargo test -p logfwd-runtime reject_work_item_emits_expected_ack -- --nocapture`
- `cargo test -p logfwd-runtime stopping_state_never_recovers_to_healthy_or_starting -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden checkpoint retry policy and worker-pool edge cases in logfwd-runtime
> - Adds `is_retryable_flush_error` in [`checkpoint_io.rs`](https://github.com/strawgate/memagent/pull/1805/files#diff-91c3d323471451ee5268763e17924169cd82ed14b70e43d68c196e407a7e7804) to classify `io::ErrorKind` values as retryable; `flush_checkpoint_with_retry` now retries only for retryable errors and returns immediately for non-retryable ones, with a `retryable` field added to error logs.
> - `Pipeline::run` and `Pipeline::run_async` in [`mod.rs`](https://github.com/strawgate/memagent/pull/1805/files#diff-97916cb5dc28dce0511ea2f0c1abb95441b6dc4715410d1c1e5a4b8e640016b5) now reject a zero `batch_timeout` early with `io::ErrorKind::InvalidInput`.
> - [`pool.rs`](https://github.com/strawgate/memagent/pull/1805/files#diff-13b80879333078b9fe5cd8cdeae7626d8e2aa8e10adcb04cd4165cf3485f5205) sets worker channel capacity to 1 (down from 2) and handles `Full`/`Closed` errors when sending to a newly spawned worker, falling back to the wait path or rejecting with a consistent ack via a new `reject_work_item` helper.
> - [`types.rs`](https://github.com/strawgate/memagent/pull/1805/files#diff-03aa8809b54851500833cf0d5ba744ba74b299e77e90f7103cf97df944636843) fixes `bound_reason_to_limit` to respect UTF-8 boundaries and handle tiny byte limits without panicking.
> - Behavioral Change: non-retryable flush errors now abort immediately instead of exhausting all retry attempts; worker channels now buffer at most 1 item.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ffbc57.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->