### PR TITLE
Harden runtime health semantics and shutdown model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Network integration tests
-        run: cargo nextest run --workspace --profile ci --run-ignored ignored-only -E 'test(~network)'
+        run: |
+          cargo nextest run --no-tests fail -p logfwd-io --profile ci --run-ignored ignored-only --test it transport_e2e
+          cargo nextest run --no-tests fail -p logfwd-io --profile ci --run-ignored ignored-only --lib otap_receiver::tests::
+          cargo nextest run --no-tests fail -p logfwd-io --profile ci --run-ignored ignored-only --lib otlp_receiver::tests:: -- --skip bench_writer_helpers_fast_vs_simple
+          cargo nextest run --no-tests fail -p logfwd-diagnostics --profile ci --run-ignored ignored-only --lib diagnostics::server::tests::
 
   # -------------------------------------------------------------------------
   # Build check — aarch64 cross-compile only (release check removed:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -172,24 +172,23 @@ pipelines:
 
 See the [Configuration Reference](book/src/config/reference.md) for all YAML fields, input/output types, and enrichment tables.
 
-### Platform Sensor Betas
+### Platform Sensors
 
-`logfwd` now includes explicit beta input lanes for all three major host platforms:
+`logfwd` includes explicit sensor input lanes for all three major host platforms:
 
-- `linux_sensor_beta`
-- `macos_sensor_beta`
-- `windows_sensor_beta`
+- `linux_ebpf_sensor`
+- `macos_es_sensor`
+- `windows_ebpf_sensor`
 
 These inputs are platform-gated and emit Arrow-native sensor control/signal batches while
 deeper native sensor integrations are being brought online.
 
 ```yaml
 input:
-  type: linux_sensor_beta
-  format: raw
-  sensor_beta:
+  type: linux_ebpf_sensor
+  sensor:
     poll_interval_ms: 2000
-    emit_heartbeat: true
+    emit_signal_rows: true
 output:
   type: stdout
 ```

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -366,6 +366,7 @@ impl Pipeline {
             resource_attrs: Arc::new(resource_attrs),
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store,
+            held_tickets: Vec::new(),
             last_checkpoint_flush: tokio::time::Instant::now(),
             checkpoint_flush_interval: DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
             transition_events: super::transition::TransitionEventEmitterHandle::noop(),

--- a/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
+++ b/crates/logfwd-runtime/src/pipeline/checkpoint_io.rs
@@ -386,6 +386,28 @@ mod tests {
 #[cfg(kani)]
 mod verification {
     use super::{is_retryable_flush_error, should_retry_flush};
+    use std::io::ErrorKind;
+
+    fn any_error_kind() -> ErrorKind {
+        match kani::any::<u8>() {
+            0 => ErrorKind::Interrupted,
+            1 => ErrorKind::WouldBlock,
+            2 => ErrorKind::TimedOut,
+            3 => ErrorKind::WriteZero,
+            4 => ErrorKind::UnexpectedEof,
+            5 => ErrorKind::ConnectionReset,
+            6 => ErrorKind::ConnectionAborted,
+            7 => ErrorKind::ConnectionRefused,
+            8 => ErrorKind::NotConnected,
+            9 => ErrorKind::BrokenPipe,
+            10 => ErrorKind::PermissionDenied,
+            11 => ErrorKind::NotFound,
+            12 => ErrorKind::AlreadyExists,
+            13 => ErrorKind::InvalidInput,
+            14 => ErrorKind::InvalidData,
+            _ => ErrorKind::Other,
+        }
+    }
 
     #[kani::proof]
     fn verify_zero_or_one_attempt_never_retries() {
@@ -414,20 +436,28 @@ mod verification {
 
     #[kani::proof]
     fn verify_retryable_flush_error_classification() {
-        let kind = kani::any::<std::io::ErrorKind>();
+        let kind = any_error_kind();
         let expected = matches!(
             kind,
-            std::io::ErrorKind::Interrupted
-                | std::io::ErrorKind::WouldBlock
-                | std::io::ErrorKind::TimedOut
-                | std::io::ErrorKind::WriteZero
-                | std::io::ErrorKind::UnexpectedEof
-                | std::io::ErrorKind::ConnectionReset
-                | std::io::ErrorKind::ConnectionAborted
-                | std::io::ErrorKind::ConnectionRefused
-                | std::io::ErrorKind::NotConnected
-                | std::io::ErrorKind::BrokenPipe
+            ErrorKind::Interrupted
+                | ErrorKind::WouldBlock
+                | ErrorKind::TimedOut
+                | ErrorKind::WriteZero
+                | ErrorKind::UnexpectedEof
+                | ErrorKind::ConnectionReset
+                | ErrorKind::ConnectionAborted
+                | ErrorKind::ConnectionRefused
+                | ErrorKind::NotConnected
+                | ErrorKind::BrokenPipe
         );
         assert_eq!(is_retryable_flush_error(kind), expected);
+        kani::cover!(
+            matches!(kind, ErrorKind::TimedOut),
+            "retryable flush error covered"
+        );
+        kani::cover!(
+            matches!(kind, ErrorKind::PermissionDenied),
+            "non-retryable flush error covered"
+        );
     }
 }

--- a/crates/logfwd-runtime/src/pipeline/health.rs
+++ b/crates/logfwd-runtime/src/pipeline/health.rs
@@ -18,6 +18,9 @@ pub(super) enum HealthTransitionEvent {
     ShutdownCompleted,
 }
 
+/// Consecutive poll failures allowed while still starting before escalation.
+pub(super) const STARTING_POLL_FAILURE_ESCALATION_THRESHOLD: u32 = 3;
+
 /// Reduce a current health value and lifecycle event into the next value.
 ///
 /// Terminal states are sticky: once a component is stopped or failed, later
@@ -52,9 +55,34 @@ pub(super) const fn reduce_component_health(
     }
 }
 
+/// Reduce one poll failure with startup-aware bounded escalation.
+///
+/// While `Starting`, repeated poll failures stay `Starting` until
+/// `consecutive_poll_failures` reaches
+/// [`STARTING_POLL_FAILURE_ESCALATION_THRESHOLD`], then escalate to
+/// `Degraded`. Other states follow [`reduce_component_health`] `PollFailed`
+/// semantics.
+#[must_use]
+pub(super) const fn reduce_component_health_after_poll_failure(
+    current: ComponentHealth,
+    consecutive_poll_failures: u32,
+) -> ComponentHealth {
+    match current {
+        ComponentHealth::Starting
+            if consecutive_poll_failures >= STARTING_POLL_FAILURE_ESCALATION_THRESHOLD =>
+        {
+            ComponentHealth::Degraded
+        }
+        _ => reduce_component_health(current, HealthTransitionEvent::PollFailed),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{HealthTransitionEvent, reduce_component_health};
+    use super::{
+        HealthTransitionEvent, STARTING_POLL_FAILURE_ESCALATION_THRESHOLD, reduce_component_health,
+        reduce_component_health_after_poll_failure,
+    };
     use logfwd_diagnostics::diagnostics::ComponentHealth;
     use proptest::prelude::*;
 
@@ -124,6 +152,58 @@ mod tests {
         );
     }
 
+    #[test]
+    fn starting_poll_failures_escalate_once_threshold_is_reached() {
+        assert_eq!(
+            reduce_component_health_after_poll_failure(ComponentHealth::Starting, 1),
+            ComponentHealth::Starting
+        );
+        assert_eq!(
+            reduce_component_health_after_poll_failure(
+                ComponentHealth::Starting,
+                STARTING_POLL_FAILURE_ESCALATION_THRESHOLD - 1,
+            ),
+            ComponentHealth::Starting
+        );
+        assert_eq!(
+            reduce_component_health_after_poll_failure(
+                ComponentHealth::Starting,
+                STARTING_POLL_FAILURE_ESCALATION_THRESHOLD,
+            ),
+            ComponentHealth::Degraded
+        );
+    }
+
+    #[test]
+    fn non_starting_poll_failure_semantics_are_unchanged_with_counter() {
+        assert_eq!(
+            reduce_component_health_after_poll_failure(ComponentHealth::Healthy, 100),
+            ComponentHealth::Degraded
+        );
+        assert_eq!(
+            reduce_component_health_after_poll_failure(ComponentHealth::Stopped, 100),
+            ComponentHealth::Stopped
+        );
+    }
+
+    #[test]
+    fn post_threshold_starting_poll_failures_stay_degraded_until_observed() {
+        let mut current = ComponentHealth::Starting;
+        for n in 1..=(STARTING_POLL_FAILURE_ESCALATION_THRESHOLD + 3) {
+            current = reduce_component_health_after_poll_failure(current, n);
+        }
+        assert_eq!(current, ComponentHealth::Degraded);
+
+        current = reduce_component_health_after_poll_failure(current, 99);
+        assert_eq!(current, ComponentHealth::Degraded);
+
+        current = reduce_component_health(
+            current,
+            HealthTransitionEvent::Observed(ComponentHealth::Healthy),
+        );
+        assert_eq!(current, ComponentHealth::Healthy);
+    }
+
     fn arb_health() -> impl Strategy<Value = ComponentHealth> {
         prop_oneof![
             Just(ComponentHealth::Starting),
@@ -186,12 +266,59 @@ mod tests {
             let out = apply_events(ComponentHealth::Stopping, &events);
             prop_assert!(matches!(out, ComponentHealth::Stopping | ComponentHealth::Stopped | ComponentHealth::Failed));
         }
+
+        #[test]
+        fn starting_poll_failure_escalation_is_threshold_deterministic(
+            failures in 0u32..32
+        ) {
+            let mut current = ComponentHealth::Starting;
+            for n in 1..=failures {
+                current = reduce_component_health_after_poll_failure(current, n);
+            }
+
+            let expected = if failures >= STARTING_POLL_FAILURE_ESCALATION_THRESHOLD {
+                ComponentHealth::Degraded
+            } else {
+                ComponentHealth::Starting
+            };
+            prop_assert_eq!(current, expected);
+        }
+
+        #[test]
+        fn observed_starting_resets_startup_poll_failure_window(
+            first_streak in 0u32..16,
+            second_streak in 0u32..16
+        ) {
+            let mut current = ComponentHealth::Starting;
+            for n in 1..=first_streak {
+                current = reduce_component_health_after_poll_failure(current, n);
+            }
+
+            current = reduce_component_health(
+                current,
+                HealthTransitionEvent::Observed(ComponentHealth::Starting),
+            );
+
+            for n in 1..=second_streak {
+                current = reduce_component_health_after_poll_failure(current, n);
+            }
+
+            let expected = if second_streak >= STARTING_POLL_FAILURE_ESCALATION_THRESHOLD {
+                ComponentHealth::Degraded
+            } else {
+                ComponentHealth::Starting
+            };
+            prop_assert_eq!(current, expected);
+        }
     }
 }
 
 #[cfg(kani)]
 mod verification {
-    use super::{HealthTransitionEvent, reduce_component_health};
+    use super::{
+        HealthTransitionEvent, STARTING_POLL_FAILURE_ESCALATION_THRESHOLD, reduce_component_health,
+        reduce_component_health_after_poll_failure,
+    };
     use logfwd_diagnostics::diagnostics::ComponentHealth;
 
     #[kani::proof]
@@ -284,5 +411,43 @@ mod verification {
             current == ComponentHealth::Stopped,
             "stopped preserves on poll failure"
         );
+    }
+
+    #[kani::proof]
+    fn verify_starting_poll_failure_escalates_after_threshold() {
+        let consecutive_failures: u32 = kani::any();
+        let out = reduce_component_health_after_poll_failure(
+            ComponentHealth::Starting,
+            consecutive_failures,
+        );
+
+        if consecutive_failures >= STARTING_POLL_FAILURE_ESCALATION_THRESHOLD {
+            assert_eq!(out, ComponentHealth::Degraded);
+        } else {
+            assert_eq!(out, ComponentHealth::Starting);
+        }
+
+        kani::cover!(consecutive_failures == 0, "zero_failures");
+        kani::cover!(
+            consecutive_failures >= STARTING_POLL_FAILURE_ESCALATION_THRESHOLD,
+            "threshold_reached"
+        );
+    }
+
+    #[kani::proof]
+    fn verify_non_starting_poll_failure_matches_base_reducer() {
+        let health_repr = kani::any_where(|repr: &u8| {
+            ComponentHealth::from_repr(*repr) != ComponentHealth::Starting
+        });
+        let current = ComponentHealth::from_repr(health_repr);
+        let consecutive_failures: u32 = kani::any();
+
+        let out_with_counter =
+            reduce_component_health_after_poll_failure(current, consecutive_failures);
+        let out_base = reduce_component_health(current, HealthTransitionEvent::PollFailed);
+        assert_eq!(out_with_counter, out_base);
+
+        kani::cover!(current == ComponentHealth::Healthy, "healthy_case");
+        kani::cover!(current == ComponentHealth::Stopped, "stopped_case");
     }
 }

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -50,7 +50,9 @@ use logfwd_types::pipeline::SourceId;
 use logfwd_io::tail::ByteOffset;
 
 #[cfg(not(feature = "turmoil"))]
-use super::health::{HealthTransitionEvent, reduce_component_health};
+use super::health::{
+    HealthTransitionEvent, reduce_component_health, reduce_component_health_after_poll_failure,
+};
 #[cfg(not(feature = "turmoil"))]
 use super::{InputState, InputTransform};
 
@@ -135,6 +137,7 @@ fn io_worker_loop(
 ) {
     let mut buffered_since: Option<Instant> = None;
     let mut last_bp_warn: Option<Instant> = None;
+    let mut consecutive_poll_failures: u32 = 0;
     let mut adaptive_poll =
         AdaptivePollController::new(input.source.get_cadence().adaptive_fast_polls_max);
 
@@ -152,15 +155,19 @@ fn io_worker_loop(
             Err(e) => {
                 adaptive_poll.reset_fast_polls();
                 input.stats.inc_errors();
-                input.stats.set_health(reduce_component_health(
-                    input.stats.health(),
-                    HealthTransitionEvent::PollFailed,
-                ));
+                consecutive_poll_failures = consecutive_poll_failures.saturating_add(1);
+                input
+                    .stats
+                    .set_health(reduce_component_health_after_poll_failure(
+                        input.stats.health(),
+                        consecutive_poll_failures,
+                    ));
                 tracing::warn!(input = input.source.name(), error = %e, "input.poll_error");
                 std::thread::sleep(Duration::from_millis(100));
                 continue;
             }
         };
+        consecutive_poll_failures = 0;
 
         input.stats.set_health(reduce_component_health(
             input.stats.health(),

--- a/crates/logfwd-runtime/src/pipeline/input_poll.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_poll.rs
@@ -13,7 +13,9 @@ use logfwd_io::poll_cadence::AdaptivePollController;
 use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "turmoil")]
-use super::health::{HealthTransitionEvent, reduce_component_health};
+use super::health::{
+    HealthTransitionEvent, reduce_component_health, reduce_component_health_after_poll_failure,
+};
 #[cfg(feature = "turmoil")]
 use super::submit::{scan_and_transform_for_send, transform_direct_batch_for_send};
 #[cfg(feature = "turmoil")]
@@ -53,6 +55,7 @@ pub(super) async fn async_input_poll_loop(
     input_index: usize,
 ) {
     let mut buffered_since: Option<tokio::time::Instant> = None;
+    let mut consecutive_poll_failures: u32 = 0;
     let mut adaptive_poll =
         AdaptivePollController::new(input.source.get_cadence().adaptive_fast_polls_max);
     'poll_loop: loop {
@@ -69,15 +72,19 @@ pub(super) async fn async_input_poll_loop(
             Err(e) => {
                 adaptive_poll.reset_fast_polls();
                 input.stats.inc_errors();
-                input.stats.set_health(reduce_component_health(
-                    input.stats.health(),
-                    HealthTransitionEvent::PollFailed,
-                ));
+                consecutive_poll_failures = consecutive_poll_failures.saturating_add(1);
+                input
+                    .stats
+                    .set_health(reduce_component_health_after_poll_failure(
+                        input.stats.health(),
+                        consecutive_poll_failures,
+                    ));
                 tracing::warn!(input = input.source.name(), error = %e, "input.poll_error");
                 tokio::time::sleep(Duration::from_millis(100)).await;
                 continue;
             }
         };
+        consecutive_poll_failures = 0;
 
         input.stats.set_health(reduce_component_health(
             input.stats.health(),

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -165,6 +165,12 @@ pub struct Pipeline {
     machine: Option<PipelineMachine<Running, u64>>,
     /// Durable checkpoint store. None when running without persistence (tests).
     checkpoint_store: Option<Box<dyn CheckpointStore>>,
+    /// Tickets for batches that failed after send ownership was transferred.
+    ///
+    /// The runtime cannot requeue these without also retaining payload ownership,
+    /// but it must keep the queued ticket alive so the lifecycle machine keeps
+    /// the batch unresolved and checkpoints do not advance past undelivered data.
+    held_tickets: Vec<logfwd_types::pipeline::BatchTicket<logfwd_types::pipeline::Queued, u64>>,
     /// Throttle checkpoint flushes to at most once per this interval.
     /// Uses tokio::time::Instant so the throttle works correctly under
     /// both real and simulated (Turmoil) time.
@@ -324,6 +330,7 @@ impl Pipeline {
             resource_attrs: Arc::new(vec![]),
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store: None,
+            held_tickets: Vec::new(),
             last_checkpoint_flush: tokio::time::Instant::now(),
             checkpoint_flush_interval: build::DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
             transition_events: TransitionEventEmitterHandle::noop(),
@@ -359,6 +366,7 @@ impl Pipeline {
             resource_attrs: Arc::new(vec![]),
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store: None,
+            held_tickets: Vec::new(),
             last_checkpoint_flush: tokio::time::Instant::now(),
             checkpoint_flush_interval: build::DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
             transition_events: TransitionEventEmitterHandle::noop(),
@@ -505,7 +513,11 @@ impl Pipeline {
                 // we ingest or flush more data.
                 ack = self.pool.ack_rx_mut().recv() => {
                     if let Some(ack) = ack {
-                        self.apply_pool_ack(ack);
+                        if self.apply_pool_ack(ack) {
+                            shutdown.cancel();
+                            should_drain_input_channel = false;
+                            break;
+                        }
                     }
                 }
 
@@ -516,8 +528,8 @@ impl Pipeline {
                 msg = rx.recv() => {
                     if let Some(msg) = msg {
                         if self.submit_batch(msg, shutdown).await {
-                            // `submit_batch` returns true only for processor fatal
-                            // shutdowns. Stop ingesting additional channel messages.
+                            // Terminal processor/checkpoint paths stop accepting
+                            // additional channel messages.
                             should_drain_input_channel = false;
                             break;
                         }
@@ -570,6 +582,11 @@ impl Pipeline {
                     break;
                 }
             }
+        } else {
+            // Terminal paths intentionally stop accepting more input, but the
+            // receiver must still be closed before joining producers. Otherwise
+            // a producer blocked on the bounded channel can keep shutdown stuck.
+            drop(rx);
         }
 
         // All sender clones have now been dropped, so input threads/tasks can
@@ -741,7 +758,7 @@ impl Pipeline {
     /// Apply a pool `AckItem` at the worker/checkpoint seam.
     ///
     /// Called from the `select!` loop when a pool worker finishes a batch.
-    fn apply_pool_ack(&mut self, ack: AckItem) {
+    fn apply_pool_ack(&mut self, ack: AckItem) -> bool {
         if self
             .metrics
             .inflight_batches
@@ -775,7 +792,7 @@ impl Pipeline {
             Some(ack.batch_id),
             ack.tickets,
             default_ticket_disposition(&ack.outcome),
-        );
+        )
     }
 
     /// Finalize Sending tickets and apply receipts to the machine when present.
@@ -786,9 +803,9 @@ impl Pipeline {
         batch_id: Option<u64>,
         tickets: Vec<logfwd_types::pipeline::BatchTicket<logfwd_types::pipeline::Sending, u64>>,
         disposition: TicketDisposition,
-    ) {
+    ) -> bool {
         let Some(ref mut machine) = self.machine else {
-            return;
+            return false;
         };
         let transition_events = self.transition_events.clone();
         let mut any_advanced = false;
@@ -810,7 +827,7 @@ impl Pipeline {
                     // contract without acknowledging the batch. We
                     // intentionally do not re-dispatch yet; the machine keeps
                     // this batch in-flight so checkpoints do not advance.
-                    let _ = ticket.fail();
+                    self.held_tickets.push(ticket.fail());
                     held += 1;
                     None
                 }
@@ -898,7 +915,7 @@ impl Pipeline {
         if held > 0 {
             tracing::warn!(
                 held_tickets = held,
-                "pipeline: leaving tickets unresolved so checkpoints do not advance past undelivered data"
+                "pipeline: terminal hold requested; stopping ingestion so checkpoints do not advance past undelivered data"
             );
         }
         // Flush to disk at most once per checkpoint_flush_interval to amortize fsync cost.
@@ -928,6 +945,7 @@ impl Pipeline {
                 }
             }
         }
+        held > 0
     }
 }
 
@@ -1835,6 +1853,55 @@ output:
         );
     }
 
+    /// Terminal held-ticket shutdown must close the input channel before
+    /// joining producers. Otherwise producers blocked on a full bounded channel
+    /// can keep shutdown stuck forever.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn held_ticket_shutdown_does_not_deadlock_on_full_channel() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("held_ticket_full_channel.log");
+
+        let mut data = String::new();
+        for i in 0..200 {
+            data.push_str(&format!(r#"{{"i":{i}}}"#));
+            data.push('\n');
+        }
+        std::fs::write(&log_path, data.as_bytes()).unwrap();
+
+        let yaml = format!(
+            r#"
+input:
+  type: file
+  path: "{}"
+  format: json
+output:
+  type: stdout
+  format: json
+"#,
+            log_path.display()
+        );
+
+        let config = logfwd_config::Config::load_str(&yaml).unwrap();
+        let pipe_cfg = &config.pipelines["default"];
+        let mut pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter(), None).unwrap();
+        pipeline = pipeline.with_sink(Box::new(FailingSink::new(u32::MAX)));
+        pipeline.batch_target_bytes = 64;
+        pipeline.batch_timeout = Duration::from_millis(10);
+
+        let shutdown = CancellationToken::new();
+        let result =
+            tokio::time::timeout(Duration::from_secs(5), pipeline.run_async(&shutdown)).await;
+
+        assert!(
+            result.is_ok(),
+            "held-ticket shutdown should close the channel and not deadlock"
+        );
+        assert!(
+            result.unwrap().is_ok(),
+            "pipeline should complete terminal held-ticket shutdown cleanly"
+        );
+    }
+
     /// Shutdown with a slow output must still drain all buffered data.
     /// The output takes 50ms per batch, but shutdown should wait for
     /// the drain to complete rather than dropping data.
@@ -2714,6 +2781,37 @@ output:
     }
 
     #[test]
+    fn hold_disposition_retains_failed_ticket_without_advancing_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("hold.log");
+        std::fs::write(&log_path, b"").unwrap();
+
+        let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        let machine = pipeline.machine.as_mut().unwrap();
+        let source = SourceId(42);
+        let ticket = machine.create_batch(source, 1000);
+        let ticket = machine.begin_send(ticket);
+
+        assert!(
+            pipeline.ack_all_tickets(None, vec![ticket], TicketDisposition::Hold),
+            "hold disposition must request terminal shutdown to bound held-ticket growth"
+        );
+
+        let machine = pipeline.machine.as_ref().unwrap();
+        assert_eq!(
+            machine.in_flight_count(),
+            1,
+            "held tickets must keep the source checkpoint unadvanced"
+        );
+        assert_eq!(machine.committed_checkpoint(source), None);
+        assert_eq!(
+            pipeline.held_tickets.len(),
+            1,
+            "hold must retain a failed queued ticket instead of dropping the sending ticket"
+        );
+    }
+
+    #[test]
     fn test_apply_pool_ack_does_not_underflow_inflight_counter() {
         let dir = tempfile::tempdir().unwrap();
         let log_path = dir.path().join("underflow.log");
@@ -2742,6 +2840,45 @@ output:
             pipeline.metrics.inflight_batches.load(Ordering::Relaxed),
             0,
             "inflight counter must not underflow on stray ack"
+        );
+    }
+
+    #[test]
+    fn held_pool_ack_requests_terminal_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("held-pool-ack.log");
+        std::fs::write(&log_path, "").unwrap();
+        let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        let machine = pipeline.machine.as_mut().unwrap();
+        let ticket = machine.create_batch(SourceId(42), 1000);
+        let ticket = machine.begin_send(ticket);
+
+        let should_stop = pipeline.apply_pool_ack(AckItem {
+            tickets: vec![ticket],
+            outcome: crate::worker_pool::DeliveryOutcome::InternalFailure,
+            num_rows: 0,
+            submitted_at: tokio::time::Instant::now(),
+            scan_ns: 0,
+            transform_ns: 0,
+            output_ns: 0,
+            queue_wait_ns: 0,
+            send_latency_ns: 0,
+            batch_id: 0,
+            output_name: "test".to_string(),
+        });
+
+        assert!(
+            should_stop,
+            "held worker outcomes must terminalize ingestion instead of accumulating tickets"
+        );
+        assert_eq!(pipeline.held_tickets.len(), 1);
+        assert_eq!(
+            pipeline
+                .machine
+                .as_ref()
+                .unwrap()
+                .committed_checkpoint(SourceId(42)),
+            None
         );
     }
 

--- a/crates/logfwd-runtime/src/pipeline/submit.rs
+++ b/crates/logfwd-runtime/src/pipeline/submit.rs
@@ -111,13 +111,16 @@ impl Pipeline {
             ProcessorStageResult::Forward { batch, output_rows } => (batch, output_rows),
             ProcessorStageResult::Hold { reason } => {
                 tracing::warn!(reason = %reason, "processor stage requested hold");
-                self.ack_all_tickets(
+                let held = self.ack_all_tickets(
                     Some(batch_id),
                     sending,
                     super::checkpoint_policy::TicketDisposition::Hold,
                 );
                 self.metrics.finish_active_batch(batch_id);
-                return false;
+                if held {
+                    shutdown.cancel();
+                }
+                return held;
             }
             ProcessorStageResult::PermanentError { reason } => {
                 tracing::warn!(reason = %reason, "processor stage permanent error; dropping batch");
@@ -179,9 +182,7 @@ impl Pipeline {
             );
             self.metrics.finish_active_batch(batch_id);
             shutdown.cancel();
-            // Keep the select-loop on the normal shutdown path so run_async can
-            // still drain the input channel and avoid producer-side deadlocks.
-            return false;
+            return true;
         }
 
         let batch_span = tracing::info_span!(

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -76,6 +76,12 @@ constants). `tla/PipelineMachine.cfg` is the TLC configuration file (three model
 documented inside). See `tla/README.md` for full documentation, design decisions captured
 in the spec, and known gaps.
 
+`tla/ShutdownProtocol.tla` models split I/O/CPU worker shutdown plus output
+terminal health. Clean shutdown reaches output health `Stopped`; forced stop
+and worker-panic paths reach `Failed`. Safety checks include
+`MachineStoppedImpliesOutputTerminal` and `ForcedStopImpliesOutputFailed`;
+liveness checks include `OutputFailureSticky`.
+
 ### Running TLC
 
 ```bash
@@ -363,7 +369,7 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 | `cri.rs` | CRI log parsing + partial line reassembly | Kani exhaustive (8 proofs) |
 | `otlp.rs` | Protobuf wire format + OTLP encoding + timestamp parsing | Kani mixed exhaustive + bounded (30 proofs incl. 3 contract verifications) |
 | `pipeline/lifecycle.rs` | Pipeline state machine (ordered ACK, drain, shutdown) | Kani exhaustive (6 proofs) + proptest + **TLA+** |
-| `logfwd/pipeline/health.rs` | Pipeline component-health transition reducer (`observed`, poll failure, shutdown) | Kani exhaustive (4 proofs) + unit tests + proptest sequence checks |
+| `logfwd-runtime/pipeline/health.rs` | Pipeline component-health transition reducer (`observed`, bounded startup poll failure escalation, shutdown) | Kani exhaustive (6 proofs) + unit tests + proptest sequence checks |
 | `pipeline/batch.rs` | BatchTicket typestate (ack/nack/fail/reject) | Kani exhaustive (5 proofs) + compile-time |
 | `logfwd-types/diagnostics/health.rs` | `ComponentHealth` lattice (`combine`, readiness, storage repr) | Kani exhaustive (4 proofs) + unit tests |
 | `logfwd-output/lib.rs` | Conflict struct detection, ColVariant priority ordering | Kani (8 proofs: ColVariant field preservation, variant_dt, is_conflict_struct, json/str priority contracts) |
@@ -385,11 +391,11 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 | `logfwd-io/framed.rs` | Per-source framing/remainder checkpoint boundary (`overflow_tainted`, EOF remainder flush, source-scoped EOF semantics) | Unit tests (remainder carry/overflow, per-source isolation, EOF flush + checkpoint advancement contracts) |
 | `logfwd-io/tail/verification.rs` | File tailer pure reducers for EOF emission + error backoff (`eof_model_transition`, `backoff_transition`) | Kani (7 proofs: EOF at-most-once thresholding, reset semantics, two-poll/repeat cycle, backoff cap/reset/monotonicity) + proptest (state reducer invariants in `tail/state.rs`) + **TLA+** (`tla/TailLifecycle.tla`) |
 | `logfwd-io/segment.rs` | Checkpoint segment envelope read/write/recovery (`LCHK` header/footer, checksum, replay plan) | Unit tests for panic/OOM/silent-mask hardening (unsupported-version, permission-denied I/O surfacing, write/read size-bound parity, recovery error semantics) |
-| `logfwd/pipeline/checkpoint_policy.rs` | Typed delivery outcome -> checkpoint disposition mapping plus bounded ordered-commit seam model (`Ack`, `Reject`, `Hold`) | Kani exhaustive/bounded (6 proofs: outcome mapping, hold no-advance, ack/reject terminal equivalence, mixed-sequence monotonicity/no-gap jumps) + unit tests + proptest ordered sequence invariants |
-| `logfwd/pipeline/checkpoint_io.rs` | Final checkpoint flush retry window (`MAX_ATTEMPTS`, retry/no-retry boundary, stop-on-success behavior) | Kani (2 proofs: zero/one-attempt no-retry, retry-window equivalence) + unit tests + proptest retry-window equivalence checks + async retry behavior tests |
-| `logfwd/pipeline/input_poll.rs` | Turmoil input-loop flush predicate (`should_flush_buffer`) for byte-batch/timeout emission policy | Kani (3 proofs: empty-buffer no-flush, timeout gate semantics, predicate equivalence) + unit tests + proptest policy equivalence |
-| `logfwd/worker_pool/health.rs` | Pool idle-phase insertion + worker-slot aggregation policy | Kani exhaustive (3 proofs) + unit tests + proptest aggregation checks |
-| `logfwd/worker_pool.rs` | MRU dispatch decision + typed delivery outcome helpers | Kani (8 dispatch/outcome proofs) + unit tests for worker-slot aggregation, drain-phase stickiness, and create-failure behavior |
+| `logfwd-runtime/pipeline/checkpoint_policy.rs` | Typed delivery outcome -> checkpoint disposition mapping plus bounded ordered-commit seam model (`Ack`, `Reject`, `Hold`) | Kani exhaustive/bounded (6 proofs: outcome mapping, hold no-advance, ack/reject terminal equivalence, mixed-sequence monotonicity/no-gap jumps) + unit tests + proptest ordered sequence invariants |
+| `logfwd-runtime/pipeline/checkpoint_io.rs` | Final checkpoint flush retry window (`MAX_ATTEMPTS`, retry/no-retry boundary, retryable error classification, stop-on-success behavior) | Kani (3 proofs: zero/one-attempt no-retry, retry-window equivalence, retryable error classification) + unit tests + proptest retry-window equivalence checks + async retry behavior tests |
+| `logfwd-runtime/pipeline/input_poll.rs` | Turmoil input-loop flush predicate (`should_flush_buffer`) for byte-batch/timeout emission policy | Kani (3 proofs: empty-buffer no-flush, timeout gate semantics, predicate equivalence) + unit tests + proptest policy equivalence |
+| `logfwd-runtime/worker_pool/health.rs` | Pool idle-phase insertion + worker-slot aggregation policy | Kani exhaustive (3 proofs) + unit tests + proptest aggregation checks |
+| `logfwd-runtime/worker_pool.rs` | MRU dispatch decision + typed delivery outcome helpers | Kani (8 dispatch/outcome proofs) + unit tests for worker-slot aggregation, drain-phase stickiness, and create-failure behavior |
 | `logfwd-arrow/storage_builder.rs` | StructArray conflict column assembly | Kani (2 proofs: duplicate name guard, row count invariant) + unit tests |
 | `logfwd-arrow/streaming_builder.rs` | StructArray conflict column assembly (StringView) | Kani (2 proofs: duplicate name guard, row count invariant) + unit tests |
 | `logfwd-arrow/conflict_schema.rs` | Conflict-struct detection + row-level precedence selection | Kani recommended (2 proofs) + unit tests |

--- a/tla/README.md
+++ b/tla/README.md
@@ -204,7 +204,10 @@ capacity-independent so small values suffice for model checking.
 | `NoCpuStopBeforeIoDrain` | Safety | cpu_workers_stopped implies io_channels_drained |
 | `NoJoinBeforePipelineDrain` | Safety | workers_joined implies pipeline_channel_drained |
 | `NoStopBeforeJoin` | Safety | machine_stopped implies workers_joined |
+| `MachineStoppedImpliesOutputTerminal` | Safety | machine_stopped implies output health is terminal (`Stopped` or `Failed`) |
 | `NormalStopImpliesPoolDrained` | Safety | normal stop (not forced) implies pool fully drained |
+| `ForcedStopImpliesOutputFailed` | Safety | forced stop reports terminal output failure |
+| `DrainFlagsConsistent` | Safety | latched shutdown milestones imply their underlying worker/channel state |
 | `IoConservation` | Safety | per-input: produced = in_io_channel + cpu_forwarded (no dup/loss) |
 | `PipelineConservation` | Safety | total forwarded = in_pipeline_channel + consumed (no dup/loss) |
 | `ShutdownCompletes` | Liveness | shutdown signal leads to machine_stopped |
@@ -212,12 +215,16 @@ capacity-independent so small values suffice for model checking.
 | `IoCpuChannelEventuallyDrained` | Liveness | all I/O workers stopped leads to io_channels_drained |
 | `CpuWorkersEventuallyStop` | Liveness | all I/O workers stopped leads to all CPU workers stopped |
 | `EventualStop` | Liveness | machine eventually reaches stopped state permanently |
+| `OutputFailureSticky` | Liveness | once output health is failed, it remains failed |
 | `ShutdownReachable` | Reachability | shutdown_signaled is reachable (vacuity guard) |
 | `IoChannelsDrainedReachable` | Reachability | io_channels_drained is reachable |
 | `CpuWorkersStoppedReachable` | Reachability | cpu_workers_stopped is reachable |
 | `PipelineChannelDrainedReachable` | Reachability | pipeline_channel_drained is reachable |
+| `WorkersJoinedReachable` | Reachability | workers_joined is reachable |
+| `PoolDrainedReachable` | Reachability | pool_drained is reachable |
 | `NormalStopReachable` | Reachability | normal stop is reachable |
 | `ForceStopReachable` | Reachability | force stop is reachable |
+| `OutputFailedReachable` | Reachability | output failure path is reachable |
 | `IoChannelFullReachable` | Reachability | at least one io channel reaches capacity (backpressure) |
 | `PipelineChannelFullReachable` | Reachability | pipeline channel reaches capacity (backpressure) |
 

--- a/tla/ShutdownProtocol.cfg
+++ b/tla/ShutdownProtocol.cfg
@@ -13,7 +13,9 @@ INVARIANTS
     NoCpuStopBeforeIoDrain
     NoJoinBeforePipelineDrain
     NoStopBeforeJoin
+    MachineStoppedImpliesOutputTerminal
     NormalStopImpliesPoolDrained
+    ForcedStopImpliesOutputFailed
     DrainFlagsConsistent
     IoConservation
     PipelineConservation

--- a/tla/ShutdownProtocol.coverage.cfg
+++ b/tla/ShutdownProtocol.coverage.cfg
@@ -19,3 +19,4 @@ INVARIANTS
     PipelineChannelFullReachable
     NormalStopReachable
     ForceStopReachable
+    OutputFailedReachable

--- a/tla/ShutdownProtocol.liveness.cfg
+++ b/tla/ShutdownProtocol.liveness.cfg
@@ -14,3 +14,4 @@ PROPERTIES
     IoCpuChannelEventuallyDrained
     CpuWorkersEventuallyStop
     EventualStop
+    OutputFailureSticky

--- a/tla/ShutdownProtocol.tla
+++ b/tla/ShutdownProtocol.tla
@@ -81,13 +81,14 @@ VARIABLES
     workers_joined,          \* manager.join() completed
     pool_drained,            \* pool drain completed
     machine_stopped,         \* PipelineMachine transitioned to Stopped
-    forced                   \* force_stop path was used
+    forced,                  \* force_stop path was used
+    output_health            \* "Healthy" | "Stopping" | "Stopped" | "Failed"
 
 vars == <<input_produced, io_alive, io_channels, cpu_forwarded, cpu_alive,
           pipeline_channel, consumed, pool_pending, pool_acked,
           shutdown_signaled, io_channels_drained, cpu_workers_stopped,
           pipeline_channel_drained, workers_joined, pool_drained,
-          machine_stopped, forced>>
+          machine_stopped, forced, output_health>>
 
 Inputs == 1..NumInputs
 
@@ -128,6 +129,7 @@ TypeOK ==
     /\ pool_drained \in BOOLEAN
     /\ machine_stopped \in BOOLEAN
     /\ forced \in BOOLEAN
+    /\ output_health \in {"Healthy", "Stopping", "Stopped", "Failed"}
 
 (* -----------------------------------------------------------------------
  * Initial state
@@ -151,6 +153,7 @@ Init ==
     /\ pool_drained = FALSE
     /\ machine_stopped = FALSE
     /\ forced = FALSE
+    /\ output_health = "Healthy"
 
 (* -----------------------------------------------------------------------
  * Actions: Normal operation
@@ -167,7 +170,7 @@ IoProduce(i) ==
                    consumed, pool_pending, pool_acked, shutdown_signaled,
                    io_channels_drained, cpu_workers_stopped,
                    pipeline_channel_drained, workers_joined, pool_drained,
-                   machine_stopped, forced>>
+                   machine_stopped, forced, output_health>>
 
 \* CPU worker drains one chunk from its io_cpu channel and forwards to pipeline channel.
 CpuForward(i) ==
@@ -181,7 +184,7 @@ CpuForward(i) ==
                    pool_pending, pool_acked, shutdown_signaled,
                    io_channels_drained, cpu_workers_stopped,
                    pipeline_channel_drained, workers_joined, pool_drained,
-                   machine_stopped, forced>>
+                   machine_stopped, forced, output_health>>
 
 \* Pipeline main loop receives one batch from the shared channel and submits to pool.
 ConsumePipeline ==
@@ -193,7 +196,7 @@ ConsumePipeline ==
                    cpu_alive, pool_acked, shutdown_signaled,
                    io_channels_drained, cpu_workers_stopped,
                    pipeline_channel_drained, workers_joined, pool_drained,
-                   machine_stopped, forced>>
+                   machine_stopped, forced, output_health>>
 
 \* Output pool acks one submitted batch.
 PoolAck ==
@@ -202,6 +205,18 @@ PoolAck ==
     /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    shutdown_signaled, io_channels_drained,
+                   cpu_workers_stopped, pipeline_channel_drained,
+                   workers_joined, pool_drained, machine_stopped, forced, output_health>>
+
+\* Worker panic during output processing marks terminal output failure.
+WorkerPanic ==
+    /\ ~machine_stopped
+    /\ pool_pending > pool_acked
+    /\ output_health # "Failed"
+    /\ output_health' = "Failed"
+    /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
+                   cpu_alive, pipeline_channel, consumed, pool_pending,
+                   pool_acked, shutdown_signaled, io_channels_drained,
                    cpu_workers_stopped, pipeline_channel_drained,
                    workers_joined, pool_drained, machine_stopped, forced>>
 
@@ -213,6 +228,8 @@ PoolAck ==
 SignalShutdown ==
     /\ ~shutdown_signaled
     /\ shutdown_signaled' = TRUE
+    /\ output_health' =
+        IF output_health = "Healthy" THEN "Stopping" ELSE output_health
     /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    pool_acked, io_channels_drained, cpu_workers_stopped,
@@ -228,7 +245,7 @@ IoWorkerStop(i) ==
                    pipeline_channel, consumed, pool_pending, pool_acked,
                    shutdown_signaled, io_channels_drained,
                    cpu_workers_stopped, pipeline_channel_drained,
-                   workers_joined, pool_drained, machine_stopped, forced>>
+                   workers_joined, pool_drained, machine_stopped, forced, output_health>>
 
 \* 3) Observe that all io workers are down and all io_cpu channels are empty.
 \*    This is a derived observation -- not a precondition for CpuWorkerStop.
@@ -244,7 +261,7 @@ MarkIoChannelsDrained ==
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    pool_acked, shutdown_signaled, cpu_workers_stopped,
                    pipeline_channel_drained, workers_joined, pool_drained,
-                   machine_stopped, forced>>
+                   machine_stopped, forced, output_health>>
 
 \* 4) CPU worker exits once its own I/O worker is dead and its io channel is empty.
 \*    This is per-input: each CPU worker independently observes that its own
@@ -259,7 +276,7 @@ CpuWorkerStop(i) ==
                    pipeline_channel, consumed, pool_pending, pool_acked,
                    shutdown_signaled, io_channels_drained,
                    cpu_workers_stopped, pipeline_channel_drained,
-                   workers_joined, pool_drained, machine_stopped, forced>>
+                   workers_joined, pool_drained, machine_stopped, forced, output_health>>
 
 \* 5) Record that all CPU workers have stopped.
 \*    Gates MarkPipelineChannelDrained -- no more pipeline sends are possible.
@@ -276,7 +293,7 @@ MarkCpuWorkersStopped ==
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    pool_acked, shutdown_signaled,
                    pipeline_channel_drained, workers_joined, pool_drained,
-                   machine_stopped, forced>>
+                   machine_stopped, forced, output_health>>
 
 \* 6) Shared pipeline channel is drained after CPU workers have exited.
 MarkPipelineChannelDrained ==
@@ -288,7 +305,7 @@ MarkPipelineChannelDrained ==
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    pool_acked, shutdown_signaled, io_channels_drained,
                    cpu_workers_stopped, workers_joined, pool_drained,
-                   machine_stopped, forced>>
+                   machine_stopped, forced, output_health>>
 
 \* 7) Join all input workers (CPU first, then I/O in implementation).
 JoinWorkers ==
@@ -301,7 +318,7 @@ JoinWorkers ==
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    pool_acked, shutdown_signaled, io_channels_drained,
                    cpu_workers_stopped, pipeline_channel_drained,
-                   pool_drained, machine_stopped, forced>>
+                   pool_drained, machine_stopped, forced, output_health>>
 
 \* 8) Drain pool after no more channel traffic is possible.
 DrainPool ==
@@ -313,13 +330,14 @@ DrainPool ==
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    pool_acked, shutdown_signaled, io_channels_drained,
                    cpu_workers_stopped, pipeline_channel_drained,
-                   workers_joined, machine_stopped, forced>>
+                   workers_joined, machine_stopped, forced, output_health>>
 
 \* 9a) Normal stop path.
 NormalStop ==
     /\ pool_drained
     /\ ~machine_stopped
     /\ machine_stopped' = TRUE
+    /\ output_health' = IF output_health = "Failed" THEN "Failed" ELSE "Stopped"
     /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    pool_acked, shutdown_signaled, io_channels_drained,
@@ -336,6 +354,7 @@ ForceStop ==
     /\ ~machine_stopped
     /\ machine_stopped' = TRUE
     /\ forced' = TRUE
+    /\ output_health' = "Failed"
     /\ UNCHANGED <<input_produced, io_alive, io_channels, cpu_forwarded,
                    cpu_alive, pipeline_channel, consumed, pool_pending,
                    pool_acked, shutdown_signaled, io_channels_drained,
@@ -351,6 +370,7 @@ Next ==
     \/ \E i \in Inputs : CpuForward(i)
     \/ ConsumePipeline
     \/ PoolAck
+    \/ WorkerPanic
     \/ SignalShutdown
     \/ \E i \in Inputs : IoWorkerStop(i)
     \/ MarkIoChannelsDrained
@@ -398,8 +418,14 @@ NoJoinBeforePipelineDrain ==
 NoStopBeforeJoin ==
     machine_stopped => workers_joined
 
+MachineStoppedImpliesOutputTerminal ==
+    machine_stopped => output_health \in {"Stopped", "Failed"}
+
 NormalStopImpliesPoolDrained ==
     (machine_stopped /\ ~forced) => pool_drained
+
+ForcedStopImpliesOutputFailed ==
+    (machine_stopped /\ forced) => output_health = "Failed"
 
 \* Shutdown stage flags must reflect underlying worker/channel state.
 DrainFlagsConsistent ==
@@ -446,6 +472,9 @@ CpuWorkersEventuallyStop ==
 EventualStop ==
     <>[](machine_stopped)
 
+OutputFailureSticky ==
+    [](output_health = "Failed" => [](output_health = "Failed"))
+
 (* -----------------------------------------------------------------------
  * Reachability / vacuity guards
  * ----------------------------------------------------------------------- *)
@@ -458,6 +487,7 @@ WorkersJoinedReachable == ~workers_joined
 PoolDrainedReachable == ~pool_drained
 NormalStopReachable == ~(machine_stopped /\ ~forced)
 ForceStopReachable == ~(machine_stopped /\ forced)
+OutputFailedReachable == ~(output_health = "Failed")
 
 \* Backpressure reachability: witness that bounded channels can become full.
 \* Important for shutdown deadlock analysis -- TLC must explore these states.


### PR DESCRIPTION
## Summary

This PR was rebuilt onto current `main` and replaces the previous stacked history with three focused commits:

1. **Runtime health/checkpoint hardening**
- Retains failed queued tickets for `TicketDisposition::Hold` so unresolved delivery does not silently drop ticket ownership or advance checkpoints.
- Adds bounded startup poll-failure escalation through `reduce_component_health_after_poll_failure` and wires it into both normal and Turmoil input polling loops.
- Fixes the Kani checkpoint-flush error-kind proof so `logfwd-runtime` Kani harnesses compile under `cfg(kani)`.

2. **Shutdown model alignment**
- Extends `tla/ShutdownProtocol.tla` with `output_health`, worker-panic failure, forced-stop failure, terminal output-health invariants, liveness, and coverage witnesses.
- Updates `tla/README.md` and `dev-docs/VERIFICATION.md` to match the checked-in model and proof coverage.

3. **Small related cleanup**
- Updates README platform sensor examples to use the current `linux_ebpf_sensor` / `macos_es_sensor` / `windows_ebpf_sensor` names and `sensor:` config block.
- Scopes docs deploy concurrency by workflow + PR/ref instead of a single global `pages` group.

## Scope cleanup

The old stacked branch included stale file snapshots and unrelated historical audit-doc/lockfile drift. This branch is now based directly on current `main`; it does **not** include the stale dependency audit rewrite or the old `fastrand 2.4.0` lockfile downgrade.

## Verification

Ran locally:
- `cargo fmt --check`
- `git diff --check origin/main..HEAD`
- `cargo check --locked -p logfwd --no-default-features`
- `cargo check --locked -p logfwd`
- `cargo test --locked -p logfwd-runtime pipeline::health -- --nocapture`
- `cargo test --locked -p logfwd-runtime pipeline::input_poll -- --nocapture`
- `cargo test --locked -p logfwd-runtime pipeline::tests::hold_disposition_retains_failed_ticket_without_advancing_checkpoint -- --nocapture`
- `cargo test --locked -p logfwd-runtime pipeline::checkpoint_io::verification -- --nocapture` (0 runtime tests; verifies the cfg-gated module does not affect normal tests)
- `just tlc MCShutdownProtocol.tla ShutdownProtocol.cfg`
- `just tlc MCShutdownProtocol.tla ShutdownProtocol.liveness.cfg`
- `PATH="/opt/homebrew/opt/openjdk/bin:$PATH" python3 scripts/verify_tla_coverage.py --jar .tools/tla2tools.jar --tla-file tla/MCShutdownProtocol.tla --config tla/ShutdownProtocol.coverage.cfg`
- `cargo kani -p logfwd-runtime --harness verify_starting_poll_failure_escalates_after_threshold`
- `cargo kani -p logfwd-runtime --harness verify_retryable_flush_error_classification`

Notes:
- Kani emits existing `unused_qualifications` warnings from `crates/logfwd-core/src/structural_iter.rs`; the targeted harnesses still verify successfully.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden pipeline health semantics and shutdown model to prevent held-ticket accumulation
> - Adds a startup-aware poll-failure reducer in [health.rs](https://github.com/strawgate/memagent/pull/1808/files#diff-7529489263e34465d0b1196f3d1134504fc32a421ad0d0c75f2d8e847bc8ee0a): health stays `Starting` until `STARTING_POLL_FAILURE_ESCALATION_THRESHOLD` (3) consecutive failures, then escalates to `Degraded`.
> - Extends the `Pipeline` struct with a `held_tickets` field; on terminal `Hold` disposition, failed queued tickets are retained to block checkpoint advancement past undelivered data.
> - When `apply_pool_ack` or `submit_batch` detects held tickets, the pipeline cancels shutdown, drops the input receiver to unblock producers, and joins worker threads, preventing further ingestion and deadlock.
> - Extends the TLA+ `ShutdownProtocol` spec with an `output_health` variable and new invariants (`MachineStoppedImpliesOutputTerminal`, `ForcedStopImpliesOutputFailed`) and the `OutputFailureSticky` liveness property.
> - CI integration tests now run as four targeted `cargo nextest` invocations per package instead of a single broad expression.
> - Behavioral Change: a single poll failure during startup no longer immediately degrades health; a `Hold` from processors now triggers pipeline shutdown rather than continuing ingestion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 311a680.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->