### PR TITLE
fix: address 3 improperly resolved review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,30 @@ jobs:
         run: cargo nextest run --workspace --profile ci
 
   # -------------------------------------------------------------------------
+  # Network integration tests — #[ignore] tests that bind ports / make
+  # HTTP calls.  Runs after the main test job to reuse the build cache.
+  # -------------------------------------------------------------------------
+  test-network:
+    name: Test (network integration)
+    needs: [test-linux]
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/build-dashboard
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Network integration tests
+        run: cargo nextest run --workspace --profile ci --run-ignored ignored-only -E 'test(~network)'
+
+  # -------------------------------------------------------------------------
   # Build check — aarch64 cross-compile only (release check removed:
   # clippy already does a full debug build that catches the same errors)
   # -------------------------------------------------------------------------
@@ -679,6 +703,7 @@ jobs:
       - lint
       - test-linux
       - test-macos
+      - test-network
       - build-check
       - core-no-std
       - kani

--- a/crates/logfwd-core/src/cri.rs
+++ b/crates/logfwd-core/src/cri.rs
@@ -791,28 +791,31 @@ mod verification {
         }
     }
 
-    /// Prove configurable plain-text wrapper calls are panic-free for empty input.
+    /// Prove configurable plain-text wrapper calls are panic-free for
+    /// bounded symbolic input that exercises the CRI parser logic.
     #[kani::proof]
-    #[kani::unwind(4)]
+    #[kani::unwind(12)]
     #[kani::solver(kissat)]
     fn verify_process_cri_to_buf_with_plain_text_field_no_panic() {
         let use_body: bool = kani::any();
         let field_name = if use_body { "body" } else { SHORT_FIELD_NAME };
 
-        let chunk = b"";
+        let chunk: [u8; 8] = kani::any();
         let mut out = Vec::new();
         let mut reassembler = CriReassembler::new(64);
         let (count, errors) = process_cri_to_buf_with_plain_text_field(
-            chunk,
+            &chunk,
             &mut reassembler,
             None,
             field_name,
             &mut out,
         );
 
-        assert_eq!(count, 0);
-        assert_eq!(errors, 0);
-        assert!(out.is_empty());
+        // Total processed lines can never exceed input line count.
+        let newline_count = chunk.iter().filter(|&&b| b == b'\n').count();
+        assert!(count + errors <= newline_count);
+        kani::cover!(count > 0, "successful parse reachable");
+        kani::cover!(errors > 0, "error path reachable");
         kani::cover!(use_body, "body-field branch reachable");
         kani::cover!(!use_body, "short-field branch reachable");
     }

--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -260,6 +260,7 @@ struct GeneratorGeneratedFieldState {
 
 impl GeneratorInput {
     pub fn new(name: impl Into<String>, config: GeneratorConfig) -> Self {
+        debug_assert!(config.batch_size > 0, "batch_size must be at least 1");
         let name = name.into();
         let initial_rate_credit_events = if config.events_per_sec > 0 {
             config.batch_size as f64
@@ -426,6 +427,10 @@ impl GeneratorInput {
 
 impl InputSource for GeneratorInput {
     fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+        if self.config.batch_size == 0 {
+            return Ok(vec![]);
+        }
+
         if self.done {
             return Ok(vec![]);
         }


### PR DESCRIPTION
## Summary

- **CRI Kani proof vacuity** (PR #1789): The `verify_process_cri_to_buf_with_plain_text_field_no_panic` proof hardcoded `chunk = b""`, meaning Kani only tested the empty-input fast path and never entered the parser loop. Replaced with `let chunk: [u8; 8] = kani::any()` so the proof explores actual CRI parsing logic, with assertions that `count + errors <= newline_count`.
- **Network tests not run in CI** (PR #1793): The `#[ignore = "network integration test"]` tests across `logfwd-io`, `logfwd-diagnostics`, and `logfwd-output` had no CI job running them. Added a `test-network` job that runs `cargo nextest run --workspace --run-ignored ignored-only -E 'test(~network)'` after the main test job, and wired it into the `conclusion` gate.
- **Generator `batch_size=0` division-by-zero** (PR #1774): `poll()` divides by `batch_size` in multiple places. Config validation already rejects `batch_size == 0`, but the generator itself had no guard. Added `debug_assert!` in the constructor and an early return in `poll()` for defense-in-depth.

## Test plan

- [x] `cargo clippy -p logfwd-core -p logfwd-io -- -D warnings` passes
- [x] `cargo test -p logfwd-io --lib generator` — all 33 tests pass
- [x] `cargo test -p logfwd-core --lib cri` — all 22 tests pass
- [ ] CI `test-network` job runs ignored network tests successfully
- [ ] Kani CI verifies the updated CRI proof explores parser paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix batch size zero handling, network CI job, and Kani proof in logfwd
> - Adds a `debug_assert!(config.batch_size > 0)` in [`GeneratorInput::new`](https://github.com/strawgate/memagent/pull/1810/files#diff-155a8c1574aa241af17a394ce55d6ff3fdc41c01cdb4e7affd54f0c4e45bf71f) and an early return of an empty event list when `batch_size == 0` in its `poll` method.
> - Adds a `test-network` CI job in [ci.yml](https://github.com/strawgate/memagent/pull/1810/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f) that runs ignored network integration tests via nextest, gated on `test-linux` and required for the final `conclusion` job.
> - Broadens the Kani proof in [cri.rs](https://github.com/strawgate/memagent/pull/1810/files#diff-829f2a1180f6c62efb98de842e2acb1abeb43f544f72c7f86da209f2816585d0) to use 8-byte symbolic input, increases the unwind bound to 12, and replaces strict zero-result assertions with a soundness check that `count + errors` does not exceed the newline count.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1dafeff. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->