### PR TITLE
fix(ci): use correct test targets for compliance workflow

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -30,17 +30,26 @@ jobs:
       - name: Run pipeline compliance tests
         id: pipeline
         continue-on-error: true
-        run: cargo test -p logfwd --test it -- compliance:: 2>&1 | tee compliance_pipeline.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo test -p logfwd --test it -- 'compliance::' 2>&1 | tee compliance_pipeline.txt
 
       - name: Run file handling compliance tests
         id: file
         continue-on-error: true
-        run: cargo test -p logfwd --test it -- compliance_file:: 2>&1 | tee compliance_file.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo test -p logfwd --test it -- 'compliance_file::' 2>&1 | tee compliance_file.txt
 
       - name: Run data integrity compliance tests
         id: data
         continue-on-error: true
-        run: cargo test -p logfwd-core --test it -- compliance_data:: 2>&1 | tee compliance_data.txt
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo test -p logfwd-core --test it -- 'compliance_data::' 2>&1 | tee compliance_data.txt
 
       - name: Upload compliance test logs
         uses: actions/upload-artifact@v7

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -30,17 +30,17 @@ jobs:
       - name: Run pipeline compliance tests
         id: pipeline
         continue-on-error: true
-        run: cargo test -p logfwd --test compliance 2>&1 | tee compliance_pipeline.txt
+        run: cargo test -p logfwd --test it -- compliance:: 2>&1 | tee compliance_pipeline.txt
 
       - name: Run file handling compliance tests
         id: file
         continue-on-error: true
-        run: cargo test -p logfwd --test compliance_file 2>&1 | tee compliance_file.txt
+        run: cargo test -p logfwd --test it -- compliance_file:: 2>&1 | tee compliance_file.txt
 
       - name: Run data integrity compliance tests
         id: data
         continue-on-error: true
-        run: cargo test -p logfwd-core --test compliance_data 2>&1 | tee compliance_data.txt
+        run: cargo test -p logfwd-core --test it -- compliance_data:: 2>&1 | tee compliance_data.txt
 
       - name: Upload compliance test logs
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

The nightly compliance workflow (#1814) was reporting "All suites passed" but actually failing silently because it referenced non-existent test targets.

### Root cause

The compliance tests are **modules within the `it` integration test binary**, not standalone test targets:

```
crates/logfwd/tests/it/compliance.rs      # module, not a target
crates/logfwd/tests/it/compliance_file.rs  # module, not a target
crates/logfwd-core/tests/it/compliance_data.rs  # module, not a target
```

The workflow was running `cargo test -p logfwd --test compliance` which fails with:
```
error: no test target named `compliance` in `logfwd` package
```

But `continue-on-error: true` swallowed the error, and the step `outcome` was reported as `success`.

### Fix

Use the correct invocation pattern to filter by module name:

| Before | After |
|--------|-------|
| `--test compliance` | `--test it -- compliance::` |
| `--test compliance_file` | `--test it -- compliance_file::` |
| `--test compliance_data` | `--test it -- compliance_data::` |

### Verification

Locally confirmed all three filter patterns find tests:
- `compliance::` → 5 tests
- `compliance_file::` → 7 tests  
- `compliance_data::` → 41 tests

Fixes #1814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix compliance workflow test targets to use the `it` binary with scoped filters
> - Updates three `cargo test` invocations in [compliance.yml](.github/workflows/compliance.yml) to run the consolidated `it` test binary with module-scoped filters (e.g. `-- "compliance::"`) instead of the now-removed dedicated test binaries.
> - Adds `shell: bash` and `set -o pipefail` to each test step so a failing `cargo test` command correctly fails the step even when piped through `tee`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 062bc2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->