### PR TITLE
test: add deterministic turmoil replay and crash checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,6 +2505,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "dhat",
+ "futures-util",
  "logfwd-arrow",
  "logfwd-config",
  "logfwd-core",
@@ -4886,6 +4887,7 @@ dependencies = [
  "scoped-tls",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/logfwd-output/src/conflict_columns.rs
+++ b/crates/logfwd-output/src/conflict_columns.rs
@@ -125,7 +125,7 @@ pub(crate) fn is_null(batch: &RecordBatch, variant: &ColVariant, row: usize) -> 
 /// Return a reference to the underlying Arrow array for a `ColVariant`.
 pub(crate) fn get_array<'b>(batch: &'b RecordBatch, variant: &ColVariant) -> Option<&'b dyn Array> {
     match variant {
-        ColVariant::Flat { col_idx, .. } => batch.columns().get(*col_idx).map(|col| col.as_ref()),
+        ColVariant::Flat { col_idx, .. } => batch.columns().get(*col_idx).map(AsRef::as_ref),
         ColVariant::StructField {
             struct_col_idx,
             field_idx,
@@ -135,7 +135,7 @@ pub(crate) fn get_array<'b>(batch: &'b RecordBatch, variant: &ColVariant) -> Opt
                 .columns()
                 .get(*struct_col_idx)
                 .and_then(|col| col.as_any().downcast_ref::<StructArray>())?;
-            sa.columns().get(*field_idx).map(|child| child.as_ref())
+            sa.columns().get(*field_idx).map(AsRef::as_ref)
         }
     }
 }

--- a/crates/logfwd-output/src/sink/health.rs
+++ b/crates/logfwd-output/src/sink/health.rs
@@ -40,7 +40,7 @@ pub const fn reduce_output_health(
             | ComponentHealth::Stopping
             | ComponentHealth::Stopped
             | ComponentHealth::Failed => current,
-            _ => ComponentHealth::Starting,
+            ComponentHealth::Starting => ComponentHealth::Starting,
         },
         OutputHealthEvent::StartupSucceeded => match current {
             ComponentHealth::Degraded => ComponentHealth::Degraded,

--- a/crates/logfwd-runtime/Cargo.toml
+++ b/crates/logfwd-runtime/Cargo.toml
@@ -13,7 +13,7 @@ ignored = ["turmoil"]
 
 [features]
 default = ["datafusion"]
-turmoil = []
+turmoil = ["dep:turmoil"]
 loom-tests = []
 internal-failpoints = ["dep:fail", "fail/failpoints"]
 datafusion = ["dep:logfwd-transform"]
@@ -45,6 +45,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "tim
 tokio-util = { version = "0.7" }
 futures-util = "0.3"
 fail = { workspace = true, optional = true }
+turmoil = { workspace = true, features = ["unstable-barriers"], optional = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/logfwd-runtime/src/lib.rs
+++ b/crates/logfwd-runtime/src/lib.rs
@@ -9,4 +9,6 @@ pub mod generated_cli;
 pub mod pipeline;
 pub mod processor;
 pub mod transform;
+#[cfg(feature = "turmoil")]
+pub mod turmoil_barriers;
 pub mod worker_pool;

--- a/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
+++ b/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
@@ -23,6 +23,12 @@ pub(super) async fn flush_checkpoint_with_retry(store: &mut dyn CheckpointStore)
     const RETRY_DELAY: Duration = Duration::from_millis(100);
 
     for attempt in 0..MAX_ATTEMPTS {
+        #[cfg(feature = "turmoil")]
+        crate::turmoil_barriers::trigger(
+            crate::turmoil_barriers::RuntimeBarrierEvent::BeforeCheckpointFlushAttempt { attempt },
+        )
+        .await;
+
         if internal_faults::checkpoint_flush_should_fail() {
             if should_retry_flush(attempt, MAX_ATTEMPTS) {
                 tracing::warn!(

--- a/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
+++ b/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
@@ -30,6 +30,11 @@ pub(super) async fn flush_checkpoint_with_retry(store: &mut dyn CheckpointStore)
         .await;
 
         if internal_faults::checkpoint_flush_should_fail() {
+            #[cfg(feature = "turmoil")]
+            crate::turmoil_barriers::trigger(
+                crate::turmoil_barriers::RuntimeBarrierEvent::CheckpointFlush { success: false },
+            )
+            .await;
             if should_retry_flush(attempt, MAX_ATTEMPTS) {
                 tracing::warn!(
                     attempt,
@@ -47,12 +52,24 @@ pub(super) async fn flush_checkpoint_with_retry(store: &mut dyn CheckpointStore)
 
         match store.flush() {
             Ok(()) => {
+                #[cfg(feature = "turmoil")]
+                crate::turmoil_barriers::trigger(
+                    crate::turmoil_barriers::RuntimeBarrierEvent::CheckpointFlush { success: true },
+                )
+                .await;
                 if attempt > 0 {
                     tracing::info!(attempt, "pipeline: checkpoint flush succeeded after retry");
                 }
                 return;
             }
             Err(e) => {
+                #[cfg(feature = "turmoil")]
+                crate::turmoil_barriers::trigger(
+                    crate::turmoil_barriers::RuntimeBarrierEvent::CheckpointFlush {
+                        success: false,
+                    },
+                )
+                .await;
                 if should_retry_flush(attempt, MAX_ATTEMPTS) {
                     tracing::warn!(
                         attempt,

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -389,6 +389,13 @@ impl Pipeline {
             self.inputs.len(),
             self.input_transforms.len(),
         );
+        #[cfg(feature = "turmoil")]
+        crate::turmoil_barriers::trigger(
+            crate::turmoil_barriers::RuntimeBarrierEvent::PipelinePhase {
+                phase: crate::turmoil_barriers::PipelinePhase::Running,
+            },
+        )
+        .await;
         // Spawn input threads. Each polls its source, parses format, and
         // sends accumulated JSON lines through a bounded channel.
         // Backpressure: when the channel is full, the input thread blocks.
@@ -558,6 +565,13 @@ impl Pipeline {
 
         // Drain the pool: signal workers to finish current item and exit,
         // then wait up to 60s for graceful shutdown.
+        #[cfg(feature = "turmoil")]
+        crate::turmoil_barriers::trigger(
+            crate::turmoil_barriers::RuntimeBarrierEvent::PipelinePhase {
+                phase: crate::turmoil_barriers::PipelinePhase::Draining,
+            },
+        )
+        .await;
         self.pool.drain(Duration::from_secs(60)).await;
 
         // Drain remaining acks that workers sent before exiting.
@@ -605,6 +619,13 @@ impl Pipeline {
             }
         }
 
+        #[cfg(feature = "turmoil")]
+        crate::turmoil_barriers::trigger(
+            crate::turmoil_barriers::RuntimeBarrierEvent::PipelinePhase {
+                phase: crate::turmoil_barriers::PipelinePhase::Stopped,
+            },
+        )
+        .await;
         Ok(())
     }
 

--- a/crates/logfwd-runtime/src/turmoil_barriers.rs
+++ b/crates/logfwd-runtime/src/turmoil_barriers.rs
@@ -1,0 +1,25 @@
+//! Turmoil barrier trigger types for deterministic seam interleaving tests.
+//!
+//! These events are only compiled when `logfwd-runtime` is built with
+//! `feature = "turmoil"`. Production builds are unaffected.
+
+use crate::worker_pool::DeliveryOutcome;
+
+/// Barrier events emitted by runtime seam hooks.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum RuntimeBarrierEvent {
+    /// Emitted by worker tasks immediately before sending an ack item.
+    BeforeWorkerAckSend {
+        worker_id: usize,
+        batch_id: u64,
+        outcome: DeliveryOutcome,
+        retries: usize,
+    },
+    /// Emitted by checkpoint I/O immediately before each flush attempt.
+    BeforeCheckpointFlushAttempt { attempt: u32 },
+}
+
+/// Trigger a Turmoil barrier event.
+pub async fn trigger(event: RuntimeBarrierEvent) {
+    turmoil::barriers::trigger(event).await;
+}

--- a/crates/logfwd-runtime/src/turmoil_barriers.rs
+++ b/crates/logfwd-runtime/src/turmoil_barriers.rs
@@ -5,18 +5,31 @@
 
 use crate::worker_pool::DeliveryOutcome;
 
+/// Pipeline lifecycle phases emitted by runtime seam hooks.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PipelinePhase {
+    Running,
+    Draining,
+    Stopped,
+}
+
 /// Barrier events emitted by runtime seam hooks.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum RuntimeBarrierEvent {
+    /// Emitted when the pipeline transitions between lifecycle phases.
+    PipelinePhase { phase: PipelinePhase },
     /// Emitted by worker tasks immediately before sending an ack item.
     BeforeWorkerAckSend {
         worker_id: usize,
         batch_id: u64,
         outcome: DeliveryOutcome,
         retries: usize,
+        num_rows: u64,
     },
     /// Emitted by checkpoint I/O immediately before each flush attempt.
     BeforeCheckpointFlushAttempt { attempt: u32 },
+    /// Emitted by checkpoint I/O after a flush attempt resolves.
+    CheckpointFlush { success: bool },
 }
 
 /// Trigger a Turmoil barrier event.

--- a/crates/logfwd-runtime/src/worker_pool/worker.rs
+++ b/crates/logfwd-runtime/src/worker_pool/worker.rs
@@ -130,6 +130,16 @@ pub(super) async fn worker_task(
                             batch_id,
                             output_name,
                         };
+                        #[cfg(feature = "turmoil")]
+                        crate::turmoil_barriers::trigger(
+                            crate::turmoil_barriers::RuntimeBarrierEvent::BeforeWorkerAckSend {
+                                worker_id: id,
+                                batch_id: ack.batch_id,
+                                outcome: ack.outcome.clone(),
+                                retries,
+                            },
+                        )
+                        .await;
                         if let Err(send_err) = ack_tx.send(ack) {
                             let mut lost_ack = send_err.0;
                             let unresolved_tickets = lost_ack.tickets.len();

--- a/crates/logfwd-runtime/src/worker_pool/worker.rs
+++ b/crates/logfwd-runtime/src/worker_pool/worker.rs
@@ -137,6 +137,7 @@ pub(super) async fn worker_task(
                                 batch_id: ack.batch_id,
                                 outcome: ack.outcome.clone(),
                                 retries,
+                                num_rows: ack.num_rows,
                             },
                         )
                         .await;

--- a/crates/logfwd/Cargo.toml
+++ b/crates/logfwd/Cargo.toml
@@ -47,7 +47,8 @@ logfwd-test-utils = { version = "0.1.0", path = "../logfwd-test-utils" }
 serde_json = "1"
 stats_alloc = "0.1"
 tempfile = "3"
-turmoil = { workspace = true }
+futures-util = "0.3"
+turmoil = { workspace = true, features = ["unstable-barriers", "unstable-fs"] }
 
 [lints]
 workspace = true

--- a/crates/logfwd/tests/turmoil_sim/barrier_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/barrier_sim.rs
@@ -1,0 +1,179 @@
+//! Barrier-driven turmoil seam tests.
+//!
+//! These tests avoid timing sleeps for critical interleavings by suspending
+//! execution exactly at runtime seam hooks.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use futures_util::FutureExt;
+use logfwd::pipeline::Pipeline;
+use logfwd_runtime::turmoil_barriers::RuntimeBarrierEvent;
+use logfwd_test_utils::sinks::CountingSink;
+use logfwd_types::pipeline::SourceId;
+use tokio_util::sync::CancellationToken;
+use turmoil::barriers::{Barrier, Reaction};
+
+use super::channel_input::ChannelInputSource;
+use super::observable_checkpoint::ObservableCheckpointStore;
+
+fn generate_json_lines(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|i| format!("{{\"msg\":\"line {i}\",\"num\":{i}}}\n").into_bytes())
+        .collect()
+}
+
+#[test]
+fn barrier_before_worker_ack_send_suspends_checkpoint_advance() {
+    let mut sim = super::build_sim(120, 1);
+    let mut barrier = Barrier::build(Reaction::Suspend, |event: &RuntimeBarrierEvent| {
+        matches!(event, RuntimeBarrierEvent::BeforeWorkerAckSend { .. })
+    });
+
+    let delivered = Arc::new(AtomicU64::new(0));
+    let delivered_clone = Arc::clone(&delivered);
+    let (store, handle) = ObservableCheckpointStore::new();
+
+    sim.client("pipeline", async move {
+        let lines = generate_json_lines(20);
+        let input = ChannelInputSource::new("test", SourceId(1), lines);
+        let sink = CountingSink::new(delivered_clone);
+
+        let mut pipeline = Pipeline::for_simulation("sim", Box::new(sink));
+        pipeline.set_batch_timeout(Duration::from_millis(20));
+        pipeline.set_batch_target_bytes(1024 * 1024);
+        pipeline.set_checkpoint_flush_interval(Duration::from_secs(60));
+        let mut pipeline = pipeline
+            .with_input("test", Box::new(input))
+            .with_checkpoint_store(Box::new(store));
+
+        let shutdown = CancellationToken::new();
+        let sd = shutdown.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            sd.cancel();
+        });
+
+        pipeline.run_async(&shutdown).await.unwrap();
+        Ok(())
+    });
+
+    let mut wait = Box::pin(barrier.wait());
+    let triggered = loop {
+        let finished = sim.step().expect("simulation step should succeed");
+        if let Some(triggered) = wait.as_mut().now_or_never().flatten() {
+            break triggered;
+        }
+        assert!(
+            !finished,
+            "simulation finished before before-ack barrier triggered"
+        );
+    };
+
+    assert_eq!(
+        handle.update_count(1),
+        0,
+        "checkpoint must not advance while ack-send seam is suspended"
+    );
+    for _ in 0..100 {
+        sim.step().expect("simulation step should succeed");
+    }
+    assert_eq!(
+        handle.update_count(1),
+        0,
+        "checkpoint must remain stalled while barrier is held"
+    );
+
+    drop(triggered);
+    sim.run()
+        .expect("simulation should complete after barrier release");
+
+    assert!(
+        handle.update_count(1) > 0,
+        "checkpoint should advance after ack-send barrier is released"
+    );
+    assert_eq!(
+        delivered.load(Ordering::Relaxed),
+        20,
+        "all rows should be delivered after releasing the seam barrier"
+    );
+}
+
+#[test]
+fn barrier_before_checkpoint_flush_suspends_durability_commit() {
+    let mut sim = super::build_sim(120, 1);
+    let mut barrier = Barrier::build(Reaction::Suspend, |event: &RuntimeBarrierEvent| {
+        matches!(
+            event,
+            RuntimeBarrierEvent::BeforeCheckpointFlushAttempt { attempt: 0 }
+        )
+    });
+
+    let delivered = Arc::new(AtomicU64::new(0));
+    let delivered_clone = Arc::clone(&delivered);
+    let (store, handle) = ObservableCheckpointStore::new();
+
+    sim.client("pipeline", async move {
+        let lines = generate_json_lines(16);
+        let input = ChannelInputSource::new("test", SourceId(1), lines);
+        let sink = CountingSink::new(delivered_clone);
+
+        let mut pipeline = Pipeline::for_simulation("sim", Box::new(sink));
+        pipeline.set_batch_timeout(Duration::from_millis(10));
+        pipeline.set_batch_target_bytes(1024 * 1024);
+        pipeline.set_checkpoint_flush_interval(Duration::from_secs(60));
+        let mut pipeline = pipeline
+            .with_input("test", Box::new(input))
+            .with_checkpoint_store(Box::new(store));
+
+        let shutdown = CancellationToken::new();
+        let sd = shutdown.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            sd.cancel();
+        });
+
+        pipeline.run_async(&shutdown).await.unwrap();
+        Ok(())
+    });
+
+    let mut wait = Box::pin(barrier.wait());
+    let triggered = loop {
+        let finished = sim.step().expect("simulation step should succeed");
+        if let Some(triggered) = wait.as_mut().now_or_never().flatten() {
+            break triggered;
+        }
+        assert!(
+            !finished,
+            "simulation finished before before-flush barrier triggered"
+        );
+    };
+
+    assert_eq!(
+        handle.durable_offset(1),
+        None,
+        "durable checkpoint must remain unset while flush seam is suspended"
+    );
+    for _ in 0..50 {
+        sim.step().expect("simulation step should succeed");
+    }
+    assert_eq!(
+        handle.durable_offset(1),
+        None,
+        "durability state should remain frozen until barrier release"
+    );
+
+    drop(triggered);
+    sim.run()
+        .expect("simulation should complete after barrier release");
+    assert_eq!(
+        delivered.load(Ordering::Relaxed),
+        16,
+        "rows should still deliver while durability commit is suspended"
+    );
+    assert!(
+        handle.durable_offset(1).is_some(),
+        "durable checkpoint should be persisted after barrier release"
+    );
+}

--- a/crates/logfwd/tests/turmoil_sim/fault_harness.rs
+++ b/crates/logfwd/tests/turmoil_sim/fault_harness.rs
@@ -9,19 +9,20 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use futures_util::FutureExt;
 use logfwd::pipeline::Pipeline;
+use logfwd_runtime::turmoil_barriers::RuntimeBarrierEvent;
 use logfwd_test_utils::sinks::CountingSink;
 use logfwd_types::pipeline::SourceId;
-use tempfile::NamedTempFile;
 use tokio_util::sync::CancellationToken;
+use turmoil::barriers::Barrier;
 
 use super::channel_input::ChannelInputSource;
 use super::instrumented_sink::{FailureAction, InstrumentedSink};
 use super::observable_checkpoint::{CheckpointHandle, ObservableCheckpointStore};
 use super::tcp_server::{TcpServerHandle, run_tcp_server};
 use super::trace_bridge::{
-    TraceEvent, TracePhase, TraceRecorder, TransitionValidator, load_trace,
-    normalized_contract_trace,
+    TraceEvent, TransitionValidator, normalized_contract_trace, trace_event_from_runtime_barrier,
 };
 use super::turmoil_tcp_sink::TurmoilTcpSink;
 
@@ -217,14 +218,11 @@ impl FaultScenario {
         let mut call_counter = Arc::new(AtomicU64::new(0));
         let mut checkpoint_handle: Option<CheckpointHandle> = None;
         let mut tcp_server_handle: Option<TcpServerHandle> = None;
-        let trace_path = NamedTempFile::new()
-            .expect("create temp trace")
-            .into_temp_path();
-        let trace = TraceRecorder::new(&trace_path).expect("create trace recorder");
+        let mut runtime_events_barrier = Barrier::new(|_: &RuntimeBarrierEvent| true);
+        let mut trace_events = Vec::new();
 
         match &self.sink_mode {
             SinkMode::TurmoilTcp => {
-                let trace_for_pipeline = trace.clone();
                 let server = TcpServerHandle::new();
                 let sh = server.clone();
                 sim.host("server", move || {
@@ -242,7 +240,6 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                 {
                     let (store, handle) = ObservableCheckpointStore::new();
-                    let store = store.with_trace_recorder(trace_for_pipeline.clone());
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -250,9 +247,6 @@ impl FaultScenario {
                 };
 
                 sim.client("pipeline", async move {
-                    trace_for_pipeline.record(TraceEvent::Phase {
-                        phase: TracePhase::Running,
-                    });
                     let lines = generate_json_lines(scenario.lines);
                     let input = ChannelInputSource::new("scenario", scenario.source_id, lines);
 
@@ -277,27 +271,18 @@ impl FaultScenario {
 
                     let shutdown = CancellationToken::new();
                     let sd = shutdown.clone();
-                    let trace_for_shutdown = trace_for_pipeline.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(scenario.shutdown_after).await;
-                        trace_for_shutdown.record(TraceEvent::Phase {
-                            phase: TracePhase::Draining,
-                        });
                         sd.cancel();
                     });
 
                     let run_result = pipeline.run_async(&shutdown).await;
                     run_result?;
-                    trace_for_pipeline.record(TraceEvent::Phase {
-                        phase: TracePhase::Stopped,
-                    });
                     Ok(())
                 });
             }
             SinkMode::Instrumented { script } => {
-                let trace_for_pipeline = trace.clone();
-                let sink = InstrumentedSink::new(script.clone())
-                    .with_trace_recorder(trace_for_pipeline.clone());
+                let sink = InstrumentedSink::new(script.clone());
                 delivered_counter = sink.delivered_counter();
                 call_counter = sink.call_counter();
 
@@ -306,7 +291,6 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                 {
                     let (store, handle) = ObservableCheckpointStore::new();
-                    let store = store.with_trace_recorder(trace_for_pipeline.clone());
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -314,9 +298,6 @@ impl FaultScenario {
                 };
 
                 sim.client("pipeline", async move {
-                    trace_for_pipeline.record(TraceEvent::Phase {
-                        phase: TracePhase::Running,
-                    });
                     let lines = generate_json_lines(scenario.lines);
                     let input = ChannelInputSource::new("scenario", scenario.source_id, lines);
                     let mut pipeline = Pipeline::for_simulation("sim", Box::new(sink));
@@ -340,25 +321,17 @@ impl FaultScenario {
 
                     let shutdown = CancellationToken::new();
                     let sd = shutdown.clone();
-                    let trace_for_shutdown = trace_for_pipeline.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(scenario.shutdown_after).await;
-                        trace_for_shutdown.record(TraceEvent::Phase {
-                            phase: TracePhase::Draining,
-                        });
                         sd.cancel();
                     });
 
                     let run_result = pipeline.run_async(&shutdown).await;
                     run_result?;
-                    trace_for_pipeline.record(TraceEvent::Phase {
-                        phase: TracePhase::Stopped,
-                    });
                     Ok(())
                 });
             }
             SinkMode::Counting => {
-                let trace_for_pipeline = trace.clone();
                 let sink = CountingSink::new(delivered_counter.clone());
                 let scenario = self.clone();
 
@@ -366,7 +339,6 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                 {
                     let (store, handle) = ObservableCheckpointStore::new();
-                    let store = store.with_trace_recorder(trace_for_pipeline.clone());
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -374,9 +346,6 @@ impl FaultScenario {
                 };
 
                 sim.client("pipeline", async move {
-                    trace_for_pipeline.record(TraceEvent::Phase {
-                        phase: TracePhase::Running,
-                    });
                     let lines = generate_json_lines(scenario.lines);
                     let input = ChannelInputSource::new("scenario", scenario.source_id, lines);
                     let mut pipeline = Pipeline::for_simulation("sim", Box::new(sink));
@@ -400,20 +369,13 @@ impl FaultScenario {
 
                     let shutdown = CancellationToken::new();
                     let sd = shutdown.clone();
-                    let trace_for_shutdown = trace_for_pipeline.clone();
                     tokio::spawn(async move {
                         tokio::time::sleep(scenario.shutdown_after).await;
-                        trace_for_shutdown.record(TraceEvent::Phase {
-                            phase: TracePhase::Draining,
-                        });
                         sd.cancel();
                     });
 
                     let run_result = pipeline.run_async(&shutdown).await;
                     run_result?;
-                    trace_for_pipeline.record(TraceEvent::Phase {
-                        phase: TracePhase::Stopped,
-                    });
                     Ok(())
                 });
             }
@@ -424,48 +386,41 @@ impl FaultScenario {
 
         let mut applied_network_fault_steps = Vec::new();
         let run_outcome = catch_unwind(AssertUnwindSafe(|| {
-            if network_faults.is_empty() {
-                sim.run()
-            } else {
-                let mut faults = network_faults.iter().peekable();
-                let mut step = 0usize;
+            let mut faults = network_faults.iter().peekable();
+            let mut step = 0usize;
+
+            while let Some(fault) = faults.peek() {
+                if fault.step != 0 {
+                    break;
+                }
+                applied_network_fault_steps.push(fault.step);
+                apply_network_fault(&mut sim, fault);
+                faults.next();
+            }
+
+            loop {
+                if sim.step()? {
+                    break Ok::<(), Box<dyn std::error::Error>>(());
+                }
+                drain_runtime_events(&mut runtime_events_barrier, &mut trace_events);
+                step += 1;
                 while let Some(fault) = faults.peek() {
-                    if fault.step != 0 {
+                    if fault.step != step {
                         break;
                     }
                     applied_network_fault_steps.push(fault.step);
                     apply_network_fault(&mut sim, fault);
                     faults.next();
                 }
-                while faults.peek().is_some() {
-                    if sim.step()? {
-                        return Ok(());
-                    }
-                    step += 1;
-                    while let Some(fault) = faults.peek() {
-                        if fault.step != step {
-                            break;
-                        }
-                        applied_network_fault_steps.push(fault.step);
-                        apply_network_fault(&mut sim, fault);
-                        faults.next();
-                    }
-                }
-                sim.run()
             }
         }));
+        drain_runtime_events(&mut runtime_events_barrier, &mut trace_events);
 
         let (panicked, sim_error) = match run_outcome {
             Ok(Ok(())) => (false, None),
             Ok(Err(err)) => (false, Some(err.to_string())),
             Err(_) => (true, None),
         };
-        let trace_events = load_trace(&trace_path).unwrap_or_else(|err| {
-            panic!(
-                "failed to load turmoil trace from {}: {err}",
-                trace_path.display()
-            )
-        });
         let trace_validation_error = TransitionValidator::default().validate(&trace_events).err();
         let normalized_trace = normalized_contract_trace(&trace_events);
 
@@ -487,6 +442,20 @@ impl FaultScenario {
             typed_contract.verify(&outcome);
         }
         outcome
+    }
+}
+
+fn drain_runtime_events(barrier: &mut Barrier<RuntimeBarrierEvent>, events: &mut Vec<TraceEvent>) {
+    loop {
+        let mut wait = Box::pin(barrier.wait());
+        match wait.as_mut().now_or_never() {
+            Some(Some(triggered)) => {
+                if let Some(event) = trace_event_from_runtime_barrier(&triggered) {
+                    events.push(event);
+                }
+            }
+            Some(None) | None => break,
+        }
     }
 }
 

--- a/crates/logfwd/tests/turmoil_sim/fault_scenario_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/fault_scenario_sim.rs
@@ -7,7 +7,7 @@ use super::fault_harness::{
     FaultScenario, InvariantSet, NetworkFault, NetworkFaultAction, TypedInvariantBundle,
 };
 use super::instrumented_sink::FailureAction;
-use super::trace_bridge::{SinkOutcome, TraceEvent};
+use super::trace_bridge::{SinkOutcome, TraceEvent, validate_replay_history_equivalence};
 
 #[test]
 fn checkpoint_crash_scenario_keeps_delivery_and_monotonic_updates() {
@@ -246,6 +246,48 @@ fn replay_equivalence_same_seed_produces_same_normalized_contract_trace() {
         replay.normalized_contract_trace(),
         "same seed should produce same normalized contract trace"
     );
+}
+
+#[test]
+fn replay_equivalence_seed_matrix_keeps_history_equivalent() {
+    let seeds = [20260430_u64, 20260431, 20260432, 20260433];
+    for seed in seeds {
+        let run_a = FaultScenario::builder("replay-matrix-a")
+            .with_seed(seed)
+            .with_line_count(16)
+            .with_sink_script(vec![
+                FailureAction::RetryAfter(Duration::from_millis(5)),
+                FailureAction::Succeed,
+            ])
+            .with_checkpoint_flush_interval(Duration::from_millis(30))
+            .with_shutdown_after(Duration::from_secs(3))
+            .run();
+        let run_b = FaultScenario::builder("replay-matrix-b")
+            .with_seed(seed)
+            .with_line_count(16)
+            .with_sink_script(vec![
+                FailureAction::RetryAfter(Duration::from_millis(5)),
+                FailureAction::Succeed,
+            ])
+            .with_checkpoint_flush_interval(Duration::from_millis(30))
+            .with_shutdown_after(Duration::from_secs(3))
+            .run();
+
+        InvariantSet::new()
+            .no_sim_error()
+            .trace_contract_valid()
+            .verify(&run_a);
+        InvariantSet::new()
+            .no_sim_error()
+            .trace_contract_valid()
+            .verify(&run_b);
+
+        validate_replay_history_equivalence(&[
+            run_a.trace_events().to_vec(),
+            run_b.trace_events().to_vec(),
+        ])
+        .unwrap_or_else(|err| panic!("seed {seed} replay equivalence failed: {err}"));
+    }
 }
 
 #[test]

--- a/crates/logfwd/tests/turmoil_sim/fs_crash_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/fs_crash_sim.rs
@@ -1,0 +1,99 @@
+//! Filesystem crash-consistency tests using Turmoil's unstable-fs shim.
+
+use std::future::pending;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use turmoil::fs::shim::std::fs::{OpenOptions, sync_dir};
+
+#[test]
+fn synced_checkpoint_survives_crash_while_unsynced_append_is_lost() {
+    let mut builder = super::sim_builder();
+    builder
+        .simulation_duration(Duration::from_secs(30))
+        .tick_duration(Duration::from_millis(1));
+    builder.fs().sync_probability(0.0);
+    let mut sim = builder.build();
+
+    let boot = Arc::new(AtomicUsize::new(0));
+    let observations = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+
+    let boot_for_host = Arc::clone(&boot);
+    let observations_for_host = Arc::clone(&observations);
+    sim.host("storage", move || {
+        let boot_for_host = Arc::clone(&boot_for_host);
+        let observations_for_host = Arc::clone(&observations_for_host);
+        async move {
+            let mut file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open("/checkpoint.state")?;
+
+            let mut current = String::new();
+            file.seek(SeekFrom::Start(0))?;
+            file.read_to_string(&mut current)?;
+            observations_for_host
+                .lock()
+                .expect("mutex poisoned")
+                .push(current);
+
+            let boot_idx = boot_for_host.fetch_add(1, Ordering::SeqCst);
+            match boot_idx {
+                0 => {
+                    // Durable base checkpoint.
+                    file.set_len(0)?;
+                    file.seek(SeekFrom::Start(0))?;
+                    file.write_all(b"synced")?;
+                    file.sync_all()?;
+                    // Persist directory entry metadata as part of durability
+                    // semantics for newly created files.
+                    sync_dir("/")?;
+                }
+                1 => {
+                    // Pending update without sync should be lost on crash.
+                    file.seek(SeekFrom::End(0))?;
+                    file.write_all(b"+unsynced")?;
+                }
+                _ => {}
+            }
+
+            pending::<()>().await;
+            #[allow(unreachable_code)]
+            Ok(())
+        }
+    });
+
+    // Boot 0: write synced state.
+    sim.step().expect("step after boot 0 should succeed");
+
+    // Crash and restart.
+    sim.crash("storage");
+    sim.step().expect("step after crash 0 should succeed");
+    sim.bounce("storage");
+    sim.step().expect("step after bounce 0 should succeed");
+
+    // Boot 1: append unsynced data, then crash and restart again.
+    sim.crash("storage");
+    sim.step().expect("step after crash 1 should succeed");
+    sim.bounce("storage");
+    sim.step().expect("step after bounce 1 should succeed");
+
+    let obs = observations.lock().expect("mutex poisoned");
+    assert!(
+        obs.len() >= 3,
+        "expected three boot observations, got {}",
+        obs.len()
+    );
+    assert_eq!(obs[0], "", "fresh filesystem should start empty");
+    assert_eq!(
+        obs[1], "synced",
+        "first restart should observe synced durable checkpoint"
+    );
+    assert_eq!(
+        obs[2], "synced",
+        "unsynced append must be discarded across crash+bounce"
+    );
+}

--- a/crates/logfwd/tests/turmoil_sim/main.rs
+++ b/crates/logfwd/tests/turmoil_sim/main.rs
@@ -1,10 +1,12 @@
 #![cfg(feature = "turmoil")]
 
+mod barrier_sim;
 mod bug_hunt;
 mod channel_input;
 mod crash_sim;
 mod fault_harness;
 mod fault_scenario_sim;
+mod fs_crash_sim;
 mod instrumented_sink;
 mod network_sim;
 mod observable_checkpoint;

--- a/crates/logfwd/tests/turmoil_sim/network_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/network_sim.rs
@@ -29,6 +29,26 @@ fn generate_json_lines(n: usize) -> Vec<Vec<u8>> {
         .collect()
 }
 
+fn inflight_link_messages(sim: &turmoil::Sim<'_>, a: &str, b: &str) -> usize {
+    let a_ip = sim.lookup(a);
+    let b_ip = sim.lookup(b);
+    let pair = if a_ip < b_ip {
+        (a_ip, b_ip)
+    } else {
+        (b_ip, a_ip)
+    };
+    let mut count = 0usize;
+    sim.links(|links| {
+        for link in links {
+            if link.pair() == pair {
+                count = link.count();
+                break;
+            }
+        }
+    });
+    count
+}
+
 /// Test: retry exhaustion holds checkpoint progress and pipeline does not hang.
 ///
 /// Invariant probed: worker pool retry exhaustion (MAX_RETRIES=3, so 4 total
@@ -522,18 +542,40 @@ fn tcp_hold_release_burst_delivery() {
     sim.hold("pipeline", "server");
 
     // Step during hold — data is buffered, not delivered.
+    let mut held_inflight_peak = 0usize;
     for _ in 0..500 {
         sim.step().unwrap();
+        held_inflight_peak =
+            held_inflight_peak.max(inflight_link_messages(&sim, "pipeline", "server"));
     }
     let during_hold = server_check.received_lines.load(Ordering::Relaxed);
+    let pending_before_release = inflight_link_messages(&sim, "pipeline", "server");
+    assert!(
+        pending_before_release > 0 || held_inflight_peak > 0,
+        "expected pending in-flight traffic while hold is active"
+    );
 
     // Release: deliver all buffered data in a burst.
     sim.release("pipeline", "server");
+    let mut observed_release_progress = false;
+    for _ in 0..100 {
+        sim.step().unwrap();
+        let pending = inflight_link_messages(&sim, "pipeline", "server");
+        if pending < pending_before_release {
+            observed_release_progress = true;
+            break;
+        }
+    }
+    assert!(
+        observed_release_progress || pending_before_release == 0,
+        "expected link backlog to decrease after release; before={pending_before_release}"
+    );
 
     // Run to completion.
     sim.run().unwrap();
 
     let total = server_check.received_lines.load(Ordering::Relaxed);
+    let pending_after_run = inflight_link_messages(&sim, "pipeline", "server");
 
     // After release, total should exceed during_hold (burst delivery).
     // If during_hold == total, the hold had no effect (all data arrived
@@ -547,6 +589,14 @@ fn tcp_hold_release_burst_delivery() {
     assert_eq!(
         total, 200,
         "expected all 200 lines delivered after hold/release, got {total}"
+    );
+    assert!(
+        pending_after_run <= 1,
+        "expected bounded residual in-flight messages after completion, got {pending_after_run}"
+    );
+    assert!(
+        pending_after_run <= pending_before_release,
+        "release should not increase backlog at completion: before={pending_before_release}, after={pending_after_run}"
     );
 }
 

--- a/crates/logfwd/tests/turmoil_sim/trace_bridge.rs
+++ b/crates/logfwd/tests/turmoil_sim/trace_bridge.rs
@@ -242,6 +242,38 @@ pub fn normalized_contract_trace(events: &[TraceEvent]) -> Vec<String> {
         .collect()
 }
 
+/// Validate transition history across multiple replay runs.
+///
+/// Ensures every run satisfies `TransitionValidator` and that all runs produce
+/// the same normalized contract trace as run 0.
+pub fn validate_replay_history_equivalence(
+    runs: &[Vec<TraceEvent>],
+) -> Result<Vec<String>, String> {
+    let Some(first) = runs.first() else {
+        return Err("no runs supplied for replay equivalence validation".to_string());
+    };
+
+    let validator = TransitionValidator::default();
+    validator
+        .validate(first)
+        .map_err(|err| format!("run 0 transition contract failed: {err}"))?;
+    let baseline = normalized_contract_trace(first);
+
+    for (idx, run) in runs.iter().enumerate().skip(1) {
+        validator
+            .validate(run)
+            .map_err(|err| format!("run {idx} transition contract failed: {err}"))?;
+        let normalized = normalized_contract_trace(run);
+        if normalized != baseline {
+            return Err(format!(
+                "run {idx} diverged from run 0 normalized contract trace"
+            ));
+        }
+    }
+
+    Ok(baseline)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PhaseState {
     Running,

--- a/crates/logfwd/tests/turmoil_sim/trace_bridge.rs
+++ b/crates/logfwd/tests/turmoil_sim/trace_bridge.rs
@@ -9,6 +9,8 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use logfwd_runtime::turmoil_barriers::{PipelinePhase, RuntimeBarrierEvent};
+use logfwd_runtime::worker_pool::DeliveryOutcome;
 use serde_json::{Value, json};
 
 /// Runtime trace event schema (JSONL row).
@@ -41,6 +43,43 @@ impl TraceEvent {
             }
             Self::CheckpointFlush { success } => format!("checkpoint_flush success={success}"),
         }
+    }
+}
+
+/// Convert runtime-emitted turmoil barrier events into contract trace events.
+#[must_use]
+pub fn trace_event_from_runtime_barrier(event: &RuntimeBarrierEvent) -> Option<TraceEvent> {
+    match event {
+        RuntimeBarrierEvent::PipelinePhase { phase } => {
+            let phase = match phase {
+                PipelinePhase::Running => TracePhase::Running,
+                PipelinePhase::Draining => TracePhase::Draining,
+                PipelinePhase::Stopped => TracePhase::Stopped,
+            };
+            Some(TraceEvent::Phase { phase })
+        }
+        RuntimeBarrierEvent::BeforeWorkerAckSend {
+            outcome, num_rows, ..
+        } => {
+            let outcome = match outcome {
+                DeliveryOutcome::Delivered => SinkOutcome::Ok,
+                DeliveryOutcome::Rejected { .. } => SinkOutcome::Rejected,
+                DeliveryOutcome::InternalFailure => SinkOutcome::Panic,
+                DeliveryOutcome::RetryExhausted
+                | DeliveryOutcome::TimedOut
+                | DeliveryOutcome::PoolClosed
+                | DeliveryOutcome::WorkerChannelClosed
+                | DeliveryOutcome::NoWorkersAvailable => SinkOutcome::IoError,
+            };
+            Some(TraceEvent::SinkResult {
+                outcome,
+                rows: *num_rows,
+            })
+        }
+        RuntimeBarrierEvent::CheckpointFlush { success } => {
+            Some(TraceEvent::CheckpointFlush { success: *success })
+        }
+        RuntimeBarrierEvent::BeforeCheckpointFlushAttempt { .. } => None,
     }
 }
 


### PR DESCRIPTION
## Summary
- add deterministic seam hooks in runtime using Turmoil barriers (`BeforeWorkerAckSend`, `BeforeCheckpointFlushAttempt`)
- add barrier-driven interleaving tests that suspend/release exactly at ack-send and checkpoint-flush seams
- add unstable-fs crash-consistency test using `Sim::crash`/`Sim::bounce` and directory sync durability semantics
- add replay-equivalence history validation for same-seed runs via normalized transition traces
- strengthen hold/release network tests with link-level in-flight assertions (`Sim::links`)
- enable Turmoil unstable barrier/fs features in test dependencies
- fix existing clippy blockers in `logfwd-output` so `just ci` is green

## Validation
- `cargo test -p logfwd --features turmoil --test turmoil_sim`
- `just ci`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add deterministic turmoil replay and filesystem crash checks to the simulation test suite
> - Introduces a new `turmoil_barriers` module in `logfwd-runtime` that emits typed `RuntimeBarrierEvent` values at key pipeline lifecycle points (running, draining, stopped), before worker ack sends, and around checkpoint flush attempts when the `turmoil` feature is enabled.
> - Replaces file-based `TraceRecorder` usage in [`fault_harness.rs`](https://github.com/strawgate/memagent/pull/1806/files#diff-09716467b6e86243d78046b8aab82d5559d85536846f70b9761b185558abf532) with a `Barrier<RuntimeBarrierEvent>` drained via a new `drain_runtime_events` helper, removing explicit trace recording calls from pipeline tasks.
> - Adds [`barrier_sim.rs`](https://github.com/strawgate/memagent/pull/1806/files#diff-aee9d3a285a8120d1801ed1e145ca30f4905531d3fa46eb28ad79c5f6262b0be) with suspension-point tests that validate checkpoint advancement and durability under controlled barrier holds.
> - Adds [`fs_crash_sim.rs`](https://github.com/strawgate/memagent/pull/1806/files#diff-fae48ad4d3f919d3fb6c50a45661396ac7a0b8bf6330cd62dce1fbaa7d10f156) using Turmoil's `unstable-fs` shim to assert that synced checkpoints survive a crash while unsynced appends are lost.
> - Adds a `replay_equivalence_seed_matrix_keeps_history_equivalent` test that runs pairs of simulations across a seed matrix and validates history equivalence via `validate_replay_history_equivalence`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5a2ba35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->