### PR TITLE
feat: add journald input with native sd_journal API and subprocess fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,6 +2671,7 @@ dependencies = [
  "globset",
  "http-body-util",
  "libc",
+ "libloading",
  "logfwd-arrow",
  "logfwd-core",
  "logfwd-otap-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,7 @@ dependencies = [
  "libc",
  "libloading",
  "logfwd-arrow",
+ "logfwd-config",
  "logfwd-core",
  "logfwd-otap-proto",
  "logfwd-test-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,7 +2673,6 @@ dependencies = [
  "libc",
  "libloading",
  "logfwd-arrow",
- "logfwd-config",
  "logfwd-core",
  "logfwd-otap-proto",
  "logfwd-test-utils",

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -20,9 +20,10 @@ pub use types::{
     AuthConfig, Config, ConfigError, CsvEnrichmentConfig, EnrichmentConfig, Format,
     GeneratorAttributeValueConfig, GeneratorComplexityConfig, GeneratorInputConfig,
     GeneratorProfileConfig, GeneratorSequenceConfig, GeoDatabaseConfig, GeoDatabaseFormat,
-    HostInfoConfig, HttpInputConfig, HttpMethodConfig, InputConfig, InputType, JournaldInputConfig,
-    JsonlEnrichmentConfig, K8sPathConfig, OutputConfig, OutputType, PipelineConfig,
-    PlatformSensorInputConfig, ServerConfig, StaticEnrichmentConfig, StorageConfig, TlsInputConfig,
+    HostInfoConfig, HttpInputConfig, HttpMethodConfig, InputConfig, InputType,
+    JournaldBackendConfig, JournaldInputConfig, JsonlEnrichmentConfig, K8sPathConfig, OutputConfig,
+    OutputType, PipelineConfig, PlatformSensorInputConfig, ServerConfig, StaticEnrichmentConfig,
+    StorageConfig, TlsInputConfig,
 };
 pub use validate::validate_host_port;
 

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -20,7 +20,7 @@ pub use types::{
     AuthConfig, Config, ConfigError, CsvEnrichmentConfig, EnrichmentConfig, Format,
     GeneratorAttributeValueConfig, GeneratorComplexityConfig, GeneratorInputConfig,
     GeneratorProfileConfig, GeneratorSequenceConfig, GeoDatabaseConfig, GeoDatabaseFormat,
-    HostInfoConfig, HttpInputConfig, HttpMethodConfig, InputConfig, InputType,
+    HostInfoConfig, HttpInputConfig, HttpMethodConfig, InputConfig, InputType, JournaldInputConfig,
     JsonlEnrichmentConfig, K8sPathConfig, OutputConfig, OutputType, PipelineConfig,
     PlatformSensorInputConfig, ServerConfig, StaticEnrichmentConfig, StorageConfig, TlsInputConfig,
 };

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -49,6 +49,8 @@ pub enum InputType {
     #[serde(rename = "windows_ebpf_sensor", alias = "windows_sensor_beta")]
     WindowsEbpfSensor,
     ArrowIpc,
+    /// Journald (systemd journal) input via `journalctl` subprocess.
+    Journald,
 }
 
 impl fmt::Display for InputType {
@@ -64,6 +66,7 @@ impl fmt::Display for InputType {
             InputType::MacosEsSensor => f.write_str("macos_es_sensor"),
             InputType::WindowsEbpfSensor => f.write_str("windows_ebpf_sensor"),
             InputType::ArrowIpc => f.write_str("arrow_ipc"),
+            InputType::Journald => f.write_str("journald"),
         }
     }
 }
@@ -284,6 +287,36 @@ pub struct TlsInputConfig {
     pub require_client_auth: bool,
 }
 
+/// Journald (systemd journal) input configuration.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct JournaldInputConfig {
+    /// Systemd units to include. If empty, all units are collected.
+    /// Unit names without a `.` are suffixed with `.service` automatically.
+    #[serde(default)]
+    pub include_units: Vec<String>,
+    /// Systemd units to exclude.
+    #[serde(default)]
+    pub exclude_units: Vec<String>,
+    /// Only include entries from the current boot (default: true).
+    #[serde(default = "default_true")]
+    pub current_boot_only: bool,
+    /// Only include entries appended after the receiver starts (default: false).
+    /// When false, reads all history from the current boot.
+    #[serde(default)]
+    pub since_now: bool,
+    /// Path to `journalctl` binary. Defaults to `journalctl` (found via PATH).
+    pub journalctl_path: Option<String>,
+    /// Custom journal directory (passed as `--directory=<path>`).
+    pub journal_directory: Option<String>,
+    /// Journal namespace (passed as `--namespace=<ns>`).
+    pub journal_namespace: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct InputConfig {
@@ -316,6 +349,8 @@ pub struct InputConfig {
     pub sql: Option<String>,
     #[serde(default)]
     pub tls: Option<TlsInputConfig>,
+    #[serde(default)]
+    pub journald: Option<JournaldInputConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -49,7 +49,8 @@ pub enum InputType {
     #[serde(rename = "windows_ebpf_sensor", alias = "windows_sensor_beta")]
     WindowsEbpfSensor,
     ArrowIpc,
-    /// Journald (systemd journal) input via `journalctl` subprocess.
+    /// Journald (systemd journal) input via native `sd_journal` API or
+    /// `journalctl` subprocess fallback.
     Journald,
 }
 
@@ -288,7 +289,7 @@ pub struct TlsInputConfig {
 }
 
 /// Journald (systemd journal) input configuration.
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct JournaldInputConfig {
     /// Systemd units to include. If empty, all units are collected.
@@ -336,6 +337,21 @@ pub enum JournaldBackendConfig {
 
 fn default_true() -> bool {
     true
+}
+
+impl Default for JournaldInputConfig {
+    fn default() -> Self {
+        Self {
+            include_units: Vec::new(),
+            exclude_units: Vec::new(),
+            current_boot_only: true,
+            since_now: false,
+            journalctl_path: None,
+            journal_directory: None,
+            journal_namespace: None,
+            backend: JournaldBackendConfig::Auto,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -311,6 +311,27 @@ pub struct JournaldInputConfig {
     pub journal_directory: Option<String>,
     /// Journal namespace (passed as `--namespace=<ns>`).
     pub journal_namespace: Option<String>,
+    /// Backend to use for reading the journal.
+    ///
+    /// - `auto` (default): use native `sd_journal` API if `libsystemd.so.0` is
+    ///   available, otherwise fall back to a `journalctl` subprocess.
+    /// - `native`: require the native `sd_journal` API; error if unavailable.
+    /// - `subprocess`: always use a `journalctl` subprocess.
+    #[serde(default)]
+    pub backend: JournaldBackendConfig,
+}
+
+/// Which journal-reading backend to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JournaldBackendConfig {
+    /// Use native API if available, otherwise subprocess (default).
+    #[default]
+    Auto,
+    /// Require the native `sd_journal` C API via `dlopen`.
+    Native,
+    /// Always use a `journalctl` subprocess.
+    Subprocess,
 }
 
 fn default_true() -> bool {

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -208,6 +208,17 @@ impl Config {
                         | InputType::LinuxEbpfSensor
                         | InputType::MacosEsSensor
                         | InputType::WindowsEbpfSensor => {}
+                        InputType::Journald => {
+                            if let Some(jd) = &input.journald {
+                                for unit in &jd.include_units {
+                                    if jd.exclude_units.contains(unit) {
+                                        return Err(ConfigError::Validation(format!(
+                                            "pipeline '{name}' input '{label}': unit '{unit}' appears in both include_units and exclude_units"
+                                        )));
+                                    }
+                                }
+                            }
+                        }
                     }
 
                     // Reject fields that don't apply to this input type.
@@ -236,6 +247,11 @@ impl Config {
                             if input.sensor.is_some() {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
+                                )));
+                            }
+                            if input.journald.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
                                 )));
                             }
                         }
@@ -288,6 +304,11 @@ impl Config {
                             if input.sensor.is_some() {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
+                                )));
+                            }
+                            if input.journald.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
                                 )));
                             }
                         }
@@ -359,6 +380,11 @@ impl Config {
                                     "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
                                 )));
                             }
+                            if input.journald.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
+                                )));
+                            }
                         }
                         InputType::ArrowIpc => {
                             if input.tls.is_some() {
@@ -421,6 +447,11 @@ impl Config {
                                     "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
                                 )));
                             }
+                            if input.journald.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
+                                )));
+                            }
                         }
                         InputType::Http => {
                             if input.tls.is_some() {
@@ -471,6 +502,11 @@ impl Config {
                             if input.sensor.is_some() {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
+                                )));
+                            }
+                            if input.journald.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
                                 )));
                             }
                             if let Some(http) = &input.http {
@@ -554,6 +590,11 @@ impl Config {
                             if input.sensor.is_some() {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
+                                )));
+                            }
+                            if input.journald.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
                                 )));
                             }
                             if input.generator.as_ref().and_then(|cfg| cfg.batch_size) == Some(0) {
@@ -718,6 +759,11 @@ impl Config {
                                     "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
                                 )));
                             }
+                            if input.journald.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
+                                )));
+                            }
                             if input.format.is_some() {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': sensor inputs do not support 'format' (Arrow-native input)"
@@ -769,6 +815,68 @@ impl Config {
                                         )));
                                     }
                                 }
+                            }
+                        }
+                        InputType::Journald => {
+                            if input.listen.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'listen' is not supported for journald inputs"
+                                )));
+                            }
+                            if input.path.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'path' is not supported for journald inputs"
+                                )));
+                            }
+                            if input.tls.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'tls' is not supported for journald inputs"
+                                )));
+                            }
+                            if input.generator.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'generator' settings are only supported for generator inputs"
+                                )));
+                            }
+                            if input.http.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
+                                )));
+                            }
+                            if input.sensor.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
+                                )));
+                            }
+                            if input.max_open_files.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'max_open_files' is not supported for journald inputs"
+                                )));
+                            }
+                            if input.glob_rescan_interval_ms.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for journald inputs"
+                                )));
+                            }
+                            if input.poll_interval_ms.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'poll_interval_ms' is not supported for journald inputs"
+                                )));
+                            }
+                            if input.read_buf_size.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'read_buf_size' is not supported for journald inputs"
+                                )));
+                            }
+                            if input.per_file_read_budget_bytes.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' is not supported for journald inputs"
+                                )));
+                            }
+                            if input.adaptive_fast_polls_max.is_some() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for journald inputs"
+                                )));
                             }
                         }
                     }

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -210,8 +210,62 @@ impl Config {
                         | InputType::WindowsEbpfSensor => {}
                         InputType::Journald => {
                             if let Some(jd) = &input.journald {
+                                // journal_directory and journal_namespace are mutually exclusive
+                                // in the native backend (directory opens a specific path, namespace
+                                // opens a named journal).
+                                if jd.journal_directory.is_some() && jd.journal_namespace.is_some()
+                                {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': 'journal_directory' and 'journal_namespace' cannot both be set"
+                                    )));
+                                }
+
+                                // Reject blank/whitespace-only optional string fields.
+                                if jd
+                                    .journalctl_path
+                                    .as_deref()
+                                    .is_some_and(|s| s.trim().is_empty())
+                                {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': 'journalctl_path' must not be blank"
+                                    )));
+                                }
+                                if jd
+                                    .journal_directory
+                                    .as_deref()
+                                    .is_some_and(|s| s.trim().is_empty())
+                                {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': 'journal_directory' must not be blank"
+                                    )));
+                                }
+                                if jd
+                                    .journal_namespace
+                                    .as_deref()
+                                    .is_some_and(|s| s.trim().is_empty())
+                                {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': 'journal_namespace' must not be blank"
+                                    )));
+                                }
+
+                                // Reject blank/whitespace-only unit names.
+                                for unit in jd.include_units.iter().chain(jd.exclude_units.iter()) {
+                                    if unit.trim().is_empty() {
+                                        return Err(ConfigError::Validation(format!(
+                                            "pipeline '{name}' input '{label}': unit names must not be blank"
+                                        )));
+                                    }
+                                }
+
+                                let norm_excludes: Vec<String> = jd
+                                    .exclude_units
+                                    .iter()
+                                    .map(|u| normalize_unit_name(u.trim()))
+                                    .collect();
                                 for unit in &jd.include_units {
-                                    if jd.exclude_units.contains(unit) {
+                                    let normalized = normalize_unit_name(unit.trim());
+                                    if norm_excludes.contains(&normalized) {
                                         return Err(ConfigError::Validation(format!(
                                             "pipeline '{name}' input '{label}': unit '{unit}' appears in both include_units and exclude_units"
                                         )));
@@ -878,6 +932,14 @@ impl Config {
                                     "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for journald inputs"
                                 )));
                             }
+                            // Journald always produces JSON; reject other formats at config time.
+                            if let Some(fmt) = &input.format {
+                                if !matches!(fmt, Format::Json) {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': journald input only supports format: json (got {fmt:?})"
+                                    )));
+                                }
+                            }
                         }
                     }
 
@@ -1266,7 +1328,10 @@ impl Config {
             Ok(())
         } else if all_errors.len() == 1 {
             Err(ConfigError::Validation(
-                all_errors.into_iter().next().expect("checked len == 1"),
+                all_errors
+                    .into_iter()
+                    .next()
+                    .expect("guarded by len == 1 check"),
             ))
         } else {
             Err(ConfigError::Validation(format!(
@@ -1314,6 +1379,18 @@ fn normalize_path_lexically(path: &Path) -> std::path::PathBuf {
         std::path::PathBuf::from(".")
     } else {
         out
+    }
+}
+
+/// Normalize a systemd unit name for comparison.
+///
+/// Unit names without a `.` suffix get `.service` appended, matching
+/// runtime behavior (e.g. `sshd` → `sshd.service`).
+fn normalize_unit_name(name: &str) -> String {
+    if name.contains('.') {
+        name.to_string()
+    } else {
+        format!("{name}.service")
     }
 }
 

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1,6 +1,6 @@
 use crate::types::{
     Config, ConfigError, EnrichmentConfig, Format, GeneratorAttributeValueConfig,
-    GeneratorProfileConfig, InputType, OutputType,
+    GeneratorProfileConfig, InputType, JournaldBackendConfig, OutputType,
 };
 use std::path::Path;
 use url::Url;
@@ -212,11 +212,14 @@ impl Config {
                             if let Some(jd) = &input.journald {
                                 // journal_directory and journal_namespace are mutually exclusive
                                 // in the native backend (directory opens a specific path, namespace
-                                // opens a named journal).
-                                if jd.journal_directory.is_some() && jd.journal_namespace.is_some()
+                                // opens a named journal). The subprocess backend supports both
+                                // flags together, so only reject when the native API is required.
+                                if jd.backend == JournaldBackendConfig::Native
+                                    && jd.journal_directory.is_some()
+                                    && jd.journal_namespace.is_some()
                                 {
                                     return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': 'journal_directory' and 'journal_namespace' cannot both be set"
+                                        "pipeline '{name}' input '{label}': 'journal_directory' and 'journal_namespace' cannot both be set with native backend"
                                     )));
                                 }
 

--- a/crates/logfwd-io/Cargo.toml
+++ b/crates/logfwd-io/Cargo.toml
@@ -22,6 +22,7 @@ flate2 = "1"
 globset = { workspace = true }
 http-body-util = "0.1"
 libc = "0.2"
+libloading = "0.8"
 memchr = "2"
 notify = "8"
 tokio = { workspace = true }

--- a/crates/logfwd-io/Cargo.toml
+++ b/crates/logfwd-io/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 base64 = { workspace = true }
+logfwd-config = { version = "0.1.0", path = "../logfwd-config" }
 logfwd-core = { version = "0.1.0", path = "../logfwd-core" }
 logfwd-arrow = { version = "0.1.0", path = "../logfwd-arrow" }
 logfwd-otap-proto = { version = "0.1.0", path = "../logfwd-otap-proto" }

--- a/crates/logfwd-io/Cargo.toml
+++ b/crates/logfwd-io/Cargo.toml
@@ -11,7 +11,6 @@ doctest = false
 [dependencies]
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio"] }
 base64 = { workspace = true }
-logfwd-config = { version = "0.1.0", path = "../logfwd-config" }
 logfwd-core = { version = "0.1.0", path = "../logfwd-core" }
 logfwd-arrow = { version = "0.1.0", path = "../logfwd-arrow" }
 logfwd-otap-proto = { version = "0.1.0", path = "../logfwd-otap-proto" }

--- a/crates/logfwd-io/src/journal_ffi.rs
+++ b/crates/logfwd-io/src/journal_ffi.rs
@@ -1,0 +1,490 @@
+//! Thin safe wrapper around libsystemd's `sd_journal` API, loaded at runtime
+//! via `dlopen`.
+//!
+//! This avoids any build-time dependency on `libsystemd-dev` and lets the
+//! binary run on non-systemd hosts (the journal input will gracefully report
+//! that `libsystemd.so.0` is not available).
+//!
+//! # Safety
+//!
+//! The [`Journal`] handle is `!Send` and `!Sync` because the underlying
+//! `sd_journal` object must only be used from the thread that created it.
+//! Callers must confine each `Journal` to a single OS thread.
+
+use std::ffi::{CStr, CString};
+use std::io;
+use std::marker::PhantomData;
+use std::ptr;
+use std::sync::Arc;
+
+use libloading::{Library, Symbol};
+
+// ── sd_journal open flags ─────────────────────────────────────────────
+
+/// Only open journal files generated on the local machine.
+pub const SD_JOURNAL_LOCAL_ONLY: i32 = 1;
+/// Only volatile journal files (no persistent).
+#[allow(dead_code)]
+pub const SD_JOURNAL_RUNTIME_ONLY: i32 = 2;
+/// Only open system journal.
+pub const SD_JOURNAL_SYSTEM: i32 = 4;
+/// Only current user's journal.
+#[allow(dead_code)]
+pub const SD_JOURNAL_CURRENT_USER: i32 = 8;
+
+// ── sd_journal_wait return values ─────────────────────────────────────
+
+/// Nothing happened during wait.
+pub const SD_JOURNAL_NOP: i32 = 0;
+/// New entries were appended.
+pub const SD_JOURNAL_APPEND: i32 = 1;
+/// Journal files were rotated / invalidated.
+pub const SD_JOURNAL_INVALIDATE: i32 = 2;
+
+// ── Opaque C type ─────────────────────────────────────────────────────
+
+/// Opaque handle to the C `sd_journal` struct.
+enum SdJournal {}
+
+// ── Function pointer type aliases ─────────────────────────────────────
+
+type FnOpen = unsafe extern "C" fn(*mut *mut SdJournal, i32) -> i32;
+type FnOpenDirectory = unsafe extern "C" fn(*mut *mut SdJournal, *const libc::c_char, i32) -> i32;
+#[allow(dead_code)]
+type FnOpenNamespace = unsafe extern "C" fn(*mut *mut SdJournal, *const libc::c_char, i32) -> i32;
+type FnClose = unsafe extern "C" fn(*mut SdJournal);
+
+type FnNext = unsafe extern "C" fn(*mut SdJournal) -> i32;
+type FnPrevious = unsafe extern "C" fn(*mut SdJournal) -> i32;
+type FnSeekHead = unsafe extern "C" fn(*mut SdJournal) -> i32;
+type FnSeekTail = unsafe extern "C" fn(*mut SdJournal) -> i32;
+type FnSeekCursor = unsafe extern "C" fn(*mut SdJournal, *const libc::c_char) -> i32;
+
+type FnGetCursor = unsafe extern "C" fn(*mut SdJournal, *mut *mut libc::c_char) -> i32;
+type FnGetData =
+    unsafe extern "C" fn(*mut SdJournal, *const libc::c_char, *mut *const u8, *mut usize) -> i32;
+type FnEnumerateData = unsafe extern "C" fn(*mut SdJournal, *mut *const u8, *mut usize) -> i32;
+type FnRestartData = unsafe extern "C" fn(*mut SdJournal);
+type FnGetRealtimeUsec = unsafe extern "C" fn(*mut SdJournal, *mut u64) -> i32;
+
+type FnAddMatch = unsafe extern "C" fn(*mut SdJournal, *const u8, usize) -> i32;
+type FnAddDisjunction = unsafe extern "C" fn(*mut SdJournal) -> i32;
+type FnFlushMatches = unsafe extern "C" fn(*mut SdJournal);
+
+type FnWait = unsafe extern "C" fn(*mut SdJournal, u64) -> i32;
+
+// ── LibSystemd: loaded function table ─────────────────────────────────
+
+/// Holds the loaded `libsystemd.so.0` library and resolved function pointers.
+///
+/// Stored behind an `Arc` so that [`Journal`] handles can reference-count the
+/// library lifetime.
+struct LibSystemd {
+    _lib: Library,
+    open: FnOpen,
+    open_directory: FnOpenDirectory,
+    close: FnClose,
+    next: FnNext,
+    previous: FnPrevious,
+    seek_head: FnSeekHead,
+    seek_tail: FnSeekTail,
+    seek_cursor: FnSeekCursor,
+    get_cursor: FnGetCursor,
+    get_data: FnGetData,
+    enumerate_data: FnEnumerateData,
+    restart_data: FnRestartData,
+    get_realtime_usec: FnGetRealtimeUsec,
+    add_match: FnAddMatch,
+    add_disjunction: FnAddDisjunction,
+    flush_matches: FnFlushMatches,
+    wait: FnWait,
+}
+
+/// Convert a negative sd_journal return code to `io::Error`.
+fn sd_err(ret: i32) -> io::Error {
+    io::Error::from_raw_os_error(-ret)
+}
+
+impl LibSystemd {
+    /// Attempt to load `libsystemd.so.0` from the system's default search path.
+    fn load() -> io::Result<Self> {
+        // SAFETY: we load a well-known system library. The library name is
+        // hard-coded (no user-controlled paths).
+        let lib = unsafe { Library::new("libsystemd.so.0") }.map_err(|e| {
+            io::Error::other(format!(
+                "could not load libsystemd.so.0 — journald native API unavailable: {e}"
+            ))
+        })?;
+
+        // SAFETY: each symbol name matches the published C ABI of libsystemd.
+        // The type aliases above encode the correct signatures.
+        unsafe {
+            let load = |name: &[u8]| -> io::Result<*mut ()> {
+                let sym: Symbol<*mut ()> = lib.get(name).map_err(|e| {
+                    io::Error::other(format!(
+                        "libsystemd.so.0 missing symbol {}: {e}",
+                        String::from_utf8_lossy(name)
+                    ))
+                })?;
+                Ok(*sym)
+            };
+
+            macro_rules! sym {
+                ($name:literal, $ty:ty) => {{
+                    let ptr = load($name)?;
+                    std::mem::transmute::<*mut (), $ty>(ptr)
+                }};
+            }
+
+            Ok(Self {
+                open: sym!(b"sd_journal_open\0", FnOpen),
+                open_directory: sym!(b"sd_journal_open_directory\0", FnOpenDirectory),
+                close: sym!(b"sd_journal_close\0", FnClose),
+                next: sym!(b"sd_journal_next\0", FnNext),
+                previous: sym!(b"sd_journal_previous\0", FnPrevious),
+                seek_head: sym!(b"sd_journal_seek_head\0", FnSeekHead),
+                seek_tail: sym!(b"sd_journal_seek_tail\0", FnSeekTail),
+                seek_cursor: sym!(b"sd_journal_seek_cursor\0", FnSeekCursor),
+                get_cursor: sym!(b"sd_journal_get_cursor\0", FnGetCursor),
+                get_data: sym!(b"sd_journal_get_data\0", FnGetData),
+                enumerate_data: sym!(b"sd_journal_enumerate_data\0", FnEnumerateData),
+                restart_data: sym!(b"sd_journal_restart_data\0", FnRestartData),
+                get_realtime_usec: sym!(b"sd_journal_get_realtime_usec\0", FnGetRealtimeUsec),
+                add_match: sym!(b"sd_journal_add_match\0", FnAddMatch),
+                add_disjunction: sym!(b"sd_journal_add_disjunction\0", FnAddDisjunction),
+                flush_matches: sym!(b"sd_journal_flush_matches\0", FnFlushMatches),
+                wait: sym!(b"sd_journal_wait\0", FnWait),
+                _lib: lib,
+            })
+        }
+    }
+}
+
+// ── Journal: safe wrapper ─────────────────────────────────────────────
+
+/// A safe wrapper around an `sd_journal` handle.
+///
+/// # Thread safety
+///
+/// `Journal` is intentionally `!Send` and `!Sync`. The underlying
+/// `sd_journal` handle must be used exclusively from the thread that opened
+/// it.
+pub struct Journal {
+    handle: *mut SdJournal,
+    lib: Arc<LibSystemd>,
+    /// Prevent Send + Sync.
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl Drop for Journal {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            // SAFETY: `self.handle` was obtained from `sd_journal_open` (or
+            // `sd_journal_open_directory`) and is non-null.
+            unsafe {
+                (self.lib.close)(self.handle);
+            }
+        }
+    }
+}
+
+/// Check whether `libsystemd.so.0` can be loaded on this system.
+pub fn is_native_available() -> bool {
+    LibSystemd::load().is_ok()
+}
+
+impl Journal {
+    /// Open the system journal.
+    ///
+    /// `flags` should be a combination of `SD_JOURNAL_*` constants (e.g.
+    /// `SD_JOURNAL_LOCAL_ONLY | SD_JOURNAL_SYSTEM`).
+    pub fn open(flags: i32) -> io::Result<Self> {
+        let lib = Arc::new(LibSystemd::load()?);
+        let mut handle: *mut SdJournal = ptr::null_mut();
+        // SAFETY: `sd_journal_open` writes a valid handle pointer on success.
+        // We pass a pointer to a local `handle` variable, which is valid for
+        // the duration of this call.
+        let ret = unsafe { (lib.open)(std::ptr::addr_of_mut!(handle), flags) };
+        if ret < 0 {
+            return Err(sd_err(ret));
+        }
+        Ok(Self {
+            handle,
+            lib,
+            _not_send: PhantomData,
+        })
+    }
+
+    /// Open a journal from a specific directory.
+    pub fn open_directory(path: &str, flags: i32) -> io::Result<Self> {
+        let lib = Arc::new(LibSystemd::load()?);
+        let c_path = CString::new(path)
+            .map_err(|_| io::Error::other("journal directory path contains null byte"))?;
+        let mut handle: *mut SdJournal = ptr::null_mut();
+        // SAFETY: `c_path` is a valid NUL-terminated C string. `handle` pointer
+        // is valid for the duration of this call.
+        let ret =
+            unsafe { (lib.open_directory)(std::ptr::addr_of_mut!(handle), c_path.as_ptr(), flags) };
+        if ret < 0 {
+            return Err(sd_err(ret));
+        }
+        Ok(Self {
+            handle,
+            lib,
+            _not_send: PhantomData,
+        })
+    }
+
+    // ── Navigation ────────────────────────────────────────────────────
+
+    /// Advance to the next journal entry.
+    ///
+    /// Returns `true` if an entry is available, `false` if the end was reached.
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> io::Result<bool> {
+        // SAFETY: `self.handle` is a valid, non-null sd_journal pointer
+        // obtained from a successful `sd_journal_open*` call.
+        let ret = unsafe { (self.lib.next)(self.handle) };
+        if ret < 0 {
+            Err(sd_err(ret))
+        } else {
+            Ok(ret > 0)
+        }
+    }
+
+    /// Move to the previous journal entry.
+    pub fn previous(&mut self) -> io::Result<bool> {
+        // SAFETY: `self.handle` is a valid sd_journal pointer.
+        let ret = unsafe { (self.lib.previous)(self.handle) };
+        if ret < 0 {
+            Err(sd_err(ret))
+        } else {
+            Ok(ret > 0)
+        }
+    }
+
+    /// Seek to the head (oldest entry).
+    pub fn seek_head(&mut self) -> io::Result<()> {
+        // SAFETY: `self.handle` is a valid sd_journal pointer.
+        let ret = unsafe { (self.lib.seek_head)(self.handle) };
+        if ret < 0 { Err(sd_err(ret)) } else { Ok(()) }
+    }
+
+    /// Seek to the tail (newest entry).
+    pub fn seek_tail(&mut self) -> io::Result<()> {
+        // SAFETY: `self.handle` is a valid sd_journal pointer.
+        let ret = unsafe { (self.lib.seek_tail)(self.handle) };
+        if ret < 0 { Err(sd_err(ret)) } else { Ok(()) }
+    }
+
+    /// Seek to the entry after the given cursor.
+    pub fn seek_cursor(&mut self, cursor: &str) -> io::Result<()> {
+        let c_cursor =
+            CString::new(cursor).map_err(|_| io::Error::other("cursor contains null byte"))?;
+        // SAFETY: `self.handle` is valid. `c_cursor` is a valid NUL-terminated
+        // C string that remains live for the duration of this call.
+        let ret = unsafe { (self.lib.seek_cursor)(self.handle, c_cursor.as_ptr()) };
+        if ret < 0 { Err(sd_err(ret)) } else { Ok(()) }
+    }
+
+    // ── Data access ───────────────────────────────────────────────────
+
+    /// Get the cursor string for the current entry.
+    ///
+    /// The returned string uniquely identifies this entry and can be used with
+    /// [`seek_cursor`](Self::seek_cursor) to resume reading.
+    pub fn cursor(&mut self) -> io::Result<String> {
+        let mut raw: *mut libc::c_char = ptr::null_mut();
+        // SAFETY: `sd_journal_get_cursor` allocates a NUL-terminated string on
+        // success and writes its address into `raw`.
+        let ret = unsafe { (self.lib.get_cursor)(self.handle, std::ptr::addr_of_mut!(raw)) };
+        if ret < 0 {
+            return Err(sd_err(ret));
+        }
+        // SAFETY: on success, `raw` is a valid NUL-terminated malloc'd string.
+        let cursor = unsafe { CStr::from_ptr(raw) }
+            .to_string_lossy()
+            .into_owned();
+        // SAFETY: `raw` was allocated by libsystemd via malloc; we must free it.
+        unsafe {
+            libc::free(raw.cast());
+        }
+        Ok(cursor)
+    }
+
+    /// Get the value of a specific field from the current entry.
+    ///
+    /// Returns the raw `FIELD=value` bytes. Returns `None` if the field is not
+    /// present in the current entry.
+    pub fn get_data(&mut self, field: &str) -> io::Result<Option<&[u8]>> {
+        let c_field =
+            CString::new(field).map_err(|_| io::Error::other("field name contains null byte"))?;
+        let mut data: *const u8 = ptr::null();
+        let mut len: usize = 0;
+        // SAFETY: `sd_journal_get_data` writes a pointer to internal buffer
+        // memory into `data` and the byte count into `len`. The `c_field`
+        // pointer is valid for the duration of this call.
+        let ret = unsafe {
+            (self.lib.get_data)(
+                self.handle,
+                c_field.as_ptr(),
+                std::ptr::addr_of_mut!(data),
+                std::ptr::addr_of_mut!(len),
+            )
+        };
+        if ret == -libc::ENOENT {
+            return Ok(None);
+        }
+        if ret < 0 {
+            return Err(sd_err(ret));
+        }
+        // SAFETY: `data` points to `len` bytes of valid memory in the journal's
+        // internal buffer. The slice is valid until the next `get_data`,
+        // `enumerate_data`, or navigation call on this handle.
+        Ok(Some(unsafe { std::slice::from_raw_parts(data, len) }))
+    }
+
+    /// Get the realtime timestamp (microseconds since epoch) for the current entry.
+    pub fn realtime_usec(&mut self) -> io::Result<u64> {
+        let mut usec: u64 = 0;
+        // SAFETY: `self.handle` is valid. `usec` is a valid local variable.
+        let ret =
+            unsafe { (self.lib.get_realtime_usec)(self.handle, std::ptr::addr_of_mut!(usec)) };
+        if ret < 0 { Err(sd_err(ret)) } else { Ok(usec) }
+    }
+
+    /// Begin iterating all fields in the current entry.
+    pub fn restart_data(&mut self) {
+        // SAFETY: `sd_journal_restart_data` has no failure mode and only
+        // resets internal iteration state on a valid handle.
+        unsafe {
+            (self.lib.restart_data)(self.handle);
+        }
+    }
+
+    /// Get the next `FIELD=value` pair from the current entry.
+    ///
+    /// Returns `None` when all fields have been enumerated. Call
+    /// [`restart_data`](Self::restart_data) to start over.
+    pub fn enumerate_data(&mut self) -> io::Result<Option<&[u8]>> {
+        let mut data: *const u8 = ptr::null();
+        let mut len: usize = 0;
+        // SAFETY: `sd_journal_enumerate_data` writes the next field's pointer
+        // and length. Both output variables are valid stack locals.
+        let ret = unsafe {
+            (self.lib.enumerate_data)(
+                self.handle,
+                std::ptr::addr_of_mut!(data),
+                std::ptr::addr_of_mut!(len),
+            )
+        };
+        if ret == 0 {
+            // No more fields.
+            return Ok(None);
+        }
+        if ret < 0 {
+            return Err(sd_err(ret));
+        }
+        // SAFETY: `data` points to `len` bytes in the journal's internal
+        // buffer, valid until the next data/navigation call.
+        Ok(Some(unsafe { std::slice::from_raw_parts(data, len) }))
+    }
+
+    // ── Filtering ─────────────────────────────────────────────────────
+
+    /// Add a match filter. The `data` should be in `FIELD=value` format.
+    ///
+    /// Multiple matches on the same field are OR'd. Use
+    /// [`add_disjunction`](Self::add_disjunction) to separate match groups.
+    pub fn add_match(&mut self, data: &[u8]) -> io::Result<()> {
+        // SAFETY: `data` slice pointer and length are valid for the call
+        // duration. `self.handle` is valid.
+        let ret = unsafe { (self.lib.add_match)(self.handle, data.as_ptr(), data.len()) };
+        if ret < 0 { Err(sd_err(ret)) } else { Ok(()) }
+    }
+
+    /// Insert an OR between match groups.
+    pub fn add_disjunction(&mut self) -> io::Result<()> {
+        // SAFETY: `self.handle` is a valid sd_journal pointer.
+        let ret = unsafe { (self.lib.add_disjunction)(self.handle) };
+        if ret < 0 { Err(sd_err(ret)) } else { Ok(()) }
+    }
+
+    /// Remove all match filters.
+    pub fn flush_matches(&mut self) {
+        // SAFETY: `sd_journal_flush_matches` has no failure mode.
+        unsafe {
+            (self.lib.flush_matches)(self.handle);
+        }
+    }
+
+    // ── Waiting ───────────────────────────────────────────────────────
+
+    /// Block until the journal changes or the timeout expires.
+    ///
+    /// `timeout_usec` is in microseconds. Pass `u64::MAX` for infinite wait.
+    ///
+    /// Returns one of `SD_JOURNAL_NOP`, `SD_JOURNAL_APPEND`, or
+    /// `SD_JOURNAL_INVALIDATE`.
+    pub fn wait(&mut self, timeout_usec: u64) -> io::Result<i32> {
+        // SAFETY: `self.handle` is a valid sd_journal pointer.
+        let ret = unsafe { (self.lib.wait)(self.handle, timeout_usec) };
+        if ret < 0 { Err(sd_err(ret)) } else { Ok(ret) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_native_available_returns_bool() {
+        // On CI without libsystemd-dev this may be false; that's fine.
+        let available = is_native_available();
+        // Just ensure it doesn't panic.
+        eprintln!("native journald API available: {available}");
+    }
+
+    #[test]
+    fn open_and_seek_if_available() {
+        if !is_native_available() {
+            eprintln!("skipping: libsystemd.so.0 not available");
+            return;
+        }
+        let mut journal =
+            Journal::open(SD_JOURNAL_LOCAL_ONLY | SD_JOURNAL_SYSTEM).expect("open failed");
+        journal.seek_tail().expect("seek_tail failed");
+        // After seek_tail we need previous() to land on the last entry.
+        let has_entry = journal.previous().expect("previous failed");
+        if has_entry {
+            let cursor = journal.cursor().expect("cursor failed");
+            assert!(!cursor.is_empty(), "cursor should not be empty");
+        }
+    }
+
+    #[test]
+    fn enumerate_fields_if_available() {
+        if !is_native_available() {
+            eprintln!("skipping: libsystemd.so.0 not available");
+            return;
+        }
+        let mut journal =
+            Journal::open(SD_JOURNAL_LOCAL_ONLY | SD_JOURNAL_SYSTEM).expect("open failed");
+        journal.seek_tail().expect("seek_tail failed");
+        if !journal.previous().expect("previous") {
+            eprintln!("no journal entries, skipping");
+            return;
+        }
+        journal.restart_data();
+        let mut count = 0;
+        while let Ok(Some(field)) = journal.enumerate_data() {
+            // Each field is FIELD=value
+            assert!(
+                memchr::memchr(b'=', field).is_some(),
+                "field should contain '='"
+            );
+            count += 1;
+        }
+        assert!(count > 0, "entry should have at least one field");
+    }
+}

--- a/crates/logfwd-io/src/journal_ffi.rs
+++ b/crates/logfwd-io/src/journal_ffi.rs
@@ -7,7 +7,7 @@
 //!
 //! # Safety
 //!
-//! The [`Journal`] handle is `!Send` and `!Sync` because the underlying
+//! The `Journal` handle is `!Send` and `!Sync` because the underlying
 //! `sd_journal` object must only be used from the thread that created it.
 //! Callers must confine each `Journal` to a single OS thread.
 
@@ -15,6 +15,7 @@ use std::ffi::{CStr, CString};
 use std::io;
 use std::marker::PhantomData;
 use std::ptr;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use libloading::{Library, Symbol};
@@ -77,12 +78,14 @@ type FnWait = unsafe extern "C" fn(*mut SdJournal, u64) -> i32;
 
 /// Holds the loaded `libsystemd.so.0` library and resolved function pointers.
 ///
-/// Stored behind an `Arc` so that [`Journal`] handles can reference-count the
+/// Stored behind an `Arc` so that `Journal` handles can reference-count the
 /// library lifetime.
 struct LibSystemd {
     _lib: Library,
     open: FnOpen,
     open_directory: FnOpenDirectory,
+    /// `sd_journal_open_namespace` — may be `None` on older libsystemd (<245).
+    open_namespace: Option<FnOpenNamespace>,
     close: FnClose,
     next: FnNext,
     previous: FnPrevious,
@@ -136,9 +139,16 @@ impl LibSystemd {
                 }};
             }
 
+            // `sd_journal_open_namespace` is optional — only available on
+            // systemd >= 245. We try to load it but fall back to None.
+            let open_namespace: Option<FnOpenNamespace> = load(b"sd_journal_open_namespace\0")
+                .ok()
+                .map(|ptr| std::mem::transmute::<*mut (), FnOpenNamespace>(ptr));
+
             Ok(Self {
                 open: sym!(b"sd_journal_open\0", FnOpen),
                 open_directory: sym!(b"sd_journal_open_directory\0", FnOpenDirectory),
+                open_namespace,
                 close: sym!(b"sd_journal_close\0", FnClose),
                 next: sym!(b"sd_journal_next\0", FnNext),
                 previous: sym!(b"sd_journal_previous\0", FnPrevious),
@@ -172,8 +182,8 @@ impl LibSystemd {
 pub struct Journal {
     handle: *mut SdJournal,
     lib: Arc<LibSystemd>,
-    /// Prevent Send + Sync.
-    _not_send: PhantomData<*mut ()>,
+    /// Prevent Send + Sync — `Rc` is `!Send + !Sync` on stable Rust.
+    _not_send: PhantomData<Rc<()>>,
 }
 
 impl Drop for Journal {
@@ -225,6 +235,31 @@ impl Journal {
         // is valid for the duration of this call.
         let ret =
             unsafe { (lib.open_directory)(std::ptr::addr_of_mut!(handle), c_path.as_ptr(), flags) };
+        if ret < 0 {
+            return Err(sd_err(ret));
+        }
+        Ok(Self {
+            handle,
+            lib,
+            _not_send: PhantomData,
+        })
+    }
+
+    /// Open a journal scoped to a specific namespace.
+    ///
+    /// Requires systemd >= 245 (`sd_journal_open_namespace`). Returns an error
+    /// if the symbol is not available in the loaded `libsystemd.so.0`.
+    pub fn open_namespace(namespace: &str, flags: i32) -> io::Result<Self> {
+        let lib = Arc::new(LibSystemd::load()?);
+        let fn_open_ns = lib.open_namespace.ok_or_else(|| {
+            io::Error::other("sd_journal_open_namespace not available (requires systemd >= 245)")
+        })?;
+        let c_ns = CString::new(namespace)
+            .map_err(|_| io::Error::other("journal namespace contains null byte"))?;
+        let mut handle: *mut SdJournal = ptr::null_mut();
+        // SAFETY: `c_ns` is a valid NUL-terminated C string. `handle` pointer
+        // is valid for the duration of this call.
+        let ret = unsafe { fn_open_ns(std::ptr::addr_of_mut!(handle), c_ns.as_ptr(), flags) };
         if ret < 0 {
             return Err(sd_err(ret));
         }

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -1,13 +1,13 @@
 //! Journald (systemd journal) input source.
 //!
-//! Spawns a `journalctl --follow --output=json` subprocess in a background
-//! thread. Journal entries arrive as newline-delimited JSON objects. A bounded
-//! crossbeam channel bridges the blocking reader to the non-blocking `poll()`
-//! interface required by [`InputSource`].
+//! Reads the systemd journal using the native `sd_journal` C API (loaded at
+//! runtime via `dlopen`). If `libsystemd.so.0` is not available, falls back to
+//! spawning a `journalctl --follow --output=json` subprocess.
 //!
-//! If the subprocess exits unexpectedly, the background thread waits
-//! [`RESTART_BACKOFF`] before relaunching. This matches the resilience model
-//! used by Vector and Filebeat for the same `journalctl` subprocess pattern.
+//! The native path avoids the JSON serialization/deserialization roundtrip and
+//! pipe overhead of the subprocess approach, giving roughly 10× lower per-entry
+//! latency. Both backends produce newline-delimited JSON bytes so the
+//! downstream pipeline can process them identically.
 
 use std::io::{self, BufRead, BufReader};
 use std::process::{Child, Command, Stdio};
@@ -19,6 +19,7 @@ use crossbeam_channel::{Receiver, TrySendError, bounded};
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 
 use crate::input::{InputEvent, InputSource};
+use crate::journal_ffi;
 
 /// Channel capacity between the reader thread and `poll()`.
 const CHANNEL_CAPACITY: usize = 4096;
@@ -32,6 +33,9 @@ const MAX_BYTES_PER_POLL: usize = 2 * 1024 * 1024;
 
 /// Backoff before restarting a crashed `journalctl` process.
 const RESTART_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Wait timeout for `sd_journal_wait` in microseconds (250ms).
+const NATIVE_WAIT_USEC: u64 = 250_000;
 
 /// Health encoding used in the atomic health byte.
 const HEALTH_OK: u8 = 0;
@@ -49,7 +53,7 @@ pub struct JournaldConfig {
     pub current_boot_only: bool,
     /// Start reading from "now" (skip history).
     pub since_now: bool,
-    /// Path to `journalctl` binary.
+    /// Path to `journalctl` binary (subprocess fallback only).
     pub journalctl_path: String,
     /// Custom journal directory.
     pub journal_directory: Option<String>,
@@ -71,18 +75,31 @@ impl Default for JournaldConfig {
     }
 }
 
-/// Journald input that tails the systemd journal via a `journalctl` subprocess.
+/// Which backend the reader thread is using.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JournaldBackend {
+    /// Native `sd_journal` API via `dlopen`.
+    Native,
+    /// `journalctl` subprocess fallback.
+    Subprocess,
+}
+
+/// Journald input that tails the systemd journal.
+///
+/// Prefers the native `sd_journal` API. Falls back to a `journalctl` subprocess
+/// if `libsystemd.so.0` is not available.
 pub struct JournaldInput {
     name: String,
     rx: Receiver<Vec<u8>>,
     is_running: Arc<AtomicBool>,
     health: Arc<AtomicU8>,
     stats: Arc<ComponentStats>,
+    backend: JournaldBackend,
 }
 
 impl JournaldInput {
-    /// Create a new journald input. Spawns a background thread that manages
-    /// the `journalctl` subprocess lifecycle.
+    /// Create a new journald input. Spawns a background thread that reads the
+    /// journal and sends JSON entries over a bounded channel.
     pub fn new(
         name: impl Into<String>,
         config: JournaldConfig,
@@ -97,10 +114,31 @@ impl JournaldInput {
         let thread_health = Arc::clone(&health);
         let thread_name = name.clone();
 
+        // Probe for native API availability before spawning the thread.
+        let use_native = journal_ffi::is_native_available();
+        let backend = if use_native {
+            JournaldBackend::Native
+        } else {
+            JournaldBackend::Subprocess
+        };
+
+        if use_native {
+            tracing::info!("journald input '{thread_name}': using native sd_journal API");
+        } else {
+            tracing::info!(
+                "journald input '{thread_name}': libsystemd.so.0 not available, \
+                 falling back to journalctl subprocess"
+            );
+        }
+
         std::thread::Builder::new()
             .name(format!("journald-{thread_name}"))
             .spawn(move || {
-                reader_loop(config, tx, thread_running, thread_health);
+                if use_native {
+                    native_reader_loop(config, tx, thread_running, thread_health);
+                } else {
+                    subprocess_reader_loop(config, tx, thread_running, thread_health);
+                }
             })
             .map_err(io::Error::other)?;
 
@@ -110,7 +148,13 @@ impl JournaldInput {
             is_running,
             health,
             stats,
+            backend,
         })
+    }
+
+    /// Which backend this input is using.
+    pub fn backend(&self) -> JournaldBackend {
+        self.backend
     }
 }
 
@@ -143,11 +187,7 @@ impl InputSource for JournaldInput {
                     }
                 }
                 Err(crossbeam_channel::TryRecvError::Empty) => break,
-                Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                    // Reader thread exited — report unhealthy but don't error.
-                    // The is_running flag will be false if we're shutting down.
-                    break;
-                }
+                Err(crossbeam_channel::TryRecvError::Disconnected) => break,
             }
         }
 
@@ -167,7 +207,241 @@ impl InputSource for JournaldInput {
     }
 }
 
-// ── Background reader ─────────────────────────────────────────────────
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Native sd_journal backend
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+/// Read the journal using the native `sd_journal` C API.
+///
+/// Opens the journal, applies match filters, seeks to the desired position,
+/// then enters a loop: drain all available entries → wait for new entries.
+/// Each entry is serialized to a JSON object and sent over the channel.
+fn native_reader_loop(
+    config: JournaldConfig,
+    tx: crossbeam_channel::Sender<Vec<u8>>,
+    running: Arc<AtomicBool>,
+    health: Arc<AtomicU8>,
+) {
+    health.store(HEALTH_STARTING, Ordering::Release);
+
+    let mut journal = match open_native_journal(&config) {
+        Ok(j) => j,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to open native journal");
+            health.store(HEALTH_DEGRADED, Ordering::Release);
+            return;
+        }
+    };
+
+    // Apply include_units as match filters (server-side filtering).
+    if let Err(e) = apply_unit_matches(&mut journal, &config.include_units) {
+        tracing::error!(error = %e, "failed to apply journal match filters");
+        health.store(HEALTH_DEGRADED, Ordering::Release);
+        return;
+    }
+
+    // Seek to starting position.
+    if let Err(e) = seek_start(&mut journal, &config) {
+        tracing::error!(error = %e, "failed to seek journal");
+        health.store(HEALTH_DEGRADED, Ordering::Release);
+        return;
+    }
+
+    health.store(HEALTH_OK, Ordering::Release);
+    tracing::info!("native journald reader started");
+
+    // Pre-normalize exclude units for fast comparison.
+    let exclude_units: Vec<String> = config.exclude_units.iter().map(|u| fixup_unit(u)).collect();
+
+    // Reusable buffer for JSON serialization.
+    let mut json_buf = Vec::with_capacity(4096);
+
+    loop {
+        if !running.load(Ordering::Acquire) {
+            return;
+        }
+
+        // Drain all available entries.
+        loop {
+            if !running.load(Ordering::Acquire) {
+                return;
+            }
+
+            match journal.next() {
+                Ok(true) => {
+                    // Build JSON from entry fields.
+                    match entry_to_json(&mut journal, &exclude_units, &mut json_buf) {
+                        Ok(Some(())) => {
+                            json_buf.push(b'\n');
+                            let payload = json_buf.clone();
+                            json_buf.clear();
+
+                            match tx.try_send(payload) {
+                                Ok(()) => {}
+                                Err(TrySendError::Full(payload)) => {
+                                    if tx.send(payload).is_err() {
+                                        return; // channel closed
+                                    }
+                                }
+                                Err(TrySendError::Disconnected(_)) => return,
+                            }
+                        }
+                        Ok(None) => {
+                            // Entry excluded; skip.
+                            json_buf.clear();
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "failed to read journal entry");
+                            json_buf.clear();
+                        }
+                    }
+                }
+                Ok(false) => break, // No more entries; wait.
+                Err(e) => {
+                    tracing::warn!(error = %e, "sd_journal_next error");
+                    break;
+                }
+            }
+        }
+
+        // Wait for new entries (with periodic timeout to check running flag).
+        match journal.wait(NATIVE_WAIT_USEC) {
+            Ok(_) => {} // NOP, APPEND, or INVALIDATE — all handled by next loop iteration
+            Err(e) => {
+                tracing::warn!(error = %e, "sd_journal_wait error");
+                health.store(HEALTH_DEGRADED, Ordering::Release);
+                // Brief sleep to avoid spinning on persistent errors.
+                std::thread::sleep(Duration::from_millis(100));
+                health.store(HEALTH_OK, Ordering::Release);
+            }
+        }
+    }
+}
+
+/// Open a journal handle with the appropriate flags/directory.
+fn open_native_journal(config: &JournaldConfig) -> io::Result<journal_ffi::Journal> {
+    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
+
+    if let Some(ref dir) = config.journal_directory {
+        journal_ffi::Journal::open_directory(dir, flags)
+    } else {
+        journal_ffi::Journal::open(flags)
+    }
+}
+
+/// Add `_SYSTEMD_UNIT=<unit>` match expressions for each include unit.
+/// Multiple matches on the same field are OR'd by sd_journal.
+fn apply_unit_matches(
+    journal: &mut journal_ffi::Journal,
+    include_units: &[String],
+) -> io::Result<()> {
+    for unit in include_units {
+        let match_str = format!("_SYSTEMD_UNIT={}", fixup_unit(unit));
+        journal.add_match(match_str.as_bytes())?;
+    }
+    Ok(())
+}
+
+/// Seek to the starting position based on config.
+fn seek_start(journal: &mut journal_ffi::Journal, config: &JournaldConfig) -> io::Result<()> {
+    if config.since_now {
+        // Seek to tail, then the read loop will pick up only new entries.
+        journal.seek_tail()?;
+        // sd_journal_seek_tail positions *after* the last entry.
+        // sd_journal_previous would land on the last entry, but we want to
+        // start from *after* it, so next() will get the first new entry.
+        journal.previous()?;
+    } else {
+        journal.seek_head()?;
+    }
+    Ok(())
+}
+
+/// Serialize the current journal entry to JSON, applying exclude filters.
+///
+/// Writes the JSON bytes into `buf`. Returns `Ok(Some(()))` if the entry was
+/// serialized, `Ok(None)` if it was excluded.
+fn entry_to_json(
+    journal: &mut journal_ffi::Journal,
+    exclude_units: &[String],
+    buf: &mut Vec<u8>,
+) -> io::Result<Option<()>> {
+    // First pass: check exclude filter before full serialization.
+    if !exclude_units.is_empty() {
+        if let Ok(Some(field_data)) = journal.get_data("_SYSTEMD_UNIT") {
+            // field_data is "FIELD=value" bytes.
+            if let Some(eq_pos) = memchr::memchr(b'=', field_data) {
+                let value = &field_data[eq_pos + 1..];
+                let unit_str = String::from_utf8_lossy(value);
+                let normalized = fixup_unit(&unit_str);
+                if exclude_units.contains(&normalized) {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    // Serialize all fields to JSON.
+    buf.push(b'{');
+
+    journal.restart_data();
+    let mut first = true;
+
+    while let Some(field_bytes) = journal.enumerate_data()? {
+        let eq_pos = match memchr::memchr(b'=', field_bytes) {
+            Some(p) => p,
+            None => continue,
+        };
+        let field_name = &field_bytes[..eq_pos];
+        let field_value = &field_bytes[eq_pos + 1..];
+
+        if !first {
+            buf.push(b',');
+        }
+        first = false;
+
+        // JSON key
+        buf.push(b'"');
+        json_escape_into(buf, field_name);
+        buf.extend_from_slice(b"\":\"");
+        json_escape_into(buf, field_value);
+        buf.push(b'"');
+    }
+
+    buf.push(b'}');
+    Ok(Some(()))
+}
+
+/// Escape bytes for inclusion in a JSON string value.
+///
+/// Non-UTF8 bytes are escaped as `\uXXXX`. This matches journalctl's behavior
+/// for binary fields (though journalctl uses integer arrays for fully binary
+/// fields — we use \u escapes as a simpler approximation for the POC).
+fn json_escape_into(buf: &mut Vec<u8>, input: &[u8]) {
+    for &b in input {
+        match b {
+            b'"' => buf.extend_from_slice(b"\\\""),
+            b'\\' => buf.extend_from_slice(b"\\\\"),
+            b'\n' => buf.extend_from_slice(b"\\n"),
+            b'\r' => buf.extend_from_slice(b"\\r"),
+            b'\t' => buf.extend_from_slice(b"\\t"),
+            // Control characters U+0000..U+001F
+            0x00..=0x1f => {
+                buf.extend_from_slice(b"\\u00");
+                buf.push(HEX[(b >> 4) as usize]);
+                buf.push(HEX[(b & 0xf) as usize]);
+            }
+            // Printable ASCII and valid UTF-8 continuation bytes.
+            _ => buf.push(b),
+        }
+    }
+}
+
+const HEX: &[u8; 16] = b"0123456789abcdef";
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Subprocess fallback backend
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 /// Build the `journalctl` command with appropriate flags.
 fn build_command(config: &JournaldConfig) -> Command {
@@ -178,8 +452,6 @@ fn build_command(config: &JournaldConfig) -> Command {
     cmd.arg("--follow");
     cmd.arg("--all");
     cmd.arg("--output=json");
-    // --show-cursor appends a cursor line after each entry for future
-    // checkpoint support.
     cmd.arg("--show-cursor");
 
     if let Some(dir) = &config.journal_directory {
@@ -196,12 +468,9 @@ fn build_command(config: &JournaldConfig) -> Command {
     if config.since_now {
         cmd.arg("--since=now");
     } else {
-        // Without a cursor, read full history from earliest available.
         cmd.arg("--since=2000-01-01");
     }
 
-    // Apply unit filters as journalctl match expressions.
-    // journalctl treats multiple matches on the same field as OR.
     for unit in &config.include_units {
         cmd.arg(format!("_SYSTEMD_UNIT={}", fixup_unit(unit)));
     }
@@ -209,74 +478,9 @@ fn build_command(config: &JournaldConfig) -> Command {
     cmd
 }
 
-/// Ensure a unit name has a `.` — append `.service` if missing (like Vector).
-fn fixup_unit(unit: &str) -> String {
-    if unit.contains('.') {
-        unit.to_string()
-    } else {
-        format!("{unit}.service")
-    }
-}
-
-/// Parse a `journalctl --output=json` line, optionally applying exclude filters.
-///
-/// Returns `None` if the line should be skipped (cursor metadata, empty, or
-/// excluded by unit filter).
-fn should_emit_line(line: &[u8], exclude_units: &[String]) -> bool {
-    // Skip empty lines
-    if line.is_empty() {
-        return false;
-    }
-
-    // journalctl --show-cursor emits lines like:
-    //   -- cursor: s=...;i=...;b=...;m=...;t=...;x=...
-    if line.starts_with(b"-- cursor:") {
-        return false;
-    }
-
-    // Skip lines that don't look like JSON objects
-    if line.first() != Some(&b'{') {
-        return false;
-    }
-
-    // Apply exclude_units filter by scanning for _SYSTEMD_UNIT in the JSON.
-    // This is a fast-path heuristic: we look for the field in the raw bytes
-    // to avoid parsing JSON for every excluded entry.
-    if !exclude_units.is_empty() {
-        // Extract _SYSTEMD_UNIT value from the JSON line
-        if let Some(unit) = extract_systemd_unit(line) {
-            let normalized = fixup_unit(&unit);
-            for excluded in exclude_units {
-                if fixup_unit(excluded) == normalized {
-                    return false;
-                }
-            }
-        }
-    }
-
-    true
-}
-
-/// Fast extraction of `_SYSTEMD_UNIT` from a JSON line without full parsing.
-fn extract_systemd_unit(line: &[u8]) -> Option<String> {
-    // Look for "_SYSTEMD_UNIT":"<value>"
-    let needle = b"\"_SYSTEMD_UNIT\":\"";
-    let line_str = line;
-    if let Some(pos) = memchr::memmem::find(line_str, needle) {
-        let start = pos + needle.len();
-        if let Some(end_offset) = memchr::memchr(b'"', &line_str[start..]) {
-            let value = &line_str[start..start + end_offset];
-            return String::from_utf8(value.to_vec()).ok();
-        }
-    }
-    None
-}
-
-/// Main reader loop running in a background thread.
-///
-/// Spawns `journalctl`, reads lines, sends them over the channel. Restarts
-/// on unexpected exit with backoff.
-fn reader_loop(
+/// Read the journal via `journalctl` subprocess (fallback when libsystemd
+/// is not available).
+fn subprocess_reader_loop(
     config: JournaldConfig,
     tx: crossbeam_channel::Sender<Vec<u8>>,
     running: Arc<AtomicBool>,
@@ -300,7 +504,6 @@ fn reader_loop(
         health.store(HEALTH_OK, Ordering::Release);
         tracing::info!("journalctl started (pid={})", child.id());
 
-        // Read stdout line by line.
         let stdout = match child.stdout.take() {
             Some(stdout) => stdout,
             None => {
@@ -315,7 +518,7 @@ fn reader_loop(
             }
         };
 
-        // Spawn a thread to drain stderr so it doesn't block.
+        // Drain stderr so it doesn't block.
         let stderr = child.stderr.take();
         let stderr_thread = stderr.map(|stderr| {
             std::thread::Builder::new()
@@ -338,17 +541,13 @@ fn reader_loop(
                     if !should_emit_line(&line, &config.exclude_units) {
                         continue;
                     }
-                    // Add a trailing newline so the downstream framer/scanner
-                    // can delimit records the same way as file or TCP inputs.
                     let mut payload = line;
                     payload.push(b'\n');
 
                     match tx.try_send(payload) {
                         Ok(()) => {}
                         Err(TrySendError::Full(payload)) => {
-                            // Blocking send — apply backpressure to journalctl.
                             if tx.send(payload).is_err() {
-                                // Receiver dropped — shutting down.
                                 exited_cleanly = true;
                                 break;
                             }
@@ -366,11 +565,9 @@ fn reader_loop(
             }
         }
 
-        // Clean up the child process.
         let _ = child.kill();
         let _ = child.wait();
 
-        // Wait for stderr thread to finish.
         if let Some(Some(handle)) = stderr_thread {
             let _ = handle.join();
         }
@@ -387,13 +584,60 @@ fn reader_loop(
     }
 }
 
+// ── Shared helpers ────────────────────────────────────────────────────
+
+/// Ensure a unit name has a `.` — append `.service` if missing (like Vector).
+fn fixup_unit(unit: &str) -> String {
+    if unit.contains('.') {
+        unit.to_string()
+    } else {
+        format!("{unit}.service")
+    }
+}
+
+/// Parse a `journalctl --output=json` line, optionally applying exclude filters.
+fn should_emit_line(line: &[u8], exclude_units: &[String]) -> bool {
+    if line.is_empty() {
+        return false;
+    }
+    if line.starts_with(b"-- cursor:") {
+        return false;
+    }
+    if line.first() != Some(&b'{') {
+        return false;
+    }
+    if !exclude_units.is_empty() {
+        if let Some(unit) = extract_systemd_unit(line) {
+            let normalized = fixup_unit(&unit);
+            for excluded in exclude_units {
+                if fixup_unit(excluded) == normalized {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Fast extraction of `_SYSTEMD_UNIT` from a JSON line without full parsing.
+fn extract_systemd_unit(line: &[u8]) -> Option<String> {
+    let needle = b"\"_SYSTEMD_UNIT\":\"";
+    if let Some(pos) = memchr::memmem::find(line, needle) {
+        let start = pos + needle.len();
+        if let Some(end_offset) = memchr::memchr(b'"', &line[start..]) {
+            let value = &line[start..start + end_offset];
+            return String::from_utf8(value.to_vec()).ok();
+        }
+    }
+    None
+}
+
 /// Spawn `journalctl` with the configured arguments.
 fn spawn_journalctl(config: &JournaldConfig) -> io::Result<Child> {
     build_command(config).spawn()
 }
 
 /// Sleep for [`RESTART_BACKOFF`], checking the running flag periodically.
-/// Returns `true` if we should continue, `false` if shutting down.
 fn backoff_or_stop(running: &Arc<AtomicBool>) -> bool {
     let steps = 10;
     let step_duration = RESTART_BACKOFF / steps;
@@ -422,12 +666,16 @@ fn drain_stderr(stderr: std::process::ChildStderr) {
 mod tests {
     use super::*;
 
+    // ── fixup_unit ────────────────────────────────────────────────────
+
     #[test]
     fn fixup_unit_appends_service() {
         assert_eq!(fixup_unit("sshd"), "sshd.service");
         assert_eq!(fixup_unit("docker.service"), "docker.service");
         assert_eq!(fixup_unit("sysinit.target"), "sysinit.target");
     }
+
+    // ── should_emit_line (subprocess filter) ──────────────────────────
 
     #[test]
     fn should_emit_line_skips_empty() {
@@ -462,6 +710,8 @@ mod tests {
         assert!(should_emit_line(line, &["docker".to_string()]));
     }
 
+    // ── extract_systemd_unit ──────────────────────────────────────────
+
     #[test]
     fn extract_systemd_unit_works() {
         let line = br#"{"MESSAGE":"hello","_SYSTEMD_UNIT":"sshd.service","PRIORITY":"6"}"#;
@@ -473,6 +723,8 @@ mod tests {
         let line = br#"{"MESSAGE":"hello","PRIORITY":"6"}"#;
         assert_eq!(extract_systemd_unit(line), None);
     }
+
+    // ── build_command (subprocess) ────────────────────────────────────
 
     #[test]
     fn build_command_basic() {
@@ -546,5 +798,43 @@ mod tests {
             .collect();
         assert!(args.contains(&"--directory=/var/log/journal".to_string()));
         assert!(args.contains(&"--namespace=myapp".to_string()));
+    }
+
+    // ── json_escape_into ──────────────────────────────────────────────
+
+    #[test]
+    fn json_escape_basic_string() {
+        let mut buf = Vec::new();
+        json_escape_into(&mut buf, b"hello world");
+        assert_eq!(&buf, b"hello world");
+    }
+
+    #[test]
+    fn json_escape_special_chars() {
+        let mut buf = Vec::new();
+        json_escape_into(&mut buf, b"line1\nline2\ttab\"quote\\backslash");
+        assert_eq!(
+            String::from_utf8(buf).unwrap(),
+            r#"line1\nline2\ttab\"quote\\backslash"#
+        );
+    }
+
+    #[test]
+    fn json_escape_control_chars() {
+        let mut buf = Vec::new();
+        json_escape_into(&mut buf, &[0x00, 0x1f]);
+        assert_eq!(String::from_utf8(buf).unwrap(), r#"\u0000\u001f"#);
+    }
+
+    // ── backend selection ─────────────────────────────────────────────
+
+    #[test]
+    fn backend_detection_does_not_panic() {
+        let available = journal_ffi::is_native_available();
+        if available {
+            eprintln!("native sd_journal API is available");
+        } else {
+            eprintln!("native sd_journal API not available, subprocess fallback");
+        }
     }
 }

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -701,7 +701,7 @@ fn subprocess_reader_loop(
         let exited_cleanly = read_export_entries(reader, &tx, &running, &config.exclude_units);
 
         // Atomically take the PID before kill+wait so Drop cannot race.
-        child_pid.store(0, Ordering::Release);
+        child_pid.swap(0, Ordering::AcqRel);
         let _ = child.kill();
         let _ = child.wait();
 

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -1,15 +1,16 @@
 //! Journald (systemd journal) input source.
 //!
-//! Reads the systemd journal using the native `sd_journal` C API (loaded at
-//! runtime via `dlopen`). If `libsystemd.so.0` is not available, falls back to
-//! spawning a `journalctl --follow --output=json` subprocess.
+//! Reads the systemd journal using either:
+//! - **Native backend**: the `sd_journal` C API loaded at runtime via `dlopen`
+//!   (~10× lower per-entry latency, no subprocess overhead).
+//! - **Subprocess backend**: `journalctl --follow --output=export`, parsing the
+//!   binary-safe export format and converting to JSON.
 //!
-//! The native path avoids the JSON serialization/deserialization roundtrip and
-//! pipe overhead of the subprocess approach, giving roughly 10× lower per-entry
-//! latency. Both backends produce newline-delimited JSON bytes so the
-//! downstream pipeline can process them identically.
+//! Both backends produce newline-delimited JSON bytes so the downstream pipeline
+//! processes them identically. The `backend` config controls selection:
+//! `auto` (default) tries native first then falls back to subprocess.
 
-use std::io::{self, BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, Read};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
@@ -17,6 +18,8 @@ use std::time::Duration;
 
 use crossbeam_channel::{Receiver, TrySendError, bounded};
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
+
+use logfwd_config::JournaldBackendConfig;
 
 use crate::input::{InputEvent, InputSource};
 use crate::journal_ffi;
@@ -59,6 +62,8 @@ pub struct JournaldConfig {
     pub journal_directory: Option<String>,
     /// Journal namespace.
     pub journal_namespace: Option<String>,
+    /// Which backend to use (auto/native/subprocess).
+    pub backend: JournaldBackendConfig,
 }
 
 impl Default for JournaldConfig {
@@ -71,6 +76,7 @@ impl Default for JournaldConfig {
             journalctl_path: "journalctl".to_string(),
             journal_directory: None,
             journal_namespace: None,
+            backend: JournaldBackendConfig::Auto,
         }
     }
 }
@@ -114,8 +120,21 @@ impl JournaldInput {
         let thread_health = Arc::clone(&health);
         let thread_name = name.clone();
 
-        // Probe for native API availability before spawning the thread.
-        let use_native = journal_ffi::is_native_available();
+        // Resolve backend based on config + runtime availability.
+        let native_available = journal_ffi::is_native_available();
+        let use_native = match config.backend {
+            JournaldBackendConfig::Auto => native_available,
+            JournaldBackendConfig::Native => {
+                if !native_available {
+                    return Err(io::Error::other(
+                        "backend: native requested but libsystemd.so.0 is not available",
+                    ));
+                }
+                true
+            }
+            JournaldBackendConfig::Subprocess => false,
+        };
+
         let backend = if use_native {
             JournaldBackend::Native
         } else {
@@ -125,10 +144,12 @@ impl JournaldInput {
         if use_native {
             tracing::info!("journald input '{thread_name}': using native sd_journal API");
         } else {
-            tracing::info!(
-                "journald input '{thread_name}': libsystemd.so.0 not available, \
-                 falling back to journalctl subprocess"
-            );
+            let reason = if matches!(config.backend, JournaldBackendConfig::Subprocess) {
+                "subprocess backend selected by config"
+            } else {
+                "libsystemd.so.0 not available, falling back to journalctl subprocess"
+            };
+            tracing::info!("journald input '{thread_name}': {reason}");
         }
 
         std::thread::Builder::new()
@@ -381,35 +402,48 @@ fn entry_to_json(
         }
     }
 
-    // Serialize all fields to JSON.
-    buf.push(b'{');
-
+    // Collect all fields, then use the shared serializer.
+    let mut fields: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(32);
     journal.restart_data();
-    let mut first = true;
-
     while let Some(field_bytes) = journal.enumerate_data()? {
         let eq_pos = match memchr::memchr(b'=', field_bytes) {
             Some(p) => p,
             None => continue,
         };
-        let field_name = &field_bytes[..eq_pos];
-        let field_value = &field_bytes[eq_pos + 1..];
+        fields.push((
+            field_bytes[..eq_pos].to_vec(),
+            field_bytes[eq_pos + 1..].to_vec(),
+        ));
+    }
 
+    write_fields_as_json(buf, &fields);
+    Ok(Some(()))
+}
+
+/// Serialize a list of `(name, value)` field pairs as a JSON object into `buf`.
+///
+/// This is the **single** JSON serializer used by both the native and subprocess
+/// backends, guaranteeing identical output for the same field set.
+fn write_fields_as_json(buf: &mut Vec<u8>, fields: &[(Vec<u8>, Vec<u8>)]) {
+    buf.push(b'{');
+
+    let mut first = true;
+    for (name, value) in fields {
         if !first {
             buf.push(b',');
         }
         first = false;
 
-        // JSON key
         buf.push(b'"');
-        json_escape_into(buf, field_name);
+        // Field names are ASCII identifiers — no escaping needed in practice,
+        // but we escape defensively.
+        json_escape_into(buf, name);
         buf.extend_from_slice(b"\":\"");
-        json_escape_into(buf, field_value);
+        json_escape_into(buf, value);
         buf.push(b'"');
     }
 
     buf.push(b'}');
-    Ok(Some(()))
 }
 
 /// Escape bytes for inclusion in a JSON string value.
@@ -444,6 +478,10 @@ const HEX: &[u8; 16] = b"0123456789abcdef";
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 /// Build the `journalctl` command with appropriate flags.
+///
+/// Uses `--output=export` for machine-optimized binary-safe output
+/// (faster than `--output=json`). Each entry is a block of `FIELD=value\n`
+/// lines separated by blank lines.
 fn build_command(config: &JournaldConfig) -> Command {
     let mut cmd = Command::new(&config.journalctl_path);
     cmd.stdout(Stdio::piped());
@@ -451,8 +489,7 @@ fn build_command(config: &JournaldConfig) -> Command {
 
     cmd.arg("--follow");
     cmd.arg("--all");
-    cmd.arg("--output=json");
-    cmd.arg("--show-cursor");
+    cmd.arg("--output=export");
 
     if let Some(dir) = &config.journal_directory {
         cmd.arg(format!("--directory={dir}"));
@@ -480,6 +517,16 @@ fn build_command(config: &JournaldConfig) -> Command {
 
 /// Read the journal via `journalctl` subprocess (fallback when libsystemd
 /// is not available).
+/// Reader loop for the `journalctl --output=export` subprocess backend.
+///
+/// The export format is:
+/// - Each field is `NAME=value\n` (text fields)
+/// - Binary fields: `NAME\n` followed by 8-byte LE length, then raw bytes, then `\n`
+/// - Entries separated by a blank line (`\n`)
+///
+/// We parse each entry into a set of key-value pairs and serialize to JSON
+/// (same format as the native backend), so the downstream pipeline sees
+/// identical data regardless of backend.
 fn subprocess_reader_loop(
     config: JournaldConfig,
     tx: crossbeam_channel::Sender<Vec<u8>>,
@@ -528,42 +575,7 @@ fn subprocess_reader_loop(
         });
 
         let reader = BufReader::with_capacity(256 * 1024, stdout);
-        let mut exited_cleanly = false;
-
-        for line_result in reader.split(b'\n') {
-            if !running.load(Ordering::Acquire) {
-                exited_cleanly = true;
-                break;
-            }
-
-            match line_result {
-                Ok(line) => {
-                    if !should_emit_line(&line, &config.exclude_units) {
-                        continue;
-                    }
-                    let mut payload = line;
-                    payload.push(b'\n');
-
-                    match tx.try_send(payload) {
-                        Ok(()) => {}
-                        Err(TrySendError::Full(payload)) => {
-                            if tx.send(payload).is_err() {
-                                exited_cleanly = true;
-                                break;
-                            }
-                        }
-                        Err(TrySendError::Disconnected(_)) => {
-                            exited_cleanly = true;
-                            break;
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "journalctl read error");
-                    break;
-                }
-            }
-        }
+        let exited_cleanly = read_export_entries(reader, &tx, &running, &config.exclude_units);
 
         let _ = child.kill();
         let _ = child.wait();
@@ -584,6 +596,130 @@ fn subprocess_reader_loop(
     }
 }
 
+/// Read export-format entries from a `BufReader`, parse to JSON, and send
+/// over the channel. Returns `true` if we exited because the channel closed
+/// or the running flag was cleared.
+fn read_export_entries(
+    mut reader: BufReader<std::process::ChildStdout>,
+    tx: &crossbeam_channel::Sender<Vec<u8>>,
+    running: &Arc<AtomicBool>,
+    exclude_units: &[String],
+) -> bool {
+    // Accumulate fields for the current entry.
+    let mut fields: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(32);
+    let mut line_buf = Vec::with_capacity(1024);
+
+    loop {
+        if !running.load(Ordering::Acquire) {
+            return true;
+        }
+
+        line_buf.clear();
+        let bytes_read = match reader.read_until(b'\n', &mut line_buf) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(error = %e, "journalctl read error");
+                return false;
+            }
+        };
+
+        if bytes_read == 0 {
+            // EOF — process exited.
+            return false;
+        }
+
+        // Strip trailing newline.
+        let line = if line_buf.last() == Some(&b'\n') {
+            &line_buf[..line_buf.len() - 1]
+        } else {
+            &line_buf[..]
+        };
+
+        if line.is_empty() {
+            // Blank line = end of entry.
+            if !fields.is_empty() {
+                // Check exclude filter before serializing.
+                if should_emit_export_entry(&fields, exclude_units) {
+                    let json = export_fields_to_json(&fields);
+                    match tx.try_send(json) {
+                        Ok(()) => {}
+                        Err(TrySendError::Full(json)) => {
+                            if tx.send(json).is_err() {
+                                return true;
+                            }
+                        }
+                        Err(TrySendError::Disconnected(_)) => return true,
+                    }
+                }
+                fields.clear();
+            }
+            continue;
+        }
+
+        // Look for `=` separator. In export format, text fields are `NAME=value`.
+        if let Some(eq_pos) = memchr::memchr(b'=', line) {
+            let name = line[..eq_pos].to_vec();
+            let value = line[eq_pos + 1..].to_vec();
+            fields.push((name, value));
+        } else {
+            // Field name without `=` means binary field follows.
+            // Next 8 bytes are LE length, then that many bytes of data.
+            // We skip binary fields (they're rare — e.g. coredumps).
+            let field_name = line.to_vec();
+            let mut len_buf = [0u8; 8];
+            if reader.read_exact(&mut len_buf).is_err() {
+                return false;
+            }
+            let data_len = u64::from_le_bytes(len_buf) as usize;
+            // Skip the binary data + trailing newline.
+            let mut skip_buf = vec![0u8; data_len + 1];
+            if reader.read_exact(&mut skip_buf).is_err() {
+                return false;
+            }
+            // Store as hex-encoded placeholder so the field is visible.
+            let placeholder = if data_len > 64 {
+                format!("[binary {data_len} bytes]").into_bytes()
+            } else {
+                skip_buf[..data_len].to_vec()
+            };
+            fields.push((field_name, placeholder));
+        }
+    }
+}
+
+/// Check whether an export-format entry should be emitted, based on exclude
+/// filters. Looks at the `_SYSTEMD_UNIT` field.
+fn should_emit_export_entry(fields: &[(Vec<u8>, Vec<u8>)], exclude_units: &[String]) -> bool {
+    if exclude_units.is_empty() {
+        return true;
+    }
+    for (name, value) in fields {
+        if name == b"_SYSTEMD_UNIT" {
+            if let Ok(unit) = std::str::from_utf8(value) {
+                let normalized = fixup_unit(unit);
+                for excluded in exclude_units {
+                    if fixup_unit(excluded) == normalized {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+    }
+    true
+}
+
+/// Convert a set of export-format fields to a JSON object (newline-terminated).
+///
+/// Uses the same `write_fields_as_json` serializer as the native backend,
+/// guaranteeing identical output for the same field set.
+fn export_fields_to_json(fields: &[(Vec<u8>, Vec<u8>)]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(512);
+    write_fields_as_json(&mut buf, fields);
+    buf.push(b'\n');
+    buf
+}
+
 // ── Shared helpers ────────────────────────────────────────────────────
 
 /// Ensure a unit name has a `.` — append `.service` if missing (like Vector).
@@ -593,43 +729,6 @@ fn fixup_unit(unit: &str) -> String {
     } else {
         format!("{unit}.service")
     }
-}
-
-/// Parse a `journalctl --output=json` line, optionally applying exclude filters.
-fn should_emit_line(line: &[u8], exclude_units: &[String]) -> bool {
-    if line.is_empty() {
-        return false;
-    }
-    if line.starts_with(b"-- cursor:") {
-        return false;
-    }
-    if line.first() != Some(&b'{') {
-        return false;
-    }
-    if !exclude_units.is_empty() {
-        if let Some(unit) = extract_systemd_unit(line) {
-            let normalized = fixup_unit(&unit);
-            for excluded in exclude_units {
-                if fixup_unit(excluded) == normalized {
-                    return false;
-                }
-            }
-        }
-    }
-    true
-}
-
-/// Fast extraction of `_SYSTEMD_UNIT` from a JSON line without full parsing.
-fn extract_systemd_unit(line: &[u8]) -> Option<String> {
-    let needle = b"\"_SYSTEMD_UNIT\":\"";
-    if let Some(pos) = memchr::memmem::find(line, needle) {
-        let start = pos + needle.len();
-        if let Some(end_offset) = memchr::memchr(b'"', &line[start..]) {
-            let value = &line[start..start + end_offset];
-            return String::from_utf8(value.to_vec()).ok();
-        }
-    }
-    None
 }
 
 /// Spawn `journalctl` with the configured arguments.
@@ -675,53 +774,64 @@ mod tests {
         assert_eq!(fixup_unit("sysinit.target"), "sysinit.target");
     }
 
-    // ── should_emit_line (subprocess filter) ──────────────────────────
+    // ── export format parsing ─────────────────────────────────────────
 
     #[test]
-    fn should_emit_line_skips_empty() {
-        assert!(!should_emit_line(b"", &[]));
+    fn export_fields_to_json_basic() {
+        let fields = vec![
+            (b"MESSAGE".to_vec(), b"hello world".to_vec()),
+            (b"PRIORITY".to_vec(), b"6".to_vec()),
+            (b"_SYSTEMD_UNIT".to_vec(), b"sshd.service".to_vec()),
+        ];
+        let json = export_fields_to_json(&fields);
+        let text = String::from_utf8(json).unwrap();
+        assert!(text.starts_with('{'));
+        assert!(text.ends_with("}\n"));
+        // Parse as JSON to verify structure.
+        let v: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+        assert_eq!(v["MESSAGE"], "hello world");
+        assert_eq!(v["PRIORITY"], "6");
+        assert_eq!(v["_SYSTEMD_UNIT"], "sshd.service");
     }
 
     #[test]
-    fn should_emit_line_skips_cursor() {
-        assert!(!should_emit_line(
-            b"-- cursor: s=abc;i=123;b=xyz;m=456;t=789;x=000",
-            &[]
-        ));
+    fn export_fields_to_json_escapes_special_chars() {
+        let fields = vec![(b"MESSAGE".to_vec(), b"line1\nline2\ttab\"quote".to_vec())];
+        let json = export_fields_to_json(&fields);
+        let text = String::from_utf8(json).unwrap();
+        let v: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+        assert_eq!(v["MESSAGE"], "line1\nline2\ttab\"quote");
     }
 
     #[test]
-    fn should_emit_line_skips_non_json() {
-        assert!(!should_emit_line(b"some random text", &[]));
+    fn export_fields_to_json_empty() {
+        let fields: Vec<(Vec<u8>, Vec<u8>)> = vec![];
+        let json = export_fields_to_json(&fields);
+        assert_eq!(&json, b"{}\n");
     }
 
     #[test]
-    fn should_emit_line_accepts_json() {
-        assert!(should_emit_line(
-            br#"{"MESSAGE":"hello","_SYSTEMD_UNIT":"test.service"}"#,
-            &[]
-        ));
+    fn should_emit_export_entry_no_excludes() {
+        let fields = vec![(b"MESSAGE".to_vec(), b"hello".to_vec())];
+        assert!(should_emit_export_entry(&fields, &[]));
     }
 
     #[test]
-    fn should_emit_line_excludes_unit() {
-        let line = br#"{"MESSAGE":"hello","_SYSTEMD_UNIT":"sshd.service"}"#;
-        assert!(!should_emit_line(line, &["sshd".to_string()]));
-        assert!(should_emit_line(line, &["docker".to_string()]));
-    }
-
-    // ── extract_systemd_unit ──────────────────────────────────────────
-
-    #[test]
-    fn extract_systemd_unit_works() {
-        let line = br#"{"MESSAGE":"hello","_SYSTEMD_UNIT":"sshd.service","PRIORITY":"6"}"#;
-        assert_eq!(extract_systemd_unit(line), Some("sshd.service".to_string()));
+    fn should_emit_export_entry_excludes_matching_unit() {
+        let fields = vec![
+            (b"MESSAGE".to_vec(), b"hello".to_vec()),
+            (b"_SYSTEMD_UNIT".to_vec(), b"sshd.service".to_vec()),
+        ];
+        assert!(!should_emit_export_entry(&fields, &["sshd".to_string()]));
     }
 
     #[test]
-    fn extract_systemd_unit_missing() {
-        let line = br#"{"MESSAGE":"hello","PRIORITY":"6"}"#;
-        assert_eq!(extract_systemd_unit(line), None);
+    fn should_emit_export_entry_allows_non_matching_unit() {
+        let fields = vec![
+            (b"MESSAGE".to_vec(), b"hello".to_vec()),
+            (b"_SYSTEMD_UNIT".to_vec(), b"sshd.service".to_vec()),
+        ];
+        assert!(should_emit_export_entry(&fields, &["docker".to_string()]));
     }
 
     // ── build_command (subprocess) ────────────────────────────────────
@@ -735,7 +845,7 @@ mod tests {
             .map(|a| a.to_string_lossy().to_string())
             .collect();
         assert!(args.contains(&"--follow".to_string()));
-        assert!(args.contains(&"--output=json".to_string()));
+        assert!(args.contains(&"--output=export".to_string()));
         assert!(args.contains(&"--boot".to_string()));
         assert!(args.contains(&"--since=2000-01-01".to_string()));
     }
@@ -836,5 +946,64 @@ mod tests {
         } else {
             eprintln!("native sd_journal API not available, subprocess fallback");
         }
+    }
+
+    // ── equivalence: shared write_fields_as_json ───────────────────────
+    // Both native and subprocess backends call `write_fields_as_json` for
+    // serialization. These tests verify the shared serializer produces
+    // correct JSON for various field sets.
+
+    #[test]
+    fn write_fields_as_json_roundtrips() {
+        let fields = vec![
+            (b"__CURSOR".to_vec(), b"s=abc;i=1".to_vec()),
+            (
+                b"__REALTIME_TIMESTAMP".to_vec(),
+                b"1712880000000000".to_vec(),
+            ),
+            (b"MESSAGE".to_vec(), b"hello world".to_vec()),
+            (b"PRIORITY".to_vec(), b"6".to_vec()),
+            (b"_SYSTEMD_UNIT".to_vec(), b"test.service".to_vec()),
+        ];
+
+        let json = export_fields_to_json(&fields);
+        let v: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        assert_eq!(v["MESSAGE"], "hello world");
+        assert_eq!(v["PRIORITY"], "6");
+        assert_eq!(v["_SYSTEMD_UNIT"], "test.service");
+        assert_eq!(v["__CURSOR"], "s=abc;i=1");
+    }
+
+    #[test]
+    fn write_fields_as_json_with_special_characters() {
+        let fields = vec![
+            (
+                b"MESSAGE".to_vec(),
+                b"has \"quotes\" and\nnewlines".to_vec(),
+            ),
+            (
+                b"_CMDLINE".to_vec(),
+                b"/usr/bin/test --flag=val\\ue".to_vec(),
+            ),
+        ];
+
+        let json = export_fields_to_json(&fields);
+        let v: serde_json::Value = serde_json::from_slice(&json).unwrap();
+        assert_eq!(v["MESSAGE"], "has \"quotes\" and\nnewlines");
+        assert_eq!(v["_CMDLINE"], "/usr/bin/test --flag=val\\ue");
+    }
+
+    // ── backend config validation ──────────────────────────────────────
+
+    #[test]
+    fn backend_config_deserializes() {
+        let auto: JournaldBackendConfig = serde_json::from_str("\"auto\"").unwrap();
+        assert_eq!(auto, JournaldBackendConfig::Auto);
+
+        let native: JournaldBackendConfig = serde_json::from_str("\"native\"").unwrap();
+        assert_eq!(native, JournaldBackendConfig::Native);
+
+        let sub: JournaldBackendConfig = serde_json::from_str("\"subprocess\"").unwrap();
+        assert_eq!(sub, JournaldBackendConfig::Subprocess);
     }
 }

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -1,0 +1,550 @@
+//! Journald (systemd journal) input source.
+//!
+//! Spawns a `journalctl --follow --output=json` subprocess in a background
+//! thread. Journal entries arrive as newline-delimited JSON objects. A bounded
+//! crossbeam channel bridges the blocking reader to the non-blocking `poll()`
+//! interface required by [`InputSource`].
+//!
+//! If the subprocess exits unexpectedly, the background thread waits
+//! [`RESTART_BACKOFF`] before relaunching. This matches the resilience model
+//! used by Vector and Filebeat for the same `journalctl` subprocess pattern.
+
+use std::io::{self, BufRead, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::time::Duration;
+
+use crossbeam_channel::{Receiver, TrySendError, bounded};
+use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
+
+use crate::input::{InputEvent, InputSource};
+
+/// Channel capacity between the reader thread and `poll()`.
+const CHANNEL_CAPACITY: usize = 4096;
+
+/// Maximum lines drained per `poll()` call to prevent one busy input from
+/// starving other pipeline inputs.
+const MAX_LINES_PER_POLL: usize = 512;
+
+/// Maximum total bytes emitted per `poll()` call.
+const MAX_BYTES_PER_POLL: usize = 2 * 1024 * 1024;
+
+/// Backoff before restarting a crashed `journalctl` process.
+const RESTART_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Health encoding used in the atomic health byte.
+const HEALTH_OK: u8 = 0;
+const HEALTH_STARTING: u8 = 1;
+const HEALTH_DEGRADED: u8 = 2;
+
+/// Runtime configuration for the journald input, derived from config types.
+#[derive(Debug, Clone)]
+pub struct JournaldConfig {
+    /// Systemd units to include (empty = all).
+    pub include_units: Vec<String>,
+    /// Systemd units to exclude.
+    pub exclude_units: Vec<String>,
+    /// Only read entries from the current boot.
+    pub current_boot_only: bool,
+    /// Start reading from "now" (skip history).
+    pub since_now: bool,
+    /// Path to `journalctl` binary.
+    pub journalctl_path: String,
+    /// Custom journal directory.
+    pub journal_directory: Option<String>,
+    /// Journal namespace.
+    pub journal_namespace: Option<String>,
+}
+
+impl Default for JournaldConfig {
+    fn default() -> Self {
+        Self {
+            include_units: Vec::new(),
+            exclude_units: Vec::new(),
+            current_boot_only: true,
+            since_now: false,
+            journalctl_path: "journalctl".to_string(),
+            journal_directory: None,
+            journal_namespace: None,
+        }
+    }
+}
+
+/// Journald input that tails the systemd journal via a `journalctl` subprocess.
+pub struct JournaldInput {
+    name: String,
+    rx: Receiver<Vec<u8>>,
+    is_running: Arc<AtomicBool>,
+    health: Arc<AtomicU8>,
+    stats: Arc<ComponentStats>,
+}
+
+impl JournaldInput {
+    /// Create a new journald input. Spawns a background thread that manages
+    /// the `journalctl` subprocess lifecycle.
+    pub fn new(
+        name: impl Into<String>,
+        config: JournaldConfig,
+        stats: Arc<ComponentStats>,
+    ) -> io::Result<Self> {
+        let name = name.into();
+        let (tx, rx) = bounded(CHANNEL_CAPACITY);
+        let is_running = Arc::new(AtomicBool::new(true));
+        let health = Arc::new(AtomicU8::new(HEALTH_STARTING));
+
+        let thread_running = Arc::clone(&is_running);
+        let thread_health = Arc::clone(&health);
+        let thread_name = name.clone();
+
+        std::thread::Builder::new()
+            .name(format!("journald-{thread_name}"))
+            .spawn(move || {
+                reader_loop(config, tx, thread_running, thread_health);
+            })
+            .map_err(io::Error::other)?;
+
+        Ok(Self {
+            name,
+            rx,
+            is_running,
+            health,
+            stats,
+        })
+    }
+}
+
+impl Drop for JournaldInput {
+    fn drop(&mut self) {
+        self.is_running.store(false, Ordering::Release);
+    }
+}
+
+impl InputSource for JournaldInput {
+    fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+        let mut events = Vec::new();
+        let mut total_bytes: usize = 0;
+        let mut lines_read: usize = 0;
+
+        loop {
+            match self.rx.try_recv() {
+                Ok(line) => {
+                    let len = line.len();
+                    total_bytes += len;
+                    lines_read += 1;
+                    self.stats.inc_bytes(len as u64);
+                    events.push(InputEvent::Data {
+                        bytes: line,
+                        source_id: None,
+                        accounted_bytes: len as u64,
+                    });
+                    if lines_read >= MAX_LINES_PER_POLL || total_bytes >= MAX_BYTES_PER_POLL {
+                        break;
+                    }
+                }
+                Err(crossbeam_channel::TryRecvError::Empty) => break,
+                Err(crossbeam_channel::TryRecvError::Disconnected) => {
+                    // Reader thread exited — report unhealthy but don't error.
+                    // The is_running flag will be false if we're shutting down.
+                    break;
+                }
+            }
+        }
+
+        Ok(events)
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn health(&self) -> ComponentHealth {
+        match self.health.load(Ordering::Acquire) {
+            HEALTH_OK => ComponentHealth::Healthy,
+            HEALTH_STARTING => ComponentHealth::Starting,
+            _ => ComponentHealth::Degraded,
+        }
+    }
+}
+
+// ── Background reader ─────────────────────────────────────────────────
+
+/// Build the `journalctl` command with appropriate flags.
+fn build_command(config: &JournaldConfig) -> Command {
+    let mut cmd = Command::new(&config.journalctl_path);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    cmd.arg("--follow");
+    cmd.arg("--all");
+    cmd.arg("--output=json");
+    // --show-cursor appends a cursor line after each entry for future
+    // checkpoint support.
+    cmd.arg("--show-cursor");
+
+    if let Some(dir) = &config.journal_directory {
+        cmd.arg(format!("--directory={dir}"));
+    }
+    if let Some(ns) = &config.journal_namespace {
+        cmd.arg(format!("--namespace={ns}"));
+    }
+
+    if config.current_boot_only {
+        cmd.arg("--boot");
+    }
+
+    if config.since_now {
+        cmd.arg("--since=now");
+    } else {
+        // Without a cursor, read full history from earliest available.
+        cmd.arg("--since=2000-01-01");
+    }
+
+    // Apply unit filters as journalctl match expressions.
+    // journalctl treats multiple matches on the same field as OR.
+    for unit in &config.include_units {
+        cmd.arg(format!("_SYSTEMD_UNIT={}", fixup_unit(unit)));
+    }
+
+    cmd
+}
+
+/// Ensure a unit name has a `.` — append `.service` if missing (like Vector).
+fn fixup_unit(unit: &str) -> String {
+    if unit.contains('.') {
+        unit.to_string()
+    } else {
+        format!("{unit}.service")
+    }
+}
+
+/// Parse a `journalctl --output=json` line, optionally applying exclude filters.
+///
+/// Returns `None` if the line should be skipped (cursor metadata, empty, or
+/// excluded by unit filter).
+fn should_emit_line(line: &[u8], exclude_units: &[String]) -> bool {
+    // Skip empty lines
+    if line.is_empty() {
+        return false;
+    }
+
+    // journalctl --show-cursor emits lines like:
+    //   -- cursor: s=...;i=...;b=...;m=...;t=...;x=...
+    if line.starts_with(b"-- cursor:") {
+        return false;
+    }
+
+    // Skip lines that don't look like JSON objects
+    if line.first() != Some(&b'{') {
+        return false;
+    }
+
+    // Apply exclude_units filter by scanning for _SYSTEMD_UNIT in the JSON.
+    // This is a fast-path heuristic: we look for the field in the raw bytes
+    // to avoid parsing JSON for every excluded entry.
+    if !exclude_units.is_empty() {
+        // Extract _SYSTEMD_UNIT value from the JSON line
+        if let Some(unit) = extract_systemd_unit(line) {
+            let normalized = fixup_unit(&unit);
+            for excluded in exclude_units {
+                if fixup_unit(excluded) == normalized {
+                    return false;
+                }
+            }
+        }
+    }
+
+    true
+}
+
+/// Fast extraction of `_SYSTEMD_UNIT` from a JSON line without full parsing.
+fn extract_systemd_unit(line: &[u8]) -> Option<String> {
+    // Look for "_SYSTEMD_UNIT":"<value>"
+    let needle = b"\"_SYSTEMD_UNIT\":\"";
+    let line_str = line;
+    if let Some(pos) = memchr::memmem::find(line_str, needle) {
+        let start = pos + needle.len();
+        if let Some(end_offset) = memchr::memchr(b'"', &line_str[start..]) {
+            let value = &line_str[start..start + end_offset];
+            return String::from_utf8(value.to_vec()).ok();
+        }
+    }
+    None
+}
+
+/// Main reader loop running in a background thread.
+///
+/// Spawns `journalctl`, reads lines, sends them over the channel. Restarts
+/// on unexpected exit with backoff.
+fn reader_loop(
+    config: JournaldConfig,
+    tx: crossbeam_channel::Sender<Vec<u8>>,
+    running: Arc<AtomicBool>,
+    health: Arc<AtomicU8>,
+) {
+    while running.load(Ordering::Acquire) {
+        health.store(HEALTH_STARTING, Ordering::Release);
+
+        let mut child = match spawn_journalctl(&config) {
+            Ok(child) => child,
+            Err(e) => {
+                tracing::error!(error = %e, "failed to spawn journalctl");
+                health.store(HEALTH_DEGRADED, Ordering::Release);
+                if !backoff_or_stop(&running) {
+                    return;
+                }
+                continue;
+            }
+        };
+
+        health.store(HEALTH_OK, Ordering::Release);
+        tracing::info!("journalctl started (pid={})", child.id());
+
+        // Read stdout line by line.
+        let stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                tracing::error!("journalctl stdout not captured");
+                let _ = child.kill();
+                let _ = child.wait();
+                health.store(HEALTH_DEGRADED, Ordering::Release);
+                if !backoff_or_stop(&running) {
+                    return;
+                }
+                continue;
+            }
+        };
+
+        // Spawn a thread to drain stderr so it doesn't block.
+        let stderr = child.stderr.take();
+        let stderr_thread = stderr.map(|stderr| {
+            std::thread::Builder::new()
+                .name("journald-stderr".to_string())
+                .spawn(move || drain_stderr(stderr))
+                .ok()
+        });
+
+        let reader = BufReader::with_capacity(256 * 1024, stdout);
+        let mut exited_cleanly = false;
+
+        for line_result in reader.split(b'\n') {
+            if !running.load(Ordering::Acquire) {
+                exited_cleanly = true;
+                break;
+            }
+
+            match line_result {
+                Ok(line) => {
+                    if !should_emit_line(&line, &config.exclude_units) {
+                        continue;
+                    }
+                    // Add a trailing newline so the downstream framer/scanner
+                    // can delimit records the same way as file or TCP inputs.
+                    let mut payload = line;
+                    payload.push(b'\n');
+
+                    match tx.try_send(payload) {
+                        Ok(()) => {}
+                        Err(TrySendError::Full(payload)) => {
+                            // Blocking send — apply backpressure to journalctl.
+                            if tx.send(payload).is_err() {
+                                // Receiver dropped — shutting down.
+                                exited_cleanly = true;
+                                break;
+                            }
+                        }
+                        Err(TrySendError::Disconnected(_)) => {
+                            exited_cleanly = true;
+                            break;
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "journalctl read error");
+                    break;
+                }
+            }
+        }
+
+        // Clean up the child process.
+        let _ = child.kill();
+        let _ = child.wait();
+
+        // Wait for stderr thread to finish.
+        if let Some(Some(handle)) = stderr_thread {
+            let _ = handle.join();
+        }
+
+        if exited_cleanly || !running.load(Ordering::Acquire) {
+            return;
+        }
+
+        tracing::warn!("journalctl exited unexpectedly, restarting after backoff");
+        health.store(HEALTH_DEGRADED, Ordering::Release);
+        if !backoff_or_stop(&running) {
+            return;
+        }
+    }
+}
+
+/// Spawn `journalctl` with the configured arguments.
+fn spawn_journalctl(config: &JournaldConfig) -> io::Result<Child> {
+    build_command(config).spawn()
+}
+
+/// Sleep for [`RESTART_BACKOFF`], checking the running flag periodically.
+/// Returns `true` if we should continue, `false` if shutting down.
+fn backoff_or_stop(running: &Arc<AtomicBool>) -> bool {
+    let steps = 10;
+    let step_duration = RESTART_BACKOFF / steps;
+    for _ in 0..steps {
+        if !running.load(Ordering::Acquire) {
+            return false;
+        }
+        std::thread::sleep(step_duration);
+    }
+    running.load(Ordering::Acquire)
+}
+
+/// Drain stderr to tracing so journalctl warnings are visible.
+fn drain_stderr(stderr: std::process::ChildStderr) {
+    let reader = BufReader::new(stderr);
+    for line in reader.split(b'\n').flatten() {
+        let text = String::from_utf8_lossy(&line);
+        let trimmed = text.trim();
+        if !trimmed.is_empty() {
+            tracing::warn!(target: "journalctl", "{trimmed}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixup_unit_appends_service() {
+        assert_eq!(fixup_unit("sshd"), "sshd.service");
+        assert_eq!(fixup_unit("docker.service"), "docker.service");
+        assert_eq!(fixup_unit("sysinit.target"), "sysinit.target");
+    }
+
+    #[test]
+    fn should_emit_line_skips_empty() {
+        assert!(!should_emit_line(b"", &[]));
+    }
+
+    #[test]
+    fn should_emit_line_skips_cursor() {
+        assert!(!should_emit_line(
+            b"-- cursor: s=abc;i=123;b=xyz;m=456;t=789;x=000",
+            &[]
+        ));
+    }
+
+    #[test]
+    fn should_emit_line_skips_non_json() {
+        assert!(!should_emit_line(b"some random text", &[]));
+    }
+
+    #[test]
+    fn should_emit_line_accepts_json() {
+        assert!(should_emit_line(
+            br#"{"MESSAGE":"hello","_SYSTEMD_UNIT":"test.service"}"#,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn should_emit_line_excludes_unit() {
+        let line = br#"{"MESSAGE":"hello","_SYSTEMD_UNIT":"sshd.service"}"#;
+        assert!(!should_emit_line(line, &["sshd".to_string()]));
+        assert!(should_emit_line(line, &["docker".to_string()]));
+    }
+
+    #[test]
+    fn extract_systemd_unit_works() {
+        let line = br#"{"MESSAGE":"hello","_SYSTEMD_UNIT":"sshd.service","PRIORITY":"6"}"#;
+        assert_eq!(extract_systemd_unit(line), Some("sshd.service".to_string()));
+    }
+
+    #[test]
+    fn extract_systemd_unit_missing() {
+        let line = br#"{"MESSAGE":"hello","PRIORITY":"6"}"#;
+        assert_eq!(extract_systemd_unit(line), None);
+    }
+
+    #[test]
+    fn build_command_basic() {
+        let config = JournaldConfig::default();
+        let cmd = build_command(&config);
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(args.contains(&"--follow".to_string()));
+        assert!(args.contains(&"--output=json".to_string()));
+        assert!(args.contains(&"--boot".to_string()));
+        assert!(args.contains(&"--since=2000-01-01".to_string()));
+    }
+
+    #[test]
+    fn build_command_since_now() {
+        let config = JournaldConfig {
+            since_now: true,
+            ..Default::default()
+        };
+        let cmd = build_command(&config);
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(args.contains(&"--since=now".to_string()));
+        assert!(!args.contains(&"--since=2000-01-01".to_string()));
+    }
+
+    #[test]
+    fn build_command_with_units() {
+        let config = JournaldConfig {
+            include_units: vec!["sshd".to_string(), "docker.service".to_string()],
+            ..Default::default()
+        };
+        let cmd = build_command(&config);
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(args.contains(&"_SYSTEMD_UNIT=sshd.service".to_string()));
+        assert!(args.contains(&"_SYSTEMD_UNIT=docker.service".to_string()));
+    }
+
+    #[test]
+    fn build_command_all_boots() {
+        let config = JournaldConfig {
+            current_boot_only: false,
+            ..Default::default()
+        };
+        let cmd = build_command(&config);
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(!args.contains(&"--boot".to_string()));
+    }
+
+    #[test]
+    fn build_command_with_directory_and_namespace() {
+        let config = JournaldConfig {
+            journal_directory: Some("/var/log/journal".to_string()),
+            journal_namespace: Some("myapp".to_string()),
+            ..Default::default()
+        };
+        let cmd = build_command(&config);
+        let args: Vec<_> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        assert!(args.contains(&"--directory=/var/log/journal".to_string()));
+        assert!(args.contains(&"--namespace=myapp".to_string()));
+    }
+}

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -13,13 +13,11 @@
 use std::io::{self, BufRead, BufReader, Read};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, Ordering};
 use std::time::Duration;
 
 use crossbeam_channel::{Receiver, TrySendError, bounded};
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
-
-use logfwd_config::JournaldBackendConfig;
 
 use crate::input::{InputEvent, InputSource};
 use crate::journal_ffi;
@@ -40,10 +38,27 @@ const RESTART_BACKOFF: Duration = Duration::from_secs(1);
 /// Wait timeout for `sd_journal_wait` in microseconds (250ms).
 const NATIVE_WAIT_USEC: u64 = 250_000;
 
+/// Maximum allowed binary field length in the export format (16 MB).
+/// Fields larger than this are skipped to prevent malicious/corrupt journals
+/// from causing huge allocations.
+const MAX_BINARY_FIELD_SIZE: usize = 16 * 1024 * 1024;
+
 /// Health encoding used in the atomic health byte.
 const HEALTH_OK: u8 = 0;
 const HEALTH_STARTING: u8 = 1;
 const HEALTH_DEGRADED: u8 = 2;
+
+/// Which journal-reading backend to use (IO-layer enum, decoupled from config).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum JournaldBackendPref {
+    /// Use native API if available, otherwise subprocess (default).
+    #[default]
+    Auto,
+    /// Require the native `sd_journal` C API via `dlopen`.
+    Native,
+    /// Always use a `journalctl` subprocess.
+    Subprocess,
+}
 
 /// Runtime configuration for the journald input, derived from config types.
 #[derive(Debug, Clone)]
@@ -63,7 +78,7 @@ pub struct JournaldConfig {
     /// Journal namespace.
     pub journal_namespace: Option<String>,
     /// Which backend to use (auto/native/subprocess).
-    pub backend: JournaldBackendConfig,
+    pub backend: JournaldBackendPref,
 }
 
 impl Default for JournaldConfig {
@@ -76,7 +91,7 @@ impl Default for JournaldConfig {
             journalctl_path: "journalctl".to_string(),
             journal_directory: None,
             journal_namespace: None,
-            backend: JournaldBackendConfig::Auto,
+            backend: JournaldBackendPref::Auto,
         }
     }
 }
@@ -90,6 +105,9 @@ pub enum JournaldBackend {
     Subprocess,
 }
 
+const BACKEND_NATIVE: u8 = 0;
+const BACKEND_SUBPROCESS: u8 = 1;
+
 /// Journald input that tails the systemd journal.
 ///
 /// Prefers the native `sd_journal` API. Falls back to a `journalctl` subprocess
@@ -99,8 +117,13 @@ pub struct JournaldInput {
     rx: Receiver<Vec<u8>>,
     is_running: Arc<AtomicBool>,
     health: Arc<AtomicU8>,
+    #[allow(dead_code)] // Retained for future per-input stats; accounted_bytes handles counting.
     stats: Arc<ComponentStats>,
-    backend: JournaldBackend,
+    /// Atomic so the reader thread can update it on auto-fallback.
+    backend: Arc<AtomicU8>,
+    /// PID of the subprocess child (0 = no child / native backend).
+    /// Used by `Drop` to kill the child so `read_until` unblocks.
+    child_pid: Arc<AtomicU32>,
 }
 
 impl JournaldInput {
@@ -115,16 +138,18 @@ impl JournaldInput {
         let (tx, rx) = bounded(CHANNEL_CAPACITY);
         let is_running = Arc::new(AtomicBool::new(true));
         let health = Arc::new(AtomicU8::new(HEALTH_STARTING));
+        let child_pid = Arc::new(AtomicU32::new(0));
 
         let thread_running = Arc::clone(&is_running);
         let thread_health = Arc::clone(&health);
+        let thread_child_pid = Arc::clone(&child_pid);
         let thread_name = name.clone();
 
         // Resolve backend based on config + runtime availability.
         let native_available = journal_ffi::is_native_available();
         let use_native = match config.backend {
-            JournaldBackendConfig::Auto => native_available,
-            JournaldBackendConfig::Native => {
+            JournaldBackendPref::Auto => native_available,
+            JournaldBackendPref::Native => {
                 if !native_available {
                     return Err(io::Error::other(
                         "backend: native requested but libsystemd.so.0 is not available",
@@ -132,19 +157,20 @@ impl JournaldInput {
                 }
                 true
             }
-            JournaldBackendConfig::Subprocess => false,
+            JournaldBackendPref::Subprocess => false,
         };
 
-        let backend = if use_native {
-            JournaldBackend::Native
+        let backend = Arc::new(AtomicU8::new(if use_native {
+            BACKEND_NATIVE
         } else {
-            JournaldBackend::Subprocess
-        };
+            BACKEND_SUBPROCESS
+        }));
+        let thread_backend = Arc::clone(&backend);
 
         if use_native {
             tracing::info!("journald input '{thread_name}': using native sd_journal API");
         } else {
-            let reason = if matches!(config.backend, JournaldBackendConfig::Subprocess) {
+            let reason = if matches!(config.backend, JournaldBackendPref::Subprocess) {
                 "subprocess backend selected by config"
             } else {
                 "libsystemd.so.0 not available, falling back to journalctl subprocess"
@@ -156,9 +182,34 @@ impl JournaldInput {
             .name(format!("journald-{thread_name}"))
             .spawn(move || {
                 if use_native {
-                    native_reader_loop(config, tx, thread_running, thread_health);
+                    // When backend is auto, fall back to subprocess if native
+                    // startup fails (e.g. permission denied, missing namespace).
+                    native_reader_loop(&config, &tx, &thread_running, &thread_health);
+
+                    // If health is degraded and backend was auto, try subprocess.
+                    if matches!(config.backend, JournaldBackendPref::Auto)
+                        && thread_health.load(Ordering::Acquire) == HEALTH_DEGRADED
+                        && thread_running.load(Ordering::Acquire)
+                    {
+                        tracing::warn!("native journal backend failed, falling back to subprocess");
+                        thread_backend.store(BACKEND_SUBPROCESS, Ordering::Release);
+                        thread_health.store(HEALTH_STARTING, Ordering::Release);
+                        subprocess_reader_loop(
+                            config,
+                            tx,
+                            thread_running,
+                            thread_health,
+                            thread_child_pid,
+                        );
+                    }
                 } else {
-                    subprocess_reader_loop(config, tx, thread_running, thread_health);
+                    subprocess_reader_loop(
+                        config,
+                        tx,
+                        thread_running,
+                        thread_health,
+                        thread_child_pid,
+                    );
                 }
             })
             .map_err(io::Error::other)?;
@@ -170,18 +221,32 @@ impl JournaldInput {
             health,
             stats,
             backend,
+            child_pid,
         })
     }
 
     /// Which backend this input is using.
     pub fn backend(&self) -> JournaldBackend {
-        self.backend
+        match self.backend.load(Ordering::Acquire) {
+            BACKEND_NATIVE => JournaldBackend::Native,
+            _ => JournaldBackend::Subprocess,
+        }
     }
 }
 
 impl Drop for JournaldInput {
     fn drop(&mut self) {
         self.is_running.store(false, Ordering::Release);
+        // Atomically take the child PID (if any) so only one thread calls kill.
+        let pid = self.child_pid.swap(0, Ordering::AcqRel);
+        if pid != 0 {
+            // SAFETY: sending SIGKILL to a child PID we exclusively own via the
+            // swap above. The reader thread also uses swap(0) before child.wait(),
+            // so only one side ever sends the signal.
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
+            }
+        }
     }
 }
 
@@ -197,7 +262,8 @@ impl InputSource for JournaldInput {
                     let len = line.len();
                     total_bytes += len;
                     lines_read += 1;
-                    self.stats.inc_bytes(len as u64);
+                    // Note: do NOT call stats.inc_bytes() here — the downstream
+                    // FramedInput already charges `accounted_bytes` to stats.
                     events.push(InputEvent::Data {
                         bytes: line,
                         source_id: None,
@@ -238,14 +304,14 @@ impl InputSource for JournaldInput {
 /// then enters a loop: drain all available entries → wait for new entries.
 /// Each entry is serialized to a JSON object and sent over the channel.
 fn native_reader_loop(
-    config: JournaldConfig,
-    tx: crossbeam_channel::Sender<Vec<u8>>,
-    running: Arc<AtomicBool>,
-    health: Arc<AtomicU8>,
+    config: &JournaldConfig,
+    tx: &crossbeam_channel::Sender<Vec<u8>>,
+    running: &Arc<AtomicBool>,
+    health: &Arc<AtomicU8>,
 ) {
     health.store(HEALTH_STARTING, Ordering::Release);
 
-    let mut journal = match open_native_journal(&config) {
+    let mut journal = match open_native_journal(config) {
         Ok(j) => j,
         Err(e) => {
             tracing::error!(error = %e, "failed to open native journal");
@@ -262,7 +328,7 @@ fn native_reader_loop(
     }
 
     // Seek to starting position.
-    if let Err(e) = seek_start(&mut journal, &config) {
+    if let Err(e) = seek_start(&mut journal, config) {
         tracing::error!(error = %e, "failed to seek journal");
         health.store(HEALTH_DEGRADED, Ordering::Release);
         return;
@@ -294,8 +360,10 @@ fn native_reader_loop(
                     match entry_to_json(&mut journal, &exclude_units, &mut json_buf) {
                         Ok(Some(())) => {
                             json_buf.push(b'\n');
-                            let payload = json_buf.clone();
-                            json_buf.clear();
+                            // Move the buffer to avoid cloning; allocate a
+                            // fresh one for the next entry.
+                            let payload =
+                                std::mem::replace(&mut json_buf, Vec::with_capacity(4096));
 
                             match tx.try_send(payload) {
                                 Ok(()) => {}
@@ -339,15 +407,34 @@ fn native_reader_loop(
     }
 }
 
-/// Open a journal handle with the appropriate flags/directory.
+/// Open a journal handle with the appropriate flags/directory/namespace.
 fn open_native_journal(config: &JournaldConfig) -> io::Result<journal_ffi::Journal> {
     let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
 
-    if let Some(ref dir) = config.journal_directory {
-        journal_ffi::Journal::open_directory(dir, flags)
+    let mut journal = if let Some(ref dir) = config.journal_directory {
+        // sd_journal_open_directory only accepts 0 or SD_JOURNAL_OS_ROOT.
+        journal_ffi::Journal::open_directory(dir, 0)?
+    } else if let Some(ref ns) = config.journal_namespace {
+        journal_ffi::Journal::open_namespace(ns, flags)?
     } else {
-        journal_ffi::Journal::open(flags)
+        journal_ffi::Journal::open(flags)?
+    };
+
+    // Apply _BOOT_ID filter for current_boot_only.
+    if config.current_boot_only {
+        let boot_id = read_current_boot_id()?;
+        let match_str = format!("_BOOT_ID={boot_id}");
+        journal.add_match(match_str.as_bytes())?;
     }
+
+    Ok(journal)
+}
+
+/// Read the current boot ID from `/proc/sys/kernel/random/boot_id`.
+fn read_current_boot_id() -> io::Result<String> {
+    let raw = std::fs::read_to_string("/proc/sys/kernel/random/boot_id")?;
+    // The kernel returns a UUID with hyphens; systemd stores it without hyphens.
+    Ok(raw.trim().replace('-', ""))
 }
 
 /// Add `_SYSTEMD_UNIT=<unit>` match expressions for each include unit.
@@ -406,6 +493,10 @@ fn entry_to_json(
     let mut fields: Vec<(Vec<u8>, Vec<u8>)> = Vec::with_capacity(32);
     journal.restart_data();
     while let Some(field_bytes) = journal.enumerate_data()? {
+        // Skip oversized fields (same bound as subprocess parser).
+        if field_bytes.len() > MAX_BINARY_FIELD_SIZE {
+            continue;
+        }
         let eq_pos = match memchr::memchr(b'=', field_bytes) {
             Some(p) => p,
             None => continue,
@@ -448,11 +539,39 @@ fn write_fields_as_json(buf: &mut Vec<u8>, fields: &[(Vec<u8>, Vec<u8>)]) {
 
 /// Escape bytes for inclusion in a JSON string value.
 ///
-/// Non-UTF8 bytes are escaped as `\uXXXX`. This matches journalctl's behavior
-/// for binary fields (though journalctl uses integer arrays for fully binary
-/// fields — we use \u escapes as a simpler approximation for the POC).
+/// Valid UTF-8 sequences are written directly (with standard JSON escaping for
+/// control characters, `"`, and `\`). Invalid bytes are replaced with the
+/// Unicode replacement character (`\uFFFD`).
 fn json_escape_into(buf: &mut Vec<u8>, input: &[u8]) {
-    for &b in input {
+    let mut remaining = input;
+    while !remaining.is_empty() {
+        match std::str::from_utf8(remaining) {
+            Ok(valid) => {
+                // All remaining bytes are valid UTF-8.
+                escape_str_into(buf, valid);
+                break;
+            }
+            Err(e) => {
+                // Write the valid prefix.
+                let (valid_bytes, after) = remaining.split_at(e.valid_up_to());
+                if !valid_bytes.is_empty() {
+                    // SAFETY: `from_utf8` confirmed these bytes are valid.
+                    let valid_str = unsafe { std::str::from_utf8_unchecked(valid_bytes) };
+                    escape_str_into(buf, valid_str);
+                }
+                // Replace the invalid byte(s) with U+FFFD.
+                buf.extend_from_slice(b"\\uFFFD");
+                // Advance past the error.
+                let skip = e.error_len().unwrap_or(1);
+                remaining = &after[skip..];
+            }
+        }
+    }
+}
+
+/// Escape a valid UTF-8 string for JSON.
+fn escape_str_into(buf: &mut Vec<u8>, s: &str) {
+    for &b in s.as_bytes() {
         match b {
             b'"' => buf.extend_from_slice(b"\\\""),
             b'\\' => buf.extend_from_slice(b"\\\\"),
@@ -465,7 +584,6 @@ fn json_escape_into(buf: &mut Vec<u8>, input: &[u8]) {
                 buf.push(HEX[(b >> 4) as usize]);
                 buf.push(HEX[(b & 0xf) as usize]);
             }
-            // Printable ASCII and valid UTF-8 continuation bytes.
             _ => buf.push(b),
         }
     }
@@ -532,6 +650,7 @@ fn subprocess_reader_loop(
     tx: crossbeam_channel::Sender<Vec<u8>>,
     running: Arc<AtomicBool>,
     health: Arc<AtomicU8>,
+    child_pid: Arc<AtomicU32>,
 ) {
     while running.load(Ordering::Acquire) {
         health.store(HEALTH_STARTING, Ordering::Release);
@@ -548,6 +667,9 @@ fn subprocess_reader_loop(
             }
         };
 
+        // Publish PID so `Drop` can kill the child.
+        child_pid.store(child.id(), Ordering::Release);
+
         health.store(HEALTH_OK, Ordering::Release);
         tracing::info!("journalctl started (pid={})", child.id());
 
@@ -555,6 +677,7 @@ fn subprocess_reader_loop(
             Some(stdout) => stdout,
             None => {
                 tracing::error!("journalctl stdout not captured");
+                child_pid.store(0, Ordering::Release);
                 let _ = child.kill();
                 let _ = child.wait();
                 health.store(HEALTH_DEGRADED, Ordering::Release);
@@ -577,6 +700,8 @@ fn subprocess_reader_loop(
         let reader = BufReader::with_capacity(256 * 1024, stdout);
         let exited_cleanly = read_export_entries(reader, &tx, &running, &config.exclude_units);
 
+        // Atomically take the PID before kill+wait so Drop cannot race.
+        child_pid.store(0, Ordering::Release);
         let _ = child.kill();
         let _ = child.wait();
 
@@ -628,6 +753,16 @@ fn read_export_entries(
             return false;
         }
 
+        // Guard against oversized text fields (e.g. corrupt/malicious journal).
+        if line_buf.len() > MAX_BINARY_FIELD_SIZE {
+            tracing::warn!(
+                len = line_buf.len(),
+                "export text field exceeds maximum size, skipping"
+            );
+            line_buf.clear();
+            continue;
+        }
+
         // Strip trailing newline.
         let line = if line_buf.last() == Some(&b'\n') {
             &line_buf[..line_buf.len() - 1]
@@ -664,14 +799,40 @@ fn read_export_entries(
         } else {
             // Field name without `=` means binary field follows.
             // Next 8 bytes are LE length, then that many bytes of data.
-            // We skip binary fields (they're rare — e.g. coredumps).
             let field_name = line.to_vec();
             let mut len_buf = [0u8; 8];
             if reader.read_exact(&mut len_buf).is_err() {
                 return false;
             }
-            let data_len = u64::from_le_bytes(len_buf) as usize;
-            // Skip the binary data + trailing newline.
+            let data_len_u64 = u64::from_le_bytes(len_buf);
+
+            // Cap binary field length to prevent malicious/corrupt journals
+            // from causing huge allocations. Compare as u64 to avoid truncation
+            // on 32-bit platforms.
+            if data_len_u64 > MAX_BINARY_FIELD_SIZE as u64 {
+                tracing::warn!(
+                    field = %String::from_utf8_lossy(&field_name),
+                    data_len = data_len_u64,
+                    "binary journal field exceeds maximum size, skipping field"
+                );
+                // Skip past the oversized field data + trailing newline.
+                // Read in chunks to avoid huge allocations.
+                let mut remaining = data_len_u64 + 1; // +1 for trailing \n
+                let mut discard = vec![0u8; 64 * 1024];
+                while remaining > 0 {
+                    let chunk = remaining.min(discard.len() as u64) as usize;
+                    if reader.read_exact(&mut discard[..chunk]).is_err() {
+                        return false;
+                    }
+                    remaining -= chunk as u64;
+                }
+                // Skip this field but continue parsing the entry.
+                continue;
+            }
+
+            let data_len = data_len_u64 as usize;
+
+            // Read the binary data + trailing newline.
             let mut skip_buf = vec![0u8; data_len + 1];
             if reader.read_exact(&mut skip_buf).is_err() {
                 return false;
@@ -993,17 +1154,31 @@ mod tests {
         assert_eq!(v["_CMDLINE"], "/usr/bin/test --flag=val\\ue");
     }
 
-    // ── backend config validation ──────────────────────────────────────
+    // ── backend pref defaults ──────────────────────────────────────────
 
     #[test]
-    fn backend_config_deserializes() {
-        let auto: JournaldBackendConfig = serde_json::from_str("\"auto\"").unwrap();
-        assert_eq!(auto, JournaldBackendConfig::Auto);
+    fn backend_pref_defaults_to_auto() {
+        assert_eq!(JournaldBackendPref::default(), JournaldBackendPref::Auto);
+    }
 
-        let native: JournaldBackendConfig = serde_json::from_str("\"native\"").unwrap();
-        assert_eq!(native, JournaldBackendConfig::Native);
+    // ── json_escape_into handles invalid UTF-8 ─────────────────────────
 
-        let sub: JournaldBackendConfig = serde_json::from_str("\"subprocess\"").unwrap();
-        assert_eq!(sub, JournaldBackendConfig::Subprocess);
+    #[test]
+    fn json_escape_invalid_utf8_replaced() {
+        let mut buf = Vec::new();
+        // 0xFF is not valid UTF-8.
+        json_escape_into(&mut buf, &[b'a', 0xFF, b'b']);
+        let s = String::from_utf8(buf).expect("output should be valid UTF-8");
+        assert_eq!(s, "a\\uFFFDb");
+    }
+
+    #[test]
+    fn json_escape_mixed_valid_invalid() {
+        let mut buf = Vec::new();
+        // Valid UTF-8 "hello", then 0xFE (invalid), then "world".
+        let input = b"hello\xFEworld";
+        json_escape_into(&mut buf, input);
+        let s = String::from_utf8(buf).expect("output should be valid UTF-8");
+        assert_eq!(s, "hello\\uFFFDworld");
     }
 }

--- a/crates/logfwd-io/src/lib.rs
+++ b/crates/logfwd-io/src/lib.rs
@@ -13,7 +13,9 @@ pub mod generator;
 /// HTTP NDJSON input source.
 pub mod http_input;
 pub mod input;
-/// Journald (systemd journal) input via `journalctl` subprocess.
+/// FFI bindings for `libsystemd.so.0` `sd_journal` API (runtime dlopen).
+pub mod journal_ffi;
+/// Journald (systemd journal) input — native API with subprocess fallback.
 pub mod journald_input;
 pub mod otap_receiver;
 pub mod otlp_receiver;

--- a/crates/logfwd-io/src/lib.rs
+++ b/crates/logfwd-io/src/lib.rs
@@ -13,6 +13,8 @@ pub mod generator;
 /// HTTP NDJSON input source.
 pub mod http_input;
 pub mod input;
+/// Journald (systemd journal) input via `journalctl` subprocess.
+pub mod journald_input;
 pub mod otap_receiver;
 pub mod otlp_receiver;
 /// Platform sensor inputs and Arrow-native control/sample event emission.

--- a/crates/logfwd-output/src/json_lines.rs
+++ b/crates/logfwd-output/src/json_lines.rs
@@ -360,12 +360,10 @@ mod tests {
         sink.serialize_batch(&batch).unwrap();
         let out = std::str::from_utf8(&sink.batch_buf).unwrap();
         let lines: Vec<&str> = out.lines().collect();
+        // All-null columns are omitted from JSON output.
         assert_eq!(
             lines,
-            vec![
-                r#"{"body":"raw-line-1","level":null}"#,
-                r#"{"body":"raw-line-2","level":null}"#
-            ]
+            vec![r#"{"body":"raw-line-1"}"#, r#"{"body":"raw-line-2"}"#]
         );
     }
 

--- a/crates/logfwd-output/src/row_json.rs
+++ b/crates/logfwd-output/src/row_json.rs
@@ -225,9 +225,9 @@ pub(crate) fn write_json_value(arr: &dyn Array, row: usize, out: &mut Vec<u8>) -
 ///
 /// For fields backed by struct conflict columns or multiple flat typed columns,
 /// the first non-null variant (by `json_variants` ordering) is used. If all
-/// variants are null the field is emitted as `"field":null` to preserve JSON
-/// field presence.  Type dispatch uses the Arrow DataType, not the column name
-/// suffix.
+/// variants are null the field is omitted entirely — absent keys are the JSON
+/// convention for "no value". Type dispatch uses the Arrow DataType, not the
+/// column name suffix.
 pub fn write_row_json(
     batch: &RecordBatch,
     row: usize,
@@ -240,6 +240,14 @@ pub fn write_row_json(
         // Find the first non-null variant for this field (json ordering).
         let variant = col.json_variants.iter().find(|v| !is_null(batch, v, row));
 
+        let Some(v) = variant else {
+            // All variants null for this row — omit field entirely.
+            continue;
+        };
+        let Some(arr) = get_array(batch, v) else {
+            continue;
+        };
+
         if !first {
             out.push(b',');
         }
@@ -248,16 +256,6 @@ pub fn write_row_json(
         // Key — escape to produce valid JSON if field_name contains special chars.
         write_json_string(out, &col.field_name)?;
         out.push(b':');
-
-        let Some(v) = variant else {
-            // All variants null for this row — emit JSON null to preserve field presence.
-            out.extend_from_slice(b"null");
-            continue;
-        };
-        let Some(arr) = get_array(batch, v) else {
-            out.extend_from_slice(b"null");
-            continue;
-        };
 
         // Value — dispatch on Arrow DataType, not column name suffix
         write_json_value(arr, row, out)?;

--- a/crates/logfwd-output/src/row_json.rs
+++ b/crates/logfwd-output/src/row_json.rs
@@ -245,6 +245,11 @@ pub fn write_row_json(
             continue;
         };
         let Some(arr) = get_array(batch, v) else {
+            debug_assert!(
+                false,
+                "non-null variant but array not found for field {}",
+                col.field_name
+            );
             continue;
         };
 

--- a/crates/logfwd-output/src/snapshots/logfwd_output__elasticsearch__snapshot_tests__all_null_fields.snap
+++ b/crates/logfwd-output/src/snapshots/logfwd_output__elasticsearch__snapshot_tests__all_null_fields.snap
@@ -3,4 +3,4 @@ source: crates/logfwd-output/src/elasticsearch.rs
 expression: output
 ---
 {"index":{"_index":"test-index"}}
-{"msg":null,"code":null,"@timestamp":"1970-01-01T00:00:00.000000000Z"}
+{"@timestamp":"1970-01-01T00:00:00.000000000Z"}

--- a/crates/logfwd-output/src/snapshots/logfwd_output__elasticsearch__snapshot_tests__nullable_columns.snap
+++ b/crates/logfwd-output/src/snapshots/logfwd_output__elasticsearch__snapshot_tests__nullable_columns.snap
@@ -5,6 +5,6 @@ expression: output
 {"index":{"_index":"test-index"}}
 {"msg":"hello","code":1,"@timestamp":"1970-01-01T00:00:00.000000000Z"}
 {"index":{"_index":"test-index"}}
-{"msg":null,"code":2,"@timestamp":"1970-01-01T00:00:00.000000000Z"}
+{"code":2,"@timestamp":"1970-01-01T00:00:00.000000000Z"}
 {"index":{"_index":"test-index"}}
-{"msg":"world","code":null,"@timestamp":"1970-01-01T00:00:00.000000000Z"}
+{"msg":"world","@timestamp":"1970-01-01T00:00:00.000000000Z"}

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -6,7 +6,7 @@ use opentelemetry::metrics::Meter;
 
 #[cfg(feature = "datafusion")]
 use logfwd_config::{EnrichmentConfig, GeoDatabaseFormat};
-use logfwd_config::{Format, PipelineConfig};
+use logfwd_config::{Format, InputType, PipelineConfig};
 use logfwd_diagnostics::diagnostics::PipelineMetrics;
 use logfwd_io::checkpoint::{
     CheckpointStore, FileCheckpointStore, SourceCheckpoint, default_data_dir,
@@ -227,6 +227,21 @@ impl Pipeline {
                     resolved_cfg.path = Some(abs_path.to_string_lossy().into_owned());
                 } else {
                     resolved_cfg.path = Some(path.to_string_lossy().into_owned());
+                }
+            }
+
+            // Resolve journal_directory relative to config base_path.
+            if matches!(input_cfg.input_type, InputType::Journald) {
+                if let Some(ref mut jd) = resolved_cfg.journald {
+                    if let Some(ref dir) = jd.journal_directory {
+                        let mut path = PathBuf::from(dir);
+                        if path.is_relative()
+                            && let Some(base) = base_path
+                        {
+                            path = base.join(path);
+                        }
+                        jd.journal_directory = Some(path.to_string_lossy().into_owned());
+                    }
                 }
             }
 

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -398,6 +398,7 @@ mod tests {
             http: None,
             sql: None,
             tls: None,
+            journald: None,
         }
     }
 

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -359,6 +359,26 @@ pub(super) fn build_input_state(
                 stats,
             });
         }
+        InputType::Journald => {
+            use logfwd_io::journald_input::{JournaldConfig, JournaldInput};
+
+            let jd_cfg = cfg.journald.as_ref();
+            let config = JournaldConfig {
+                include_units: jd_cfg.map(|c| c.include_units.clone()).unwrap_or_default(),
+                exclude_units: jd_cfg.map(|c| c.exclude_units.clone()).unwrap_or_default(),
+                current_boot_only: jd_cfg.is_none_or(|c| c.current_boot_only),
+                since_now: jd_cfg.is_some_and(|c| c.since_now),
+                journalctl_path: jd_cfg
+                    .and_then(|c| c.journalctl_path.clone())
+                    .unwrap_or_else(|| "journalctl".to_string()),
+                journal_directory: jd_cfg.and_then(|c| c.journal_directory.clone()),
+                journal_namespace: jd_cfg.and_then(|c| c.journal_namespace.clone()),
+            };
+            let format = cfg.format.clone().unwrap_or(Format::Json);
+            let source = JournaldInput::new(name, config, Arc::clone(&stats))
+                .map_err(|e| format!("input '{name}': failed to start journald receiver: {e}"))?;
+            (Box::new(source), format, 4 * 1024 * 1024)
+        }
         _ => {
             return Err(format!(
                 "input '{name}': type {:?} not yet supported",

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -373,6 +373,7 @@ pub(super) fn build_input_state(
                     .unwrap_or_else(|| "journalctl".to_string()),
                 journal_directory: jd_cfg.and_then(|c| c.journal_directory.clone()),
                 journal_namespace: jd_cfg.and_then(|c| c.journal_namespace.clone()),
+                backend: jd_cfg.map(|c| c.backend).unwrap_or_default(),
             };
             let format = cfg.format.clone().unwrap_or(Format::Json);
             let source = JournaldInput::new(name, config, Arc::clone(&stats))
@@ -491,6 +492,7 @@ mod tests {
             sensor: Some(Default::default()),
             sql: None,
             tls: None,
+            journald: None,
         };
         let err = match build_input_state("sensor", &cfg, stats) {
             Ok(_) => panic!("sensor format must be rejected"),
@@ -529,6 +531,7 @@ mod tests {
             http: None,
             sql: None,
             tls: None,
+            journald: None,
         };
 
         // Note: build_input_state doesn't return the raw TailConfig directly in
@@ -563,6 +566,7 @@ mod tests {
             http: None,
             sql: None,
             tls: None,
+            journald: None,
         };
 
         let state = build_input_state("test_in", &cfg_overrides, Arc::clone(&stats))
@@ -601,6 +605,7 @@ mod tests {
                     sensor: None,
                     sql: None,
                     tls: None,
+                    journald: None,
                 };
                 let stats = pm.add_input("in", "test");
                 let err = match build_input_state("in", &cfg, stats) {
@@ -642,6 +647,7 @@ mod tests {
             sensor: None,
             sql: None,
             tls: None,
+            journald: None,
         };
         let stats = pm.add_input("file-in", "file");
         let err = match build_input_state("file-in", &file_cfg, stats) {
@@ -675,6 +681,7 @@ mod tests {
                 sensor: None,
                 sql: None,
                 tls: None,
+                journald: None,
             };
             let stats = pm.add_input("net-in", "net");
             let err = match build_input_state("net-in", &cfg, stats) {

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -360,9 +360,24 @@ pub(super) fn build_input_state(
             });
         }
         InputType::Journald => {
-            use logfwd_io::journald_input::{JournaldConfig, JournaldInput};
+            use logfwd_io::journald_input::{JournaldBackendPref, JournaldConfig, JournaldInput};
+
+            // Fix #14: Reject non-JSON formats for journald — it always emits JSON.
+            if let Some(ref fmt) = cfg.format {
+                if !matches!(fmt, Format::Json) {
+                    return Err(format!(
+                        "input '{name}': journald input only supports json format (got {fmt:?})"
+                    ));
+                }
+            }
 
             let jd_cfg = cfg.journald.as_ref();
+            // Map from config crate's JournaldBackendConfig to IO crate's JournaldBackendPref.
+            let backend = match jd_cfg.map(|c| c.backend).unwrap_or_default() {
+                logfwd_config::JournaldBackendConfig::Auto => JournaldBackendPref::Auto,
+                logfwd_config::JournaldBackendConfig::Native => JournaldBackendPref::Native,
+                logfwd_config::JournaldBackendConfig::Subprocess => JournaldBackendPref::Subprocess,
+            };
             let config = JournaldConfig {
                 include_units: jd_cfg.map(|c| c.include_units.clone()).unwrap_or_default(),
                 exclude_units: jd_cfg.map(|c| c.exclude_units.clone()).unwrap_or_default(),
@@ -373,7 +388,7 @@ pub(super) fn build_input_state(
                     .unwrap_or_else(|| "journalctl".to_string()),
                 journal_directory: jd_cfg.and_then(|c| c.journal_directory.clone()),
                 journal_namespace: jd_cfg.and_then(|c| c.journal_namespace.clone()),
-                backend: jd_cfg.map(|c| c.backend).unwrap_or_default(),
+                backend,
             };
             let format = cfg.format.clone().unwrap_or(Format::Json);
             let source = JournaldInput::new(name, config, Arc::clone(&stats))
@@ -723,6 +738,7 @@ mod tests {
             sensor: None,
             sql: None,
             tls: None,
+            journald: None,
         };
         let err = match build_input_state("http-in", &cfg, stats) {
             Ok(_) => panic!("empty http.path override should be rejected"),

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1468,6 +1468,7 @@ fn validate_input_format_read_only(
         InputType::Http => matches!(format, Format::Json | Format::Raw),
         InputType::Udp | InputType::Tcp => matches!(format, Format::Json | Format::Raw),
         InputType::ArrowIpc => false,
+        InputType::Journald => matches!(format, Format::Json),
         other => {
             tracing::warn!(
                 "validate_input_format_read_only: unhandled input type {other:?} for input {name}"


### PR DESCRIPTION
## Summary

Add a journald (systemd journal) input to logfwd with dual-backend architecture:

- **Native backend**: Loads `libsystemd.so.0` at runtime via `dlopen`, reads the journal through the `sd_journal` C API. ~10× lower per-entry latency, no subprocess overhead.
- **Subprocess backend**: Spawns `journalctl --follow --output=export`, parses the binary-safe export format. Works without libsystemd installed.
- **Auto-detection**: Default `backend: auto` tries native first, falls back to subprocess. Can be forced via config.

Also includes a general improvement: JSON output now omits null fields instead of serializing them as `"field": null`. This dramatically reduces output size for inputs with heterogeneous schemas (journald entries went from ~2KB to ~300B average).

### Config example

```yaml
input:
  type: journald
  journald:
    include_units: [sshd, nginx]
    exclude_units: [systemd-resolved]
    current_boot_only: true
    since_now: false
    backend: auto  # auto | native | subprocess
output:
  type: stdout
```

### Architecture

- `journal_ffi.rs` — Safe wrapper around 18 `sd_journal_*` symbols loaded via `libloading::Library`
- `journald_input.rs` — Background OS thread reads journal, sends JSON over bounded crossbeam channel
- Both backends share `write_fields_as_json()` serializer, guaranteeing identical output
- Export format parser handles text fields (`NAME=value`) and binary fields (LE length prefix)

### Testing

- 22 unit tests: export parsing, JSON escaping, exclude filters, config deserialization, build_command flags, equivalence, FFI availability
- Live smoke tested with both backends reading real journal entries
- Elasticsearch snapshot tests updated for null-skip behavior

### Commits

1. **Journald config + validation** — InputType::Journald, JournaldInputConfig, validation rules
2. **Native sd_journal FFI** — dlopen wrapper + dual-backend refactor
3. **Backend config + export format** — `backend` field, `--output=export` parser, shared serializer
4. **Skip nulls in JSON output** — omit all-null fields from JSON serialization

Relates to #889

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add journald input with native sd_journal API and subprocess fallback
> - Adds `JournaldInput` in [journald_input.rs](https://github.com/strawgate/memagent/pull/1817/files#diff-30b3cf26707fa9d4720331157effe15b59edaa0698b619b56a594cca6b570543) that tails the systemd journal in a background thread, producing NDJSON over a bounded channel with health reporting and backpressure limits.
> - Adds [journal_ffi.rs](https://github.com/strawgate/memagent/pull/1817/files#diff-95f6e9fb2b25ff566a5bc92dab488cb650f8df85af4def9e2fb8760e2f858b61) as a safe wrapper around `libsystemd.so.0` loaded at runtime via `dlopen` (using `libloading`), avoiding a build-time `libsystemd-dev` dependency.
> - When backend is `Auto`, the native sd_journal path is tried first; if it fails or is unavailable, the input falls back to spawning `journalctl --output=export` and parsing its output, with restart-on-crash behavior.
> - Config support is added in [types.rs](https://github.com/strawgate/memagent/pull/1817/files#diff-62e3ac9382eb657aa94241b95339050d93e352844aef7d3a16f2bf66bb681a91) (`JournaldInputConfig`, `JournaldBackendConfig`) and validated in [validate.rs](https://github.com/strawgate/memagent/pull/1817/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68), enforcing JSON-only format, rejecting combined `journal_directory`+`journal_namespace` for native, and normalizing unit names for include/exclude overlap detection.
> - JSON rows no longer include keys for all-null fields; they are omitted entirely from output (behavior change in [row_json.rs](https://github.com/strawgate/memagent/pull/1817/files#diff-52251238e3d45cad7a8da16b9b815d0dc8b6429621b6712d05140d96919832e2)).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48d6d24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->