### PR TITLE
bench: canonical dashboard data paths + publish index to data/*

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,584 @@
+name: Nightly Benchmarks
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+    inputs:
+      lines:
+        description: "Log lines per competitive benchmark"
+        default: "20000000"
+        type: string
+      iterations:
+        description: "Iterations per agent/scenario cell"
+        default: "3"
+        type: string
+      scenarios:
+        description: "Comma-separated scenarios"
+        default: "passthrough,json_parse,filter"
+        type: string
+      agents:
+        description: "Comma-separated agents (blank = all)"
+        default: ""
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  contents: write
+
+env:
+  LINES: ${{ inputs.lines || '20000000' }}
+  ITERATIONS: ${{ inputs.iterations || '3' }}
+  SCENARIOS: ${{ inputs.scenarios || 'passthrough,json_parse,filter' }}
+  AGENTS_INPUT: ${{ inputs.agents || '' }}
+
+jobs:
+  # -------------------------------------------------------------------
+  # Build logfwd (release + dhat) and bench harness — unblocks matrix
+  # -------------------------------------------------------------------
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check binary cache
+        id: bin-cache
+        uses: actions/cache@v5
+        with:
+          path: cached-binaries
+          key: bench-binaries-${{ hashFiles('Cargo.lock', 'crates/*/src/**', 'crates/*/Cargo.toml') }}
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+        if: steps.bin-cache.outputs.cache-hit != 'true'
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.bin-cache.outputs.cache-hit != 'true'
+      - uses: Swatinem/rust-cache@v2
+        if: steps.bin-cache.outputs.cache-hit != 'true'
+        with:
+          cache-on-failure: true
+
+      - name: Build release + bench harness
+        if: steps.bin-cache.outputs.cache-hit != 'true'
+        env:
+          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3"
+        run: |
+          cargo build --release -p logfwd
+          cp target/release/logfwd target/release/logfwd-clean
+          cargo build --release -p logfwd-competitive-bench
+          cargo build --release --features dhat-heap -p logfwd
+          cp target/release/logfwd target/release/logfwd-dhat
+          cp target/release/logfwd-clean target/release/logfwd
+          mkdir -p cached-binaries
+          cp target/release/logfwd cached-binaries/
+          cp target/release/logfwd-dhat cached-binaries/
+          cp target/release/logfwd-competitive-bench cached-binaries/
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-binaries
+          path: cached-binaries/
+          retention-days: 1
+
+  # -------------------------------------------------------------------
+  # PGO build + bench (fully parallel, doesn't block anything)
+  # -------------------------------------------------------------------
+  pgo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Build + benchmark PGO variant
+        run: |
+          RUSTFLAGS="-Ctarget-cpu=x86-64-v3" cargo build --release -p logfwd -p logfwd-competitive-bench
+
+          rustup component add llvm-tools
+          RUSTFLAGS="-Ctarget-cpu=x86-64-v3 -Cprofile-generate=/tmp/pgo-data" \
+            cargo build --release -p logfwd
+
+          LOGFWD=./target/release/logfwd ./target/release/logfwd-competitive-bench \
+            --lines 500000 --agents logfwd --scenarios passthrough --no-download
+
+          PROFDATA=$(find "$(rustc --print sysroot)" -name llvm-profdata -type f | head -1)
+          if [ -n "$PROFDATA" ] && "$PROFDATA" merge -output=/tmp/pgo-data/merged.profdata /tmp/pgo-data/*.profraw 2>/dev/null; then
+            RUSTFLAGS="-Ctarget-cpu=x86-64-v3 -Cprofile-use=/tmp/pgo-data/merged.profdata" \
+              cargo build --release -p logfwd
+          else
+            echo "::warning::PGO profile merge failed; using standard release build"
+          fi
+
+          LOGFWD=./target/release/logfwd ./target/release/logfwd-competitive-bench \
+            --lines ${{ env.LINES }} --agents logfwd \
+            --scenarios ${{ env.SCENARIOS }} --iterations ${{ env.ITERATIONS }} \
+            --results-file pgo-results.jsonl --no-download
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pgo-results
+          path: pgo-results.jsonl
+          retention-days: 7
+
+  # -------------------------------------------------------------------
+  # Generate matrix from inputs
+  # -------------------------------------------------------------------
+  matrix-setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - id: gen
+        run: |
+          SCENARIOS="${{ env.SCENARIOS }}"
+          SCENARIO_JSON=$(echo "$SCENARIOS" | tr ',' '\n' | jq -R . | jq -sc .)
+          AGENTS="${{ env.AGENTS_INPUT }}"
+          if [ -z "$AGENTS" ]; then
+            AGENTS="logfwd,vector,fluent-bit,filebeat,otelcol,vlagent"
+          fi
+          AGENT_JSON=$(echo "$AGENTS" | tr ',' '\n' | jq -R . | jq -sc .)
+          MATRIX=$(jq -nc --argjson s "$SCENARIO_JSON" --argjson a "$AGENT_JSON" '{scenario: $s, agent: $a}')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  # -------------------------------------------------------------------
+  # Competitive benchmarks (parallel matrix: agent x scenario)
+  # -------------------------------------------------------------------
+  bench:
+    runs-on: ubuntu-latest
+    needs: [build, matrix-setup]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix-setup.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: bench-binaries
+          path: bin
+      - run: chmod +x bin/*
+
+      - name: Run benchmark cell
+        continue-on-error: true
+        run: |
+          bin/logfwd-competitive-bench \
+            --lines ${{ env.LINES }} \
+            --iterations ${{ env.ITERATIONS }} \
+            --scenarios ${{ matrix.scenario }} \
+            --agents ${{ matrix.agent }} \
+            --mode binary \
+            --results-file results.jsonl
+        env:
+          LOGFWD: ./bin/logfwd
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: results-${{ matrix.agent }}-${{ matrix.scenario }}
+          path: results.jsonl
+          retention-days: 7
+
+  # -------------------------------------------------------------------
+  # Rate-ingest benchmark (logfwd only, measures RSS/CPU at each rate)
+  # -------------------------------------------------------------------
+  rate-bench:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
+        with:
+          name: bench-binaries
+          path: bin
+      - run: chmod +x bin/*
+
+      - name: Run rate-ingest benchmark
+        run: |
+          bin/logfwd-competitive-bench \
+            --rate-bench \
+            --json-file rate-bench-result.json \
+            --gh-bench-file rate-gh-bench.json
+        env:
+          LOGFWD: ./bin/logfwd
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: rate-bench-results
+          path: |
+            rate-bench-result.json
+            rate-gh-bench.json
+          retention-days: 7
+
+  # -------------------------------------------------------------------
+  # Criterion microbenchmarks + JSON scraping
+  # -------------------------------------------------------------------
+  micro:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Run criterion benchmarks
+        env:
+          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3"
+        run: |
+          cargo bench -p logfwd-bench 2>&1 \
+            | sed 's/\x1b\[[0-9;]*m//g' \
+            | grep -E '(^[a-z_/]+.*$|^\s+time:|^\s+thrpt:)' \
+            > micro_raw.txt || true
+          {
+            echo "### Criterion Microbenchmarks"
+            echo ""
+            echo '```'
+            cat micro_raw.txt
+            echo '```'
+          } > micro_body.md
+
+      - name: Scrape criterion JSON results
+        run: |
+          # Extract estimates from criterion's JSON output.
+          BENCH_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          export BENCH_DATE
+          BENCH_COMMIT="$(git rev-parse --short HEAD)"
+          export BENCH_COMMIT
+          python3 -c "
+          import json, os, glob
+
+          results = {}
+          for est_file in glob.glob('target/criterion/**/new/estimates.json', recursive=True):
+              parts = est_file.split('/criterion/')[1].split('/new/')[0]
+              bench_name = parts.replace('/', '/')
+              with open(est_file) as f:
+                  data = json.load(f)
+              mean_ns = data.get('mean', {}).get('point_estimate', 0)
+              results[bench_name] = {'mean_ns': mean_ns}
+
+          # Also grab throughput if available.
+          for thr_file in glob.glob('target/criterion/**/new/benchmark.json', recursive=True):
+              parts = thr_file.split('/criterion/')[1].split('/new/')[0]
+              bench_name = parts.replace('/', '/')
+              with open(thr_file) as f:
+                  data = json.load(f)
+              tp = data.get('throughput')
+              if tp and bench_name in results:
+                  results[bench_name]['throughput'] = tp
+
+          output = {
+              'id': os.environ.get('GITHUB_RUN_ID', 'local'),
+              'date': os.environ.get('BENCH_DATE', ''),
+              'commit': os.environ.get('BENCH_COMMIT', ''),
+              'benchmarks': results
+          }
+          with open('criterion-data.json', 'w') as f:
+              json.dump(output, f, indent=2)
+          print(f'Scraped {len(results)} criterion benchmarks')
+          "
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: micro-results
+          path: |
+            micro_body.md
+            criterion-data.json
+          retention-days: 7
+
+  # -------------------------------------------------------------------
+  # CPU/memory profiling (logfwd only)
+  # -------------------------------------------------------------------
+  profile:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install profiling tools
+        run: |
+          cargo install inferno 2>/dev/null || true
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq "linux-tools-$(uname -r)" linux-tools-generic 2>/dev/null || true
+      - uses: actions/download-artifact@v8
+        with:
+          name: bench-binaries
+          path: bin
+      - run: chmod +x bin/*
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Build logfwd with profiling
+        env:
+          RUSTFLAGS: "-Ctarget-cpu=x86-64-v3"
+        run: |
+          cargo build --release --features cpu-profiling -p logfwd
+          cp target/release/logfwd bin/logfwd-prof
+
+      - name: Run profiling pass
+        run: |
+          bin/logfwd-competitive-bench \
+            --lines ${{ env.LINES }} \
+            --agents logfwd \
+            --scenarios passthrough \
+            --mode binary \
+            --profile ./profiles \
+            --dhat-binary ./bin/logfwd-dhat
+        env:
+          LOGFWD: ./bin/logfwd-prof
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: logfwd-profiles
+          path: profiles/
+          retention-days: 30
+
+  # -------------------------------------------------------------------
+  # Summarize + deploy dashboard
+  # -------------------------------------------------------------------
+  summarize:
+    runs-on: ubuntu-latest
+    needs: [build, bench, rate-bench, micro, pgo]
+    if: always() && needs.build.result == 'success' && needs.bench.result != 'cancelled'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: results-*
+          path: all-results
+          merge-multiple: false
+      - uses: actions/download-artifact@v8
+        with:
+          name: bench-binaries
+          path: bin
+      - uses: actions/download-artifact@v8
+        with:
+          name: rate-bench-results
+          path: rate-results
+        continue-on-error: true
+      - uses: actions/download-artifact@v8
+        with:
+          name: micro-results
+          path: micro
+        continue-on-error: true
+      - uses: actions/download-artifact@v8
+        with:
+          name: pgo-results
+          path: all-results/pgo
+        continue-on-error: true
+
+      - run: chmod +x bin/*
+
+      # Summarize competitive results (includes PGO if available).
+      - name: Summarize competitive results
+        run: |
+          bin/logfwd-competitive-bench summarize \
+            --results-dir all-results \
+            --markdown \
+            --gh-bench-file gh-bench.json \
+            --dashboard-file dashboard-data.json \
+            > competitive_body.md
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SHA: ${{ github.sha }}
+
+      # Commit bench data to the bench-data branch so the dashboard can fetch
+      # it live via raw.githubusercontent.com — no Pages redeploy needed.
+      - name: Commit results to bench-data branch
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
+        run: |
+          git fetch origin bench-data || {
+            echo "::warning::bench-data branch not found; skipping data commit"
+            exit 0
+          }
+          git worktree add /tmp/bench-data origin/bench-data -b bench-data-push
+
+          cd /tmp/bench-data
+          mkdir -p data/runs data/rate-runs data/criterion-runs
+
+          # Copy run data files to canonical data/* paths.
+          [ -f "$GITHUB_WORKSPACE/dashboard-data.json" ] && \
+            cp "$GITHUB_WORKSPACE/dashboard-data.json" "data/runs/${RUN_ID}.json"
+          [ -f "$GITHUB_WORKSPACE/rate-results/rate-bench-result.json" ] && \
+            cp "$GITHUB_WORKSPACE/rate-results/rate-bench-result.json" "data/rate-runs/${RUN_ID}.json"
+          [ -f "$GITHUB_WORKSPACE/micro/criterion-data.json" ] && \
+            cp "$GITHUB_WORKSPACE/micro/criterion-data.json" "data/criterion-runs/${RUN_ID}.json"
+
+          # Update canonical data/index.json.
+          python3 - <<'PYEOF'
+          import json, os
+
+          index_path = "data/index.json"
+          run_id = os.environ["RUN_ID"]
+
+          def load_json(path):
+              try:
+                  with open(path) as f:
+                      return json.load(f)
+              except (FileNotFoundError, json.JSONDecodeError):
+                  return None
+
+          index = load_json(index_path)
+          if not isinstance(index, dict):
+              index = {"runs": [], "rate_runs": [], "criterion_runs": []}
+
+          # Ensure all three lists exist.
+          for key in ("runs", "rate_runs", "criterion_runs"):
+              index.setdefault(key, [])
+
+          # Normalize runs entries to object form expected by o11ykit index shape.
+          normalized_runs = []
+          for entry in index["runs"]:
+              if isinstance(entry, dict):
+                  rid = str(entry.get("id", "")).strip()
+                  if not rid:
+                      continue
+                  obj = dict(entry)
+                  obj.setdefault("id", rid)
+                  if "timestamp" not in obj and obj.get("date"):
+                      obj["timestamp"] = obj.get("date")
+                  normalized_runs.append(obj)
+              else:
+                  rid = str(entry).strip()
+                  if rid:
+                      normalized_runs.append({"id": rid})
+          index["runs"] = normalized_runs
+
+          workspace = os.environ.get("GITHUB_WORKSPACE", "")
+
+          # Add competitive run entry from index-entry file.
+          entry_path = f"{workspace}/dashboard-index-entry.json"
+          if os.path.exists(entry_path):
+              with open(entry_path) as f:
+                  entry = json.load(f)
+              entry_id = str(entry.get("id", "")).strip()
+              if entry_id:
+                  run_entry = {
+                      "id": entry_id,
+                      "timestamp": entry.get("date"),
+                      "commit": entry.get("commit"),
+                      "ref": "refs/heads/main",
+                  }
+                  run_entry = {k: v for k, v in run_entry.items() if v not in (None, "")}
+                  index["runs"] = [r for r in index["runs"] if r.get("id") != entry_id]
+                  index["runs"].insert(0, run_entry)
+                  index["runs"] = index["runs"][:90]
+
+          # Record rate-run id.
+          if os.path.exists(f"data/rate-runs/{run_id}.json"):
+              if run_id not in index["rate_runs"]:
+                  index["rate_runs"].append(run_id)
+              index["rate_runs"] = index["rate_runs"][-90:]
+
+          # Record criterion-run id.
+          if os.path.exists(f"data/criterion-runs/{run_id}.json"):
+              if run_id not in index["criterion_runs"]:
+                  index["criterion_runs"].append(run_id)
+              index["criterion_runs"] = index["criterion_runs"][-90:]
+
+          # Convenience field used by dashboard consumers.
+          index["competitive_runs"] = [r.get("id") for r in index["runs"] if isinstance(r, dict) and r.get("id")]
+
+          os.makedirs("data", exist_ok=True)
+          with open(index_path, "w") as f:
+              json.dump(index, f, indent=2)
+
+          print(f"Index updated: {len(index['runs'])} competitive, "
+                f"{len(index['rate_runs'])} rate, {len(index['criterion_runs'])} criterion runs")
+          PYEOF
+
+          git add -A
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          COMMIT=$(git -C "$GITHUB_WORKSPACE" rev-parse --short HEAD)
+          git commit -m "bench: add run ${RUN_ID} (${COMMIT})"
+          git push origin HEAD:bench-data
+
+      # Note: docs.yml performs the only Pages deployment so docs + dashboard
+      # remain available under the same published site.
+      # Upload summary for retention.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bench-summary-${{ github.run_number }}
+          path: |
+            competitive_body.md
+            gh-bench.json
+            dashboard-data.json
+          retention-days: 90
+
+      # Post results as GitHub issue.
+      - name: Post issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Ensure benchmark label exists (gh issue create --label fails otherwise).
+          gh label create benchmark --description "Nightly benchmark reports" --color "1D76DB" 2>/dev/null || true
+
+          DATE=$(date -u +%Y-%m-%d)
+          COMMIT=$(git rev-parse --short HEAD)
+
+          MICRO=""
+          if [ -f micro/micro_body.md ]; then
+            MICRO="---
+
+          $(cat micro/micro_body.md)"
+          fi
+
+          RATE=""
+          if [ -f rate-results/rate-bench-result.json ]; then
+            RATE="---
+
+          ### Rate-Ingest Benchmark
+          See [development dashboard](https://strawgate.github.io/memagent/bench/development.html) for full results."
+          fi
+
+          TITLE="Benchmark results ${DATE} (${COMMIT})"
+          BODY="$(cat <<HEREDOC
+          ## Benchmark Results --- ${DATE}
+
+          **Commit:** \`${COMMIT}\` on \`main\`
+          **Runner:** \`ubuntu-latest\` (matrix: agent x scenario)
+          **Iterations:** ${{ env.ITERATIONS }} per cell
+          **Dashboard:** https://strawgate.github.io/memagent/bench/
+
+          ---
+
+          $(cat competitive_body.md)
+
+          ${MICRO}
+
+          ${RATE}
+
+          ---
+
+          CPU flamegraph and dhat-heap profile uploaded as workflow artifacts.
+
+          <sub>Generated by [nightly bench workflow](.github/workflows/bench.yml)</sub>
+          HEREDOC
+          )"
+
+          gh issue list --label benchmark --state open --json number -q '.[].number' | while read -r num; do
+            gh issue close "$num" --comment "Superseded by new benchmark run." 2>/dev/null || true
+          done
+
+          gh issue create \
+            --title "$TITLE" \
+            --body "$BODY" \
+            --label benchmark

--- a/bench/dashboard/competitive.html
+++ b/bench/dashboard/competitive.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#10243a">
   <title>Competitive Analysis - Benchmark Dashboard</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
@@ -13,7 +14,11 @@
     <a href="index.html">Dashboard</a><span class="sep">/</span>Competitive
   </div>
 
-  <h1>Competitive Analysis</h1>
+  <header class="hero">
+    <p class="eyebrow">competitive lane</p>
+    <h1>Competitive Analysis</h1>
+    <p class="lede">Compare collector throughput by scenario, inspect trend movement over recent runs, and spot stability gaps quickly.</p>
+  </header>
 
   <nav class="nav-pills">
     <a href="index.html">Overview</a>
@@ -23,6 +28,8 @@
 
   <div id="loading" class="loading">Loading competitive data...</div>
   <div id="content" style="display:none">
+    <div class="tracking-cards" id="competitive-kpis"></div>
+
     <div id="charts-section" class="section">
       <h2>Per-Scenario Throughput</h2>
       <div class="chart-grid" id="scenario-charts"></div>
@@ -35,7 +42,7 @@
 
     <div id="table-section" class="section">
       <h2>Full Results</h2>
-      <div class="card">
+      <div class="card table-card">
         <table id="results-table">
           <thead id="results-thead"></thead>
           <tbody id="results-tbody"></tbody>
@@ -45,7 +52,9 @@
   </div>
 </div>
 
-<script>
+<script type="module">
+import { fetchBenchIndex, fetchBenchRun, toTrendDataset, shortId } from "./o11y-client.js";
+
 const SCENARIO_NAMES = {
   'passthrough': { title: 'Passthrough (No Transforms)', config: 'transform: "SELECT * FROM logs"' },
   'json_parse': { title: 'JSON Parsing & Extraction', config: 'transform: "SELECT timestamp_str, level_str, message_str, duration_ms_int AS latency_ms, request_id_str, service_str FROM logs"' },
@@ -78,6 +87,16 @@ function formatBytes(b) {
   return b + 'B';
 }
 
+function averageLps(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  if (Number.isFinite(entry.avg_lps)) return Math.max(0, entry.avg_lps);
+  if (Array.isArray(entry.lps)) {
+    const values = entry.lps.filter((v) => Number.isFinite(v));
+    if (values.length > 0) return values.reduce((sum, v) => sum + v, 0) / values.length;
+  }
+  return null;
+}
+
 function isDark() { return window.matchMedia('(prefers-color-scheme: dark)').matches; }
 
 function chartColors() {
@@ -86,21 +105,14 @@ function chartColors() {
   Chart.defaults.borderColor = dark ? '#30363d' : '#d0d7de';
 }
 
-const DATA_BASE = 'https://raw.githubusercontent.com/strawgate/memagent/bench-data';
-
 function runId(entry) {
   if (entry && typeof entry === 'object') return entry.id;
   return entry;
 }
 
-async function loadJSON(url) {
-  try { const r = await fetch(url); if (!r.ok) return null; return await r.json(); }
-  catch { return null; }
-}
-
 async function main() {
   chartColors();
-  const index = await loadJSON(DATA_BASE + '/index.json');
+  const index = await fetchBenchIndex();
   if (!index) {
     document.getElementById('loading').textContent = 'No data/index.json found.';
     return;
@@ -114,7 +126,7 @@ async function main() {
     return;
   }
 
-  const allRuns = (await Promise.all(runIds.map(id => loadJSON(DATA_BASE + '/runs/' + id + '.json')))).filter(Boolean);
+  const allRuns = (await Promise.all(runIds.map(id => fetchBenchRun(id)))).filter(Boolean);
   if (allRuns.length === 0) {
     document.getElementById('loading').textContent = 'Could not load any run data.';
     return;
@@ -126,6 +138,34 @@ async function main() {
   const latestRun = allRuns[allRuns.length - 1];
   const scenarios = latestRun.scenario_names || Object.keys(latestRun.scenarios || {});
   const agents = latestRun.agents || [];
+  const kpisEl = document.getElementById('competitive-kpis');
+
+  let fastest = null;
+  for (const sn of scenarios) {
+      const sc = latestRun.scenarios?.[sn];
+      if (!sc) continue;
+      for (const agent of agents) {
+      const lps = averageLps(sc[agent]) || 0;
+      if (!fastest || lps > fastest.lps) fastest = { agent, scenario: sn, lps };
+      }
+  }
+  kpisEl.innerHTML = `
+    <div class="tracking-card">
+      <span class="label">Latest Run</span>
+      <span class="value">#${latestRun.id || '--'}</span>
+      <span class="subtitle">${allRuns.length} runs in trend window</span>
+    </div>
+    <div class="tracking-card">
+      <span class="label">Fastest Collector</span>
+      <span class="value">${fastest ? formatLPS(fastest.lps) : '--'}</span>
+      <span class="subtitle">${fastest ? fastest.agent + ' · ' + getScenarioTitle(fastest.scenario) : 'no throughput data'}</span>
+    </div>
+    <div class="tracking-card">
+      <span class="label">Coverage</span>
+      <span class="value">${scenarios.length} × ${agents.length}</span>
+      <span class="subtitle">scenarios × collectors in latest run</span>
+    </div>
+  `;
 
   // Per-scenario horizontal bar charts (latest run)
   const chartsEl = document.getElementById('scenario-charts');
@@ -144,7 +184,7 @@ async function main() {
     for (const agent of agents) {
       if (!sc[agent]) continue;
       labels.push(agent);
-      data.push(sc[agent].avg_lps);
+      data.push(averageLps(sc[agent]) || 0);
       colors.push(AGENT_COLORS[agent] || '#64748b');
     }
 
@@ -169,7 +209,7 @@ async function main() {
     });
   }
 
-  // Throughput trend sparklines per scenario/agent
+  // Throughput trends per scenario/agent (o11ykit adapter-backed)
   const trendsEl = document.getElementById('trend-charts');
   for (const sn of scenarios) {
     const cardDiv = document.createElement('div');
@@ -177,18 +217,42 @@ async function main() {
     cardDiv.innerHTML = `<h3>${getScenarioTitle(sn)} Trend</h3><canvas id="trend-${sn}" height="200"></canvas>`;
     trendsEl.appendChild(cardDiv);
 
-    const labels = allRuns.map(r => r.id || '');
+    const labels = allRuns.map((r) => shortId(r.id || ""));
     const datasets = [];
     for (const agent of agents) {
-      const data = allRuns.map(r => r.scenarios?.[sn]?.[agent]?.avg_lps || null);
-      if (data.every(d => d === null)) continue;
+      const points = allRuns.map((r, idx) => ({
+        timestamp: r.date || new Date(Date.UTC(2020, 0, 1, 0, 0, idx)).toISOString(),
+        value: averageLps(r.scenarios?.[sn]?.[agent]),
+      }));
+      if (points.every((p) => p.value == null)) continue;
+
+      const adapted = toTrendDataset(agent, points, {
+        color: AGENT_COLORS[agent] || '#64748b',
+        direction: 'bigger_is_better',
+        threshold: 8,
+        window: 3,
+      });
+
+      const compactColors = Array.isArray(adapted.dataset.pointBackgroundColor)
+        ? adapted.dataset.pointBackgroundColor
+        : [];
+      let colorIdx = 0;
+      const pointColors = points.map((p) => {
+        if (p.value == null) return 'transparent';
+        const next = compactColors[colorIdx];
+        colorIdx += 1;
+        return next || (AGENT_COLORS[agent] || '#64748b');
+      });
+
       datasets.push({
         label: agent,
-        data,
+        data: points.map((p) => p.value),
         borderColor: AGENT_COLORS[agent] || '#64748b',
         backgroundColor: 'transparent',
         borderWidth: 2,
-        pointRadius: 2,
+        pointRadius: 2.5,
+        pointBackgroundColor: pointColors,
+        pointBorderColor: pointColors,
         tension: 0.3,
         spanGaps: true
       });
@@ -203,7 +267,10 @@ async function main() {
           tooltip: { callbacks: { label: ctx => ctx.dataset.label + ': ' + formatLPS(ctx.raw) } }
         },
         scales: {
-          x: { ticks: { maxTicksLimit: 10 }, grid: { color: isDark() ? '#30363d' : '#e5e7eb' } },
+          x: {
+            ticks: { maxTicksLimit: 7, maxRotation: 0, minRotation: 0 },
+            grid: { color: isDark() ? '#30363d' : '#e5e7eb' }
+          },
           y: { ticks: { callback: v => formatLPS(v) }, grid: { color: isDark() ? '#30363d' : '#e5e7eb' } }
         }
       }
@@ -233,7 +300,8 @@ async function main() {
       // Find winner
       let bestAgent = null, bestLps = 0;
       for (const a of agents) {
-        if (sc[a]?.avg_lps > bestLps) { bestLps = sc[a].avg_lps; bestAgent = a; }
+        const lps = averageLps(sc[a]) || 0;
+        if (lps > bestLps) { bestLps = lps; bestAgent = a; }
       }
 
       let row = `<td><a href="run.html?id=${run.id}">#${run.id}</a></td><td>${getScenarioTitle(sn)}</td>`;

--- a/bench/dashboard/development.html
+++ b/bench/dashboard/development.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#10243a">
   <title>Development Metrics - Benchmark Dashboard</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
@@ -13,7 +14,11 @@
     <a href="index.html">Dashboard</a><span class="sep">/</span>Development
   </div>
 
-  <h1>Development Metrics</h1>
+  <header class="hero">
+    <p class="eyebrow">development lane</p>
+    <h1>Development Metrics</h1>
+    <p class="lede">Watch resource curves and criterion drift so we can defend scanner and pipeline performance with real trend evidence.</p>
+  </header>
 
   <nav class="nav-pills">
     <a href="index.html">Overview</a>
@@ -23,16 +28,17 @@
 
   <div id="loading" class="loading">Loading development data...</div>
   <div id="content" style="display:none">
+    <div class="tracking-cards" id="development-kpis"></div>
 
     <!-- Rate Ingest Section -->
     <div id="rate-section" class="section" style="display:none">
       <h2>Rate Ingest: Resource Usage vs EPS</h2>
       <div class="chart-grid">
-        <div class="card">
+        <div class="card" id="rate-rss-card">
           <h3>RSS vs EPS Rate</h3>
           <canvas id="chart-rss"></canvas>
         </div>
-        <div class="card">
+        <div class="card" id="rate-cpu-card">
           <h3>CPU % vs EPS Rate</h3>
           <canvas id="chart-cpu"></canvas>
         </div>
@@ -40,11 +46,11 @@
       <div id="rate-trend-section" style="display:none">
         <h3>Rate Trends Over Time</h3>
         <div class="chart-grid">
-          <div class="card">
+          <div class="card" id="rate-rss-trend-card">
             <h3>RSS at 100K eps Over Time</h3>
             <canvas id="chart-rss-trend"></canvas>
           </div>
-          <div class="card">
+          <div class="card" id="rate-cpu-trend-card">
             <h3>CPU at 100K eps Over Time</h3>
             <canvas id="chart-cpu-trend"></canvas>
           </div>
@@ -55,7 +61,7 @@
     <!-- Criterion Section -->
     <div id="criterion-section" class="section" style="display:none">
       <h2>Criterion Benchmarks</h2>
-      <div class="card">
+      <div class="card table-card">
         <table id="criterion-table">
           <thead>
             <tr>
@@ -72,7 +78,9 @@
   </div>
 </div>
 
-<script>
+<script type="module">
+import { fetchBenchIndex, fetchBenchJson } from "./o11y-client.js";
+
 function formatNs(ns) {
   if (ns >= 1e9) return (ns / 1e9).toFixed(2) + 's';
   if (ns >= 1e6) return (ns / 1e6).toFixed(2) + 'ms';
@@ -107,21 +115,50 @@ function drawSparkline(canvas, data, color) {
   });
 }
 
-const DATA_BASE = 'https://raw.githubusercontent.com/strawgate/memagent/bench-data';
+function normalizeRateMap(rateRun) {
+  if (!rateRun || typeof rateRun !== 'object') return {};
+  if (rateRun.rates && typeof rateRun.rates === 'object') return rateRun.rates;
+  const out = {};
+  if (Array.isArray(rateRun.results)) {
+    for (const row of rateRun.results) {
+      const eps = Number(row?.eps);
+      if (!Number.isFinite(eps)) continue;
+      out[String(Math.trunc(eps))] = {
+        rss_mb: Number.isFinite(row?.rss_mb) ? row.rss_mb : (Number.isFinite(row?.rss_kb) ? row.rss_kb / 1024 : null),
+        cpu_pct: Number.isFinite(row?.cpu_pct) ? row.cpu_pct : (Number.isFinite(row?.cpu_percent) ? row.cpu_percent : null),
+        actual_eps: Number.isFinite(row?.actual_eps) ? row.actual_eps : null,
+      };
+    }
+  }
+  return out;
+}
+
+function formatCriterionThroughput(entry) {
+  if (!entry || typeof entry !== 'object') return '--';
+  if (Number.isFinite(entry.thrpt_mib_s)) return entry.thrpt_mib_s.toFixed(1) + ' MiB/s';
+  if (Number.isFinite(entry.thrpt_melem_s)) return entry.thrpt_melem_s.toFixed(1) + ' Melem/s';
+  const meanNs = Number(entry.mean_ns);
+  const bytes = Number(entry.throughput?.Bytes);
+  const elems = Number(entry.throughput?.Elements);
+  if (Number.isFinite(meanNs) && meanNs > 0 && Number.isFinite(bytes)) {
+    const mibPerSec = (bytes / (meanNs / 1e9)) / (1024 * 1024);
+    return mibPerSec.toFixed(1) + ' MiB/s';
+  }
+  if (Number.isFinite(meanNs) && meanNs > 0 && Number.isFinite(elems)) {
+    const melemPerSec = (elems / (meanNs / 1e9)) / 1e6;
+    return melemPerSec.toFixed(1) + ' Melem/s';
+  }
+  return '--';
+}
 
 function runId(entry) {
   if (entry && typeof entry === 'object') return entry.id;
   return entry;
 }
 
-async function loadJSON(url) {
-  try { const r = await fetch(url); if (!r.ok) return null; return await r.json(); }
-  catch { return null; }
-}
-
 async function main() {
   chartColors();
-  const index = await loadJSON(DATA_BASE + '/index.json');
+  const index = await fetchBenchIndex();
   if (!index) {
     document.getElementById('loading').textContent = 'No data found.';
     return;
@@ -130,8 +167,8 @@ async function main() {
   const rateRunIds = (index.rate_runs || []).map(runId).filter(Boolean).map(String);
   const criterionRunIds = (index.criterion_runs || []).map(runId).filter(Boolean).map(String);
 
-  const rateRuns = (await Promise.all(rateRunIds.map(id => loadJSON(DATA_BASE + '/rate-runs/' + id + '.json')))).filter(Boolean);
-  const criterionRuns = (await Promise.all(criterionRunIds.map(id => loadJSON(DATA_BASE + '/criterion-runs/' + id + '.json')))).filter(Boolean);
+  const rateRuns = (await Promise.all(rateRunIds.map(id => fetchBenchJson('rate-runs/' + id + '.json')))).filter(Boolean);
+  const criterionRuns = (await Promise.all(criterionRunIds.map(id => fetchBenchJson('criterion-runs/' + id + '.json')))).filter(Boolean);
 
   if (rateRuns.length === 0 && criterionRuns.length === 0) {
     document.getElementById('loading').textContent = 'No development data available.';
@@ -140,103 +177,167 @@ async function main() {
 
   document.getElementById('loading').style.display = 'none';
   document.getElementById('content').style.display = '';
+  const kpisEl = document.getElementById('development-kpis');
+  const latestRate = rateRuns.length ? rateRuns[rateRuns.length - 1] : null;
+  const latestCriterion = criterionRuns.length ? criterionRuns[criterionRuns.length - 1] : null;
+  const latestRateLabel = latestRate?.id || (rateRunIds.length ? rateRunIds[rateRunIds.length - 1] : null);
+  const latestRateMap = normalizeRateMap(latestRate);
+  const rss100k = latestRateMap["100000"]?.rss_mb;
+  const cpu100k = latestRateMap["100000"]?.cpu_pct;
+  const criterionCount = latestCriterion ? Object.keys(latestCriterion.benchmarks || {}).length : 0;
+  const ratePointCount = latestRate ? Object.keys(latestRateMap).filter(k => Number.isFinite(Number(k))).length : 0;
+  kpisEl.innerHTML = `
+    <div class="tracking-card">
+      <span class="label">Latest Rate Run</span>
+      <span class="value">${latestRateLabel ? '#' + latestRateLabel : '--'}</span>
+      <span class="subtitle">${ratePointCount} EPS steps captured</span>
+    </div>
+    <div class="tracking-card">
+      <span class="label">100K EPS Snapshot</span>
+      <span class="value">${rss100k != null ? rss100k.toFixed(1) + ' MB' : '--'}</span>
+      <span class="subtitle">${cpu100k != null ? cpu100k.toFixed(1) + '% CPU' : 'CPU unavailable at 100K'}</span>
+    </div>
+    <div class="tracking-card">
+      <span class="label">Criterion Benchmarks</span>
+      <span class="value">${criterionCount || '--'}</span>
+      <span class="subtitle">${criterionRuns.length} historical runs</span>
+    </div>
+  `;
 
   // Rate Ingest Charts
   if (rateRuns.length > 0) {
-    document.getElementById('rate-section').style.display = '';
     const latest = rateRuns[rateRuns.length - 1];
-    const rates = latest.rates || {};
-    const sortedRates = Object.keys(rates).map(Number).sort((a, b) => a - b);
-    const labels = sortedRates.map(r => r >= 1000 ? (r / 1000) + 'K' : r.toString());
+    const rates = normalizeRateMap(latest);
+    const sortedRates = Object.keys(rates).map(Number).filter(Number.isFinite).sort((a, b) => a - b);
+    const labels = sortedRates.map(r => r === 0 ? 'max' : (r >= 1000 ? (r / 1000) + 'K' : r.toString()));
+    const rssSeries = sortedRates.map(r => {
+      const value = rates[r]?.rss_mb;
+      return typeof value === 'number' ? value : null;
+    });
+    const cpuSeries = sortedRates.map(r => {
+      const value = rates[r]?.cpu_pct;
+      return typeof value === 'number' ? value : null;
+    });
+    const hasRssSeries = rssSeries.some(v => v != null);
+    const hasCpuSeries = cpuSeries.some(v => v != null);
+    const hasRateSeries = sortedRates.length > 0 && (hasRssSeries || hasCpuSeries);
 
-    // RSS chart
-    new Chart(document.getElementById('chart-rss'), {
-      type: 'line',
-      data: {
-        labels,
-        datasets: [{
-          label: 'RSS (MB)',
-          data: sortedRates.map(r => rates[r]?.rss_mb),
-          borderColor: '#2563eb',
-          backgroundColor: 'rgba(37, 99, 235, 0.1)',
-          fill: true,
-          borderWidth: 2,
-          pointRadius: 4,
-          tension: 0.3
-        }]
-      },
-      options: {
-        responsive: true,
-        plugins: { tooltip: { callbacks: { label: ctx => ctx.raw?.toFixed(1) + ' MB' } } },
-        scales: {
-          x: { title: { display: true, text: 'Events/sec' }, grid: { color: gridColor() } },
-          y: { title: { display: true, text: 'RSS (MB)' }, grid: { color: gridColor() } }
+    if (hasRateSeries) {
+      document.getElementById('rate-section').style.display = '';
+
+      if (hasRssSeries) {
+        new Chart(document.getElementById('chart-rss'), {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [{
+              label: 'RSS (MB)',
+              data: rssSeries,
+              borderColor: '#2563eb',
+              backgroundColor: 'rgba(37, 99, 235, 0.1)',
+              fill: true,
+              borderWidth: 2,
+              pointRadius: 4,
+              tension: 0.3
+            }]
+          },
+          options: {
+            responsive: true,
+            plugins: { tooltip: { callbacks: { label: ctx => ctx.raw?.toFixed(1) + ' MB' } } },
+            scales: {
+              x: { title: { display: true, text: 'Events/sec' }, grid: { color: gridColor() } },
+              y: { title: { display: true, text: 'RSS (MB)' }, grid: { color: gridColor() } }
+            }
+          }
+        });
+      } else {
+        document.getElementById('chart-rss').style.display = 'none';
+        document.getElementById('rate-rss-card').insertAdjacentHTML('beforeend', '<p class="info-note">RSS data is not present in this rate run.</p>');
+      }
+
+      if (hasCpuSeries) {
+        new Chart(document.getElementById('chart-cpu'), {
+          type: 'line',
+          data: {
+            labels,
+            datasets: [{
+              label: 'CPU %',
+              data: cpuSeries,
+              borderColor: '#d97706',
+              backgroundColor: 'rgba(217, 119, 6, 0.1)',
+              fill: true,
+              borderWidth: 2,
+              pointRadius: 4,
+              tension: 0.3
+            }]
+          },
+          options: {
+            responsive: true,
+            plugins: { tooltip: { callbacks: { label: ctx => ctx.raw?.toFixed(1) + '%' } } },
+            scales: {
+              x: { title: { display: true, text: 'Events/sec' }, grid: { color: gridColor() } },
+              y: { title: { display: true, text: 'CPU %' }, grid: { color: gridColor() } }
+            }
+          }
+        });
+      } else {
+        document.getElementById('chart-cpu').style.display = 'none';
+        document.getElementById('rate-cpu-card').insertAdjacentHTML('beforeend', '<p class="info-note">CPU data is not present in this rate run.</p>');
+      }
+
+      if (rateRuns.length > 1) {
+        const trendLabels = rateRuns.map(r => r.id || '');
+        const rss100kTrend = rateRuns.map(r => normalizeRateMap(r)["100000"]?.rss_mb ?? null);
+        const cpu100kTrend = rateRuns.map(r => normalizeRateMap(r)["100000"]?.cpu_pct ?? null);
+        const hasRssTrend = rss100kTrend.some(v => v != null);
+        const hasCpuTrend = cpu100kTrend.some(v => v != null);
+
+        if (hasRssTrend || hasCpuTrend) {
+          document.getElementById('rate-trend-section').style.display = '';
+        }
+
+        if (hasRssTrend) {
+          new Chart(document.getElementById('chart-rss-trend'), {
+            type: 'line',
+            data: {
+              labels: trendLabels,
+              datasets: [{ label: 'RSS at 100K', data: rss100kTrend, borderColor: '#2563eb', borderWidth: 2, pointRadius: 3, tension: 0.3, spanGaps: true }]
+            },
+            options: {
+              responsive: true,
+              scales: {
+                x: { grid: { color: gridColor() } },
+                y: { title: { display: true, text: 'MB' }, grid: { color: gridColor() } }
+              }
+            }
+          });
+        } else {
+          document.getElementById('chart-rss-trend').style.display = 'none';
+          document.getElementById('rate-rss-trend-card').insertAdjacentHTML('beforeend', '<p class="info-note">No RSS 100K trend points yet.</p>');
+        }
+
+        if (hasCpuTrend) {
+          new Chart(document.getElementById('chart-cpu-trend'), {
+            type: 'line',
+            data: {
+              labels: trendLabels,
+              datasets: [{ label: 'CPU at 100K', data: cpu100kTrend, borderColor: '#d97706', borderWidth: 2, pointRadius: 3, tension: 0.3, spanGaps: true }]
+            },
+            options: {
+              responsive: true,
+              scales: {
+                x: { grid: { color: gridColor() } },
+                y: { title: { display: true, text: 'CPU %' }, grid: { color: gridColor() } }
+              }
+            }
+          });
+        } else {
+          document.getElementById('chart-cpu-trend').style.display = 'none';
+          document.getElementById('rate-cpu-trend-card').insertAdjacentHTML('beforeend', '<p class="info-note">No CPU 100K trend points yet.</p>');
         }
       }
-    });
-
-    // CPU chart
-    new Chart(document.getElementById('chart-cpu'), {
-      type: 'line',
-      data: {
-        labels,
-        datasets: [{
-          label: 'CPU %',
-          data: sortedRates.map(r => rates[r]?.cpu_pct),
-          borderColor: '#d97706',
-          backgroundColor: 'rgba(217, 119, 6, 0.1)',
-          fill: true,
-          borderWidth: 2,
-          pointRadius: 4,
-          tension: 0.3
-        }]
-      },
-      options: {
-        responsive: true,
-        plugins: { tooltip: { callbacks: { label: ctx => ctx.raw?.toFixed(1) + '%' } } },
-        scales: {
-          x: { title: { display: true, text: 'Events/sec' }, grid: { color: gridColor() } },
-          y: { title: { display: true, text: 'CPU %' }, grid: { color: gridColor() } }
-        }
-      }
-    });
-
-    // Trends over time at 100K eps
-    if (rateRuns.length > 1) {
-      document.getElementById('rate-trend-section').style.display = '';
-      const trendLabels = rateRuns.map(r => r.id || '');
-      const rss100k = rateRuns.map(r => r.rates?.["100000"]?.rss_mb ?? null);
-      const cpu100k = rateRuns.map(r => r.rates?.["100000"]?.cpu_pct ?? null);
-
-      new Chart(document.getElementById('chart-rss-trend'), {
-        type: 'line',
-        data: {
-          labels: trendLabels,
-          datasets: [{ label: 'RSS at 100K', data: rss100k, borderColor: '#2563eb', borderWidth: 2, pointRadius: 3, tension: 0.3, spanGaps: true }]
-        },
-        options: {
-          responsive: true,
-          scales: {
-            x: { grid: { color: gridColor() } },
-            y: { title: { display: true, text: 'MB' }, grid: { color: gridColor() } }
-          }
-        }
-      });
-
-      new Chart(document.getElementById('chart-cpu-trend'), {
-        type: 'line',
-        data: {
-          labels: trendLabels,
-          datasets: [{ label: 'CPU at 100K', data: cpu100k, borderColor: '#d97706', borderWidth: 2, pointRadius: 3, tension: 0.3, spanGaps: true }]
-        },
-        options: {
-          responsive: true,
-          scales: {
-            x: { grid: { color: gridColor() } },
-            y: { title: { display: true, text: 'CPU %' }, grid: { color: gridColor() } }
-          }
-        }
-      });
+    } else {
+      document.getElementById('rate-section').style.display = 'none';
     }
   }
 
@@ -255,8 +356,7 @@ async function main() {
     let rowsHtml = '';
     for (const name of Object.keys(benchmarks)) {
       const b = benchmarks[name];
-      const thrpt = b.thrpt_mib_s ? b.thrpt_mib_s.toFixed(1) + ' MiB/s'
-                  : b.thrpt_melem_s ? b.thrpt_melem_s.toFixed(1) + ' Melem/s' : '--';
+      const thrpt = formatCriterionThroughput(b);
 
       const sparkId = 'crit-spark-' + sparkIdx++;
       rowsHtml += `<tr>

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -3,13 +3,18 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#10243a">
   <title>Benchmark Dashboard</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
 </head>
 <body>
 <div class="container">
-  <h1>Benchmark Dashboard</h1>
+  <header class="hero">
+    <p class="eyebrow">memagent benchmark suite</p>
+    <h1>Benchmark Control Room</h1>
+    <p class="lede">Track competitive throughput, development resource curves, and run-level details from nightly data in one view.</p>
+  </header>
 
   <nav class="nav-pills">
     <a href="index.html" class="active">Overview</a>
@@ -58,7 +63,9 @@
   </div>
 </div>
 
-<script>
+<script type="module">
+import { fetchBenchIndex, fetchBenchJson, fetchBenchRun } from "./o11y-client.js";
+
 const SCENARIO_NAMES = {
   'passthrough': { title: 'Passthrough (No Transforms)', config: 'transform: "SELECT * FROM logs"' },
   'json_parse': { title: 'JSON Parsing & Extraction', config: 'transform: "SELECT timestamp_str, level_str, message_str, duration_ms_int AS latency_ms, request_id_str, service_str FROM logs"' },
@@ -84,6 +91,52 @@ function formatNs(ns) {
   if (ns >= 1e6) return (ns / 1e6).toFixed(2) + 'ms';
   if (ns >= 1e3) return (ns / 1e3).toFixed(1) + 'us';
   return Math.round(ns) + 'ns';
+}
+
+function averageLps(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  if (Number.isFinite(entry.avg_lps)) return Math.max(0, entry.avg_lps);
+  if (Array.isArray(entry.lps)) {
+    const values = entry.lps.filter((v) => Number.isFinite(v));
+    if (values.length > 0) return values.reduce((sum, v) => sum + v, 0) / values.length;
+  }
+  return null;
+}
+
+function normalizeRateMap(rateRun) {
+  if (!rateRun || typeof rateRun !== 'object') return {};
+  if (rateRun.rates && typeof rateRun.rates === 'object') return rateRun.rates;
+  const out = {};
+  if (Array.isArray(rateRun.results)) {
+    for (const row of rateRun.results) {
+      const eps = Number(row?.eps);
+      if (!Number.isFinite(eps)) continue;
+      out[String(Math.trunc(eps))] = {
+        rss_mb: Number.isFinite(row?.rss_mb) ? row.rss_mb : (Number.isFinite(row?.rss_kb) ? row.rss_kb / 1024 : null),
+        cpu_pct: Number.isFinite(row?.cpu_pct) ? row.cpu_pct : (Number.isFinite(row?.cpu_percent) ? row.cpu_percent : null),
+        actual_eps: Number.isFinite(row?.actual_eps) ? row.actual_eps : null,
+      };
+    }
+  }
+  return out;
+}
+
+function formatCriterionThroughput(entry) {
+  if (!entry || typeof entry !== 'object') return '--';
+  if (Number.isFinite(entry.thrpt_mib_s)) return entry.thrpt_mib_s.toFixed(1) + ' MiB/s';
+  if (Number.isFinite(entry.thrpt_melem_s)) return entry.thrpt_melem_s.toFixed(1) + ' Melem/s';
+  const meanNs = Number(entry.mean_ns);
+  const bytes = Number(entry.throughput?.Bytes);
+  const elems = Number(entry.throughput?.Elements);
+  if (Number.isFinite(meanNs) && meanNs > 0 && Number.isFinite(bytes)) {
+    const mibPerSec = (bytes / (meanNs / 1e9)) / (1024 * 1024);
+    return mibPerSec.toFixed(1) + ' MiB/s';
+  }
+  if (Number.isFinite(meanNs) && meanNs > 0 && Number.isFinite(elems)) {
+    const melemPerSec = (elems / (meanNs / 1e9)) / 1e6;
+    return melemPerSec.toFixed(1) + ' Melem/s';
+  }
+  return '--';
 }
 
 function isDark() {
@@ -113,21 +166,14 @@ function drawSparkline(canvas, data, color) {
   });
 }
 
-const DATA_BASE = 'https://raw.githubusercontent.com/strawgate/memagent/bench-data';
-
 function runId(entry) {
   if (entry && typeof entry === 'object') return entry.id;
   return entry;
 }
 
-async function loadJSON(url) {
-  try { const r = await fetch(url); if (!r.ok) return null; return r.json(); }
-  catch { return null; }
-}
-
 async function main() {
   chartDefaults();
-  const index = await loadJSON(DATA_BASE + '/index.json');
+  const index = await fetchBenchIndex();
   if (!index) {
     document.getElementById('loading').textContent = 'No data available.';
     return;
@@ -136,17 +182,17 @@ async function main() {
   const runEntries = index.competitive_runs || index.runs || [];
   // bench-data index is newest-first; normalize to oldest->newest for downstream logic
   const runs = runEntries.map(runId).filter(Boolean).map(String).reverse();
-  const rateRuns = index.rate_runs || [];
-  const criterionRuns = index.criterion_runs || [];
+  const rateRuns = (index.rate_runs || []).map(runId).filter(Boolean).map(String);
+  const criterionRuns = (index.criterion_runs || []).map(runId).filter(Boolean).map(String);
 
   // Load latest of each type
-  const latestRun = runs.length ? await loadJSON(DATA_BASE + '/runs/' + runs[runs.length - 1] + '.json') : null;
-  const latestRate = rateRuns.length ? await loadJSON(DATA_BASE + '/rate-runs/' + rateRuns[rateRuns.length - 1] + '.json') : null;
-  const latestCriterion = criterionRuns.length ? await loadJSON(DATA_BASE + '/criterion-runs/' + criterionRuns[criterionRuns.length - 1] + '.json') : null;
+  const latestRun = runs.length ? await fetchBenchRun(runs[runs.length - 1]) : null;
+  const latestRate = rateRuns.length ? await fetchBenchJson('rate-runs/' + rateRuns[rateRuns.length - 1] + '.json') : null;
+  const latestCriterion = criterionRuns.length ? await fetchBenchJson('criterion-runs/' + criterionRuns[criterionRuns.length - 1] + '.json') : null;
 
   // Load a few recent runs for sparklines
   const recentRunIds = runs.slice(-10);
-  const recentRuns = (await Promise.all(recentRunIds.map(id => loadJSON(DATA_BASE + '/runs/' + id + '.json')))).filter(Boolean);
+  const recentRuns = (await Promise.all(recentRunIds.map(id => fetchBenchRun(id)))).filter(Boolean);
 
   document.getElementById('loading').style.display = 'none';
   document.getElementById('content').style.display = '';
@@ -154,38 +200,60 @@ async function main() {
   // Headline cards
   const cardsEl = document.getElementById('headline-cards');
 
-  // Card 1: Latest logfwd throughput
-  let logfwdLps = null;
-  let logfwdSparkData = [];
+  // Card 1: Latest primary-scenario winner
+  let primaryWinner = null;
+  let primarySparkData = [];
   if (latestRun && latestRun.scenarios) {
     const firstScenario = latestRun.scenario_names?.[0] || Object.keys(latestRun.scenarios)[0];
-    if (firstScenario && latestRun.scenarios[firstScenario]?.logfwd) {
-      logfwdLps = latestRun.scenarios[firstScenario].logfwd.avg_lps;
+    const firstScenarioData = firstScenario ? latestRun.scenarios[firstScenario] : null;
+    if (firstScenarioData) {
+      let bestAgent = null;
+      let bestLps = 0;
+      for (const [agent, stats] of Object.entries(firstScenarioData)) {
+        const avg = averageLps(stats) || 0;
+        if (avg > bestLps) {
+          bestLps = avg;
+          bestAgent = agent;
+        }
+      }
+      if (bestAgent && bestLps > 0) {
+        primaryWinner = { agent: bestAgent, lps: bestLps, scenario: firstScenario };
+      }
     }
-    // Sparkline from recent runs
+    // Sparkline from recent runs (winner of primary scenario per run)
     for (const r of recentRuns) {
       const sc = r.scenario_names?.[0] || Object.keys(r.scenarios || {})[0];
-      if (sc && r.scenarios?.[sc]?.logfwd) logfwdSparkData.push(r.scenarios[sc].logfwd.avg_lps);
+      const scenarioData = sc ? r.scenarios?.[sc] : null;
+      if (!scenarioData) continue;
+      let bestLps = 0;
+      for (const stats of Object.values(scenarioData)) {
+        const avg = averageLps(stats) || 0;
+        if (avg > bestLps) bestLps = avg;
+      }
+      if (bestLps > 0) primarySparkData.push(bestLps);
     }
   }
   cardsEl.innerHTML += `
     <div class="tracking-card">
-      <span class="label">logfwd Throughput</span>
-      <span class="value">${logfwdLps ? formatLPS(logfwdLps) : '--'}</span>
-      <span class="subtitle">lines/sec (${getScenarioTitle(latestRun?.scenario_names?.[0]) || 'primary'})</span>
+      <span class="label">Primary Scenario Winner</span>
+      <span class="value">${primaryWinner ? formatLPS(primaryWinner.lps) : '--'}</span>
+      <span class="subtitle">${primaryWinner ? primaryWinner.agent + ' (' + getScenarioTitle(primaryWinner.scenario) + ')' : 'no recent competitive data'}</span>
       <canvas class="sparkline" id="spark-lps" width="120" height="36"></canvas>
     </div>`;
 
-  // Card 2: Best competitive ratio
+  // Card 2: Best logfwd ratio where available
   let bestRatio = null;
   if (latestRun && latestRun.scenarios) {
     for (const sn of (latestRun.scenario_names || Object.keys(latestRun.scenarios))) {
       const sc = latestRun.scenarios[sn];
       if (!sc?.logfwd) continue;
-      const scenarioLogfwdLps = sc.logfwd.avg_lps;
+      const scenarioLogfwdLps = averageLps(sc.logfwd);
+      if (!(scenarioLogfwdLps > 0)) continue;
       for (const agent of Object.keys(sc)) {
         if (agent === 'logfwd') continue;
-        const ratio = scenarioLogfwdLps / (sc[agent].avg_lps || 1);
+        const competitorLps = averageLps(sc[agent]) || 0;
+        if (!(competitorLps > 0)) continue;
+        const ratio = scenarioLogfwdLps / competitorLps;
         if (!bestRatio || ratio > bestRatio.value) bestRatio = { value: ratio, vs: agent, scenario: sn };
       }
     }
@@ -199,8 +267,9 @@ async function main() {
 
   // Card 3: RSS at 100K eps
   let rss100k = null;
-  if (latestRate && latestRate.rates?.["100000"]) {
-    rss100k = latestRate.rates["100000"].rss_mb;
+  const rateMap = normalizeRateMap(latestRate);
+  if (rateMap["100000"]) {
+    rss100k = rateMap["100000"].rss_mb;
   }
   cardsEl.innerHTML += `
     <div class="tracking-card">
@@ -210,7 +279,7 @@ async function main() {
     </div>`;
 
   // Draw sparklines after DOM update
-  if (logfwdSparkData.length > 1) drawSparkline(document.getElementById('spark-lps'), logfwdSparkData, '#2563eb');
+  if (primarySparkData.length > 1) drawSparkline(document.getElementById('spark-lps'), primarySparkData, '#2563eb');
 
   // Recent competitive results table
   if (latestRun && latestRun.scenarios) {
@@ -226,13 +295,19 @@ async function main() {
     for (const sn of (latestRun.scenario_names || Object.keys(latestRun.scenarios))) {
       const sc = latestRun.scenarios[sn];
       let bestAgent = null, bestLps = 0;
-      agents.forEach(a => { if (sc?.[a]?.avg_lps > bestLps) { bestLps = sc[a].avg_lps; bestAgent = a; } });
+      agents.forEach(a => {
+        const lps = averageLps(sc?.[a]) || 0;
+        if (lps > bestLps) {
+          bestLps = lps;
+          bestAgent = a;
+        }
+      });
 
       let row = `<td><a href="competitive.html">${getScenarioTitle(sn)}</a></td>`;
       agents.forEach(a => {
-        const lps = sc?.[a]?.avg_lps;
+        const lps = averageLps(sc?.[a]);
         const cls = a === bestAgent ? 'numeric winner' : 'numeric';
-        row += `<td class="${cls}">${lps ? formatLPS(lps) : '--'}</td>`;
+        row += `<td class="${cls}">${lps != null ? formatLPS(lps) : '--'}</td>`;
       });
       rowsHtml += `<tr>${row}</tr>`;
     }
@@ -247,8 +322,7 @@ async function main() {
     const benchmarks = latestCriterion.benchmarks;
     let rowsHtml = '';
     for (const [name, data] of Object.entries(benchmarks).slice(0, 10)) {
-      const thrpt = data.thrpt_mib_s ? data.thrpt_mib_s.toFixed(1) + ' MiB/s'
-                  : data.thrpt_melem_s ? data.thrpt_melem_s.toFixed(1) + ' Melem/s' : '--';
+      const thrpt = formatCriterionThroughput(data);
       rowsHtml += `<tr>
         <td><a href="development.html">${name}</a></td>
         <td class="numeric">${formatNs(data.mean_ns)}</td>

--- a/bench/dashboard/o11y-client.js
+++ b/bench/dashboard/o11y-client.js
@@ -1,0 +1,67 @@
+import {
+  fetchIndex,
+  fetchRun,
+  rawUrl,
+} from "https://cdn.jsdelivr.net/npm/@benchkit/chart@0.2.2/dist/fetch.js/+esm";
+import { trendChartDataset } from "https://cdn.jsdelivr.net/npm/@benchkit/adapters@0.2.2/dist/chartjs.js/+esm";
+
+export const benchDataSource = {
+  owner: "strawgate",
+  repo: "memagent",
+  branch: "bench-data",
+};
+
+function withDataPrefix(filePath) {
+  const cleaned = String(filePath || "").replace(/^\/+/, "");
+  return cleaned.startsWith("data/") ? cleaned : `data/${cleaned}`;
+}
+
+export function benchDataUrl(filePath) {
+  return rawUrl(benchDataSource, withDataPrefix(filePath));
+}
+
+async function fetchJsonAtPath(filePath, signal) {
+  const url = rawUrl(benchDataSource, filePath);
+  try {
+    const res = await fetch(url, { signal });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchBenchJson(filePath, signal) {
+  return fetchJsonAtPath(withDataPrefix(filePath), signal);
+}
+
+export async function fetchBenchIndex(signal) {
+  try {
+    return await fetchIndex(benchDataSource, signal);
+  } catch {
+    return fetchJsonAtPath("data/index.json", signal);
+  }
+}
+
+export async function fetchBenchRun(runId, signal) {
+  try {
+    return await fetchRun(benchDataSource, runId, signal);
+  } catch {
+    return fetchJsonAtPath(`data/runs/${runId}.json`, signal);
+  }
+}
+
+export function toTrendDataset(metricName, points, options = {}) {
+  const entry = {
+    tags: {},
+    points: points
+      .filter((p) => p && p.timestamp && Number.isFinite(p.value))
+      .map((p) => ({ timestamp: p.timestamp, value: p.value })),
+  };
+  return trendChartDataset(metricName, entry, options);
+}
+
+export function shortId(value) {
+  const s = String(value ?? "");
+  return s.length > 8 ? `#${s.slice(-8)}` : `#${s}`;
+}

--- a/bench/dashboard/run.html
+++ b/bench/dashboard/run.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#10243a">
   <title>Run Detail - Benchmark Dashboard</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
@@ -13,12 +14,19 @@
     <a href="index.html">Dashboard</a><span class="sep">/</span><span id="breadcrumb-title">Run</span>
   </div>
 
+  <header class="hero">
+    <p class="eyebrow">run inspector</p>
+    <h1>Run Detail</h1>
+    <p class="lede">Deep-dive one benchmark run to compare per-scenario throughput and resource peaks across all configured collectors.</p>
+  </header>
+
   <div id="loading" class="loading">Loading run data...</div>
   <div id="content" style="display:none">
     <div class="run-header">
       <h1 id="run-title"></h1>
     </div>
     <div class="run-meta" id="run-meta"></div>
+    <div class="tracking-cards" id="run-kpis"></div>
 
     <div class="section">
       <h2>Scenario Results</h2>
@@ -32,16 +40,17 @@
           <h3>Peak Memory (RSS)</h3>
           <canvas id="chart-peak-rss"></canvas>
         </div>
-        <div class="card">
+        <div class="card" id="cpu-card">
           <h3>Peak CPU Usage</h3>
           <canvas id="chart-peak-cpu"></canvas>
+          <p class="info-note" id="cpu-note" style="display:none">CPU peak metrics are not present in this run artifact.</p>
         </div>
       </div>
     </div>
 
     <div class="section">
       <h2>Full Results</h2>
-      <div class="card">
+      <div class="card table-card">
         <table id="results-table">
           <thead id="results-thead"></thead>
           <tbody id="results-tbody"></tbody>
@@ -51,7 +60,9 @@
   </div>
 </div>
 
-<script>
+<script type="module">
+import { fetchBenchRun } from "./o11y-client.js";
+
 const SCENARIO_NAMES = {
   'passthrough': { title: 'Passthrough (No Transforms)', config: 'transform: "SELECT * FROM logs"' },
   'json_parse': { title: 'JSON Parsing & Extraction', config: 'transform: "SELECT timestamp_str, level_str, message_str, duration_ms_int AS latency_ms, request_id_str, service_str FROM logs"' },
@@ -84,6 +95,16 @@ function formatBytes(b) {
   return b + 'B';
 }
 
+function averageLps(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  if (Number.isFinite(entry.avg_lps)) return Math.max(0, entry.avg_lps);
+  if (Array.isArray(entry.lps)) {
+    const values = entry.lps.filter((v) => Number.isFinite(v));
+    if (values.length > 0) return values.reduce((sum, v) => sum + v, 0) / values.length;
+  }
+  return null;
+}
+
 function isDark() { return window.matchMedia('(prefers-color-scheme: dark)').matches; }
 
 function chartColors() {
@@ -93,13 +114,6 @@ function chartColors() {
 }
 
 function gridColor() { return isDark() ? '#30363d' : '#e5e7eb'; }
-
-const DATA_BASE = 'https://raw.githubusercontent.com/strawgate/memagent/bench-data';
-
-async function loadJSON(url) {
-  try { const r = await fetch(url); if (!r.ok) return null; return await r.json(); }
-  catch { return null; }
-}
 
 async function main() {
   chartColors();
@@ -117,9 +131,9 @@ async function main() {
 
   document.getElementById('breadcrumb-title').textContent = 'Run #' + runId;
 
-  const run = await loadJSON(DATA_BASE + '/runs/' + runId + '.json');
+  const run = await fetchBenchRun(runId);
   if (!run) {
-    document.getElementById('loading').textContent = 'Could not load run ' + runId + '. File runs/' + runId + '.json not found in bench-data branch.';
+    document.getElementById('loading').textContent = 'Could not load run ' + runId + '. File data/runs/' + runId + '.json not found in bench-data branch.';
     return;
   }
 
@@ -139,6 +153,38 @@ async function main() {
 
   const scenarios = run.scenario_names || Object.keys(run.scenarios || {});
   const agents = run.agents || [];
+  const kpisEl = document.getElementById('run-kpis');
+
+  let fastest = null;
+  let totalIterations = 0;
+  for (const sn of scenarios) {
+    const sc = run.scenarios?.[sn];
+    if (!sc) continue;
+    for (const agent of agents) {
+      const d = sc[agent];
+      if (!d) continue;
+      const lps = averageLps(d) || 0;
+      if (!fastest || lps > fastest.lps) fastest = { lps, agent, scenario: sn };
+      if (typeof d.iterations === 'number') totalIterations += d.iterations;
+    }
+  }
+  kpisEl.innerHTML = `
+    <div class="tracking-card">
+      <span class="label">Scenario Count</span>
+      <span class="value">${scenarios.length}</span>
+      <span class="subtitle">${agents.length} collectors in this run</span>
+    </div>
+    <div class="tracking-card">
+      <span class="label">Fastest Result</span>
+      <span class="value">${fastest ? formatLPS(fastest.lps) : '--'}</span>
+      <span class="subtitle">${fastest ? fastest.agent + ' · ' + getScenarioTitle(fastest.scenario) : 'no throughput data'}</span>
+    </div>
+    <div class="tracking-card">
+      <span class="label">Total Iterations</span>
+      <span class="value">${totalIterations > 0 ? totalIterations.toLocaleString() : '--'}</span>
+      <span class="subtitle">sum of reported benchmark iterations</span>
+    </div>
+  `;
 
   // Per-scenario bar charts
   const chartsEl = document.getElementById('scenario-charts');
@@ -159,7 +205,7 @@ async function main() {
     for (const agent of agents) {
       if (!sc[agent]) continue;
       labels.push(agent);
-      data.push(sc[agent].avg_lps);
+      data.push(averageLps(sc[agent]) || 0);
       colors.push(AGENT_COLORS[agent] || '#64748b');
     }
 
@@ -188,6 +234,7 @@ async function main() {
   const resourceSection = document.getElementById('resource-section');
   const rssCanvas = document.getElementById('chart-peak-rss');
   const cpuCanvas = document.getElementById('chart-peak-cpu');
+  const cpuNote = document.getElementById('cpu-note');
 
   if (resourceSection && rssCanvas && cpuCanvas) {
     const rssData = [];
@@ -205,14 +252,14 @@ async function main() {
         if (d) {
           found = true;
           if (d.avg_max_rss > maxRss) maxRss = d.avg_max_rss;
-          // Note: if we added avg_max_cpu to dashboard JSON we'd use it here.
-          // For now, if missing, we skip CPU or use a placeholder.
+          if (typeof d.avg_max_cpu === 'number' && d.avg_max_cpu > maxCpu) maxCpu = d.avg_max_cpu;
         }
       }
 
       if (found) {
         labels.push(agent);
         rssData.push(maxRss);
+        cpuData.push(maxCpu > 0 ? maxCpu : null);
         colors.push(AGENT_COLORS[agent] || '#64748b');
       }
     }
@@ -228,7 +275,21 @@ async function main() {
           scales: { x: { ticks: { callback: v => formatBytes(v) }, grid: { color: gridColor() } }, y: { grid: { display: false } } }
         }
       });
-      // Placeholder or actual CPU chart if data added to JSON
+
+      if (cpuData.some(v => v != null)) {
+        new Chart(cpuCanvas, {
+          type: 'bar',
+          data: { labels, datasets: [{ data: cpuData, backgroundColor: colors, borderRadius: 3 }] },
+          options: {
+            indexAxis: 'y',
+            plugins: { legend: { display: false }, tooltip: { callbacks: { label: ctx => (ctx.raw ?? 0).toFixed(1) + '%' } } },
+            scales: { x: { ticks: { callback: v => v + '%' }, grid: { color: gridColor() } }, y: { grid: { display: false } } }
+          }
+        });
+      } else {
+        cpuCanvas.style.display = 'none';
+        if (cpuNote) cpuNote.style.display = '';
+      }
     }
   }
 
@@ -250,7 +311,8 @@ async function main() {
     // Find winner
     let bestAgent = null, bestLps = 0;
     for (const a of agents) {
-      if (sc[a]?.avg_lps > bestLps) { bestLps = sc[a].avg_lps; bestAgent = a; }
+      const lps = averageLps(sc[a]) || 0;
+      if (lps > bestLps) { bestLps = lps; bestAgent = a; }
     }
 
     let row = `<td>${getScenarioTitle(sn)}</td>`;


### PR DESCRIPTION
## Summary
- remove legacy dashboard data path fallbacks; read canonical `data/*` only
- publish benchmark artifacts/index to `bench-data:data/*` only
- update dashboard rendering to keep zero-throughput collectors visible as `0`
- make development/overview parsing tolerant of current rate/criterion payload shapes

## Notes
- this intentionally starts canonical tracking from now forward
- dashboards will populate after next benchmark write to `data/index.json`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add nightly benchmark pipeline and canonical dashboard data paths for bench results
> - Introduces a [bench.yml](https://github.com/strawgate/memagent/pull/1828/files#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7) GitHub Actions workflow that builds binaries (including PGO and dhat variants), runs competitive, rate-ingest, criterion, and profiling benchmarks, and commits summarized results to a `bench-data` branch, opening a GitHub issue with the output.
> - Adds [o11y-client.js](https://github.com/strawgate/memagent/pull/1828/files#diff-47bc58b3d1668a5904bf40c36f20f300e430b6d188f536b896f9d48d523ef019) as a centralized fetch client for dashboard pages, resolving benchmark data via canonical `data/*` paths with fallbacks.
> - Converts all dashboard pages ([index.html](https://github.com/strawgate/memagent/pull/1828/files#diff-4966c221d2dcf0d441633340bea8e27c6fc5c3d0af479777fdeebcc70117278f), [competitive.html](https://github.com/strawgate/memagent/pull/1828/files#diff-15e643b9a518c97d68474972f5866b223bfa889f3243e0b5a3bbcd644cb018b1), [development.html](https://github.com/strawgate/memagent/pull/1828/files#diff-f52eeddce0ecbc2e938a4bab9dd793d347f8e091e01c48606c534a7b15e8a084), [run.html](https://github.com/strawgate/memagent/pull/1828/files#diff-26289190a0d3cf8e8b7db69e3e0280e35ca436bf7d26d3f1c7a58f2f5e66960a)) to ES modules that fetch via `o11y-client`, add hero headers and KPI cards, and tolerate multiple JSON shapes for rate and criterion data.
> - Trend charts now apply per-point anomaly coloring from adapter metadata and use abbreviated run IDs on x-axis labels.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b2cdc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->