### PR TITLE
fix: address unresolved review threads from merged PRs

### DIFF
--- a/crates/logfwd-core/src/cri.rs
+++ b/crates/logfwd-core/src/cri.rs
@@ -757,7 +757,8 @@ mod verification {
     #[kani::unwind(34)]
     fn verify_parse_cri_line_no_panic() {
         let input: [u8; 32] = kani::any();
-        let _ = parse_cri_line(&input);
+        let result = parse_cri_line(&input);
+        kani::cover!(result.is_some(), "some path reachable");
     }
 
     /// Prove parse_cri_line semantic correctness: if it returns Some,

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -22,7 +22,7 @@ use arrow::ipc::reader::StreamReader;
 use arrow::record_batch::RecordBatch;
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::header::{CONTENT_ENCODING, CONTENT_TYPE};
+use axum::http::header::CONTENT_ENCODING;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
@@ -33,7 +33,7 @@ use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::input::{InputEvent, InputSource};
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
-use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_limited_body};
+use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body};
 
 /// Bounded channel capacity — limits memory when the pipeline falls behind.
 const CHANNEL_BOUND: usize = 256;
@@ -429,21 +429,6 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
     Ok(is_zstd.then_some("zstd".to_string()))
 }
 
-fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
-    let Some(value) = headers.get(CONTENT_TYPE) else {
-        return Ok(None);
-    };
-    let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
-    let mime = parsed
-        .split(';')
-        .next()
-        .map(str::trim)
-        .ok_or(StatusCode::BAD_REQUEST)?;
-    if mime.is_empty() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-    Ok(Some(mime.to_ascii_lowercase()))
-}
 
 impl Drop for ArrowIpcReceiver {
     fn drop(&mut self) {
@@ -494,6 +479,7 @@ impl InputSource for ArrowIpcReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::header::CONTENT_TYPE;
 
     // Regression test for issue #1142: clean shutdown
     #[test]

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -33,7 +33,9 @@ use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::input::{InputEvent, InputSource};
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
-use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body};
+use crate::receiver_http::{
+    MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body,
+};
 
 /// Bounded channel capacity — limits memory when the pipeline falls behind.
 const CHANNEL_BOUND: usize = 256;
@@ -428,7 +430,6 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
     }
     Ok(is_zstd.then_some("zstd".to_string()))
 }
-
 
 impl Drop for ArrowIpcReceiver {
     fn drop(&mut self) {

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -35,7 +35,7 @@ use tokio::sync::oneshot;
 use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
-use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_limited_body};
+use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body};
 
 /// Bounded channel capacity.
 const CHANNEL_BOUND: usize = 256;
@@ -332,21 +332,6 @@ async fn handle_otap_request(
     }
 }
 
-fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
-    let Some(value) = headers.get(CONTENT_TYPE) else {
-        return Ok(None);
-    };
-    let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
-    let mime = parsed
-        .split(';')
-        .next()
-        .map(str::trim)
-        .ok_or(StatusCode::BAD_REQUEST)?;
-    if mime.is_empty() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-    Ok(Some(mime.to_ascii_lowercase()))
-}
 
 /// Decoded `BatchArrowRecords` message.
 struct BatchArrowRecords {

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -35,7 +35,9 @@ use tokio::sync::oneshot;
 use crate::InputError;
 use crate::background_http_task::BackgroundHttpTask;
 use crate::receiver_health::{ReceiverHealthEvent, reduce_receiver_health};
-use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body};
+use crate::receiver_http::{
+    MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body,
+};
 
 /// Bounded channel capacity.
 const CHANNEL_BOUND: usize = 256;
@@ -331,7 +333,6 @@ async fn handle_otap_request(
         }
     }
 }
-
 
 /// Decoded `BatchArrowRecords` message.
 struct BatchArrowRecords {

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -11,7 +11,7 @@ use axum::response::{IntoResponse, Response};
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 
 use crate::InputError;
-use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, read_limited_body};
+use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body};
 
 use super::decode::{decode_otlp_json, decode_otlp_protobuf, decompress_gzip, decompress_zstd};
 use super::{OtlpServerState, ReceiverPayload};
@@ -180,14 +180,3 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
     Ok(Some(parsed.to_ascii_lowercase()))
 }
 
-fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
-    let Some(value) = headers.get(CONTENT_TYPE) else {
-        return Ok(None);
-    };
-    let raw = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
-    let media_type = raw.split(';').next().unwrap_or_default().trim();
-    if media_type.is_empty() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-    Ok(Some(media_type.to_ascii_lowercase()))
-}

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -11,7 +11,9 @@ use axum::response::{IntoResponse, Response};
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 
 use crate::InputError;
-use crate::receiver_http::{MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body};
+use crate::receiver_http::{
+    MAX_REQUEST_BODY_SIZE, declared_content_length, parse_content_type, read_limited_body,
+};
 
 use super::decode::{decode_otlp_json, decode_otlp_protobuf, decompress_gzip, decompress_zstd};
 use super::{OtlpServerState, ReceiverPayload};
@@ -179,4 +181,3 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
     let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
     Ok(Some(parsed.to_ascii_lowercase()))
 }
-

--- a/crates/logfwd-io/src/receiver_http.rs
+++ b/crates/logfwd-io/src/receiver_http.rs
@@ -1,9 +1,23 @@
 use axum::body::Body;
-use axum::http::{HeaderMap, StatusCode, header::CONTENT_LENGTH};
+use axum::http::{HeaderMap, StatusCode, header::CONTENT_LENGTH, header::CONTENT_TYPE};
 use http_body_util::BodyExt as _;
 
 /// Maximum request body size shared by all HTTP receivers: 10 MB.
 pub(crate) const MAX_REQUEST_BODY_SIZE: usize = 10 * 1024 * 1024;
+
+/// Parse the `Content-Type` header, stripping parameters (e.g., `; charset=utf-8`).
+/// Returns the lowercased media type, or `None` if the header is absent.
+pub(crate) fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, StatusCode> {
+    let Some(value) = headers.get(CONTENT_TYPE) else {
+        return Ok(None);
+    };
+    let raw = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let media_type = raw.split(';').next().unwrap_or_default().trim();
+    if media_type.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    Ok(Some(media_type.to_ascii_lowercase()))
+}
 
 pub(crate) fn declared_content_length(headers: &HeaderMap) -> Option<u64> {
     headers


### PR DESCRIPTION
## Summary

Fixes 2 real issues flagged by review bots on recently merged PRs.

- **Kani vacuity guard** (#1789): `verify_parse_cri_line_no_panic` now includes `kani::cover!(result.is_some())` to prevent vacuous proofs
- **Consolidate `parse_content_type`** (#1797): 3 identical copies in arrow_ipc_receiver, otap_receiver, and otlp_receiver/server replaced with shared function in `receiver_http.rs`

## Test plan

- [x] `cargo clippy -p logfwd-io -p logfwd-core -- -D warnings` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `parse_content_type` into a shared `receiver_http` helper
> - Adds a new `pub(crate)` `parse_content_type` function in [`receiver_http.rs`](https://github.com/strawgate/memagent/pull/1807/files#diff-9d9775cf63feef7bb2824a772942a5ae2b1423c21bf3d08b50070ba44c2ba2ac) that strips parameters, trims whitespace, lowercases the media type, and returns `None` when the header is absent.
> - Removes duplicate local `parse_content_type` implementations from [`arrow_ipc_receiver.rs`](https://github.com/strawgate/memagent/pull/1807/files#diff-09612a16750832e6b7a4b59dbdd6a982a63b88557c06b3d49e74545813f8a46b), [`otap_receiver.rs`](https://github.com/strawgate/memagent/pull/1807/files#diff-d857a8f6754a55babf2b290bc90d4dc983d53420419d6c33740dd7bab066964a), and [`otlp_receiver/server.rs`](https://github.com/strawgate/memagent/pull/1807/files#diff-79c2aa47d4a6663c41f6d4600ae976eb353c7067c59848773f702daddf493d40), updating each to import the shared helper.
> - Adds a `kani::cover!` assertion to the `verify_parse_cri_line_no_panic` proof in [`cri.rs`](https://github.com/strawgate/memagent/pull/1807/files#diff-829f2a1180f6c62efb98de842e2acb1abeb43f544f72c7f86da209f2816585d0) to confirm the `Some` result path is reachable during verification.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93ae645.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->