### PR TITLE
fix: address linearizability review follow-ups

### DIFF
--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -104,7 +104,7 @@ pub(crate) struct ChannelMsg {
 
 #[derive(Debug, Default)]
 struct TicketApplication {
-    held: bool,
+    has_held: bool,
     checkpoint_advances: Vec<(u64, u64)>,
 }
 
@@ -822,7 +822,7 @@ impl Pipeline {
             },
         )
         .await;
-        application.held
+        application.has_held
     }
 
     /// Finalize Sending tickets and apply receipts to the machine when present.
@@ -947,7 +947,7 @@ impl Pipeline {
             }
         }
         if held > 0 {
-            application.held = true;
+            application.has_held = true;
             tracing::warn!(
                 held_tickets = held,
                 "pipeline: terminal hold requested; stopping ingestion so checkpoints do not advance past undelivered data"
@@ -980,6 +980,7 @@ impl Pipeline {
                 }
             }
         }
+        application.checkpoint_advances.sort_unstable();
         application
     }
 }
@@ -2830,7 +2831,7 @@ output:
         assert!(
             pipeline
                 .ack_all_tickets(None, vec![ticket], TicketDisposition::Hold)
-                .held,
+                .has_held,
             "hold disposition must request terminal shutdown to bound held-ticket growth"
         );
 

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -814,6 +814,12 @@ impl Pipeline {
             default_ticket_disposition(&ack.outcome),
         );
         #[cfg(feature = "turmoil")]
+        let application = {
+            let mut application = application;
+            application.checkpoint_advances.sort_unstable();
+            application
+        };
+        #[cfg(feature = "turmoil")]
         crate::turmoil_barriers::trigger(
             crate::turmoil_barriers::RuntimeBarrierEvent::AckApplied {
                 batch_id,
@@ -980,7 +986,6 @@ impl Pipeline {
                 }
             }
         }
-        application.checkpoint_advances.sort_unstable();
         application
     }
 }

--- a/crates/logfwd-runtime/src/pipeline/submit.rs
+++ b/crates/logfwd-runtime/src/pipeline/submit.rs
@@ -117,7 +117,7 @@ impl Pipeline {
                         sending,
                         super::checkpoint_policy::TicketDisposition::Hold,
                     )
-                    .held;
+                    .has_held;
                 self.metrics.finish_active_batch(batch_id);
                 if held {
                     shutdown.cancel();

--- a/crates/logfwd/tests/turmoil_sim/fault_harness.rs
+++ b/crates/logfwd/tests/turmoil_sim/fault_harness.rs
@@ -346,7 +346,10 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                     || scenario.crash_on_nth_flush.is_some()
                 {
-                    let (store, handle) = ObservableCheckpointStore::new();
+                    let (mut store, handle) = ObservableCheckpointStore::new();
+                    if let Some(n) = self.crash_on_nth_flush {
+                        store = store.with_crash_on_nth_flush(n);
+                    }
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -372,9 +375,6 @@ impl FaultScenario {
 
                     if let Some((store, handle)) = maybe_checkpoint {
                         pipeline = pipeline.with_checkpoint_store(Box::new(store));
-                        if let Some(n) = scenario.crash_on_nth_flush {
-                            handle.crash_on_nth_flush(n);
-                        }
                         if let Some(crash_after) = scenario.arm_checkpoint_crash_after {
                             tokio::spawn(async move {
                                 tokio::time::sleep(crash_after).await;
@@ -405,7 +405,10 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                     || scenario.crash_on_nth_flush.is_some()
                 {
-                    let (store, handle) = ObservableCheckpointStore::new();
+                    let (mut store, handle) = ObservableCheckpointStore::new();
+                    if let Some(n) = self.crash_on_nth_flush {
+                        store = store.with_crash_on_nth_flush(n);
+                    }
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -430,9 +433,6 @@ impl FaultScenario {
 
                     if let Some((store, handle)) = maybe_checkpoint {
                         pipeline = pipeline.with_checkpoint_store(Box::new(store));
-                        if let Some(n) = scenario.crash_on_nth_flush {
-                            handle.crash_on_nth_flush(n);
-                        }
                         if let Some(crash_after) = scenario.arm_checkpoint_crash_after {
                             tokio::spawn(async move {
                                 tokio::time::sleep(crash_after).await;
@@ -461,7 +461,10 @@ impl FaultScenario {
                     || scenario.arm_checkpoint_crash_after.is_some()
                     || scenario.crash_on_nth_flush.is_some()
                 {
-                    let (store, handle) = ObservableCheckpointStore::new();
+                    let (mut store, handle) = ObservableCheckpointStore::new();
+                    if let Some(n) = self.crash_on_nth_flush {
+                        store = store.with_crash_on_nth_flush(n);
+                    }
                     checkpoint_handle = Some(handle.clone());
                     Some((store, handle))
                 } else {
@@ -486,9 +489,6 @@ impl FaultScenario {
 
                     if let Some((store, handle)) = maybe_checkpoint {
                         pipeline = pipeline.with_checkpoint_store(Box::new(store));
-                        if let Some(n) = scenario.crash_on_nth_flush {
-                            handle.crash_on_nth_flush(n);
-                        }
                         if let Some(crash_after) = scenario.arm_checkpoint_crash_after {
                             tokio::spawn(async move {
                                 tokio::time::sleep(crash_after).await;

--- a/crates/logfwd/tests/turmoil_sim/fault_scenario_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/fault_scenario_sim.rs
@@ -414,7 +414,7 @@ fn one_way_fault_schedule_recovers_after_directional_repair() {
 }
 
 fn replay_equivalence_run(seed: u64, name: &str) -> Vec<TraceEvent> {
-    FaultScenario::builder(name)
+    let outcome = FaultScenario::builder(name)
         .with_seed(seed)
         .with_line_count(16)
         .with_sink_script(vec![
@@ -423,9 +423,12 @@ fn replay_equivalence_run(seed: u64, name: &str) -> Vec<TraceEvent> {
         ])
         .with_checkpoint_flush_interval(Duration::from_millis(30))
         .with_shutdown_after(Duration::from_secs(3))
-        .run()
-        .trace_events()
-        .to_vec()
+        .run();
+    InvariantSet::new()
+        .no_sim_error()
+        .trace_contract_valid()
+        .verify(&outcome);
+    outcome.trace_events().to_vec()
 }
 
 #[test]

--- a/crates/logfwd/tests/turmoil_sim/observable_checkpoint.rs
+++ b/crates/logfwd/tests/turmoil_sim/observable_checkpoint.rs
@@ -35,7 +35,6 @@ pub struct CheckpointState {
 pub struct CheckpointHandle {
     state: Arc<Mutex<CheckpointState>>,
     crash_armed: Arc<AtomicBool>,
-    crash_on_flush_number: Arc<AtomicU64>,
 }
 
 #[allow(dead_code)]
@@ -59,11 +58,6 @@ impl CheckpointHandle {
     /// Arm a crash — next flush() will fail and lose pending data.
     pub fn arm_crash(&self) {
         self.crash_armed.store(true, Ordering::SeqCst);
-    }
-
-    /// Crash exactly on the Nth `flush` call (1-indexed).
-    pub fn crash_on_nth_flush(&self, n: u64) {
-        self.crash_on_flush_number.store(n, Ordering::SeqCst);
     }
 
     /// Verify that offsets for a given source never decrease in update history.
@@ -153,7 +147,6 @@ impl ObservableCheckpointStore {
         let handle = CheckpointHandle {
             state: state.clone(),
             crash_armed: crash_armed.clone(),
-            crash_on_flush_number: crash_on_flush_number.clone(),
         };
         let store = Self {
             state,
@@ -171,6 +164,13 @@ impl ObservableCheckpointStore {
     /// `CheckpointFlush` events as the pipeline updates and flushes state.
     pub fn with_trace_recorder(mut self, trace: TraceRecorder) -> Self {
         self.trace = Some(trace);
+        self
+    }
+
+    /// Configure the store to fail exactly on the Nth `flush` call (1-indexed).
+    pub fn with_crash_on_nth_flush(self, n: u64) -> Self {
+        assert!(n > 0, "crash trigger is 1-indexed; 0 disables crash path");
+        self.crash_on_flush_number.store(n, Ordering::SeqCst);
         self
     }
 }

--- a/scripts/linearizability/main.go
+++ b/scripts/linearizability/main.go
@@ -50,6 +50,7 @@ type modelState struct {
 	Committed    uint64
 	HasCommitted bool
 	Durable      *uint64
+	SourceID     *uint64
 	Order        []uint64
 	Batches      map[uint64]batchState
 }
@@ -66,10 +67,16 @@ func cloneState(s modelState) modelState {
 		d := *s.Durable
 		durableCopy = &d
 	}
+	var sourceCopy *uint64
+	if s.SourceID != nil {
+		source := *s.SourceID
+		sourceCopy = &source
+	}
 	return modelState{
 		Committed:    s.Committed,
 		HasCommitted: s.HasCommitted,
 		Durable:      durableCopy,
+		SourceID:     sourceCopy,
 		Order:        orderCopy,
 		Batches:      batchesCopy,
 	}
@@ -96,6 +103,7 @@ func buildModel() porcupine.Model {
 				Committed:    0,
 				HasCommitted: false,
 				Durable:      nil,
+				SourceID:     nil,
 				Order:        make([]uint64, 0),
 				Batches:      make(map[uint64]batchState),
 			}
@@ -107,6 +115,12 @@ func buildModel() porcupine.Model {
 			switch input.Op {
 			case "submit":
 				if _, exists := state.Batches[input.BatchID]; exists {
+					return false, state
+				}
+				if state.SourceID == nil {
+					source := input.SourceID
+					state.SourceID = &source
+				} else if input.SourceID != *state.SourceID {
 					return false, state
 				}
 				state.Batches[input.BatchID] = batchState{
@@ -187,6 +201,9 @@ func buildModel() porcupine.Model {
 				}
 				return true, state
 			case "read_durable":
+				if state.SourceID == nil || input.SourceID != *state.SourceID {
+					return false, state
+				}
 				if state.Durable == nil {
 					return output.Durable == nil, state
 				}
@@ -205,6 +222,12 @@ func buildModel() porcupine.Model {
 				return false
 			}
 			if left.Durable != nil && *left.Durable != *right.Durable {
+				return false
+			}
+			if (left.SourceID == nil) != (right.SourceID == nil) {
+				return false
+			}
+			if left.SourceID != nil && *left.SourceID != *right.SourceID {
 				return false
 			}
 			for i := range left.Order {


### PR DESCRIPTION
## Summary

Follow-up to #1823 for the final CodeRabbit findings that landed as #1823 was being merged.

- Rename the ticket application held flag to follow boolean naming conventions.
- Sort AckApplied checkpoint advances before emitting runtime barrier payloads.
- Validate replay-equivalence runs before comparing normalized traces.
- Validate read_durable source IDs in the Porcupine model.
- Move nth-flush crash setup onto the observable checkpoint store instead of handle mutation.

## Validation

- cargo clippy --workspace -- -D warnings
- cargo test -p logfwd --features turmoil --test turmoil_sim fault_scenario_sim::replay_equivalence_seed_supports_three_identical_replays -- --exact
- go test ./... (scripts/linearizability)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce single-source constraint in linearizability model and fix review follow-ups
> - The linearizability model in [`main.go`](https://github.com/strawgate/memagent/pull/1836/files#diff-811216d0f80b28c72ea0beed6ca9ff5a1ac5298e80f8e8fd9e9cb929521e820e) now tracks a `SourceID` field, rejecting `submit` operations from a different source and requiring matching `SourceID` on `read_durable`.
> - Sorts `checkpoint_advances` before emitting the `AckApplied` barrier in turmoil builds to produce deterministic ordering.
> - Refactors `ObservableCheckpointStore` to configure crash-on-nth-flush via a builder method `with_crash_on_nth_flush` instead of through `CheckpointHandle`, removing the `crash_on_nth_flush` handle method.
> - Adds invariant verification (`no_sim_error`, `trace_contract_valid`) to the `replay_equivalence_run` helper in fault scenario tests.
> - Renames `TicketApplication.held` to `has_held` across pipeline code for clarity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 077859e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->