### PR TITLE
refactor: replace flat InputConfig with tagged enum (Pattern A)

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -17,13 +17,15 @@ mod validate;
 #[cfg(test)]
 pub(crate) use env::expand_env_vars;
 pub use types::{
-    AuthConfig, Config, ConfigError, CsvEnrichmentConfig, EnrichmentConfig, Format,
-    GeneratorAttributeValueConfig, GeneratorComplexityConfig, GeneratorInputConfig,
-    GeneratorProfileConfig, GeneratorSequenceConfig, GeoDatabaseConfig, GeoDatabaseFormat,
-    HostInfoConfig, HttpInputConfig, HttpMethodConfig, InputConfig, InputType,
-    JournaldBackendConfig, JournaldInputConfig, JsonlEnrichmentConfig, K8sPathConfig, OutputConfig,
-    OutputType, PipelineConfig, PlatformSensorInputConfig, ServerConfig, StaticEnrichmentConfig,
-    StorageConfig, TlsInputConfig,
+    ArrowIpcTypeConfig, AuthConfig, Config, ConfigError, CsvEnrichmentConfig, EnrichmentConfig,
+    FileTypeConfig, Format, GeneratorAttributeValueConfig, GeneratorComplexityConfig,
+    GeneratorInputConfig, GeneratorProfileConfig, GeneratorSequenceConfig, GeneratorTypeConfig,
+    GeoDatabaseConfig, GeoDatabaseFormat, HostInfoConfig, HttpInputConfig, HttpMethodConfig,
+    HttpTypeConfig, InputConfig, InputType, InputTypeConfig, JournaldBackendConfig,
+    JournaldInputConfig, JournaldTypeConfig, JsonlEnrichmentConfig, K8sPathConfig, OtlpTypeConfig,
+    OutputConfig, OutputType, PipelineConfig, PlatformSensorInputConfig, SensorTypeConfig,
+    ServerConfig, StaticEnrichmentConfig, StorageConfig, TcpTypeConfig, TlsInputConfig,
+    UdpTypeConfig,
 };
 pub use validate::validate_host_port;
 
@@ -63,11 +65,11 @@ storage:
         assert_eq!(cfg.pipelines.len(), 1);
         let pipe = &cfg.pipelines["default"];
         assert_eq!(pipe.inputs.len(), 1);
-        assert_eq!(pipe.inputs[0].input_type, InputType::File);
-        assert_eq!(
-            pipe.inputs[0].path.as_deref(),
-            Some("/var/log/pods/**/*.log")
-        );
+        assert_eq!(pipe.inputs[0].input_type(), InputType::File);
+        assert!(matches!(
+            &pipe.inputs[0].type_config,
+            InputTypeConfig::File(f) if f.path == "/var/log/pods/**/*.log"
+        ));
         assert_eq!(pipe.inputs[0].format, Some(Format::Cri));
         assert!(pipe.transform.as_ref().unwrap().contains("SELECT"));
         assert_eq!(pipe.outputs[0].output_type, OutputType::Otlp);
@@ -113,9 +115,12 @@ server:
         assert_eq!(cfg.pipelines.len(), 1);
         let pipe = &cfg.pipelines["app_logs"];
         assert_eq!(pipe.inputs.len(), 2);
-        assert_eq!(pipe.inputs[0].input_type, InputType::File);
-        assert_eq!(pipe.inputs[1].input_type, InputType::Udp);
-        assert_eq!(pipe.inputs[1].listen.as_deref(), Some("0.0.0.0:514"));
+        assert_eq!(pipe.inputs[0].input_type(), InputType::File);
+        assert_eq!(pipe.inputs[1].input_type(), InputType::Udp);
+        assert!(matches!(
+            &pipe.inputs[1].type_config,
+            InputTypeConfig::Udp(u) if u.listen == "0.0.0.0:514"
+        ));
         assert_eq!(pipe.outputs.len(), 2);
         assert_eq!(pipe.outputs[0].output_type, OutputType::Otlp);
         assert_eq!(pipe.outputs[1].output_type, OutputType::Stdout);
@@ -167,7 +172,7 @@ output:
         let cfg = Config::load(&path).expect("Config::load should parse file");
         assert_eq!(cfg.pipelines.len(), 1);
         let pipe = &cfg.pipelines["default"];
-        assert_eq!(pipe.inputs[0].input_type, InputType::File);
+        assert_eq!(pipe.inputs[0].input_type(), InputType::File);
         assert_eq!(pipe.outputs[0].output_type, OutputType::Stdout);
         let _ = fs::remove_file(&path);
     }
@@ -318,11 +323,11 @@ output:
         let cfg = Config::load_str(yaml).expect("otlp input with resource_prefix should parse");
         let pipe = &cfg.pipelines["default"];
         assert_eq!(pipe.inputs.len(), 1);
-        assert_eq!(pipe.inputs[0].input_type, InputType::Otlp);
-        assert_eq!(
-            pipe.inputs[0].resource_prefix.as_deref(),
-            Some("resource.attributes.")
-        );
+        assert_eq!(pipe.inputs[0].input_type(), InputType::Otlp);
+        assert!(matches!(
+            &pipe.inputs[0].type_config,
+            InputTypeConfig::Otlp(o) if o.resource_prefix.as_deref() == Some("resource.attributes.")
+        ));
     }
 
     #[test]
@@ -346,6 +351,8 @@ output:
 
     #[test]
     fn non_otlp_input_rejects_resource_prefix() {
+        // With the tagged-enum refactor, `resource_prefix` is only valid inside
+        // the `otlp` variant.  Serde rejects it at parse time for other types.
         let yaml = r#"
 input:
   type: file
@@ -357,8 +364,8 @@ output:
         let err = Config::load_str(yaml).expect_err("resource_prefix must be otlp-only");
         let msg = err.to_string();
         assert!(
-            msg.contains("resource_prefix") && msg.contains("only supported for otlp"),
-            "expected otlp-only resource_prefix validation error, got: {msg}"
+            msg.contains("resource_prefix") || msg.contains("unknown field"),
+            "expected serde rejection of resource_prefix for file input, got: {msg}"
         );
     }
 
@@ -675,6 +682,7 @@ pipelines:
             ("linux_ebpf_sensor", ""),
             ("macos_es_sensor", ""),
             ("windows_ebpf_sensor", ""),
+            ("journald", ""),
         ] {
             let yaml = format!("input:\n  type: {itype}\n  {extra}\noutput:\n  type: stdout\n");
             Config::load_str(&yaml).unwrap_or_else(|e| panic!("failed for {itype}: {e}"));
@@ -712,9 +720,13 @@ output:
         let cfg = Config::load_str(yaml).unwrap();
         let pipe = &cfg.pipelines["default"];
         let input = &pipe.inputs[0];
-        assert_eq!(input.poll_interval_ms, Some(100));
-        assert_eq!(input.read_buf_size, Some(1048576));
-        assert_eq!(input.per_file_read_budget_bytes, Some(2097152));
+        let f = match &input.type_config {
+            InputTypeConfig::File(f) => f,
+            _ => panic!("expected File type_config"),
+        };
+        assert_eq!(f.poll_interval_ms, Some(100));
+        assert_eq!(f.read_buf_size, Some(1048576));
+        assert_eq!(f.per_file_read_budget_bytes, Some(2097152));
     }
 
     #[test]
@@ -763,6 +775,8 @@ output:
 
     #[test]
     fn non_file_input_rejects_tuning_knobs() {
+        // With the tagged-enum refactor, file-only tuning knobs are rejected by
+        // serde `deny_unknown_fields` at parse time for non-file input types.
         let inputs = [
             ("http", "listen: 0.0.0.0:8080"),
             ("tcp", "listen: 0.0.0.0:8080"),
@@ -791,8 +805,8 @@ output:
                 let err = Config::load_str(&yaml).unwrap_err().to_string();
                 let field_name = field.split(':').next().unwrap();
                 assert!(
-                    err.contains(&format!("'{field_name}' is not supported for")),
-                    "expected error about {field_name} not supported for {in_type}, got: {err}"
+                    err.contains(field_name) || err.contains("unknown field"),
+                    "expected serde rejection of {field_name} for {in_type}, got: {err}"
                 );
             }
         }
@@ -800,6 +814,8 @@ output:
 
     #[test]
     fn file_input_rejects_sensor_block() {
+        // With the tagged-enum refactor, the `sensor` key is only valid inside
+        // sensor input variants.  Serde rejects it at parse time for file inputs.
         let yaml = r"
 input:
   type: file
@@ -811,8 +827,9 @@ output:
 ";
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("'sensor' settings are only supported for sensor inputs")
+            err.to_string().contains("sensor") || err.to_string().contains("unknown field"),
+            "expected serde rejection of sensor for file input: {}",
+            err
         );
     }
 
@@ -1796,6 +1813,8 @@ enrichment:
 
     #[test]
     fn file_input_rejects_listen() {
+        // With the tagged-enum refactor, `listen` is not a valid field for file
+        // inputs. Serde rejects it at parse time via `deny_unknown_fields`.
         let yaml = r#"
 pipelines:
   test:
@@ -1806,11 +1825,7 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("listen"),
-            "expected listen rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("file input must reject listen");
     }
 
     #[test]
@@ -1825,11 +1840,7 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("path"),
-            "expected path rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("tcp input must reject path");
     }
 
     #[test]
@@ -1844,11 +1855,7 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("max_open_files"),
-            "expected max_open_files rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("tcp input must reject max_open_files");
     }
 
     #[test]
@@ -1863,11 +1870,7 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("adaptive_fast_polls_max"),
-            "expected adaptive_fast_polls_max rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("tcp input must reject adaptive_fast_polls_max");
     }
 
     #[test]
@@ -1943,6 +1946,8 @@ pipelines:
 
     #[test]
     fn udp_rejects_tls_block() {
+        // With the tagged-enum refactor, UDP has no `tls` field. Serde rejects
+        // it at parse time via `deny_unknown_fields`.
         let yaml = r#"
 pipelines:
   test:
@@ -1955,11 +1960,7 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("TLS is not supported for UDP"),
-            "expected UDP TLS rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("udp input must reject tls");
     }
 
     #[test]
@@ -1974,11 +1975,7 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("glob_rescan_interval_ms"),
-            "expected glob_rescan_interval_ms rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("tcp input must reject glob_rescan_interval_ms");
     }
 
     #[test]
@@ -1992,11 +1989,7 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("path"),
-            "expected path rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("generator input must reject path");
     }
 
     #[test]
@@ -2025,10 +2018,11 @@ pipelines:
       - type: null
 "#;
         let cfg = Config::load_str(yaml).expect("generator block should be valid");
-        let generator = cfg.pipelines["test"].inputs[0]
-            .generator
-            .as_ref()
-            .expect("generator config");
+        let gen_type = match &cfg.pipelines["test"].inputs[0].type_config {
+            InputTypeConfig::Generator(g) => g,
+            _ => panic!("expected Generator type_config"),
+        };
+        let generator = gen_type.generator.as_ref().expect("generator config");
         assert_eq!(generator.events_per_sec, Some(25000));
         assert_eq!(generator.batch_size, Some(2048));
         assert_eq!(generator.total_events, Some(123));
@@ -2080,16 +2074,13 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("'listen' is not supported for generator inputs"),
-            "expected generator listen rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("generator input must reject listen");
     }
 
     #[test]
     fn non_generator_input_rejects_generator_block() {
+        // With the tagged-enum refactor, the `generator` key is only valid inside
+        // the generator variant. Serde rejects it at parse time for file inputs.
         let yaml = r#"
 pipelines:
   test:
@@ -2101,12 +2092,7 @@ pipelines:
     outputs:
       - type: null
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("only supported for generator inputs"),
-            "expected generator block rejection: {err}"
-        );
+        let _ = Config::load_str(yaml).expect_err("file input must reject generator block");
     }
 
     #[test]
@@ -2318,7 +2304,11 @@ pipelines:
       - type: null
 "#;
         let cfg = Config::load_str(yaml).expect("timestamp config should be valid");
-        let ts = cfg.pipelines["test"].inputs[0]
+        let gen_type = match &cfg.pipelines["test"].inputs[0].type_config {
+            InputTypeConfig::Generator(g) => g,
+            _ => panic!("expected Generator type_config"),
+        };
+        let ts = gen_type
             .generator
             .as_ref()
             .unwrap()

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -386,7 +386,11 @@ pub enum InputTypeConfig {
     Generator(GeneratorTypeConfig),
     #[serde(rename = "linux_ebpf_sensor", alias = "linux_sensor_beta")]
     LinuxEbpfSensor(SensorTypeConfig),
-    #[serde(rename = "macos_es_sensor", alias = "macos_sensor_beta")]
+    #[serde(
+        rename = "macos_es_sensor",
+        alias = "macos_sensor_beta",
+        alias = "macos_endpointsecurity_sensor"
+    )]
     MacosEsSensor(SensorTypeConfig),
     #[serde(rename = "windows_ebpf_sensor", alias = "windows_sensor_beta")]
     WindowsEbpfSensor(SensorTypeConfig),

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -355,17 +355,70 @@ impl Default for JournaldInputConfig {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct InputConfig {
     pub name: Option<String>,
-    #[serde(rename = "type")]
-    pub input_type: InputType,
-    pub path: Option<String>,
-    pub listen: Option<String>,
-    /// Prefix applied to OTLP resource attributes when flattening into columns.
-    /// Defaults to `resource.attributes.` when omitted.
-    pub resource_prefix: Option<String>,
     pub format: Option<Format>,
+    pub sql: Option<String>,
+    #[serde(flatten)]
+    pub type_config: InputTypeConfig,
+}
+
+impl InputConfig {
+    /// Returns the [`InputType`] for this input.
+    pub fn input_type(&self) -> InputType {
+        self.type_config.input_type()
+    }
+}
+
+/// Tagged‐union carrying per‐input‐type configuration.
+///
+/// Serde tags on `"type"` and uses `deny_unknown_fields` on each variant
+/// struct, so a YAML like `type: file` with an `listen:` key is rejected
+/// at parse time instead of silently ignored.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InputTypeConfig {
+    File(FileTypeConfig),
+    Udp(UdpTypeConfig),
+    Tcp(TcpTypeConfig),
+    Otlp(OtlpTypeConfig),
+    Http(HttpTypeConfig),
+    Generator(GeneratorTypeConfig),
+    #[serde(rename = "linux_ebpf_sensor", alias = "linux_sensor_beta")]
+    LinuxEbpfSensor(SensorTypeConfig),
+    #[serde(rename = "macos_es_sensor", alias = "macos_sensor_beta")]
+    MacosEsSensor(SensorTypeConfig),
+    #[serde(rename = "windows_ebpf_sensor", alias = "windows_sensor_beta")]
+    WindowsEbpfSensor(SensorTypeConfig),
+    ArrowIpc(ArrowIpcTypeConfig),
+    Journald(JournaldTypeConfig),
+}
+
+impl InputTypeConfig {
+    /// Map the variant back to the flat [`InputType`] discriminant.
+    pub fn input_type(&self) -> InputType {
+        match self {
+            Self::File(_) => InputType::File,
+            Self::Udp(_) => InputType::Udp,
+            Self::Tcp(_) => InputType::Tcp,
+            Self::Otlp(_) => InputType::Otlp,
+            Self::Http(_) => InputType::Http,
+            Self::Generator(_) => InputType::Generator,
+            Self::LinuxEbpfSensor(_) => InputType::LinuxEbpfSensor,
+            Self::MacosEsSensor(_) => InputType::MacosEsSensor,
+            Self::WindowsEbpfSensor(_) => InputType::WindowsEbpfSensor,
+            Self::ArrowIpc(_) => InputType::ArrowIpc,
+            Self::Journald(_) => InputType::Journald,
+        }
+    }
+}
+
+// ── Per-type config structs ────────────────────────────────────────────
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileTypeConfig {
+    pub path: String,
     /// File input poll cadence in milliseconds (default: 50, minimum: 1).
     pub poll_interval_ms: Option<u64>,
     /// File tail read buffer in bytes (default: 262_144, minimum: 1, maximum: 4_194_304).
@@ -377,15 +430,62 @@ pub struct InputConfig {
     pub adaptive_fast_polls_max: Option<u8>,
     pub max_open_files: Option<usize>,
     pub glob_rescan_interval_ms: Option<u64>,
-    #[serde(default)]
-    pub generator: Option<GeneratorInputConfig>,
-    #[serde(default, alias = "sensor_beta")]
-    pub sensor: Option<PlatformSensorInputConfig>,
-    #[serde(default)]
-    pub http: Option<HttpInputConfig>,
-    pub sql: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UdpTypeConfig {
+    pub listen: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TcpTypeConfig {
+    pub listen: String,
     #[serde(default)]
     pub tls: Option<TlsInputConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OtlpTypeConfig {
+    pub listen: String,
+    /// Prefix applied to OTLP resource attributes when flattening into columns.
+    /// Defaults to `resource.attributes.` when omitted.
+    pub resource_prefix: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HttpTypeConfig {
+    pub listen: String,
+    #[serde(default)]
+    pub http: Option<HttpInputConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct GeneratorTypeConfig {
+    #[serde(default)]
+    pub generator: Option<GeneratorInputConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct SensorTypeConfig {
+    #[serde(default, alias = "sensor_beta")]
+    pub sensor: Option<PlatformSensorInputConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArrowIpcTypeConfig {
+    pub listen: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct JournaldTypeConfig {
     #[serde(default)]
     pub journald: Option<JournaldInputConfig>,
 }

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1,6 +1,6 @@
 use crate::types::{
     Config, ConfigError, EnrichmentConfig, Format, GeneratorAttributeValueConfig,
-    GeneratorProfileConfig, InputType, JournaldBackendConfig, OutputType,
+    GeneratorProfileConfig, InputType, InputTypeConfig, JournaldBackendConfig, OutputType,
 };
 use std::path::Path;
 use url::Url;
@@ -103,274 +103,61 @@ impl Config {
                         .as_deref()
                         .map_or_else(|| format!("#{i}"), String::from);
 
-                    if input.input_type != InputType::Otlp && input.resource_prefix.is_some() {
-                        return Err(ConfigError::Validation(format!(
-                            "pipeline '{name}' input '{label}': 'resource_prefix' is only supported for otlp inputs"
-                        )));
-                    }
-                    match input.input_type {
-                        InputType::File => {
-                            match &input.path {
-                                None => {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': file input requires 'path'"
-                                    )));
-                                }
-                                Some(p) if p.trim().is_empty() => {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': file input 'path' must not be empty"
-                                    )));
-                                }
-                                _ => {}
+                    match &input.type_config {
+                        InputTypeConfig::File(f) => {
+                            if f.path.trim().is_empty() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': file input 'path' must not be empty"
+                                )));
                             }
-                            if input.poll_interval_ms == Some(0) {
+                            if f.poll_interval_ms == Some(0) {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': 'poll_interval_ms' must be at least 1"
                                 )));
                             }
-                            if input.read_buf_size == Some(0) {
+                            if f.read_buf_size == Some(0) {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': 'read_buf_size' must be at least 1"
                                 )));
                             }
-                            if input.per_file_read_budget_bytes == Some(0) {
+                            if f.per_file_read_budget_bytes == Some(0) {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' must be at least 1"
                                 )));
                             }
-                        }
-                        InputType::Udp | InputType::Tcp => {
-                            if input.listen.is_none() {
+                            if f.max_open_files == Some(0) {
                                 return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': udp/tcp input requires 'listen'"
-                                )));
-                            }
-                            if let Some(addr) = &input.listen {
-                                if let Err(msg) = validate_bind_addr(addr) {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': {msg}"
-                                    )));
-                                }
-                            }
-                            if let Some(tls) = &input.tls {
-                                if matches!(input.input_type, InputType::Udp) {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': TLS is not supported for UDP inputs (DTLS is not implemented)"
-                                    )));
-                                }
-                                if matches!(input.input_type, InputType::Tcp) {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': TLS is not yet supported for TCP inputs (runtime TLS termination is not implemented)"
-                                    )));
-                                }
-                                let has_cert =
-                                    tls.cert_file.as_ref().is_some_and(|v| !v.trim().is_empty());
-                                let has_key =
-                                    tls.key_file.as_ref().is_some_and(|v| !v.trim().is_empty());
-                                if has_cert != has_key {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': tls.cert_file and tls.key_file must be set together"
-                                    )));
-                                }
-                                if !has_cert && tls.require_client_auth {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': tls.require_client_auth requires tls.cert_file and tls.key_file"
-                                    )));
-                                }
-                                if tls.require_client_auth
-                                    && tls
-                                        .client_ca_file
-                                        .as_ref()
-                                        .is_none_or(|v| v.trim().is_empty())
-                                {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': tls.client_ca_file is required when tls.require_client_auth=true"
-                                    )));
-                                }
-                            }
-                        }
-                        InputType::Otlp | InputType::Http | InputType::ArrowIpc => {
-                            if input.listen.is_none() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'listen' is required for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if let Some(addr) = &input.listen {
-                                if let Err(msg) = validate_bind_addr(addr) {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': {msg}"
-                                    )));
-                                }
-                            }
-                        }
-                        InputType::Generator
-                        | InputType::LinuxEbpfSensor
-                        | InputType::MacosEsSensor
-                        | InputType::WindowsEbpfSensor => {}
-                        InputType::Journald => {
-                            if let Some(jd) = &input.journald {
-                                // journal_directory and journal_namespace are mutually exclusive
-                                // in the native backend (directory opens a specific path, namespace
-                                // opens a named journal). The subprocess backend supports both
-                                // flags together, so only reject when the native API is required.
-                                if jd.backend == JournaldBackendConfig::Native
-                                    && jd.journal_directory.is_some()
-                                    && jd.journal_namespace.is_some()
-                                {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': 'journal_directory' and 'journal_namespace' cannot both be set with native backend"
-                                    )));
-                                }
-
-                                // Reject blank/whitespace-only optional string fields.
-                                if jd
-                                    .journalctl_path
-                                    .as_deref()
-                                    .is_some_and(|s| s.trim().is_empty())
-                                {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': 'journalctl_path' must not be blank"
-                                    )));
-                                }
-                                if jd
-                                    .journal_directory
-                                    .as_deref()
-                                    .is_some_and(|s| s.trim().is_empty())
-                                {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': 'journal_directory' must not be blank"
-                                    )));
-                                }
-                                if jd
-                                    .journal_namespace
-                                    .as_deref()
-                                    .is_some_and(|s| s.trim().is_empty())
-                                {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': 'journal_namespace' must not be blank"
-                                    )));
-                                }
-
-                                // Reject blank/whitespace-only unit names.
-                                for unit in jd.include_units.iter().chain(jd.exclude_units.iter()) {
-                                    if unit.trim().is_empty() {
-                                        return Err(ConfigError::Validation(format!(
-                                            "pipeline '{name}' input '{label}': unit names must not be blank"
-                                        )));
-                                    }
-                                }
-
-                                let norm_excludes: Vec<String> = jd
-                                    .exclude_units
-                                    .iter()
-                                    .map(|u| normalize_unit_name(u.trim()))
-                                    .collect();
-                                for unit in &jd.include_units {
-                                    let normalized = normalize_unit_name(unit.trim());
-                                    if norm_excludes.contains(&normalized) {
-                                        return Err(ConfigError::Validation(format!(
-                                            "pipeline '{name}' input '{label}': unit '{unit}' appears in both include_units and exclude_units"
-                                        )));
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Reject fields that don't apply to this input type.
-                    match input.input_type {
-                        InputType::File => {
-                            if input.generator.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'generator' settings are only supported for generator inputs"
-                                )));
-                            }
-                            if input.http.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
-                                )));
-                            }
-                            if input.listen.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'listen' is not supported for file inputs"
-                                )));
-                            }
-                            if input.tls.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'tls' is not supported for file inputs"
-                                )));
-                            }
-                            if input.sensor.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
-                                )));
-                            }
-                            if input.journald.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
+                                    "pipeline '{name}' input '{label}': max_open_files must be at least 1"
                                 )));
                             }
                         }
-                        InputType::Tcp | InputType::Udp => {
-                            if input.generator.is_some() {
+                        InputTypeConfig::Udp(u) => {
+                            if let Err(msg) = validate_bind_addr(&u.listen) {
                                 return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'generator' settings are only supported for generator inputs"
-                                )));
-                            }
-                            if input.http.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
-                                )));
-                            }
-                            if input.path.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'path' is not supported for tcp/udp inputs"
-                                )));
-                            }
-                            if input.max_open_files.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'max_open_files' is not supported for tcp/udp inputs"
-                                )));
-                            }
-                            if input.glob_rescan_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for tcp/udp inputs"
-                                )));
-                            }
-                            if input.poll_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'poll_interval_ms' is not supported for tcp/udp inputs"
-                                )));
-                            }
-                            if input.read_buf_size.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'read_buf_size' is not supported for tcp/udp inputs"
-                                )));
-                            }
-                            if input.per_file_read_budget_bytes.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' is not supported for tcp/udp inputs"
-                                )));
-                            }
-                            if input.adaptive_fast_polls_max.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for tcp/udp inputs"
-                                )));
-                            }
-                            if input.sensor.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
-                                )));
-                            }
-                            if input.journald.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
+                                    "pipeline '{name}' input '{label}': {msg}"
                                 )));
                             }
                         }
-                        InputType::Otlp => {
-                            if let Some(prefix) = input.resource_prefix.as_deref() {
+                        InputTypeConfig::Tcp(t) => {
+                            if let Err(msg) = validate_bind_addr(&t.listen) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': {msg}"
+                                )));
+                            }
+                            if t.tls.is_some() {
+                                // TCP TLS is not yet implemented at runtime.
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': TLS is not yet supported for TCP inputs (runtime TLS termination is not implemented)"
+                                )));
+                            }
+                        }
+                        InputTypeConfig::Otlp(o) => {
+                            if let Err(msg) = validate_bind_addr(&o.listen) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': {msg}"
+                                )));
+                            }
+                            if let Some(prefix) = o.resource_prefix.as_deref() {
                                 if prefix.trim().is_empty() {
                                     return Err(ConfigError::Validation(format!(
                                         "pipeline '{name}' input '{label}': 'resource_prefix' must not be empty for otlp inputs"
@@ -382,191 +169,14 @@ impl Config {
                                     )));
                                 }
                             }
-                            if input.tls.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'tls' is not supported for otlp inputs"
-                                )));
-                            }
-                            if input.http.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
-                                )));
-                            }
-                            if input.generator.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'generator' settings are only supported for generator inputs"
-                                )));
-                            }
-                            if input.path.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'path' is not supported for otlp inputs"
-                                )));
-                            }
-                            if input.max_open_files.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'max_open_files' is not supported for otlp inputs"
-                                )));
-                            }
-                            if input.glob_rescan_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for otlp inputs"
-                                )));
-                            }
-                            if input.poll_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'poll_interval_ms' is not supported for otlp inputs"
-                                )));
-                            }
-                            if input.read_buf_size.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'read_buf_size' is not supported for otlp inputs"
-                                )));
-                            }
-                            if input.per_file_read_budget_bytes.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' is not supported for otlp inputs"
-                                )));
-                            }
-                            if input.adaptive_fast_polls_max.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for otlp inputs"
-                                )));
-                            }
-                            if input.sensor.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
-                                )));
-                            }
-                            if input.journald.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
-                                )));
-                            }
                         }
-                        InputType::ArrowIpc => {
-                            if input.tls.is_some() {
+                        InputTypeConfig::Http(h) => {
+                            if let Err(msg) = validate_bind_addr(&h.listen) {
                                 return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'tls' is not supported for arrow_ipc inputs"
+                                    "pipeline '{name}' input '{label}': {msg}"
                                 )));
                             }
-                            if input.format.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'format' is not supported for arrow_ipc inputs"
-                                )));
-                            }
-                            if input.http.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
-                                )));
-                            }
-                            if input.generator.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'generator' settings are only supported for generator inputs"
-                                )));
-                            }
-                            if input.path.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'path' is not supported for arrow_ipc inputs"
-                                )));
-                            }
-                            if input.max_open_files.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'max_open_files' is not supported for arrow_ipc inputs"
-                                )));
-                            }
-                            if input.glob_rescan_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for arrow_ipc inputs"
-                                )));
-                            }
-                            if input.poll_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'poll_interval_ms' is not supported for arrow_ipc inputs"
-                                )));
-                            }
-                            if input.read_buf_size.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'read_buf_size' is not supported for arrow_ipc inputs"
-                                )));
-                            }
-                            if input.per_file_read_budget_bytes.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' is not supported for arrow_ipc inputs"
-                                )));
-                            }
-                            if input.adaptive_fast_polls_max.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for arrow_ipc inputs"
-                                )));
-                            }
-                            if input.sensor.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
-                                )));
-                            }
-                            if input.journald.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
-                                )));
-                            }
-                        }
-                        InputType::Http => {
-                            if input.tls.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'tls' is not supported for http inputs"
-                                )));
-                            }
-                            if input.generator.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'generator' settings are only supported for generator inputs"
-                                )));
-                            }
-                            if input.path.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'path' is not supported for http inputs; use http.path"
-                                )));
-                            }
-                            if input.max_open_files.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'max_open_files' is not supported for http inputs"
-                                )));
-                            }
-                            if input.glob_rescan_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for http inputs"
-                                )));
-                            }
-                            if input.poll_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'poll_interval_ms' is not supported for http inputs"
-                                )));
-                            }
-                            if input.read_buf_size.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'read_buf_size' is not supported for http inputs"
-                                )));
-                            }
-                            if input.per_file_read_budget_bytes.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' is not supported for http inputs"
-                                )));
-                            }
-                            if input.adaptive_fast_polls_max.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for http inputs"
-                                )));
-                            }
-                            if input.sensor.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
-                                )));
-                            }
-                            if input.journald.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
-                                )));
-                            }
-                            if let Some(http) = &input.http {
+                            if let Some(http) = &h.http {
                                 if let Some(path) = &http.path
                                     && !path.starts_with('/')
                                 {
@@ -593,73 +203,13 @@ impl Config {
                                 }
                             }
                         }
-                        InputType::Generator => {
-                            if input.tls.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'tls' is not supported for generator inputs"
-                                )));
-                            }
-                            if input.listen.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'listen' is not supported for generator inputs; use generator.events_per_sec"
-                                )));
-                            }
-                            if input.http.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
-                                )));
-                            }
-                            if input.path.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'path' is not supported for generator inputs"
-                                )));
-                            }
-                            if input.max_open_files.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'max_open_files' is not supported for generator inputs"
-                                )));
-                            }
-                            if input.glob_rescan_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for generator inputs"
-                                )));
-                            }
-                            if input.poll_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'poll_interval_ms' is not supported for generator inputs"
-                                )));
-                            }
-                            if input.read_buf_size.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'read_buf_size' is not supported for generator inputs"
-                                )));
-                            }
-                            if input.per_file_read_budget_bytes.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' is not supported for generator inputs"
-                                )));
-                            }
-                            if input.adaptive_fast_polls_max.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for generator inputs"
-                                )));
-                            }
-                            if input.sensor.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
-                                )));
-                            }
-                            if input.journald.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
-                                )));
-                            }
-                            if input.generator.as_ref().and_then(|cfg| cfg.batch_size) == Some(0) {
+                        InputTypeConfig::Generator(g) => {
+                            if g.generator.as_ref().and_then(|cfg| cfg.batch_size) == Some(0) {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': generator.batch_size must be at least 1"
                                 )));
                             }
-                            if let Some(generator) = &input.generator {
+                            if let Some(generator) = &g.generator {
                                 let is_record_profile = matches!(
                                     generator.profile,
                                     Some(GeneratorProfileConfig::Record)
@@ -749,91 +299,21 @@ impl Config {
                                 }
                             }
                         }
-                        InputType::LinuxEbpfSensor
-                        | InputType::MacosEsSensor
-                        | InputType::WindowsEbpfSensor => {
-                            if input.generator.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'generator' settings are only supported for generator inputs"
-                                )));
-                            }
-                            if input.listen.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'listen' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.poll_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'poll_interval_ms' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.read_buf_size.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'read_buf_size' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.per_file_read_budget_bytes.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.path.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'path' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.max_open_files.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'max_open_files' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.glob_rescan_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.adaptive_fast_polls_max.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.tls.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'tls' is not supported for {} inputs",
-                                    input.input_type
-                                )));
-                            }
-                            if input.http.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
-                                )));
-                            }
-                            if input.journald.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'journald' settings are only supported for journald inputs"
-                                )));
-                            }
+                        InputTypeConfig::LinuxEbpfSensor(s)
+                        | InputTypeConfig::MacosEsSensor(s)
+                        | InputTypeConfig::WindowsEbpfSensor(s) => {
+                            let input_type = input.input_type();
                             if input.format.is_some() {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': sensor inputs do not support 'format' (Arrow-native input)"
                                 )));
                             }
-                            if input.sensor.as_ref().and_then(|cfg| cfg.poll_interval_ms) == Some(0)
-                            {
+                            if s.sensor.as_ref().and_then(|cfg| cfg.poll_interval_ms) == Some(0) {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': sensor.poll_interval_ms must be at least 1"
                                 )));
                             }
-                            if input
-                                .sensor
+                            if s.sensor
                                 .as_ref()
                                 .and_then(|cfg| cfg.control_reload_interval_ms)
                                 == Some(0)
@@ -842,8 +322,7 @@ impl Config {
                                     "pipeline '{name}' input '{label}': sensor.control_reload_interval_ms must be at least 1"
                                 )));
                             }
-                            if input
-                                .sensor
+                            if s.sensor
                                 .as_ref()
                                 .and_then(|cfg| cfg.control_path.as_deref())
                                 .is_some_and(|path| path.trim().is_empty())
@@ -852,7 +331,7 @@ impl Config {
                                     "pipeline '{name}' input '{label}': sensor.control_path must not be empty"
                                 )));
                             }
-                            if let Some(families) = input
+                            if let Some(families) = s
                                 .sensor
                                 .as_ref()
                                 .and_then(|cfg| cfg.enabled_families.as_ref())
@@ -864,76 +343,94 @@ impl Config {
                                             "pipeline '{name}' input '{label}': sensor.enabled_families entries must not be empty"
                                         )));
                                     }
-                                    if !is_sensor_family_supported(&input.input_type, normalized) {
+                                    if !is_sensor_family_supported(&input_type, normalized) {
                                         return Err(ConfigError::Validation(format!(
                                             "pipeline '{name}' input '{label}': unknown sensor family '{normalized}' for {} input (supported: {})",
-                                            input.input_type,
-                                            sensor_supported_families_csv(&input.input_type)
+                                            input_type,
+                                            sensor_supported_families_csv(&input_type)
                                         )));
                                     }
                                 }
                             }
                         }
-                        InputType::Journald => {
-                            if input.listen.is_some() {
+                        InputTypeConfig::ArrowIpc(a) => {
+                            if let Err(msg) = validate_bind_addr(&a.listen) {
                                 return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'listen' is not supported for journald inputs"
+                                    "pipeline '{name}' input '{label}': {msg}"
                                 )));
                             }
-                            if input.path.is_some() {
+                            if input.format.is_some() {
                                 return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'path' is not supported for journald inputs"
+                                    "pipeline '{name}' input '{label}': 'format' is not supported for arrow_ipc inputs"
                                 )));
                             }
-                            if input.tls.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'tls' is not supported for journald inputs"
-                                )));
-                            }
-                            if input.generator.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'generator' settings are only supported for generator inputs"
-                                )));
-                            }
-                            if input.http.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'http' settings are only supported for http inputs"
-                                )));
-                            }
-                            if input.sensor.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'sensor' settings are only supported for sensor inputs"
-                                )));
-                            }
-                            if input.max_open_files.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'max_open_files' is not supported for journald inputs"
-                                )));
-                            }
-                            if input.glob_rescan_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'glob_rescan_interval_ms' is not supported for journald inputs"
-                                )));
-                            }
-                            if input.poll_interval_ms.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'poll_interval_ms' is not supported for journald inputs"
-                                )));
-                            }
-                            if input.read_buf_size.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'read_buf_size' is not supported for journald inputs"
-                                )));
-                            }
-                            if input.per_file_read_budget_bytes.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'per_file_read_budget_bytes' is not supported for journald inputs"
-                                )));
-                            }
-                            if input.adaptive_fast_polls_max.is_some() {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': 'adaptive_fast_polls_max' is not supported for journald inputs"
-                                )));
+                        }
+                        InputTypeConfig::Journald(j) => {
+                            if let Some(jd) = &j.journald {
+                                // journal_directory and journal_namespace are mutually exclusive
+                                // in the native backend (directory opens a specific path, namespace
+                                // opens a named journal). The subprocess backend supports both
+                                // flags together, so only reject when the native API is required.
+                                if jd.backend == JournaldBackendConfig::Native
+                                    && jd.journal_directory.is_some()
+                                    && jd.journal_namespace.is_some()
+                                {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': 'journal_directory' and 'journal_namespace' cannot both be set with native backend"
+                                    )));
+                                }
+
+                                // Reject blank/whitespace-only optional string fields.
+                                if jd
+                                    .journalctl_path
+                                    .as_deref()
+                                    .is_some_and(|s| s.trim().is_empty())
+                                {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': 'journalctl_path' must not be blank"
+                                    )));
+                                }
+                                if jd
+                                    .journal_directory
+                                    .as_deref()
+                                    .is_some_and(|s| s.trim().is_empty())
+                                {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': 'journal_directory' must not be blank"
+                                    )));
+                                }
+                                if jd
+                                    .journal_namespace
+                                    .as_deref()
+                                    .is_some_and(|s| s.trim().is_empty())
+                                {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': 'journal_namespace' must not be blank"
+                                    )));
+                                }
+
+                                // Reject blank/whitespace-only unit names.
+                                for unit in jd.include_units.iter().chain(jd.exclude_units.iter()) {
+                                    if unit.trim().is_empty() {
+                                        return Err(ConfigError::Validation(format!(
+                                            "pipeline '{name}' input '{label}': unit names must not be blank"
+                                        )));
+                                    }
+                                }
+
+                                let norm_excludes: Vec<String> = jd
+                                    .exclude_units
+                                    .iter()
+                                    .map(|u| normalize_unit_name(u.trim()))
+                                    .collect();
+                                for unit in &jd.include_units {
+                                    let normalized = normalize_unit_name(unit.trim());
+                                    if norm_excludes.contains(&normalized) {
+                                        return Err(ConfigError::Validation(format!(
+                                            "pipeline '{name}' input '{label}': unit '{unit}' appears in both include_units and exclude_units"
+                                        )));
+                                    }
+                                }
                             }
                             // Journald always produces JSON; reject other formats at config time.
                             if let Some(fmt) = &input.format {
@@ -950,13 +447,6 @@ impl Config {
                     if let Some(fmt @ (Format::Logfmt | Format::Syslog)) = &input.format {
                         return Err(ConfigError::Validation(format!(
                             "pipeline '{name}' input '{label}': format {fmt:?} is not yet implemented",
-                        )));
-                    }
-
-                    // max_open_files: 0 silently disables all file reading (#696).
-                    if input.max_open_files == Some(0) {
-                        return Err(ConfigError::Validation(format!(
-                            "pipeline '{name}' input '{label}': max_open_files must be at least 1"
                         )));
                     }
 
@@ -1262,14 +752,11 @@ impl Config {
                     Vec::new();
                 let mut glob_input_patterns: Vec<String> = Vec::new();
 
-                for input in pipe
-                    .inputs
-                    .iter()
-                    .filter(|i| i.input_type == InputType::File)
-                {
-                    if let Some(p) = input.path.as_deref() {
+                for input in &pipe.inputs {
+                    if let InputTypeConfig::File(f) = &input.type_config {
+                        let p = &f.path;
                         if p.contains('*') || p.contains('?') || p.contains('[') {
-                            glob_input_patterns.push(p.to_string());
+                            glob_input_patterns.push(p.clone());
                         } else {
                             let pb = std::path::PathBuf::from(p);
                             let norm = normalize_path_for_compare(&pb);

--- a/crates/logfwd-io/src/journal_ffi.rs
+++ b/crates/logfwd-io/src/journal_ffi.rs
@@ -7,7 +7,7 @@
 //!
 //! # Safety
 //!
-//! The `Journal` handle is `!Send` and `!Sync` because the underlying
+//! The [`Journal`](crate::journal_ffi::Journal) handle is `!Send` and `!Sync` because the underlying
 //! `sd_journal` object must only be used from the thread that created it.
 //! Callers must confine each `Journal` to a single OS thread.
 

--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -65,7 +65,7 @@ pub async fn run_pipelines(
     let has_file_inputs = config.pipelines.values().any(|pipe| {
         pipe.inputs
             .iter()
-            .any(|input| matches!(input.input_type, logfwd_config::InputType::File))
+            .any(|input| matches!(input.type_config, logfwd_config::InputTypeConfig::File(_)))
     });
     let _lock_guard = if has_file_inputs {
         acquire_instance_lock(&config)?
@@ -393,19 +393,19 @@ pub fn format_bytes(b: u64) -> String {
 }
 
 fn input_label(i: &logfwd_config::InputConfig) -> String {
-    use logfwd_config::InputType;
-    match i.input_type {
-        InputType::File => format!("file  {}", i.path.as_deref().unwrap_or("*")),
-        InputType::Tcp => format!("tcp   {}", i.listen.as_deref().unwrap_or(":514")),
-        InputType::Udp => format!("udp   {}", i.listen.as_deref().unwrap_or(":514")),
-        InputType::Otlp => format!("otlp  {}", i.listen.as_deref().unwrap_or(":4318")),
-        InputType::Http => format!("http  {}", i.listen.as_deref().unwrap_or(":8080")),
-        InputType::ArrowIpc => "arrow_ipc".to_string(),
-        InputType::Generator => "generator".to_string(),
-        InputType::LinuxEbpfSensor => "linux_ebpf_sensor".to_string(),
-        InputType::MacosEsSensor => "macos_es_sensor".to_string(),
-        InputType::WindowsEbpfSensor => "windows_ebpf_sensor".to_string(),
-        _ => "unknown".to_string(),
+    use logfwd_config::InputTypeConfig;
+    match &i.type_config {
+        InputTypeConfig::File(f) => format!("file  {}", f.path),
+        InputTypeConfig::Tcp(t) => format!("tcp   {}", t.listen),
+        InputTypeConfig::Udp(u) => format!("udp   {}", u.listen),
+        InputTypeConfig::Otlp(o) => format!("otlp  {}", o.listen),
+        InputTypeConfig::Http(h) => format!("http  {}", h.listen),
+        InputTypeConfig::ArrowIpc(a) => format!("arrow_ipc  {}", a.listen),
+        InputTypeConfig::Generator(_) => "generator".to_string(),
+        InputTypeConfig::LinuxEbpfSensor(_) => "linux_ebpf_sensor".to_string(),
+        InputTypeConfig::MacosEsSensor(_) => "macos_es_sensor".to_string(),
+        InputTypeConfig::WindowsEbpfSensor(_) => "windows_ebpf_sensor".to_string(),
+        InputTypeConfig::Journald(_) => "journald".to_string(),
     }
 }
 

--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -65,7 +65,7 @@ pub async fn run_pipelines(
     let has_file_inputs = config.pipelines.values().any(|pipe| {
         pipe.inputs
             .iter()
-            .any(|input| matches!(input.type_config, logfwd_config::InputTypeConfig::File(_)))
+            .any(|input| matches!(&input.type_config, logfwd_config::InputTypeConfig::File(_)))
     });
     let _lock_guard = if has_file_inputs {
         acquire_instance_lock(&config)?

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -6,7 +6,7 @@ use opentelemetry::metrics::Meter;
 
 #[cfg(feature = "datafusion")]
 use logfwd_config::{EnrichmentConfig, GeoDatabaseFormat};
-use logfwd_config::{Format, InputType, PipelineConfig};
+use logfwd_config::{Format, InputTypeConfig, PipelineConfig};
 use logfwd_diagnostics::diagnostics::PipelineMetrics;
 use logfwd_io::checkpoint::{
     CheckpointStore, FileCheckpointStore, SourceCheckpoint, default_data_dir,
@@ -216,23 +216,23 @@ impl Pipeline {
 
         for (i, input_cfg) in config.inputs.iter().enumerate() {
             let mut resolved_cfg = input_cfg.clone();
-            if let Some(path_str) = &input_cfg.path {
-                let mut path = PathBuf::from(path_str);
+            if let InputTypeConfig::File(ref mut f) = resolved_cfg.type_config {
+                let mut path = PathBuf::from(&f.path);
                 if path.is_relative()
                     && let Some(base) = base_path
                 {
                     path = base.join(path);
                 }
                 if let Ok(abs_path) = std::fs::canonicalize(&path) {
-                    resolved_cfg.path = Some(abs_path.to_string_lossy().into_owned());
+                    f.path = abs_path.to_string_lossy().into_owned();
                 } else {
-                    resolved_cfg.path = Some(path.to_string_lossy().into_owned());
+                    f.path = path.to_string_lossy().into_owned();
                 }
             }
 
             // Resolve journal_directory relative to config base_path.
-            if matches!(input_cfg.input_type, InputType::Journald) {
-                if let Some(ref mut jd) = resolved_cfg.journald {
+            if let InputTypeConfig::Journald(ref mut j) = resolved_cfg.type_config {
+                if let Some(ref mut jd) = j.journald {
                     if let Some(ref dir) = jd.journal_directory {
                         let mut path = PathBuf::from(dir);
                         if path.is_relative()
@@ -249,7 +249,7 @@ impl Pipeline {
                 .name
                 .clone()
                 .unwrap_or_else(|| format!("input_{i}"));
-            let input_type_str = format!("{:?}", input_cfg.input_type).to_lowercase();
+            let input_type_str = input_cfg.input_type().to_string();
             let input_stats = metrics.add_input(&input_name, &input_type_str);
 
             // Determine the SQL for this input: per-input > pipeline-level > passthrough.

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -393,28 +393,22 @@ impl Pipeline {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use logfwd_config::{InputConfig, InputType, OutputConfig, OutputType};
+    use logfwd_config::{InputConfig, InputTypeConfig, OutputConfig, OutputType};
 
     fn minimal_input(path: String) -> InputConfig {
         InputConfig {
             name: Some("input".to_string()),
-            input_type: InputType::File,
-            path: Some(path),
-            listen: None,
-            resource_prefix: None,
             format: Some(Format::Json),
-            poll_interval_ms: None,
-            read_buf_size: None,
-            per_file_read_budget_bytes: None,
-            adaptive_fast_polls_max: None,
-            max_open_files: None,
-            glob_rescan_interval_ms: None,
-            generator: None,
-            sensor: None,
-            http: None,
             sql: None,
-            tls: None,
-            journald: None,
+            type_config: InputTypeConfig::File(logfwd_config::FileTypeConfig {
+                path,
+                poll_interval_ms: None,
+                read_buf_size: None,
+                per_file_read_budget_bytes: None,
+                adaptive_fast_polls_max: None,
+                max_open_files: None,
+                glob_rescan_interval_ms: None,
+            }),
         }
     }
 

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use bytes::BytesMut;
 use logfwd_config::{
     Format, GeneratorAttributeValueConfig, GeneratorComplexityConfig, GeneratorProfileConfig,
-    HttpMethodConfig, InputConfig, InputType, PlatformSensorInputConfig,
+    HttpMethodConfig, InputConfig, InputType, InputTypeConfig, PlatformSensorInputConfig,
 };
 use logfwd_diagnostics::diagnostics::ComponentStats;
 use logfwd_io::format::FormatDecoder;
@@ -97,27 +97,26 @@ pub(super) fn build_input_state(
     cfg: &InputConfig,
     stats: Arc<ComponentStats>,
 ) -> Result<InputState, String> {
-    let (raw_source, format, buf_cap): (Box<dyn InputSource>, Format, usize) = match cfg.input_type
+    let (raw_source, format, buf_cap): (Box<dyn InputSource>, Format, usize) = match &cfg
+        .type_config
     {
-        InputType::File => {
-            let path = require_non_empty(name, "file", "path", cfg.path.as_ref())?;
+        InputTypeConfig::File(f) => {
+            let path = require_non_empty(name, "file", "path", Some(&f.path))?;
             let format = cfg.format.clone().unwrap_or(Format::Auto);
             let mut tail_config = TailConfig {
                 start_from_end: false,
-                poll_interval_ms: cfg
-                    .poll_interval_ms
-                    .unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
-                read_buf_size: cfg.read_buf_size.unwrap_or(DEFAULT_READ_BUF_SIZE),
-                per_file_read_budget_bytes: cfg
+                poll_interval_ms: f.poll_interval_ms.unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
+                read_buf_size: f.read_buf_size.unwrap_or(DEFAULT_READ_BUF_SIZE),
+                per_file_read_budget_bytes: f
                     .per_file_read_budget_bytes
                     .unwrap_or(DEFAULT_PER_FILE_READ_BUDGET_BYTES),
-                max_open_files: cfg.max_open_files.unwrap_or(DEFAULT_MAX_OPEN_FILES),
+                max_open_files: f.max_open_files.unwrap_or(DEFAULT_MAX_OPEN_FILES),
                 ..Default::default()
             };
-            if let Some(interval) = cfg.glob_rescan_interval_ms {
+            if let Some(interval) = f.glob_rescan_interval_ms {
                 tail_config.glob_rescan_interval_ms = interval;
             }
-            if let Some(max) = cfg.adaptive_fast_polls_max {
+            if let Some(max) = f.adaptive_fast_polls_max {
                 tail_config.adaptive_fast_polls_max = max;
             }
             let is_glob = path.contains('*') || path.contains('?') || path.contains('[');
@@ -140,13 +139,13 @@ pub(super) fn build_input_state(
             validate_input_format(name, InputType::File, &format)?;
             (Box::new(source), format, 4 * 1024 * 1024)
         }
-        InputType::Generator => {
+        InputTypeConfig::Generator(g) => {
             use logfwd_io::generator::{
                 GeneratorAttributeValue, GeneratorComplexity, GeneratorConfig,
                 GeneratorGeneratedField, GeneratorInput, GeneratorProfile, GeneratorTimestamp,
                 parse_iso8601_to_epoch_ms,
             };
-            let generator_cfg = cfg.generator.as_ref();
+            let generator_cfg = g.generator.as_ref();
             let config = GeneratorConfig {
                 events_per_sec: generator_cfg.and_then(|c| c.events_per_sec).unwrap_or(0),
                 batch_size: generator_cfg
@@ -209,19 +208,19 @@ pub(super) fn build_input_state(
                     None => GeneratorTimestamp::default(),
                     Some(ts) => {
                         let start_epoch_ms = match ts.start.as_deref() {
-                            None => GeneratorTimestamp::default().start_epoch_ms,
-                            Some(s) if s.eq_ignore_ascii_case("now") => {
-                                std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .map_err(|_| {
-                                        format!("input '{name}': system clock is before Unix epoch, cannot resolve timestamp.start=\"now\"")
-                                    })?
-                                    .as_millis() as i64
-                            }
-                            Some(s) => parse_iso8601_to_epoch_ms(s).map_err(|e| {
-                                format!("input '{name}': invalid timestamp.start: {e}")
-                            })?,
-                        };
+                                None => GeneratorTimestamp::default().start_epoch_ms,
+                                Some(s) if s.eq_ignore_ascii_case("now") => {
+                                    std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map_err(|_| {
+                                            format!("input '{name}': system clock is before Unix epoch, cannot resolve timestamp.start=\"now\"")
+                                        })?
+                                        .as_millis() as i64
+                                }
+                                Some(s) => parse_iso8601_to_epoch_ms(s).map_err(|e| {
+                                    format!("input '{name}': invalid timestamp.start: {e}")
+                                })?,
+                            };
                         GeneratorTimestamp {
                             start_epoch_ms,
                             step_ms: ts.step_ms.unwrap_or(1),
@@ -234,9 +233,9 @@ pub(super) fn build_input_state(
             let source = GeneratorInput::new(name, config);
             (Box::new(source), format, 4 * 1024 * 1024)
         }
-        InputType::Otlp => {
-            let addr = require_non_empty(name, "otlp", "listen", cfg.listen.as_ref())?;
-            let resource_prefix = cfg
+        InputTypeConfig::Otlp(o) => {
+            let addr = require_non_empty(name, "otlp", "listen", Some(&o.listen))?;
+            let resource_prefix = o
                 .resource_prefix
                 .as_deref()
                 .unwrap_or(logfwd_types::field_names::DEFAULT_RESOURCE_PREFIX);
@@ -252,20 +251,20 @@ pub(super) fn build_input_state(
                 .map_err(|e| format!("input '{name}': failed to start OTLP receiver: {e}"))?;
             (Box::new(source), format, 4 * 1024 * 1024)
         }
-        InputType::ArrowIpc => {
-            let addr = require_non_empty(name, "arrow_ipc", "listen", cfg.listen.as_ref())?;
+        InputTypeConfig::ArrowIpc(a) => {
+            let addr = require_non_empty(name, "arrow_ipc", "listen", Some(&a.listen))?;
             let format = cfg.format.clone().unwrap_or(Format::Json);
             validate_input_format(name, InputType::ArrowIpc, &format)?;
             let source = logfwd_io::arrow_ipc_receiver::ArrowIpcReceiver::new(name, addr)
                 .map_err(|e| format!("input '{name}': failed to start Arrow IPC receiver: {e}"))?;
             (Box::new(source), format, 4 * 1024 * 1024)
         }
-        InputType::Http => {
-            let addr = require_non_empty(name, "http", "listen", cfg.listen.as_ref())?;
+        InputTypeConfig::Http(h) => {
+            let addr = require_non_empty(name, "http", "listen", Some(&h.listen))?;
             let format = cfg.format.clone().unwrap_or(Format::Json);
             validate_input_format(name, InputType::Http, &format)?;
             let mut options = logfwd_io::http_input::HttpInputOptions::default();
-            if let Some(http) = &cfg.http {
+            if let Some(http) = &h.http {
                 if let Some(path) = &http.path {
                     if path.trim().is_empty() {
                         return Err(format!(
@@ -304,8 +303,8 @@ pub(super) fn build_input_state(
                 .map_err(|e| format!("input '{name}': failed to start HTTP input: {e}"))?;
             (Box::new(source), format, 4 * 1024 * 1024)
         }
-        InputType::Udp => {
-            let addr = require_non_empty(name, "udp", "listen", cfg.listen.as_ref())?;
+        InputTypeConfig::Udp(u) => {
+            let addr = require_non_empty(name, "udp", "listen", Some(&u.listen))?;
             if matches!(cfg.format, Some(Format::Cri | Format::Auto)) {
                 return Err(format!(
                     "input '{name}': CRI/auto format is not supported for UDP inputs (CRI is a file-based container log format)"
@@ -317,8 +316,8 @@ pub(super) fn build_input_state(
             validate_input_format(name, InputType::Udp, &format)?;
             (Box::new(source), format, 1024 * 1024)
         }
-        InputType::Tcp => {
-            let addr = require_non_empty(name, "tcp", "listen", cfg.listen.as_ref())?;
+        InputTypeConfig::Tcp(t) => {
+            let addr = require_non_empty(name, "tcp", "listen", Some(&t.listen))?;
             if matches!(cfg.format, Some(Format::Cri | Format::Auto)) {
                 return Err(format!(
                     "input '{name}': CRI/auto format is not supported for TCP inputs (CRI is a file-based container log format)"
@@ -330,13 +329,15 @@ pub(super) fn build_input_state(
             validate_input_format(name, InputType::Tcp, &format)?;
             (Box::new(source), format, 4 * 1024 * 1024)
         }
-        InputType::LinuxEbpfSensor | InputType::MacosEsSensor | InputType::WindowsEbpfSensor => {
+        InputTypeConfig::LinuxEbpfSensor(s)
+        | InputTypeConfig::MacosEsSensor(s)
+        | InputTypeConfig::WindowsEbpfSensor(s) => {
             use logfwd_io::platform_sensor::{PlatformSensorInput, PlatformSensorTarget};
 
-            let target = match cfg.input_type {
-                InputType::LinuxEbpfSensor => PlatformSensorTarget::Linux,
-                InputType::MacosEsSensor => PlatformSensorTarget::Macos,
-                InputType::WindowsEbpfSensor => PlatformSensorTarget::Windows,
+            let target = match &cfg.type_config {
+                InputTypeConfig::LinuxEbpfSensor(_) => PlatformSensorTarget::Linux,
+                InputTypeConfig::MacosEsSensor(_) => PlatformSensorTarget::Macos,
+                InputTypeConfig::WindowsEbpfSensor(_) => PlatformSensorTarget::Windows,
                 _ => unreachable!("handled by outer match"),
             };
 
@@ -346,11 +347,11 @@ pub(super) fn build_input_state(
                 ));
             }
 
-            let sensor_cfg = build_platform_sensor_config(cfg.sensor.as_ref());
+            let sensor_cfg = build_platform_sensor_config(s.sensor.as_ref());
             let source = PlatformSensorInput::new(name, target, sensor_cfg).map_err(|e| {
                 format!(
                     "input '{name}': failed to initialize {} input: {e}",
-                    cfg.input_type
+                    cfg.input_type()
                 )
             })?;
             return Ok(InputState {
@@ -359,7 +360,7 @@ pub(super) fn build_input_state(
                 stats,
             });
         }
-        InputType::Journald => {
+        InputTypeConfig::Journald(j) => {
             use logfwd_io::journald_input::{JournaldBackendPref, JournaldConfig, JournaldInput};
 
             // Fix #14: Reject non-JSON formats for journald — it always emits JSON.
@@ -371,7 +372,7 @@ pub(super) fn build_input_state(
                 }
             }
 
-            let jd_cfg = cfg.journald.as_ref();
+            let jd_cfg = j.journald.as_ref();
             // Map from config crate's JournaldBackendConfig to IO crate's JournaldBackendPref.
             let backend = match jd_cfg.map(|c| c.backend).unwrap_or_default() {
                 logfwd_config::JournaldBackendConfig::Auto => JournaldBackendPref::Auto,
@@ -395,16 +396,10 @@ pub(super) fn build_input_state(
                 .map_err(|e| format!("input '{name}': failed to start journald receiver: {e}"))?;
             (Box::new(source), format, 4 * 1024 * 1024)
         }
-        _ => {
-            return Err(format!(
-                "input '{name}': type {:?} not yet supported",
-                cfg.input_type
-            ));
-        }
     };
 
     // Wrap the raw transport with framing + format processing.
-    let format_proc = make_format(name, cfg.input_type.clone(), &format, &stats)?;
+    let format_proc = make_format(name, cfg.input_type(), &format, &stats)?;
     let framed = FramedInput::new(raw_source, format_proc, Arc::clone(&stats));
 
     Ok(InputState {
@@ -482,32 +477,27 @@ mod tests {
             &logfwd_test_utils::test_meter(),
         );
         let stats = pm.add_input("sensor", "test");
-        let input_type = if cfg!(target_os = "linux") {
-            InputType::LinuxEbpfSensor
+        let (input_type_config, _input_type) = if cfg!(target_os = "linux") {
+            (
+                InputTypeConfig::LinuxEbpfSensor(Default::default()),
+                InputType::LinuxEbpfSensor,
+            )
         } else if cfg!(target_os = "macos") {
-            InputType::MacosEsSensor
+            (
+                InputTypeConfig::MacosEsSensor(Default::default()),
+                InputType::MacosEsSensor,
+            )
         } else {
-            InputType::WindowsEbpfSensor
+            (
+                InputTypeConfig::WindowsEbpfSensor(Default::default()),
+                InputType::WindowsEbpfSensor,
+            )
         };
         let cfg = InputConfig {
             name: Some("sensor".to_string()),
-            input_type,
-            path: None,
-            listen: None,
-            resource_prefix: None,
             format: Some(Format::Raw),
-            poll_interval_ms: None,
-            read_buf_size: None,
-            per_file_read_budget_bytes: None,
-            adaptive_fast_polls_max: None,
-            max_open_files: None,
-            glob_rescan_interval_ms: None,
-            generator: None,
-            http: None,
-            sensor: Some(Default::default()),
             sql: None,
-            tls: None,
-            journald: None,
+            type_config: input_type_config,
         };
         let err = match build_input_state("sensor", &cfg, stats) {
             Ok(_) => panic!("sensor format must be rejected"),
@@ -530,23 +520,17 @@ mod tests {
         // Omitted / defaults
         let cfg_defaults = InputConfig {
             name: Some("test_in".into()),
-            input_type: InputType::File,
-            path: Some("/tmp/test.log".into()),
-            listen: None,
-            resource_prefix: None,
             format: None,
-            poll_interval_ms: None,
-            read_buf_size: None,
-            per_file_read_budget_bytes: None,
-            adaptive_fast_polls_max: None,
-            max_open_files: None,
-            glob_rescan_interval_ms: None,
-            generator: None,
-            sensor: None,
-            http: None,
             sql: None,
-            tls: None,
-            journald: None,
+            type_config: InputTypeConfig::File(logfwd_config::FileTypeConfig {
+                path: "/tmp/test.log".into(),
+                poll_interval_ms: None,
+                read_buf_size: None,
+                per_file_read_budget_bytes: None,
+                adaptive_fast_polls_max: None,
+                max_open_files: None,
+                glob_rescan_interval_ms: None,
+            }),
         };
 
         // Note: build_input_state doesn't return the raw TailConfig directly in
@@ -565,23 +549,17 @@ mod tests {
         // Explicit tuning overrides
         let cfg_overrides = InputConfig {
             name: Some("test_in".into()),
-            input_type: InputType::File,
-            path: Some("/tmp/test.log".into()),
-            listen: None,
-            resource_prefix: None,
             format: None,
-            poll_interval_ms: Some(123),
-            read_buf_size: Some(456),
-            per_file_read_budget_bytes: Some(789),
-            adaptive_fast_polls_max: Some(11),
-            max_open_files: Some(10),
-            glob_rescan_interval_ms: None,
-            generator: None,
-            sensor: None,
-            http: None,
             sql: None,
-            tls: None,
-            journald: None,
+            type_config: InputTypeConfig::File(logfwd_config::FileTypeConfig {
+                path: "/tmp/test.log".into(),
+                poll_interval_ms: Some(123),
+                read_buf_size: Some(456),
+                per_file_read_budget_bytes: Some(789),
+                adaptive_fast_polls_max: Some(11),
+                max_open_files: Some(10),
+                glob_rescan_interval_ms: None,
+            }),
         };
 
         let state = build_input_state("test_in", &cfg_overrides, Arc::clone(&stats))
@@ -600,27 +578,31 @@ mod tests {
         let meter = logfwd_test_utils::test_meter();
         let mut pm = PipelineMetrics::new("p", "SELECT 1", &meter);
 
-        for input_type in [InputType::Udp, InputType::Tcp] {
+        for (input_type, type_config_fn) in [
+            (
+                InputType::Udp,
+                (|listen: &str| {
+                    InputTypeConfig::Udp(logfwd_config::UdpTypeConfig {
+                        listen: listen.to_string(),
+                    })
+                }) as fn(&str) -> InputTypeConfig,
+            ),
+            (
+                InputType::Tcp,
+                (|listen: &str| {
+                    InputTypeConfig::Tcp(logfwd_config::TcpTypeConfig {
+                        listen: listen.to_string(),
+                        tls: None,
+                    })
+                }) as fn(&str) -> InputTypeConfig,
+            ),
+        ] {
             for format in [Format::Cri, Format::Auto] {
                 let cfg = InputConfig {
                     name: Some("in".to_string()),
-                    input_type: input_type.clone(),
-                    path: None,
-                    listen: Some("127.0.0.1:0".to_string()),
-                    resource_prefix: None,
                     format: Some(format),
-                    poll_interval_ms: None,
-                    read_buf_size: None,
-                    per_file_read_budget_bytes: None,
-                    adaptive_fast_polls_max: None,
-                    max_open_files: None,
-                    glob_rescan_interval_ms: None,
-                    generator: None,
-                    http: None,
-                    sensor: None,
                     sql: None,
-                    tls: None,
-                    journald: None,
+                    type_config: type_config_fn("127.0.0.1:0"),
                 };
                 let stats = pm.add_input("in", "test");
                 let err = match build_input_state("in", &cfg, stats) {
@@ -646,23 +628,17 @@ mod tests {
 
         let file_cfg = InputConfig {
             name: Some("file-in".to_string()),
-            input_type: InputType::File,
-            path: Some("   ".to_string()),
-            listen: None,
-            resource_prefix: None,
             format: Some(Format::Json),
-            poll_interval_ms: None,
-            read_buf_size: None,
-            per_file_read_budget_bytes: None,
-            adaptive_fast_polls_max: None,
-            max_open_files: None,
-            glob_rescan_interval_ms: None,
-            generator: None,
-            http: None,
-            sensor: None,
             sql: None,
-            tls: None,
-            journald: None,
+            type_config: InputTypeConfig::File(logfwd_config::FileTypeConfig {
+                path: "   ".to_string(),
+                poll_interval_ms: None,
+                read_buf_size: None,
+                per_file_read_budget_bytes: None,
+                adaptive_fast_polls_max: None,
+                max_open_files: None,
+                glob_rescan_interval_ms: None,
+            }),
         };
         let stats = pm.add_input("file-in", "file");
         let err = match build_input_state("file-in", &file_cfg, stats) {
@@ -671,32 +647,48 @@ mod tests {
         };
         assert!(err.contains("non-empty 'path'"), "unexpected error: {err}");
 
-        for input_type in [
-            InputType::Otlp,
-            InputType::ArrowIpc,
-            InputType::Http,
-            InputType::Udp,
-            InputType::Tcp,
-        ] {
+        let type_configs: Vec<(InputType, InputTypeConfig)> = vec![
+            (
+                InputType::Otlp,
+                InputTypeConfig::Otlp(logfwd_config::OtlpTypeConfig {
+                    listen: "   ".to_string(),
+                    resource_prefix: None,
+                }),
+            ),
+            (
+                InputType::ArrowIpc,
+                InputTypeConfig::ArrowIpc(logfwd_config::ArrowIpcTypeConfig {
+                    listen: "   ".to_string(),
+                }),
+            ),
+            (
+                InputType::Http,
+                InputTypeConfig::Http(logfwd_config::HttpTypeConfig {
+                    listen: "   ".to_string(),
+                    http: None,
+                }),
+            ),
+            (
+                InputType::Udp,
+                InputTypeConfig::Udp(logfwd_config::UdpTypeConfig {
+                    listen: "   ".to_string(),
+                }),
+            ),
+            (
+                InputType::Tcp,
+                InputTypeConfig::Tcp(logfwd_config::TcpTypeConfig {
+                    listen: "   ".to_string(),
+                    tls: None,
+                }),
+            ),
+        ];
+
+        for (_input_type, type_config) in type_configs {
             let cfg = InputConfig {
                 name: Some("net-in".to_string()),
-                input_type,
-                path: None,
-                listen: Some("   ".to_string()),
-                resource_prefix: None,
                 format: Some(Format::Json),
-                poll_interval_ms: None,
-                read_buf_size: None,
-                per_file_read_budget_bytes: None,
-                adaptive_fast_polls_max: None,
-                max_open_files: None,
-                glob_rescan_interval_ms: None,
-                generator: None,
-                http: None,
-                sensor: None,
                 sql: None,
-                tls: None,
-                journald: None,
+                type_config,
             };
             let stats = pm.add_input("net-in", "net");
             let err = match build_input_state("net-in", &cfg, stats) {

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -711,26 +711,15 @@ mod tests {
         let stats = pm.add_input("http-in", "http");
         let cfg = InputConfig {
             name: Some("http-in".to_string()),
-            input_type: InputType::Http,
-            path: None,
-            listen: Some("127.0.0.1:0".to_string()),
-            resource_prefix: None,
             format: Some(Format::Json),
-            poll_interval_ms: None,
-            read_buf_size: None,
-            per_file_read_budget_bytes: None,
-            adaptive_fast_polls_max: None,
-            max_open_files: None,
-            glob_rescan_interval_ms: None,
-            generator: None,
-            http: Some(logfwd_config::HttpInputConfig {
-                path: Some("   ".to_string()),
-                ..Default::default()
-            }),
-            sensor: None,
             sql: None,
-            tls: None,
-            journald: None,
+            type_config: InputTypeConfig::Http(logfwd_config::HttpTypeConfig {
+                listen: "127.0.0.1:0".to_string(),
+                http: Some(logfwd_config::HttpInputConfig {
+                    path: Some("   ".to_string()),
+                    ..Default::default()
+                }),
+            }),
         };
         let err = match build_input_state("http-in", &cfg, stats) {
             Ok(_) => panic!("empty http.path override should be rejected"),

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1417,6 +1417,7 @@ fn validate_pipeline_read_only(
             InputTypeConfig::LinuxEbpfSensor(_)
                 | InputTypeConfig::MacosEsSensor(_)
                 | InputTypeConfig::WindowsEbpfSensor(_)
+                | InputTypeConfig::ArrowIpc(_)
         ) {
             if input_cfg.format.is_some() {
                 return Err(format!(

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1288,7 +1288,7 @@ fn validate_pipeline_read_only(
     use logfwd::transform::SqlTransform;
     #[cfg(feature = "datafusion")]
     use logfwd_config::{EnrichmentConfig, GeoDatabaseFormat};
-    use logfwd_config::{Format, InputType};
+    use logfwd_config::{Format, InputTypeConfig};
     #[cfg(feature = "datafusion")]
     use std::path::PathBuf;
 
@@ -1413,8 +1413,10 @@ fn validate_pipeline_read_only(
             .clone()
             .unwrap_or_else(|| format!("input_{i}"));
         if matches!(
-            input_cfg.input_type,
-            InputType::LinuxEbpfSensor | InputType::MacosEsSensor | InputType::WindowsEbpfSensor
+            input_cfg.type_config,
+            InputTypeConfig::LinuxEbpfSensor(_)
+                | InputTypeConfig::MacosEsSensor(_)
+                | InputTypeConfig::WindowsEbpfSensor(_)
         ) {
             if input_cfg.format.is_some() {
                 return Err(format!(
@@ -1425,11 +1427,11 @@ fn validate_pipeline_read_only(
             let format = input_cfg
                 .format
                 .clone()
-                .unwrap_or(match input_cfg.input_type {
-                    InputType::File => Format::Auto,
+                .unwrap_or(match input_cfg.type_config {
+                    InputTypeConfig::File(_) => Format::Auto,
                     _ => Format::Json,
                 });
-            validate_input_format_read_only(&input_name, input_cfg.input_type.clone(), &format)?;
+            validate_input_format_read_only(&input_name, input_cfg.input_type(), &format)?;
         }
 
         let input_sql = input_cfg.sql.as_deref().unwrap_or(pipeline_sql);


### PR DESCRIPTION
## Summary

Replace the flat `InputConfig` struct (15 `Option` fields, ~660 lines of N² validation) with a wrapper + `InputTypeConfig` serde-tagged enum pattern.

Depends on #1817 (journald PR).

### What changed

- **types.rs**: `InputConfig` is now a wrapper with shared fields (`name`, `format`, `sql`) + `#[serde(flatten)] type_config: InputTypeConfig` tagged enum. Each variant holds a per-type config struct with `#[serde(deny_unknown_fields)]`.
- **validate.rs**: Deleted ~660 lines of `reject irrelevant fields` blocks. Serde handles cross-type field rejection at parse time. Remaining: semantic validation (empty strings, numeric ranges, cross-field constraints).
- **input_build.rs, build.rs, bootstrap.rs, main.rs**: Updated consumers to match on `InputTypeConfig` variants.
- **lib.rs**: Updated test assertions.

### Impact

- **-457 net lines** (7 files changed, +423, -880)
- Required fields (`path` for File, `listen` for Tcp/Udp/Otlp/Http) are now non-Optional — serde enforces presence at parse time
- Error messages improve: serde reports `unknown field 'resource_prefix', expected one of ...` listing only the current type's fields

### Test plan

- All 1344 existing tests pass
- Clippy clean, fmt clean


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace flat `InputConfig` with a tagged enum `InputTypeConfig` for per-type field validation
> - Refactors [`types.rs`](https://github.com/strawgate/memagent/pull/1827/files#diff-62e3ac9382eb657aa94241b95339050d93e352844aef7d3a16f2bf66bb681a91) to replace the flat `InputConfig` struct with a tagged serde enum `InputTypeConfig`, where each variant (e.g. `File`, `Tcp`, `Udp`, `Otlp`, `Journald`, etc.) carries only its own fields and applies `deny_unknown_fields`.
> - Validation in [`validate.rs`](https://github.com/strawgate/memagent/pull/1827/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68), pipeline building in [`build.rs`](https://github.com/strawgate/memagent/pull/1827/files#diff-9066bdb853d1e2fff1f2d2ad02a5eb7c17a2b62826ba724bbb990487b851ae83) and [`input_build.rs`](https://github.com/strawgate/memagent/pull/1827/files#diff-ca354d25bc72dec0d7f48518cd76a40d5bfab0a1f22f56449adbd8e2a81ffc4f), and bootstrap labeling in [`bootstrap.rs`](https://github.com/strawgate/memagent/pull/1827/files#diff-851a18d1d09b862e055016804787b7d10ede93b9fda47be883bab270fb223c68) are all updated to match on `InputTypeConfig` variants and read fields from the concrete inner structs.
> - Invalid fields for a given input type (e.g. `tls` on UDP, `path` on TCP) are now rejected at parse time rather than silently ignored.
> - Behavioral Change: the metrics input-type label is now derived from `InputConfig::input_type().to_string()` instead of a lowercased `Debug` string, which may change existing label values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1da7bfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->