### PR TITLE
docs: add recommended VS Code extensions and install recipe

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,33 @@
+{
+  "recommendations": [
+    // Rust
+    "rust-lang.rust-analyzer",
+    "tamasfe.even-better-toml",
+    "vadimcn.vscode-lldb",
+    "serayuzgur.crates",
+
+    // Task runner & build
+    "skellock.just",
+
+    // Protobuf
+    "zxh404.vscode-proto3",
+
+    // TLA+
+    "alygin.vscode-tlaplus",
+
+    // Containers & deployment
+    "ms-azuretools.vscode-docker",
+    "ms-kubernetes-tools.vscode-kubernetes-tools",
+
+    // Markdown / mdbook
+    "yzhang.markdown-all-in-one",
+
+    // TypeScript / frontend (dashboard)
+    "biomejs.biome",
+
+    // General
+    "github.copilot",
+    "editorconfig.editorconfig",
+    "tekumara.typos-vscode"
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -605,6 +605,23 @@ install-tools:
     @echo "Optional: cargo install inferno"
     @echo "Install just: https://just.systems/man/en/installation.html"
 
+# Install recommended VS Code extensions from .vscode/extensions.json
+install-extensions:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v code &>/dev/null; then
+        echo "ERROR: 'code' CLI not found. Open VS Code and run:"
+        echo "  Cmd/Ctrl+Shift+P → 'Shell Command: Install code command in PATH'"
+        exit 1
+    fi
+    grep -oP '"[a-zA-Z0-9_-]+\.[a-zA-Z0-9._-]+"' .vscode/extensions.json \
+        | tr -d '"' \
+        | while read -r ext; do
+            echo "Installing $ext …"
+            code --install-extension "$ext" --force
+        done
+    echo "Done."
+
 # Set up git pre-commit hook (works from any worktree)
 install-hooks:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -614,7 +614,7 @@ install-extensions:
         echo "  Cmd/Ctrl+Shift+P → 'Shell Command: Install code command in PATH'"
         exit 1
     fi
-    grep -oP '"[a-zA-Z0-9_-]+\.[a-zA-Z0-9._-]+"' .vscode/extensions.json \
+    grep -oE '"[a-zA-Z0-9_-]+\.[a-zA-Z0-9._-]+"' .vscode/extensions.json \
         | tr -d '"' \
         | while read -r ext; do
             echo "Installing $ext …"


### PR DESCRIPTION
## Summary

Add VS Code recommended extensions and a `just install-extensions` recipe so contributors can quickly set up their editor.

### Changes

- **`.vscode/extensions.json`** — recommends extensions for Rust, just, protobuf, TLA+, Docker, Kubernetes, Markdown, Biome, Copilot, EditorConfig, and typos
- **`justfile`** — adds `install-extensions` recipe that bulk-installs all recommended extensions via `code --install-extension`

### Test plan

- `just install-extensions` installs all listed extensions when the `code` CLI is available
- VS Code prompts to install recommended extensions when opening the workspace


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add recommended VS Code extensions and `just install-extensions` recipe
> - Adds [.vscode/extensions.json](https://github.com/strawgate/memagent/pull/1812/files#diff-c16655a98a3ee89a7636a59c59a72b0e93649e3a1e947327cfc43a1336b4e912) listing recommended extensions for Rust, TOML, LLDB, Protobuf, TLA+, Docker, Markdown, Biome, Copilot, and others.
> - Adds an `install-extensions` recipe to the [justfile](https://github.com/strawgate/memagent/pull/1812/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) that reads extension IDs from that file and installs each via `code --install-extension`.
> - Checks for the `code` CLI before running and prints setup instructions if it is missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6e0dc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->