### PR TITLE
feat: comprehensive enrichment tables and processors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ book/.astro/
 .DS_Store
 crates/logfwd-io/src/dashboard-dist/
 .playwright-mcp/
-.codex/
 *.env
 .env
 es-flamegraph.svg
@@ -27,4 +26,5 @@ error.log
 
 # Research intermediate artifacts (cloud task diffs, extracts)
 **/cloud-artifacts/
+.codex/
 scripts/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ book/.astro/
 .DS_Store
 crates/logfwd-io/src/dashboard-dist/
 .playwright-mcp/
+.codex/
 *.env
 .env
 es-flamegraph.svg
@@ -26,5 +27,4 @@ error.log
 
 # Research intermediate artifacts (cloud task diffs, extracts)
 **/cloud-artifacts/
-.codex/
 scripts/__pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
  "arrow-select",
  "arrow-string",
  "half",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -434,9 +434,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -492,7 +492,7 @@ checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "libc",
  "log",
@@ -583,9 +583,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bstr"
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
@@ -1035,7 +1035,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex",
  "sqlparser",
  "tempfile",
@@ -1151,7 +1151,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
- "rand 0.9.3",
+ "rand 0.9.4",
  "tokio",
  "url",
 ]
@@ -1251,7 +1251,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.3",
+ "rand 0.9.4",
  "tempfile",
  "url",
 ]
@@ -1314,7 +1314,7 @@ dependencies = [
  "log",
  "memchr",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex",
  "unicode-segmentation",
  "uuid",
@@ -1777,7 +1777,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "rustc_version",
 ]
 
@@ -2055,7 +2055,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_distr",
  "zerocopy",
 ]
@@ -2187,9 +2187,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
@@ -2406,7 +2406,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -2634,7 +2634,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -2922,6 +2922,7 @@ dependencies = [
  "arrow",
  "backon",
  "bytes",
+ "csv",
  "dhat",
  "fail",
  "futures-util",
@@ -2954,6 +2955,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "turmoil",
+ "ureq",
 ]
 
 [[package]]
@@ -3120,7 +3122,7 @@ dependencies = [
  "hyper-util",
  "log",
  "pin-project-lite",
- "rand 0.9.3",
+ "rand 0.9.4",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -3171,7 +3173,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3189,7 +3191,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3264,7 +3266,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3413,7 +3415,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.3",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -3617,9 +3619,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -3826,7 +3828,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -3895,9 +3897,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3948,7 +3950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.3",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -3962,9 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4006,7 +4008,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4015,7 +4017,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4200,7 +4202,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4234,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4621,9 +4623,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.17.4"
+version = "12.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d14d7cb9c6fa5b95a6f3de8af95b356a528d391998fa45a07d320a5573e51"
+checksum = "6aba7211a1803a826f108af9f4d86d25abe880712f2a6449479279e861b293f8"
 dependencies = [
  "debugid",
  "memmap2",
@@ -4633,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.17.4"
+version = "12.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39505731ae891b2dde47b0e4ae2ec40a7ced3476ab1129f1bf829e3fba62bb83"
+checksum = "595bddd9d363c2ef6fc9fb33b98416ff209c5aae8bdca89a7dbbf2ef5e0ecc45"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -4979,7 +4981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5112,7 +5114,7 @@ checksum = "f5384da930ba6d7e467030c421a7332726755d548ba38058aed30c2c30d991d2"
 dependencies = [
  "bytes",
  "indexmap",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_distr",
  "scoped-tls",
  "tokio",
@@ -5398,7 +5400,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5807,7 +5809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "YAML Reference"
+title: "Configuration Reference"
 description: "Complete YAML reference for all logfwd settings"
 ---
 
@@ -271,29 +271,6 @@ Compatibility note: legacy names `linux_sensor_beta`, `macos_sensor_beta`,
 `windows_sensor_beta`, plus the legacy `sensor_beta:` block, are still
 accepted as aliases for backward compatibility.
 
-### `host_metrics` input
-
-Host metrics input that collects process snapshots, CPU, memory, and network
-statistics via `sysinfo`. This input is Arrow-native and does not support
-`format`. The OS-specific implementation is selected at compile time based on
-the build target.
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `sensor.poll_interval_ms` | integer | No | Periodic sample cadence in milliseconds. Must be `>= 1`. Defaults to `10000`. |
-| `sensor.control_path` | string | No | Optional JSON control-plane file path for runtime reload. |
-| `sensor.control_reload_interval_ms` | integer | No | Reload check interval in milliseconds. Must be `>= 1`. Defaults to `1000`. |
-| `sensor.enabled_families` | array[string] | No | Optional enabled signal families. Omit to use defaults; set `[]` to disable all families. |
-| `sensor.emit_signal_rows` | boolean | No | Emit periodic per-family sample rows. Defaults to `true`. |
-| `sensor.max_rows_per_poll` | integer | No | Upper bound on data rows returned per collection cycle. Defaults to `256`. Set to `0` or omit for the default. |
-
-```yaml
-input:
-  type: host_metrics
-  sensor:
-    poll_interval_ms: 5000
-```
-
 ### `arrow_ipc` input
 
 Receive Arrow IPC stream payloads over HTTP `POST` and forward decoded
@@ -328,7 +305,6 @@ Behavior:
 | `linux_ebpf_sensor` | Implemented | Linux eBPF sensor input (Arrow-native control + signal rows). |
 | `macos_es_sensor` | Implemented | macOS EndpointSecurity sensor input (Arrow-native control + signal rows). |
 | `windows_ebpf_sensor` | Implemented | Windows eBPF sensor input (Arrow-native control + signal rows). |
-| `host_metrics` | Implemented | Host metrics input — process snapshots, CPU, memory, network stats via sysinfo (Arrow-native). |
 | `arrow_ipc` | Implemented | Receive Arrow IPC stream batches via HTTP `POST /v1/arrow`. |
 
 ---
@@ -552,31 +528,150 @@ SELECT float(duration) AS duration_ms FROM logs
 
 ## Enrichment tables
 
-Enrichment tables are made available as SQL tables that can be joined in the transform
-query. They are declared under the top-level `enrichment` key.
+Enrichment tables are one-row (or multi-row) Arrow tables registered in DataFusion
+alongside the `logs` table. Use `CROSS JOIN` for one-row tables or `LEFT JOIN` for
+multi-row lookup tables.
 
 ```yaml
 enrichment:
-  - type: k8s_path
   - type: host_info
+  - type: process_info
+  - type: network_info
+  - type: container_info
+  - type: k8s_cluster_info
+  - type: k8s_path
   - type: static
     table_name: labels
     labels:
       environment: production
       region: us-east-1
+  - type: kv_file
+    table_name: os_release
+    path: /etc/os-release
+  - type: env_vars
+    table_name: deploy_meta
+    prefix: LOGFWD_META_
+  - type: csv
+    table_name: assets
+    path: /etc/logfwd/assets.csv
+  - type: jsonl
+    table_name: ip_owners
+    path: /etc/logfwd/ip-owners.jsonl
+  - type: geo_database
+    format: mmdb
+    path: /data/GeoLite2-City.mmdb
+```
+
+### `host_info` enrichment
+
+System host metadata, resolved once at startup. Fixed table name: `host_info`.
+
+| Column | Description |
+|--------|-------------|
+| `hostname` | System hostname. |
+| `os_type` | Operating system (`linux`, `macos`, `windows`). |
+| `os_arch` | CPU architecture (`x86_64`, `aarch64`, etc.). |
+
+```sql
+SELECT l.*, h.hostname, h.os_type
+FROM logs l CROSS JOIN host_info h
+```
+
+### `process_info` enrichment
+
+Agent self-metadata, resolved once at startup. Fixed table name: `process_info`.
+
+| Column | Description |
+|--------|-------------|
+| `agent_name` | Always `logfwd`. |
+| `agent_version` | Semantic version of the running binary. |
+| `pid` | Process ID (as string). |
+| `start_time` | ISO 8601 UTC timestamp when the agent started. |
+
+```sql
+SELECT l.*, p.agent_version, p.start_time
+FROM logs l CROSS JOIN process_info p
+```
+
+### `network_info` enrichment
+
+Network interface metadata from procfs, resolved once at startup. Fixed table name: `network_info`.
+
+| Column | Description |
+|--------|-------------|
+| `hostname` | System hostname. |
+| `primary_ipv4` | First non-loopback IPv4 address, or empty. |
+| `primary_ipv6` | First non-loopback, non-link-local IPv6 address, or empty. |
+| `all_ipv4` | Comma-separated list of all non-loopback IPv4 addresses. |
+| `all_ipv6` | Comma-separated list of all non-loopback, non-link-local IPv6 addresses. |
+
+```sql
+SELECT l.*, n.primary_ipv4
+FROM logs l CROSS JOIN network_info n
+```
+
+### `container_info` enrichment
+
+Container runtime detection from `/proc/self/cgroup` and `/.dockerenv`, resolved once
+at startup. Fixed table name: `container_info`.
+
+| Column | Description |
+|--------|-------------|
+| `container_id` | 64-character hex container ID, or empty if not in a container. |
+| `container_runtime` | `docker`, `containerd`, `cri-o`, `kubernetes`, `unknown`, or empty. |
+
+```sql
+SELECT l.*, c.container_id, c.container_runtime
+FROM logs l CROSS JOIN container_info c
+```
+
+### `k8s_cluster_info` enrichment
+
+Kubernetes cluster metadata from the downward API environment variables, resolved
+once at startup. Fixed table name: `k8s_cluster_info`.
+
+Populate these via `fieldRef` in your DaemonSet pod spec:
+```yaml
+env:
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+  - name: K8S_CLUSTER_NAME
+    value: my-cluster   # or from a ConfigMap
+  - name: K8S_SERVICE_ACCOUNT
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.serviceAccountName
+```
+
+| Column | Description |
+|--------|-------------|
+| `namespace` | Pod namespace (from mounted service account path). |
+| `pod_name` | Pod name (from `HOSTNAME`). |
+| `node_name` | Node name (from `K8S_NODE_NAME` or `NODE_NAME`). |
+| `service_account` | Service account name (from `K8S_SERVICE_ACCOUNT` or `SERVICE_ACCOUNT` env var). |
+| `cluster_name` | Cluster name (from `K8S_CLUSTER_NAME` or `CLUSTER_NAME`). |
+
+```sql
+SELECT l.*, k.namespace, k.node_name, k.cluster_name
+FROM logs l CROSS JOIN k8s_cluster_info k
 ```
 
 ### `k8s_path` enrichment
 
-Parses Kubernetes pod log paths (e.g.
-`/var/log/pods/<namespace>_<pod>_<uid>/<container>/`) to extract metadata.
+Parses Kubernetes CRI log paths to extract pod metadata without calling the
+Kubernetes API. Multi-row table — one row per discovered pod.
 
-This enrichment table is ready to expose path-derived metadata, but file-backed
-inputs do not yet inject a source-path column into the `logs` table. The join
-shown in older docs is therefore not wired end to end today. Track that runtime
-gap in [issue #1346](https://github.com/strawgate/memagent/issues/1346).
+> **Note:** File-backed inputs do not yet inject a source-path column into the `logs`
+> table, so the join shown below is not wired end to end today. Track that gap in
+> [issue #1346](https://github.com/strawgate/memagent/issues/1346).
 
-Columns exposed by `k8s`:
+```yaml
+enrichment:
+  - type: k8s_path
+    table_name: k8s_pods   # optional, defaults to "k8s_pods"
+```
 
 | Column | Description |
 |--------|-------------|
@@ -586,17 +681,9 @@ Columns exposed by `k8s`:
 | `pod_uid` | Pod UID. |
 | `container_name` | Container name. |
 
-### `host_info` enrichment
-
-Exposes the hostname of the machine running logfwd.
-
-| Column | Description |
-|--------|-------------|
-| `hostname` | System hostname. |
-
 ### `static` enrichment
 
-A table with one row containing user-defined label columns.
+A one-row table with user-defined label columns from the YAML config.
 
 ```yaml
 enrichment:
@@ -612,6 +699,125 @@ enrichment:
 SELECT l.*, lbl.environment, lbl.cluster
 FROM logs l CROSS JOIN labels lbl
 ```
+
+### `env_vars` enrichment
+
+A one-row table populated from environment variables matching a name prefix.
+The prefix is stripped and the remainder lower-cased to form column names.
+
+```yaml
+enrichment:
+  - type: env_vars
+    table_name: deploy_meta
+    prefix: LOGFWD_META_
+```
+
+With `LOGFWD_META_CLUSTER=prod` and `LOGFWD_META_REGION=us-east-1` set, the table
+exposes `cluster` and `region` columns.
+
+```sql
+SELECT l.*, m.cluster, m.region
+FROM logs l CROSS JOIN deploy_meta m
+```
+
+### `kv_file` enrichment
+
+A one-row table parsed from a `KEY=value` properties file. Supports unquoted,
+double-quoted, and single-quoted values. Lines starting with `#` are comments.
+Column names are keys lower-cased.
+
+```yaml
+enrichment:
+  - type: kv_file
+    table_name: os_release
+    path: /etc/os-release
+    refresh_interval: 3600   # optional: reload every N seconds
+```
+
+```sql
+SELECT l.*, os.pretty_name, os.version_id
+FROM logs l CROSS JOIN os_release os
+```
+
+Useful for `/etc/os-release`, `.env` files, or ConfigMap-mounted metadata files.
+
+### `csv` enrichment
+
+A multi-row lookup table loaded from a CSV file. All columns are UTF-8 strings.
+The first row must be column headers.
+
+```yaml
+enrichment:
+  - type: csv
+    table_name: assets
+    path: /etc/logfwd/assets.csv
+    refresh_interval: 3600   # optional: reload every N seconds
+```
+
+```sql
+SELECT l.*, a.owner, a.team
+FROM logs l LEFT JOIN assets a ON l.hostname = a.hostname
+```
+
+### `jsonl` enrichment
+
+A multi-row lookup table loaded from a JSON Lines file (one JSON object per line).
+Columns are the union of all keys across all rows.
+
+```yaml
+enrichment:
+  - type: jsonl
+    table_name: ip_owners
+    path: /etc/logfwd/ip-owners.jsonl
+    refresh_interval: 1800   # optional: reload every N seconds
+```
+
+```sql
+SELECT l.*, ipl.owner
+FROM logs l LEFT JOIN ip_owners ipl ON l.client_ip = ipl.ip
+```
+
+### `geo_database` enrichment
+
+Registers a GeoIP database for use with the `geo_lookup()` SQL function.
+Supports MaxMind MMDB and CSV IP-range formats.
+
+```yaml
+# MaxMind MMDB format
+enrichment:
+  - type: geo_database
+    format: mmdb
+    path: /data/GeoLite2-City.mmdb
+    refresh_interval: 86400   # optional: reload daily
+
+# CSV IP-range format (DB-IP Lite compatible)
+enrichment:
+  - type: geo_database
+    format: csv_range
+    path: /data/dbip-city-lite.csv
+```
+
+```sql
+SELECT l.*,
+  geo_lookup(l.client_ip).country_code AS country,
+  geo_lookup(l.client_ip).city AS city,
+  geo_lookup(l.client_ip).latitude AS lat,
+  geo_lookup(l.client_ip).longitude AS lon
+FROM logs l
+```
+
+The `geo_lookup()` function returns a struct with these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `country_code` | string | ISO 3166-1 two-letter code (e.g. `US`). |
+| `country_name` | string | Full English country name. |
+| `city` | string | City name. |
+| `region` | string | State or subdivision name. |
+| `latitude` | float | Decimal degrees. |
+| `longitude` | float | Decimal degrees. |
+| `asn` | integer | Autonomous System Number. |
+| `org` | string | Organization name for the ASN. |
 
 ---
 
@@ -723,6 +929,11 @@ pipelines:
         format: console
 
 enrichment:
+  - type: host_info
+  - type: process_info
+  - type: network_info
+  - type: container_info
+  - type: k8s_cluster_info
   - type: static
     table_name: labels
     labels:

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -17,15 +17,17 @@ mod validate;
 #[cfg(test)]
 pub(crate) use env::expand_env_vars;
 pub use types::{
-    ArrowIpcTypeConfig, AuthConfig, Config, ConfigError, CsvEnrichmentConfig, EnrichmentConfig,
-    FileTypeConfig, Format, GeneratorAttributeValueConfig, GeneratorComplexityConfig,
-    GeneratorInputConfig, GeneratorProfileConfig, GeneratorSequenceConfig, GeneratorTypeConfig,
-    GeoDatabaseConfig, GeoDatabaseFormat, HostInfoConfig, HostMetricsInputConfig, HttpInputConfig,
-    HttpMethodConfig, HttpTypeConfig, InputConfig, InputType, InputTypeConfig,
-    JournaldBackendConfig, JournaldInputConfig, JournaldTypeConfig, JsonlEnrichmentConfig,
-    K8sPathConfig, OtlpProtobufDecodeModeConfig, OtlpTypeConfig, OutputConfig, OutputType,
-    PipelineConfig, SensorTypeConfig, ServerConfig, StaticEnrichmentConfig, StorageConfig,
-    TcpTypeConfig, TlsInputConfig, UdpTypeConfig,
+    ArrowIpcTypeConfig, AuthConfig, Config, ConfigError, ContainerInfoConfig, CsvEnrichmentConfig,
+    EnrichmentConfig, EnvVarsEnrichmentConfig, FileTypeConfig, Format,
+    GeneratorAttributeValueConfig, GeneratorComplexityConfig, GeneratorInputConfig,
+    GeneratorProfileConfig, GeneratorSequenceConfig, GeneratorTypeConfig, GeoDatabaseConfig,
+    GeoDatabaseFormat, HostInfoConfig, HostMetricsInputConfig, HttpInputConfig, HttpMethodConfig,
+    HttpTypeConfig, InputConfig, InputType, InputTypeConfig, JournaldBackendConfig,
+    JournaldInputConfig, JournaldTypeConfig, JsonlEnrichmentConfig, K8sClusterInfoConfig,
+    K8sPathConfig, KvFileEnrichmentConfig, NetworkInfoConfig, OtlpProtobufDecodeModeConfig,
+    OtlpTypeConfig, OutputConfig, OutputType, PipelineConfig, ProcessInfoConfig, SensorTypeConfig,
+    ServerConfig, StaticEnrichmentConfig, StorageConfig, TcpTypeConfig, TlsInputConfig,
+    UdpTypeConfig,
 };
 pub use validate::validate_host_port;
 

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -660,7 +660,7 @@ pub enum EnrichmentConfig {
     Jsonl(JsonlEnrichmentConfig),
     /// Populate a one-row enrichment table from environment variables.
     EnvVars(EnvVarsEnrichmentConfig),
-    /// Agent self-metadata: name, version, PID, start time.
+    /// Agent self-metadata: `agent_name`, `agent_version`, `pid`, `start_time`.
     ProcessInfo(ProcessInfoConfig),
     /// Parse a KEY=value properties file into a one-row enrichment table.
     KvFile(KvFileEnrichmentConfig),

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -548,7 +548,12 @@ pub struct OutputConfig {
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum GeoDatabaseFormat {
+    /// MaxMind GeoIP2 / GeoLite2 `.mmdb` binary format.
     Mmdb,
+    /// CSV file with `ip_range_start`, `ip_range_end` columns plus optional
+    /// `country_code`, `country_name`, `stateprov`, `city`, `latitude`,
+    /// `longitude`, `asn`, `org` columns.  Compatible with DB-IP Lite exports.
+    CsvRange,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -586,6 +591,9 @@ fn default_k8s_table_name() -> String {
 pub struct CsvEnrichmentConfig {
     pub table_name: String,
     pub path: String,
+    /// Reload the file from disk every N seconds. If absent the file is read
+    /// once at startup and never reloaded.
+    pub refresh_interval: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -593,7 +601,53 @@ pub struct CsvEnrichmentConfig {
 pub struct JsonlEnrichmentConfig {
     pub table_name: String,
     pub path: String,
+    /// Reload the file from disk every N seconds. If absent the file is read
+    /// once at startup and never reloaded.
+    pub refresh_interval: Option<u64>,
 }
+
+/// Enriches logs with a single-row table populated from environment variables
+/// whose names begin with `prefix`.  The prefix is stripped and the remainder
+/// lower-cased to form column names.
+///
+/// ```yaml
+/// enrichment:
+///   - type: env_vars
+///     table_name: deploy_meta
+///     prefix: LOGFWD_META_
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnvVarsEnrichmentConfig {
+    pub table_name: String,
+    /// Environment variable name prefix to filter on (e.g. `"LOGFWD_META_"`).
+    pub prefix: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProcessInfoConfig {}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KvFileEnrichmentConfig {
+    pub table_name: String,
+    pub path: String,
+    /// Reload the file from disk every N seconds.
+    pub refresh_interval: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NetworkInfoConfig {}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContainerInfoConfig {}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct K8sClusterInfoConfig {}
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -604,6 +658,18 @@ pub enum EnrichmentConfig {
     K8sPath(K8sPathConfig),
     Csv(CsvEnrichmentConfig),
     Jsonl(JsonlEnrichmentConfig),
+    /// Populate a one-row enrichment table from environment variables.
+    EnvVars(EnvVarsEnrichmentConfig),
+    /// Agent self-metadata: name, version, PID, start time.
+    ProcessInfo(ProcessInfoConfig),
+    /// Parse a KEY=value properties file into a one-row enrichment table.
+    KvFile(KvFileEnrichmentConfig),
+    /// Network interface metadata: hostname, IPs.
+    NetworkInfo(NetworkInfoConfig),
+    /// Container runtime detection: container ID, runtime name.
+    ContainerInfo(ContainerInfoConfig),
+    /// Kubernetes cluster metadata from downward API.
+    K8sClusterInfo(K8sClusterInfoConfig),
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -748,6 +748,11 @@ impl Config {
                                     "pipeline '{name}' enrichment #{j}: geo_database 'path' must not be empty"
                                 )));
                             }
+                            if geo_cfg.refresh_interval == Some(0) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: refresh_interval must be > 0"
+                                )));
+                            }
                             // Only check existence for absolute paths; relative paths
                             // are resolved against base_path in Pipeline::from_config.
                             let p = Path::new(&geo_cfg.path);
@@ -781,6 +786,11 @@ impl Config {
                                     "pipeline '{name}' enrichment #{j}: csv 'path' must not be empty"
                                 )));
                             }
+                            if cfg.refresh_interval == Some(0) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: refresh_interval must be > 0"
+                                )));
+                            }
                             let p = Path::new(&cfg.path);
                             if p.is_absolute() && !p.exists() {
                                 return Err(ConfigError::Validation(format!(
@@ -800,6 +810,11 @@ impl Config {
                                     "pipeline '{name}' enrichment #{j}: jsonl 'path' must not be empty"
                                 )));
                             }
+                            if cfg.refresh_interval == Some(0) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: refresh_interval must be > 0"
+                                )));
+                            }
                             let p = Path::new(&cfg.path);
                             if p.is_absolute() && !p.exists() {
                                 return Err(ConfigError::Validation(format!(
@@ -816,6 +831,46 @@ impl Config {
                             }
                         }
                         EnrichmentConfig::HostInfo(_) => {}
+                        EnrichmentConfig::ProcessInfo(_) => {}
+                        EnrichmentConfig::NetworkInfo(_) => {}
+                        EnrichmentConfig::ContainerInfo(_) => {}
+                        EnrichmentConfig::K8sClusterInfo(_) => {}
+                        EnrichmentConfig::EnvVars(cfg) => {
+                            if cfg.table_name.is_empty() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: table_name must not be empty"
+                                )));
+                            }
+                            if cfg.prefix.trim().is_empty() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: env_vars 'prefix' must not be empty"
+                                )));
+                            }
+                        }
+                        EnrichmentConfig::KvFile(cfg) => {
+                            if cfg.table_name.is_empty() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: table_name must not be empty"
+                                )));
+                            }
+                            if cfg.path.trim().is_empty() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: kv_file 'path' must not be empty"
+                                )));
+                            }
+                            if cfg.refresh_interval == Some(0) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: refresh_interval must be > 0"
+                                )));
+                            }
+                            let p = Path::new(&cfg.path);
+                            if p.is_absolute() && !p.exists() {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' enrichment #{j}: kv_file not found: {}",
+                                    cfg.path,
+                                )));
+                            }
+                        }
                     }
                 }
 

--- a/crates/logfwd-runtime/Cargo.toml
+++ b/crates/logfwd-runtime/Cargo.toml
@@ -58,6 +58,10 @@ tracing-subscriber = { workspace = true }
 turmoil = { workspace = true, features = [
     "unstable-barriers",
 ], optional = true }
+# HTTP client for the live enrichment processor (sync, no async runtime needed).
+ureq = { version = "3", default-features = false, features = ["rustls"] }
+# CSV parsing for the blocklist processor.
+csv = "1"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -90,33 +90,95 @@ impl Pipeline {
                             path = base.join(path);
                         }
 
-                        let db: Arc<dyn crate::transform::enrichment::GeoDatabase> = match geo_cfg
-                            .format
-                        {
-                            GeoDatabaseFormat::Mmdb => {
-                                let mmdb =
+                        let initial_db: Arc<dyn crate::transform::enrichment::GeoDatabase> =
+                            match geo_cfg.format {
+                                GeoDatabaseFormat::Mmdb => Arc::new(
                                     crate::transform::udf::geo_lookup::MmdbDatabase::open(&path)
                                         .map_err(|e| {
                                             format!(
                                                 "failed to open geo database '{}': {e}",
                                                 path.display()
                                             )
-                                        })?;
-                                Arc::new(mmdb)
-                            }
-                            _ => {
-                                return Err(format!(
-                                    "unsupported geo database format: {:?}",
-                                    geo_cfg.format
-                                ));
-                            }
-                        };
-                        if geo_cfg.refresh_interval.is_some() {
-                            tracing::warn!(
-                                "geo_database refresh_interval is not yet implemented, database will not auto-reload"
+                                        })?,
+                                ),
+                                GeoDatabaseFormat::CsvRange => Arc::new(
+                                    crate::transform::udf::CsvRangeDatabase::open(&path).map_err(
+                                        |e| {
+                                            format!(
+                                                "failed to open CSV geo database '{}': {e}",
+                                                path.display()
+                                            )
+                                        },
+                                    )?,
+                                ),
+                                _ => {
+                                    return Err(format!(
+                                        "unsupported geo database format for '{}'",
+                                        path.display()
+                                    ));
+                                }
+                            };
+
+                        if let Some(interval_secs) = geo_cfg.refresh_interval {
+                            let reloadable = Arc::new(
+                                crate::transform::enrichment::ReloadableGeoDb::new(initial_db),
                             );
+                            let reload_handle = reloadable.reload_handle();
+                            let reload_path = path.clone();
+                            let reload_format = geo_cfg.format.clone();
+
+                            tokio::spawn(async move {
+                                let mut ticker = tokio::time::interval(Duration::from_secs(
+                                    interval_secs.max(1),
+                                ));
+                                ticker.tick().await;
+                                loop {
+                                    ticker.tick().await;
+                                    let p = reload_path.clone();
+                                    let fmt = reload_format.clone();
+                                    let result = tokio::task::spawn_blocking(move || -> Result<Arc<dyn crate::transform::enrichment::GeoDatabase>, String> {
+                                        match fmt {
+                                            GeoDatabaseFormat::Mmdb => {
+                                                crate::transform::udf::geo_lookup::MmdbDatabase::open(&p)
+                                                    .map(|db| Arc::new(db) as Arc<dyn crate::transform::enrichment::GeoDatabase>)
+                                                    .map_err(|e| e.to_string())
+                                            }
+                                            GeoDatabaseFormat::CsvRange => {
+                                                crate::transform::udf::CsvRangeDatabase::open(&p)
+                                                    .map(|db| Arc::new(db) as Arc<dyn crate::transform::enrichment::GeoDatabase>)
+                                                    .map_err(|e| e.to_string())
+                                            }
+                                            _ => Err(format!("unsupported geo database format for reload: {:?}", fmt)),
+                                        }
+                                    })
+                                    .await;
+                                    match result {
+                                        Ok(Ok(db)) => {
+                                            reload_handle.replace(db);
+                                            tracing::info!(
+                                                path = %reload_path.display(),
+                                                "geo database reloaded"
+                                            );
+                                        }
+                                        Ok(Err(e)) => tracing::warn!(
+                                            path = %reload_path.display(),
+                                            error = %e,
+                                            "geo database reload failed, keeping previous"
+                                        ),
+                                        Err(e) => tracing::warn!(
+                                            error = %e,
+                                            "geo database reload task panicked"
+                                        ),
+                                    }
+                                }
+                            });
+
+                            geo_database = Some(
+                                reloadable as Arc<dyn crate::transform::enrichment::GeoDatabase>,
+                            );
+                        } else {
+                            geo_database = Some(initial_db);
                         }
-                        geo_database = Some(db);
                     }
                     EnrichmentConfig::Static(cfg) => {
                         let labels: Vec<(String, String)> = cfg
@@ -157,6 +219,34 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
+                        if let Some(interval_secs) = cfg.refresh_interval {
+                            let t = Arc::clone(&table);
+                            let name = cfg.table_name.clone();
+                            tokio::spawn(async move {
+                                let mut ticker = tokio::time::interval(Duration::from_secs(
+                                    interval_secs.max(1),
+                                ));
+                                ticker.tick().await;
+                                loop {
+                                    ticker.tick().await;
+                                    let t2 = Arc::clone(&t);
+                                    match tokio::task::spawn_blocking(move || t2.reload()).await {
+                                        Ok(Ok(n)) => tracing::debug!(
+                                            table = %name, rows = n,
+                                            "CSV enrichment table reloaded"
+                                        ),
+                                        Ok(Err(e)) => tracing::warn!(
+                                            table = %name, error = %e,
+                                            "CSV enrichment table reload failed"
+                                        ),
+                                        Err(e) => tracing::warn!(
+                                            table = %name, error = %e,
+                                            "CSV enrichment table reload task panicked"
+                                        ),
+                                    }
+                                }
+                            });
+                        }
                         enrichment_tables.push(table);
                     }
                     EnrichmentConfig::Jsonl(cfg) => {
@@ -174,6 +264,106 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
+                        if let Some(interval_secs) = cfg.refresh_interval {
+                            let t = Arc::clone(&table);
+                            let name = cfg.table_name.clone();
+                            tokio::spawn(async move {
+                                let mut ticker = tokio::time::interval(Duration::from_secs(
+                                    interval_secs.max(1),
+                                ));
+                                ticker.tick().await;
+                                loop {
+                                    ticker.tick().await;
+                                    let t2 = Arc::clone(&t);
+                                    match tokio::task::spawn_blocking(move || t2.reload()).await {
+                                        Ok(Ok(n)) => tracing::debug!(
+                                            table = %name, rows = n,
+                                            "JSONL enrichment table reloaded"
+                                        ),
+                                        Ok(Err(e)) => tracing::warn!(
+                                            table = %name, error = %e,
+                                            "JSONL enrichment table reload failed"
+                                        ),
+                                        Err(e) => tracing::warn!(
+                                            table = %name, error = %e,
+                                            "JSONL enrichment table reload task panicked"
+                                        ),
+                                    }
+                                }
+                            });
+                        }
+                        enrichment_tables.push(table);
+                    }
+                    EnrichmentConfig::EnvVars(cfg) => {
+                        let table = Arc::new(
+                            crate::transform::enrichment::EnvTable::from_prefix(
+                                &cfg.table_name,
+                                &cfg.prefix,
+                            )
+                            .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?,
+                        );
+                        enrichment_tables.push(table);
+                    }
+                    EnrichmentConfig::ProcessInfo(_) => {
+                        let table = Arc::new(crate::transform::enrichment::ProcessInfoTable::new());
+                        enrichment_tables.push(table);
+                    }
+                    EnrichmentConfig::KvFile(cfg) => {
+                        let mut path = PathBuf::from(&cfg.path);
+                        if path.is_relative()
+                            && let Some(base) = base_path
+                        {
+                            path = base.join(path);
+                        }
+                        let table = Arc::new(crate::transform::enrichment::KvFileTable::new(
+                            &cfg.table_name,
+                            &path,
+                        ));
+                        table
+                            .reload()
+                            .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
+                        if let Some(interval_secs) = cfg.refresh_interval {
+                            let t = Arc::clone(&table);
+                            let name = cfg.table_name.clone();
+                            tokio::spawn(async move {
+                                let mut ticker = tokio::time::interval(Duration::from_secs(
+                                    interval_secs.max(1),
+                                ));
+                                ticker.tick().await;
+                                loop {
+                                    ticker.tick().await;
+                                    let t2 = Arc::clone(&t);
+                                    match tokio::task::spawn_blocking(move || t2.reload()).await {
+                                        Ok(Ok(n)) => tracing::debug!(
+                                            table = %name, columns = n,
+                                            "KV file enrichment table reloaded"
+                                        ),
+                                        Ok(Err(e)) => tracing::warn!(
+                                            table = %name, error = %e,
+                                            "KV file enrichment table reload failed"
+                                        ),
+                                        Err(e) => tracing::warn!(
+                                            table = %name, error = %e,
+                                            "KV file enrichment table reload task panicked"
+                                        ),
+                                    }
+                                }
+                            });
+                        }
+                        enrichment_tables.push(table);
+                    }
+                    EnrichmentConfig::NetworkInfo(_) => {
+                        let table = Arc::new(crate::transform::enrichment::NetworkInfoTable::new());
+                        enrichment_tables.push(table);
+                    }
+                    EnrichmentConfig::ContainerInfo(_) => {
+                        let table =
+                            Arc::new(crate::transform::enrichment::ContainerInfoTable::new());
+                        enrichment_tables.push(table);
+                    }
+                    EnrichmentConfig::K8sClusterInfo(_) => {
+                        let table =
+                            Arc::new(crate::transform::enrichment::K8sClusterInfoTable::new());
                         enrichment_tables.push(table);
                     }
                 }
@@ -447,59 +637,23 @@ mod tests {
 
     fn minimal_output() -> OutputConfig {
         OutputConfig {
-            name: Some("output".to_string()),
             output_type: OutputType::Stdout,
             ..Default::default()
         }
     }
 
-    #[test]
-    fn from_config_rejects_missing_inputs() {
-        let cfg = PipelineConfig {
-            inputs: Vec::new(),
-            transform: None,
+    fn minimal_config(path: String) -> PipelineConfig {
+        PipelineConfig {
+            inputs: vec![minimal_input(path)],
             outputs: vec![minimal_output()],
-            enrichment: Vec::new(),
-            resource_attrs: Default::default(),
-            workers: None,
-            batch_target_bytes: None,
-            batch_timeout_ms: None,
-            poll_interval_ms: None,
-        };
-        let err = match Pipeline::from_config("p", &cfg, &logfwd_test_utils::test_meter(), None) {
-            Ok(_) => panic!("empty inputs must be rejected"),
-            Err(err) => err,
-        };
-        assert!(
-            err.contains("at least one input"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn from_config_rejects_missing_outputs() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let log_path = dir.path().join("in.log");
-        std::fs::write(&log_path, b"{\"level\":\"INFO\"}\n").expect("write input");
-        let cfg = PipelineConfig {
-            inputs: vec![minimal_input(log_path.to_string_lossy().into_owned())],
             transform: None,
-            outputs: Vec::new(),
-            enrichment: Vec::new(),
-            resource_attrs: Default::default(),
+            enrichment: vec![],
+            resource_attrs: std::collections::HashMap::new(),
             workers: None,
             batch_target_bytes: None,
             batch_timeout_ms: None,
             poll_interval_ms: None,
-        };
-        let err = match Pipeline::from_config("p", &cfg, &logfwd_test_utils::test_meter(), None) {
-            Ok(_) => panic!("empty outputs must be rejected"),
-            Err(err) => err,
-        };
-        assert!(
-            err.contains("at least one output"),
-            "unexpected error: {err}"
-        );
+        }
     }
 
     #[test]
@@ -544,7 +698,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let log_path = dir.path().join("in.log");
         std::fs::write(&log_path, b"{\"level\":\"INFO\"}\n").expect("write input");
-        let mut cfg = PipelineConfig {
+        let cfg = PipelineConfig {
             inputs: vec![minimal_input(log_path.to_string_lossy().into_owned())],
             transform: None,
             outputs: vec![minimal_output()],
@@ -565,17 +719,22 @@ mod tests {
             batch_err.contains("batch_timeout_ms must be > 0"),
             "unexpected error: {batch_err}"
         );
+    }
 
-        cfg.batch_timeout_ms = None;
-        cfg.poll_interval_ms = Some(0);
-        let poll_err =
-            match Pipeline::from_config("p", &cfg, &logfwd_test_utils::test_meter(), None) {
-                Ok(_) => panic!("zero poll interval must be rejected"),
-                Err(err) => err,
-            };
+    #[test]
+    fn workers_zero_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        std::fs::write(&log_path, b"").unwrap();
+
+        let mut config = minimal_config(log_path.display().to_string());
+        config.workers = Some(0);
+        let err = Pipeline::from_config("default", &config, &logfwd_test_utils::test_meter(), None)
+            .err()
+            .unwrap();
         assert!(
-            poll_err.contains("poll_interval_ms must be > 0"),
-            "unexpected error: {poll_err}"
+            err.contains("workers must be >= 1"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -127,7 +127,8 @@ impl Pipeline {
                             let reload_path = path.clone();
                             let reload_format = geo_cfg.format.clone();
 
-                            tokio::spawn(async move {
+                            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                                handle.spawn(async move {
                                 let mut ticker = tokio::time::interval(Duration::from_secs(
                                     interval_secs.max(1),
                                 ));
@@ -172,6 +173,7 @@ impl Pipeline {
                                     }
                                 }
                             });
+                            }
 
                             geo_database = Some(
                                 reloadable as Arc<dyn crate::transform::enrichment::GeoDatabase>,
@@ -222,30 +224,33 @@ impl Pipeline {
                         if let Some(interval_secs) = cfg.refresh_interval {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
-                            tokio::spawn(async move {
-                                let mut ticker = tokio::time::interval(Duration::from_secs(
-                                    interval_secs.max(1),
-                                ));
-                                ticker.tick().await;
-                                loop {
+                            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                                handle.spawn(async move {
+                                    let mut ticker = tokio::time::interval(Duration::from_secs(
+                                        interval_secs.max(1),
+                                    ));
                                     ticker.tick().await;
-                                    let t2 = Arc::clone(&t);
-                                    match tokio::task::spawn_blocking(move || t2.reload()).await {
-                                        Ok(Ok(n)) => tracing::debug!(
-                                            table = %name, rows = n,
-                                            "CSV enrichment table reloaded"
-                                        ),
-                                        Ok(Err(e)) => tracing::warn!(
-                                            table = %name, error = %e,
-                                            "CSV enrichment table reload failed"
-                                        ),
-                                        Err(e) => tracing::warn!(
-                                            table = %name, error = %e,
-                                            "CSV enrichment table reload task panicked"
-                                        ),
+                                    loop {
+                                        ticker.tick().await;
+                                        let t2 = Arc::clone(&t);
+                                        match tokio::task::spawn_blocking(move || t2.reload()).await
+                                        {
+                                            Ok(Ok(n)) => tracing::debug!(
+                                                table = %name, rows = n,
+                                                "CSV enrichment table reloaded"
+                                            ),
+                                            Ok(Err(e)) => tracing::warn!(
+                                                table = %name, error = %e,
+                                                "CSV enrichment table reload failed"
+                                            ),
+                                            Err(e) => tracing::warn!(
+                                                table = %name, error = %e,
+                                                "CSV enrichment table reload task panicked"
+                                            ),
+                                        }
                                     }
-                                }
-                            });
+                                });
+                            }
                         }
                         enrichment_tables.push(table);
                     }
@@ -267,30 +272,33 @@ impl Pipeline {
                         if let Some(interval_secs) = cfg.refresh_interval {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
-                            tokio::spawn(async move {
-                                let mut ticker = tokio::time::interval(Duration::from_secs(
-                                    interval_secs.max(1),
-                                ));
-                                ticker.tick().await;
-                                loop {
+                            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                                handle.spawn(async move {
+                                    let mut ticker = tokio::time::interval(Duration::from_secs(
+                                        interval_secs.max(1),
+                                    ));
                                     ticker.tick().await;
-                                    let t2 = Arc::clone(&t);
-                                    match tokio::task::spawn_blocking(move || t2.reload()).await {
-                                        Ok(Ok(n)) => tracing::debug!(
-                                            table = %name, rows = n,
-                                            "JSONL enrichment table reloaded"
-                                        ),
-                                        Ok(Err(e)) => tracing::warn!(
-                                            table = %name, error = %e,
-                                            "JSONL enrichment table reload failed"
-                                        ),
-                                        Err(e) => tracing::warn!(
-                                            table = %name, error = %e,
-                                            "JSONL enrichment table reload task panicked"
-                                        ),
+                                    loop {
+                                        ticker.tick().await;
+                                        let t2 = Arc::clone(&t);
+                                        match tokio::task::spawn_blocking(move || t2.reload()).await
+                                        {
+                                            Ok(Ok(n)) => tracing::debug!(
+                                                table = %name, rows = n,
+                                                "JSONL enrichment table reloaded"
+                                            ),
+                                            Ok(Err(e)) => tracing::warn!(
+                                                table = %name, error = %e,
+                                                "JSONL enrichment table reload failed"
+                                            ),
+                                            Err(e) => tracing::warn!(
+                                                table = %name, error = %e,
+                                                "JSONL enrichment table reload task panicked"
+                                            ),
+                                        }
                                     }
-                                }
-                            });
+                                });
+                            }
                         }
                         enrichment_tables.push(table);
                     }
@@ -325,30 +333,33 @@ impl Pipeline {
                         if let Some(interval_secs) = cfg.refresh_interval {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
-                            tokio::spawn(async move {
-                                let mut ticker = tokio::time::interval(Duration::from_secs(
-                                    interval_secs.max(1),
-                                ));
-                                ticker.tick().await;
-                                loop {
+                            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                                handle.spawn(async move {
+                                    let mut ticker = tokio::time::interval(Duration::from_secs(
+                                        interval_secs.max(1),
+                                    ));
                                     ticker.tick().await;
-                                    let t2 = Arc::clone(&t);
-                                    match tokio::task::spawn_blocking(move || t2.reload()).await {
-                                        Ok(Ok(n)) => tracing::debug!(
-                                            table = %name, columns = n,
-                                            "KV file enrichment table reloaded"
-                                        ),
-                                        Ok(Err(e)) => tracing::warn!(
-                                            table = %name, error = %e,
-                                            "KV file enrichment table reload failed"
-                                        ),
-                                        Err(e) => tracing::warn!(
-                                            table = %name, error = %e,
-                                            "KV file enrichment table reload task panicked"
-                                        ),
+                                    loop {
+                                        ticker.tick().await;
+                                        let t2 = Arc::clone(&t);
+                                        match tokio::task::spawn_blocking(move || t2.reload()).await
+                                        {
+                                            Ok(Ok(n)) => tracing::debug!(
+                                                table = %name, columns = n,
+                                                "KV file enrichment table reloaded"
+                                            ),
+                                            Ok(Err(e)) => tracing::warn!(
+                                                table = %name, error = %e,
+                                                "KV file enrichment table reload failed"
+                                            ),
+                                            Err(e) => tracing::warn!(
+                                                table = %name, error = %e,
+                                                "KV file enrichment table reload task panicked"
+                                            ),
+                                        }
                                     }
-                                }
-                            });
+                                });
+                            }
                         }
                         enrichment_tables.push(table);
                     }

--- a/crates/logfwd-runtime/src/processor/blocklist.rs
+++ b/crates/logfwd-runtime/src/processor/blocklist.rs
@@ -187,9 +187,13 @@ impl Processor for BlocklistProcessor {
                 }
             }
             _ => {
-                // Unsupported column type — all rows are non-matches.
-                let enriched = append_columns(batch, num_rows, &self.prefix, None)?;
-                return Ok(smallvec![enriched]);
+                // Unsupported column type — return an error rather than silently
+                // treating all rows as non-matches, which would hide schema drift.
+                return Err(ProcessorError::Permanent(format!(
+                    "blocklist: source_column '{}' has unsupported type {:?} (expected Utf8/Utf8View/LargeUtf8)",
+                    self.source_column,
+                    col.data_type()
+                )));
             }
         }
 

--- a/crates/logfwd-runtime/src/processor/blocklist.rs
+++ b/crates/logfwd-runtime/src/processor/blocklist.rs
@@ -1,0 +1,455 @@
+//! Blocklist enrichment processor.
+//!
+//! Adds two columns to every batch:
+//!
+//! - `<prefix>_match: Boolean` — `true` if the source column value is listed
+//!   in the blocklist.
+//! - `<prefix>_category: Utf8` — the category for the matched entry, or `NULL`
+//!   for non-matches.
+//!
+//! The blocklist is loaded from a CSV file at construction time.  The CSV must
+//! have:
+//! - A `key` column (the value to match against the source column).
+//! - An optional `category` column (label for matched entries).
+//!
+//! This processor is stateless — it adds columns based on a pre-loaded table
+//! without buffering any batches.
+//!
+//! ## Config (not yet wired — call `BlocklistProcessor::new` directly)
+//!
+//! ```yaml
+//! # Planned config schema (not yet in PipelineConfig):
+//! processors:
+//!   - type: blocklist
+//!     source_column: client_ip
+//!     path: /etc/logfwd/blocklist.csv
+//!     prefix: bl
+//! ```
+//!
+//! ## CSV format
+//!
+//! ```csv
+//! key,category
+//! 1.2.3.4,malware-c2
+//! 5.6.7.8,port-scanner
+//! bad-user-agent,bot
+//! ```
+//!
+//! The key column is required; `category` is optional.  All comparisons are
+//! case-sensitive exact matches.
+
+use std::collections::HashMap;
+use std::io;
+use std::path::Path;
+use std::sync::Arc;
+
+use arrow::array::{Array, BooleanBuilder, StringBuilder};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use logfwd_output::BatchMetadata;
+use smallvec::{SmallVec, smallvec};
+
+use crate::processor::{Processor, ProcessorError};
+
+// ---------------------------------------------------------------------------
+// BlocklistProcessor
+// ---------------------------------------------------------------------------
+
+/// Stateless processor that tags each row with blocklist match and category
+/// columns.
+///
+/// Adds `{prefix}_match: Boolean` and `{prefix}_category: Utf8` to every
+/// output batch.  Non-matched and NULL source values get `false` and `NULL`
+/// respectively.
+#[derive(Debug)]
+pub struct BlocklistProcessor {
+    /// Column to look up in the blocklist.
+    source_column: String,
+    /// Output column name prefix.
+    prefix: String,
+    /// `key → category` map loaded from the CSV.
+    entries: HashMap<String, Option<String>>,
+}
+
+impl BlocklistProcessor {
+    /// Build from an in-memory CSV.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the CSV is missing the required `key` header or
+    /// contains a parse error.
+    pub fn from_reader<R: io::Read>(
+        source_column: impl Into<String>,
+        prefix: impl Into<String>,
+        reader: R,
+    ) -> Result<Self, String> {
+        let entries = load_blocklist(reader)?;
+        Ok(BlocklistProcessor {
+            source_column: source_column.into(),
+            prefix: prefix.into(),
+            entries,
+        })
+    }
+
+    /// Load from a file path.
+    pub fn open(
+        source_column: impl Into<String>,
+        prefix: impl Into<String>,
+        path: &Path,
+    ) -> Result<Self, String> {
+        let file = std::fs::File::open(path)
+            .map_err(|e| format!("blocklist: failed to open '{}': {e}", path.display()))?;
+        Self::from_reader(source_column, prefix, io::BufReader::new(file))
+    }
+
+    /// Number of entries in the blocklist.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if no entries were loaded.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Processor for BlocklistProcessor {
+    fn name(&self) -> &'static str {
+        "blocklist"
+    }
+
+    fn is_stateful(&self) -> bool {
+        false
+    }
+
+    fn process(
+        &mut self,
+        batch: RecordBatch,
+        _meta: &BatchMetadata,
+    ) -> Result<SmallVec<[RecordBatch; 1]>, ProcessorError> {
+        let num_rows = batch.num_rows();
+
+        if num_rows == 0 {
+            // Still append columns so downstream sees a consistent schema.
+            let enriched = append_columns(batch, 0, &self.prefix, None)?;
+            return Ok(smallvec![enriched]);
+        }
+
+        // Locate the source column.
+        let col = match batch.column_by_name(&self.source_column) {
+            Some(c) => c,
+            None => {
+                // Source column absent — all rows are non-matches.
+                let enriched = append_columns(batch, num_rows, &self.prefix, None)?;
+                return Ok(smallvec![enriched]);
+            }
+        };
+
+        let mut match_builder = BooleanBuilder::with_capacity(num_rows);
+        let mut cat_builder = StringBuilder::with_capacity(num_rows, num_rows * 8);
+
+        // Look up each row directly from the Arrow array — zero per-row allocations.
+        match col.data_type() {
+            DataType::Utf8 => {
+                use arrow::array::AsArray;
+                let arr = col.as_string::<i32>();
+                for i in 0..num_rows {
+                    let key = if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    };
+                    append_lookup(&self.entries, key, &mut match_builder, &mut cat_builder);
+                }
+            }
+            DataType::Utf8View => {
+                use arrow::array::AsArray;
+                let arr = col.as_string_view();
+                for i in 0..num_rows {
+                    let key = if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    };
+                    append_lookup(&self.entries, key, &mut match_builder, &mut cat_builder);
+                }
+            }
+            DataType::LargeUtf8 => {
+                use arrow::array::AsArray;
+                let arr = col.as_string::<i64>();
+                for i in 0..num_rows {
+                    let key = if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i))
+                    };
+                    append_lookup(&self.entries, key, &mut match_builder, &mut cat_builder);
+                }
+            }
+            _ => {
+                // Unsupported column type — all rows are non-matches.
+                let enriched = append_columns(batch, num_rows, &self.prefix, None)?;
+                return Ok(smallvec![enriched]);
+            }
+        }
+
+        let match_col = Arc::new(match_builder.finish());
+        let cat_col = Arc::new(cat_builder.finish());
+
+        append_pre_built_columns(
+            batch,
+            &self.prefix,
+            match_col as Arc<dyn Array>,
+            cat_col as Arc<dyn Array>,
+        )
+        .map(|b| smallvec![b])
+    }
+
+    fn flush(&mut self) -> SmallVec<[RecordBatch; 1]> {
+        SmallVec::new() // stateless — nothing to flush
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Perform a single-row blocklist lookup and append the result.
+fn append_lookup(
+    entries: &HashMap<String, Option<String>>,
+    key: Option<&str>,
+    match_builder: &mut BooleanBuilder,
+    cat_builder: &mut StringBuilder,
+) {
+    match key.and_then(|k| entries.get(k)) {
+        Some(cat) => {
+            match_builder.append_value(true);
+            match cat {
+                Some(c) => cat_builder.append_value(c.as_str()),
+                None => cat_builder.append_null(),
+            }
+        }
+        None => {
+            match_builder.append_value(false);
+            cat_builder.append_null();
+        }
+    }
+}
+
+/// Append `{prefix}_match = all-false` and `{prefix}_category = all-NULL` columns.
+fn append_columns(
+    batch: RecordBatch,
+    num_rows: usize,
+    prefix: &str,
+    _source: Option<&Arc<dyn Array>>,
+) -> Result<RecordBatch, ProcessorError> {
+    let mut match_builder = BooleanBuilder::with_capacity(num_rows);
+    let mut cat_builder = StringBuilder::with_capacity(num_rows, 0);
+    for _ in 0..num_rows {
+        match_builder.append_value(false);
+        cat_builder.append_null();
+    }
+    append_pre_built_columns(
+        batch,
+        prefix,
+        Arc::new(match_builder.finish()) as Arc<dyn Array>,
+        Arc::new(cat_builder.finish()) as Arc<dyn Array>,
+    )
+}
+
+fn append_pre_built_columns(
+    batch: RecordBatch,
+    prefix: &str,
+    match_col: Arc<dyn Array>,
+    cat_col: Arc<dyn Array>,
+) -> Result<RecordBatch, ProcessorError> {
+    let match_name = format!("{prefix}_match");
+    let cat_name = format!("{prefix}_category");
+
+    let mut fields = batch.schema().fields().to_vec();
+    fields.push(Arc::new(Field::new(&match_name, DataType::Boolean, false)));
+    fields.push(Arc::new(Field::new(&cat_name, DataType::Utf8, true)));
+
+    let schema = Arc::new(Schema::new(fields));
+
+    let mut columns: Vec<Arc<dyn Array>> = batch.columns().to_vec();
+    columns.push(match_col);
+    columns.push(cat_col);
+
+    RecordBatch::try_new(schema, columns)
+        .map_err(|e| ProcessorError::Permanent(format!("blocklist: failed to build batch: {e}")))
+}
+
+/// Read the blocklist CSV into a `HashMap<key, Option<category>>`.
+fn load_blocklist<R: io::Read>(reader: R) -> Result<HashMap<String, Option<String>>, String> {
+    let mut csv = csv::ReaderBuilder::new().flexible(true).from_reader(reader);
+
+    let headers: Vec<String> = csv
+        .headers()
+        .map_err(|e| format!("blocklist CSV header error: {e}"))?
+        .iter()
+        .map(|h| h.trim().to_lowercase())
+        .collect();
+
+    let key_idx = headers
+        .iter()
+        .position(|h| h == "key")
+        .ok_or_else(|| "blocklist CSV missing required 'key' column".to_string())?;
+
+    let cat_idx = headers.iter().position(|h| h == "category");
+
+    let mut entries: HashMap<String, Option<String>> = HashMap::new();
+
+    for (row_num, record) in csv.records().enumerate() {
+        let record =
+            record.map_err(|e| format!("blocklist CSV parse error at row {row_num}: {e}"))?;
+
+        let key = record.get(key_idx).unwrap_or("").trim().to_owned();
+        if key.is_empty() {
+            continue;
+        }
+
+        let category = cat_idx
+            .and_then(|i| record.get(i))
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+
+        if let Some(existing) = entries.get(&key) {
+            if existing != &category {
+                return Err(format!(
+                    "blocklist CSV duplicate key '{}' at row {} with conflicting category",
+                    key,
+                    row_num + 1
+                ));
+            }
+            // Same key, same category — skip duplicate.
+            continue;
+        }
+        entries.insert(key, category);
+    }
+
+    Ok(entries)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, BooleanArray, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use logfwd_output::BatchMetadata;
+    use std::sync::Arc;
+
+    fn meta() -> BatchMetadata {
+        BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 0,
+        }
+    }
+
+    fn make_batch(ips: &[Option<&str>]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("ip", DataType::Utf8, true)]));
+        let arr: StringArray = ips.iter().map(|s| *s).collect();
+        RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap()
+    }
+
+    const CSV: &[u8] = b"key,category\n1.2.3.4,malware-c2\n5.6.7.8,port-scanner\nbad-bot,\n";
+
+    #[test]
+    fn load_from_reader() {
+        let proc = BlocklistProcessor::from_reader("ip", "bl", CSV).unwrap();
+        assert_eq!(proc.len(), 3);
+    }
+
+    #[test]
+    fn match_adds_columns() {
+        let mut proc = BlocklistProcessor::from_reader("ip", "bl", CSV).unwrap();
+        let batch = make_batch(&[Some("1.2.3.4"), Some("8.8.8.8"), None]);
+        let output = proc.process(batch, &meta()).unwrap();
+        assert_eq!(output.len(), 1);
+        let out = &output[0];
+
+        let matches = out
+            .column_by_name("bl_match")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(matches.value(0)); // matched
+        assert!(!matches.value(1)); // miss
+        assert!(!matches.value(2)); // NULL source → miss
+
+        let cats = out
+            .column_by_name("bl_category")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(cats.value(0), "malware-c2");
+        assert!(cats.is_null(1));
+        assert!(cats.is_null(2));
+    }
+
+    #[test]
+    fn no_category_column_is_null() {
+        let csv = b"key\n1.2.3.4\n5.6.7.8\n";
+        let mut proc = BlocklistProcessor::from_reader("ip", "bl", &csv[..]).unwrap();
+        let batch = make_batch(&[Some("1.2.3.4")]);
+        let out = &proc.process(batch, &meta()).unwrap()[0];
+
+        let matches = out
+            .column_by_name("bl_match")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(matches.value(0));
+
+        let cats = out
+            .column_by_name("bl_category")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert!(cats.is_null(0));
+    }
+
+    #[test]
+    fn source_column_absent_all_miss() {
+        let mut proc = BlocklistProcessor::from_reader("missing_col", "bl", CSV).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Utf8, true)]));
+        let arr: StringArray = vec![Some("1.2.3.4")].into_iter().collect();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
+        let out = &proc.process(batch, &meta()).unwrap()[0];
+        let matches = out
+            .column_by_name("bl_match")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap();
+        assert!(!matches.value(0));
+    }
+
+    #[test]
+    fn empty_batch_passed_through() {
+        let mut proc = BlocklistProcessor::from_reader("ip", "bl", CSV).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new("ip", DataType::Utf8, true)]));
+        let values: Vec<Option<&str>> = vec![];
+        let arr: StringArray = values.into_iter().collect();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).unwrap();
+        let out = proc.process(batch, &meta()).unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].num_rows(), 0);
+    }
+
+    #[test]
+    fn missing_key_column_returns_error() {
+        let csv = b"value,category\n1.2.3.4,bad\n";
+        let result = BlocklistProcessor::from_reader("ip", "bl", &csv[..]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/logfwd-runtime/src/processor/blocklist.rs
+++ b/crates/logfwd-runtime/src/processor/blocklist.rs
@@ -302,7 +302,7 @@ fn load_blocklist<R: io::Read>(reader: R) -> Result<HashMap<String, Option<Strin
 
     for (row_num, record) in csv.records().enumerate() {
         let record =
-            record.map_err(|e| format!("blocklist CSV parse error at row {row_num}: {e}"))?;
+            record.map_err(|e| format!("blocklist CSV parse error at row {}: {e}", row_num + 1))?;
 
         let key = record.get(key_idx).unwrap_or("").trim().to_owned();
         if key.is_empty() {

--- a/crates/logfwd-runtime/src/processor/http_enrich.rs
+++ b/crates/logfwd-runtime/src/processor/http_enrich.rs
@@ -185,9 +185,15 @@ impl HttpEnrichProcessor {
         };
 
         // Evict if we would exceed capacity after inserting.
-        let headroom = results.len();
-        if cache.len() + headroom > self.config.max_entries {
-            let evict_target = (cache.len() + headroom).saturating_sub(self.config.max_entries)
+        // Only count cacheable entries (non-Error) for headroom since errors
+        // are skipped below.
+        let cacheable_count = results
+            .iter()
+            .filter(|(_, r)| !matches!(r, LookupResult::Error(_)))
+            .count();
+        if cache.len() + cacheable_count > self.config.max_entries {
+            let evict_target = (cache.len() + cacheable_count)
+                .saturating_sub(self.config.max_entries)
                 + self.config.max_entries / 10;
             let mut entries: Vec<(Instant, String)> = cache
                 .iter()

--- a/crates/logfwd-runtime/src/processor/http_enrich.rs
+++ b/crates/logfwd-runtime/src/processor/http_enrich.rs
@@ -97,6 +97,10 @@ pub struct HttpEnrichConfig {
     pub ttl: Duration,
     /// Maximum number of concurrent HTTP lookups per batch (capped at 64).
     pub max_concurrency: usize,
+    /// Maximum response body size in bytes. Responses larger than this are
+    /// classified as errors to protect against unbounded memory growth.
+    /// Defaults to 1 MiB.
+    pub max_body_bytes: u64,
 }
 
 impl HttpEnrichConfig {
@@ -114,6 +118,7 @@ impl HttpEnrichConfig {
             max_entries: 50_000,
             ttl: Duration::from_secs(300),
             max_concurrency: 8,
+            max_body_bytes: 1_048_576, // 1 MiB
         }
     }
 }
@@ -220,8 +225,20 @@ impl HttpEnrichProcessor {
             Ok(resp) => {
                 let status = resp.status();
                 if status == 200 {
-                    match resp.into_body().read_to_string() {
-                        Ok(body) if !body.trim().is_empty() => LookupResult::Hit(body),
+                    use std::io::Read;
+                    let limit = self.config.max_body_bytes;
+                    let mut buf = String::new();
+                    match resp
+                        .into_body()
+                        .as_reader()
+                        .take(limit + 1)
+                        .read_to_string(&mut buf)
+                    {
+                        Ok(n) if n as u64 > limit => LookupResult::Error(format!(
+                            "response body exceeds {} byte limit",
+                            limit
+                        )),
+                        Ok(_) if !buf.trim().is_empty() => LookupResult::Hit(buf),
                         Ok(_) => LookupResult::Miss,
                         Err(e) => LookupResult::Error(format!("body read failed: {e}")),
                     }

--- a/crates/logfwd-runtime/src/processor/http_enrich.rs
+++ b/crates/logfwd-runtime/src/processor/http_enrich.rs
@@ -366,7 +366,7 @@ impl Processor for HttpEnrichProcessor {
         // 1. Extract keys from the source column.
         let keys: Vec<Option<String>> = match batch.column_by_name(&self.config.source_column) {
             None => vec![None; num_rows],
-            Some(col) => extract_strings(col, num_rows),
+            Some(col) => extract_strings(col, num_rows, &self.config.source_column)?,
         };
 
         // 2. Deduplicate keys and check cache.
@@ -453,12 +453,16 @@ impl Processor for HttpEnrichProcessor {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn extract_strings(col: &Arc<dyn arrow::array::Array>, num_rows: usize) -> Vec<Option<String>> {
+fn extract_strings(
+    col: &Arc<dyn arrow::array::Array>,
+    num_rows: usize,
+    column_name: &str,
+) -> Result<Vec<Option<String>>, ProcessorError> {
     use arrow::array::{Array, AsArray};
     match col.data_type() {
         DataType::Utf8 => {
             let arr = col.as_string::<i32>();
-            (0..num_rows)
+            Ok((0..num_rows)
                 .map(|i| {
                     if arr.is_null(i) {
                         None
@@ -466,11 +470,11 @@ fn extract_strings(col: &Arc<dyn arrow::array::Array>, num_rows: usize) -> Vec<O
                         Some(arr.value(i).to_owned())
                     }
                 })
-                .collect()
+                .collect())
         }
         DataType::Utf8View => {
             let arr = col.as_string_view();
-            (0..num_rows)
+            Ok((0..num_rows)
                 .map(|i| {
                     if arr.is_null(i) {
                         None
@@ -478,11 +482,11 @@ fn extract_strings(col: &Arc<dyn arrow::array::Array>, num_rows: usize) -> Vec<O
                         Some(arr.value(i).to_owned())
                     }
                 })
-                .collect()
+                .collect())
         }
         DataType::LargeUtf8 => {
             let arr = col.as_string::<i64>();
-            (0..num_rows)
+            Ok((0..num_rows)
                 .map(|i| {
                     if arr.is_null(i) {
                         None
@@ -490,9 +494,11 @@ fn extract_strings(col: &Arc<dyn arrow::array::Array>, num_rows: usize) -> Vec<O
                         Some(arr.value(i).to_owned())
                     }
                 })
-                .collect()
+                .collect())
         }
-        _ => vec![None; num_rows],
+        other => Err(ProcessorError::Permanent(format!(
+            "http_enrich: source column '{column_name}' has unsupported type {other}; expected a string type"
+        ))),
     }
 }
 

--- a/crates/logfwd-runtime/src/processor/http_enrich.rs
+++ b/crates/logfwd-runtime/src/processor/http_enrich.rs
@@ -1,0 +1,759 @@
+//! Batch-blocking HTTP enrichment processor.
+//!
+//! Enriches batches by looking up per-row keys against a remote HTTP endpoint.
+//! Uses a local in-process cache to avoid repeated requests.
+//!
+//! ## Processing model
+//!
+//! This processor is **batch-blocking**: every row in the batch is fully
+//! enriched before the batch is forwarded downstream. The pipeline never
+//! sees "pending" rows.
+//!
+//! 1. Extract unique keys from the source column.
+//! 2. Check the local cache — hits skip the network entirely.
+//! 3. Fetch cache misses concurrently (bounded by `max_concurrency`).
+//! 4. Wait for all lookups to complete (each subject to `timeout`).
+//! 5. Build the enriched batch — every row gets `"hit"`, `"miss"`, or
+//!    `"error"` status.
+//!
+//! ## Output columns
+//!
+//! Given `prefix = "acct"`:
+//!
+//! - `acct_json: Utf8` — raw JSON response body, or `NULL` on miss/error
+//! - `acct_status: Utf8` — one of `"hit"`, `"miss"`, `"error: <reason>"`
+//!
+//! Use DataFusion's `json()` / `json_str()` UDFs to extract specific fields
+//! from `acct_json` in a subsequent SQL transform.
+//!
+//! ## Config (not yet wired — call `HttpEnrichProcessor::new` directly)
+//!
+//! ```yaml
+//! # Planned config schema:
+//! processors:
+//!   - type: http_enrich
+//!     source_column: customer_id
+//!     url_template: "http://customer-svc.internal/api/customers/{key}"
+//!     prefix: acct
+//!     timeout_ms: 500
+//!     max_concurrency: 8
+//!     max_cache_entries: 50000
+//!     ttl_seconds: 300
+//! ```
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use arrow::array::StringBuilder;
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use logfwd_output::BatchMetadata;
+use smallvec::{SmallVec, smallvec};
+use std::sync::Arc;
+
+use crate::processor::{Processor, ProcessorError};
+
+// ---------------------------------------------------------------------------
+// Cache types
+// ---------------------------------------------------------------------------
+
+/// Result of an HTTP enrichment lookup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum LookupResult {
+    /// Successful lookup; contains the raw JSON body.
+    Hit(String),
+    /// The endpoint returned 404 or an empty/unrecognised response.
+    Miss,
+    /// The fetch failed (timeout, network error, non-200/404 status).
+    Error(String),
+}
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    result: LookupResult,
+    inserted_at: Instant,
+}
+
+// ---------------------------------------------------------------------------
+// HttpEnrichProcessor
+// ---------------------------------------------------------------------------
+
+/// Configuration for `HttpEnrichProcessor`.
+#[derive(Debug, Clone)]
+pub struct HttpEnrichConfig {
+    /// The batch column whose value is used as the lookup key.
+    pub source_column: String,
+    /// URL template.  Occurrences of `{key}` are replaced with the URL-encoded
+    /// column value.
+    pub url_template: String,
+    /// Prefix for output columns (`{prefix}_json`, `{prefix}_status`).
+    pub prefix: String,
+    /// Per-request timeout.
+    pub timeout: Duration,
+    /// Maximum number of entries in the in-process cache.
+    pub max_entries: usize,
+    /// How long a cache entry is considered fresh.
+    pub ttl: Duration,
+    /// Maximum number of concurrent HTTP lookups per batch (capped at 64).
+    pub max_concurrency: usize,
+}
+
+impl HttpEnrichConfig {
+    /// Create with sensible defaults.
+    pub fn new(
+        source_column: impl Into<String>,
+        url_template: impl Into<String>,
+        prefix: impl Into<String>,
+    ) -> Self {
+        HttpEnrichConfig {
+            source_column: source_column.into(),
+            url_template: url_template.into(),
+            prefix: prefix.into(),
+            timeout: Duration::from_millis(500),
+            max_entries: 50_000,
+            ttl: Duration::from_secs(300),
+            max_concurrency: 8,
+        }
+    }
+}
+
+/// A stateless [`Processor`] that enriches batches via HTTP with local caching.
+///
+/// See the [module-level documentation](self) for design details.
+#[derive(Debug)]
+pub struct HttpEnrichProcessor {
+    config: HttpEnrichConfig,
+    cache: Mutex<HashMap<String, CacheEntry>>,
+    agent: ureq::Agent,
+}
+
+impl HttpEnrichProcessor {
+    /// Create a new processor.  No I/O happens at construction time.
+    ///
+    /// Returns an error if `url_template` does not contain `{key}`.
+    pub fn new(config: HttpEnrichConfig) -> Result<Self, String> {
+        if !config.url_template.contains("{key}") {
+            return Err(format!(
+                "http_enrich url_template must contain '{{key}}' placeholder, got: {}",
+                config.url_template
+            ));
+        }
+        let agent = ureq::Agent::config_builder()
+            .timeout_global(Some(config.timeout))
+            .build()
+            .new_agent();
+        Ok(HttpEnrichProcessor {
+            config,
+            cache: Mutex::new(HashMap::new()),
+            agent,
+        })
+    }
+
+    /// Look up a key in the cache.  Returns `Some` if the entry is fresh.
+    fn cache_get(&self, key: &str) -> Option<LookupResult> {
+        let cache = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.get(key).and_then(|entry| {
+            if entry.inserted_at.elapsed() <= self.config.ttl {
+                Some(entry.result.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Insert results into the cache, evicting stale entries if necessary.
+    fn cache_put_batch(&self, results: &[(String, LookupResult)]) {
+        let mut cache = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // If more results than capacity, only keep the newest ones.
+        let results = if results.len() > self.config.max_entries {
+            &results[results.len() - self.config.max_entries..]
+        } else {
+            results
+        };
+
+        // Evict if we would exceed capacity after inserting.
+        let headroom = results.len();
+        if cache.len() + headroom > self.config.max_entries {
+            let evict_target = (cache.len() + headroom).saturating_sub(self.config.max_entries)
+                + self.config.max_entries / 10;
+            let mut entries: Vec<(Instant, String)> = cache
+                .iter()
+                .map(|(k, v)| (v.inserted_at, k.clone()))
+                .collect();
+            entries.sort_by_key(|(t, _)| *t);
+            for (_, k) in entries.into_iter().take(evict_target) {
+                cache.remove(&k);
+            }
+        }
+
+        let now = Instant::now();
+        for (key, result) in results {
+            // Only cache Hit/Miss — errors are transient and should be retried.
+            if matches!(result, LookupResult::Error(_)) {
+                continue;
+            }
+            cache.insert(
+                key.clone(),
+                CacheEntry {
+                    result: result.clone(),
+                    inserted_at: now,
+                },
+            );
+        }
+    }
+
+    /// Fetch a single key from the HTTP endpoint (blocking I/O).
+    fn fetch_key(&self, key: &str) -> LookupResult {
+        let url = self.config.url_template.replace("{key}", &urlencoded(key));
+
+        let result = self.agent.get(&url).call();
+
+        match result {
+            Ok(resp) => {
+                let status = resp.status();
+                if status == 200 {
+                    match resp.into_body().read_to_string() {
+                        Ok(body) if !body.trim().is_empty() => LookupResult::Hit(body),
+                        Ok(_) => LookupResult::Miss,
+                        Err(e) => LookupResult::Error(format!("body read failed: {e}")),
+                    }
+                } else if status == 404 {
+                    LookupResult::Miss
+                } else {
+                    LookupResult::Error(format!("HTTP {status}"))
+                }
+            }
+            Err(e) => {
+                // ureq turns 4xx/5xx into StatusCode errors by default.
+                // Classify 404 as a miss.
+                if let ureq::Error::StatusCode(404) = &e {
+                    LookupResult::Miss
+                } else if let ureq::Error::StatusCode(code) = &e {
+                    LookupResult::Error(format!("HTTP {code}"))
+                } else {
+                    LookupResult::Error(e.to_string())
+                }
+            }
+        }
+    }
+
+    /// Fetch all missing keys concurrently using scoped threads.
+    ///
+    /// Keys are chunked into groups of `max_concurrency` so we never have
+    /// more than that many in-flight HTTP requests at once.
+    fn fetch_missing(&self, keys: &[String]) -> Vec<(String, LookupResult)> {
+        if keys.is_empty() {
+            return Vec::new();
+        }
+
+        let mut all_results = Vec::with_capacity(keys.len());
+
+        let concurrency = self.config.max_concurrency.clamp(1, 64);
+
+        for chunk in keys.chunks(concurrency) {
+            // Keep a reference to the chunk keys so we can recover them on panic.
+            let chunk_keys: Vec<&str> = chunk.iter().map(String::as_str).collect();
+
+            std::thread::scope(|s| {
+                let handles: Vec<_> = chunk_keys
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, &key)| {
+                        let key_owned = key.to_owned();
+                        s.spawn(move || {
+                            let result = self.fetch_key(&key_owned);
+                            (idx, key_owned, result)
+                        })
+                    })
+                    .collect();
+
+                for handle in handles {
+                    match handle.join() {
+                        Ok((_idx, key, result)) => all_results.push((key, result)),
+                        Err(_) => {
+                            // Thread panicked — shouldn't happen with ureq, but
+                            // record an error. We can't recover the key from the
+                            // panicked thread, but the idx lets us look it up.
+                        }
+                    }
+                }
+
+                // Check for any keys missing from results (due to panicked threads).
+                let result_keys: HashSet<&str> =
+                    all_results.iter().map(|(k, _)| k.as_str()).collect();
+                let missing: Vec<String> = chunk_keys
+                    .iter()
+                    .filter(|k| !result_keys.contains(**k))
+                    .map(ToString::to_string)
+                    .collect();
+                for key in missing {
+                    all_results.push((
+                        key,
+                        LookupResult::Error("internal: fetch thread panicked".to_owned()),
+                    ));
+                }
+            });
+        }
+
+        all_results
+    }
+}
+
+impl Processor for HttpEnrichProcessor {
+    fn name(&self) -> &'static str {
+        "http_enrich"
+    }
+
+    fn is_stateful(&self) -> bool {
+        false // stateless from the pipeline's perspective (cache is internal)
+    }
+
+    fn process(
+        &mut self,
+        batch: RecordBatch,
+        _meta: &BatchMetadata,
+    ) -> Result<SmallVec<[RecordBatch; 1]>, ProcessorError> {
+        let num_rows = batch.num_rows();
+        let json_col_name = format!("{}_json", self.config.prefix);
+        let status_col_name = format!("{}_status", self.config.prefix);
+
+        if num_rows == 0 {
+            // Return an empty batch with the correct enriched schema so
+            // downstream consumers see a consistent column set.
+            let mut fields = batch.schema().fields().to_vec();
+            fields.push(Arc::new(Field::new(&json_col_name, DataType::Utf8, true)));
+            fields.push(Arc::new(Field::new(
+                &status_col_name,
+                DataType::Utf8,
+                false,
+            )));
+            let schema = Arc::new(Schema::new(fields));
+            let empty = RecordBatch::new_empty(schema);
+            return Ok(smallvec![empty]);
+        }
+
+        // 1. Extract keys from the source column.
+        let keys: Vec<Option<String>> = match batch.column_by_name(&self.config.source_column) {
+            None => vec![None; num_rows],
+            Some(col) => extract_strings(col, num_rows),
+        };
+
+        // 2. Deduplicate keys and check cache.
+        let mut resolved: HashMap<String, LookupResult> = HashMap::new();
+        let mut to_fetch_set: HashSet<String> = HashSet::new();
+        let mut to_fetch: Vec<String> = Vec::new();
+
+        for key in keys.iter().flatten() {
+            if resolved.contains_key(key) || to_fetch_set.contains(key) {
+                continue;
+            }
+            if let Some(cached) = self.cache_get(key) {
+                resolved.insert(key.clone(), cached);
+            } else {
+                to_fetch_set.insert(key.clone());
+                to_fetch.push(key.clone());
+            }
+        }
+
+        // 3. Fetch cache misses (blocks until all complete).
+        if !to_fetch.is_empty() {
+            let fetched = self.fetch_missing(&to_fetch);
+            self.cache_put_batch(&fetched);
+            for (k, v) in fetched {
+                resolved.insert(k, v);
+            }
+        }
+
+        // 4. Build output columns.
+        let mut json_builder = StringBuilder::with_capacity(num_rows, num_rows * 64);
+        let mut status_builder = StringBuilder::with_capacity(num_rows, num_rows * 8);
+
+        for key_opt in &keys {
+            match key_opt {
+                None => {
+                    json_builder.append_null();
+                    status_builder.append_value("miss");
+                }
+                Some(key) => match resolved.get(key) {
+                    Some(LookupResult::Hit(json)) => {
+                        json_builder.append_value(json);
+                        status_builder.append_value("hit");
+                    }
+                    Some(LookupResult::Miss) | None => {
+                        json_builder.append_null();
+                        status_builder.append_value("miss");
+                    }
+                    Some(LookupResult::Error(e)) => {
+                        json_builder.append_null();
+                        // Reuse a stack buffer to avoid per-row allocation.
+                        let mut err_buf = String::with_capacity(7 + e.len());
+                        err_buf.push_str("error: ");
+                        err_buf.push_str(e);
+                        status_builder.append_value(&err_buf);
+                    }
+                },
+            }
+        }
+
+        let mut fields = batch.schema().fields().to_vec();
+        fields.push(Arc::new(Field::new(&json_col_name, DataType::Utf8, true)));
+        fields.push(Arc::new(Field::new(
+            &status_col_name,
+            DataType::Utf8,
+            false,
+        )));
+        let schema = Arc::new(Schema::new(fields));
+
+        let mut columns: Vec<Arc<dyn arrow::array::Array>> = batch.columns().to_vec();
+        columns.push(Arc::new(json_builder.finish()));
+        columns.push(Arc::new(status_builder.finish()));
+
+        RecordBatch::try_new(schema, columns)
+            .map(|b| smallvec![b])
+            .map_err(|e| ProcessorError::Permanent(format!("http_enrich: batch build error: {e}")))
+    }
+
+    fn flush(&mut self) -> SmallVec<[RecordBatch; 1]> {
+        SmallVec::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn extract_strings(col: &Arc<dyn arrow::array::Array>, num_rows: usize) -> Vec<Option<String>> {
+    use arrow::array::{Array, AsArray};
+    match col.data_type() {
+        DataType::Utf8 => {
+            let arr = col.as_string::<i32>();
+            (0..num_rows)
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_owned())
+                    }
+                })
+                .collect()
+        }
+        DataType::Utf8View => {
+            let arr = col.as_string_view();
+            (0..num_rows)
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_owned())
+                    }
+                })
+                .collect()
+        }
+        DataType::LargeUtf8 => {
+            let arr = col.as_string::<i64>();
+            (0..num_rows)
+                .map(|i| {
+                    if arr.is_null(i) {
+                        None
+                    } else {
+                        Some(arr.value(i).to_owned())
+                    }
+                })
+                .collect()
+        }
+        _ => vec![None; num_rows],
+    }
+}
+
+/// Percent-encode a key for safe URL interpolation.
+///
+/// Only encodes characters outside `[A-Za-z0-9._~-]` (unreserved per RFC 3986).
+fn urlencoded(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '~' | '-') {
+            out.push(c);
+        } else {
+            let mut buf = [0u8; 4];
+            let encoded = c.encode_utf8(&mut buf);
+            for b in encoded.bytes() {
+                out.push('%');
+                out.push(
+                    char::from_digit(u32::from(b >> 4), 16)
+                        .unwrap_or('0')
+                        .to_ascii_uppercase(),
+                );
+                out.push(
+                    char::from_digit(u32::from(b & 0xF), 16)
+                        .unwrap_or('0')
+                        .to_ascii_uppercase(),
+                );
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn urlencoded_safe_chars_unchanged() {
+        assert_eq!(urlencoded("hello123"), "hello123");
+        assert_eq!(urlencoded("user.name_v2"), "user.name_v2");
+    }
+
+    #[test]
+    fn urlencoded_encodes_spaces_and_specials() {
+        let encoded = urlencoded("hello world");
+        assert!(encoded.contains("%20"));
+        let encoded2 = urlencoded("a/b");
+        assert!(encoded2.contains("%2F"));
+    }
+
+    #[test]
+    fn new_processor_starts_with_empty_cache() {
+        let cfg = HttpEnrichConfig::new("customer_id", "http://localhost/{key}", "acct");
+        let proc = HttpEnrichProcessor::new(cfg).unwrap();
+        assert!(
+            proc.cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn empty_batch_passed_through() {
+        let cfg = HttpEnrichConfig::new("customer_id", "http://localhost/{key}", "acct");
+        let mut proc = HttpEnrichProcessor::new(cfg).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "customer_id",
+            DataType::Utf8,
+            true,
+        )]));
+        let values: Vec<Option<&str>> = vec![];
+        let arr: arrow::array::StringArray = values.into_iter().collect();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).expect("valid batch");
+
+        let meta = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 0,
+        };
+        let out = proc.process(batch, &meta).expect("process should succeed");
+        assert_eq!(out[0].num_rows(), 0);
+    }
+
+    fn make_batch(keys: &[Option<&str>]) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, true)]));
+        let arr: arrow::array::StringArray = keys.iter().copied().collect();
+        RecordBatch::try_new(schema, vec![Arc::new(arr)]).expect("valid batch")
+    }
+
+    fn test_meta() -> BatchMetadata {
+        BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 0,
+        }
+    }
+
+    #[test]
+    fn cache_hit_skips_network() {
+        let cfg = HttpEnrichConfig::new("id", "http://localhost/{key}", "e");
+        let mut proc = HttpEnrichProcessor::new(cfg).unwrap();
+
+        // Seed the cache.
+        {
+            let mut cache = proc.cache.lock().expect("lock");
+            cache.insert(
+                "abc".to_owned(),
+                CacheEntry {
+                    result: LookupResult::Hit(r#"{"name":"test"}"#.to_owned()),
+                    inserted_at: Instant::now(),
+                },
+            );
+        }
+
+        let batch = make_batch(&[Some("abc")]);
+        let out = proc.process(batch, &test_meta()).expect("process");
+        assert_eq!(out[0].num_rows(), 1);
+
+        use arrow::array::AsArray;
+        let json_col = out[0].column_by_name("e_json").expect("e_json");
+        let arr = json_col.as_string::<i32>();
+        assert!(arr.value(0).contains("test"));
+
+        let status_col = out[0].column_by_name("e_status").expect("e_status");
+        let arr = status_col.as_string::<i32>();
+        assert_eq!(arr.value(0), "hit");
+    }
+
+    #[test]
+    fn cache_miss_returns_miss() {
+        let cfg = HttpEnrichConfig::new("id", "http://localhost/{key}", "e");
+        let mut proc = HttpEnrichProcessor::new(cfg).unwrap();
+
+        // Seed with a Miss result.
+        {
+            let mut cache = proc.cache.lock().expect("lock");
+            cache.insert(
+                "gone".to_owned(),
+                CacheEntry {
+                    result: LookupResult::Miss,
+                    inserted_at: Instant::now(),
+                },
+            );
+        }
+
+        let batch = make_batch(&[Some("gone")]);
+        let out = proc.process(batch, &test_meta()).expect("process");
+
+        use arrow::array::AsArray;
+        let status_col = out[0].column_by_name("e_status").expect("e_status");
+        let arr = status_col.as_string::<i32>();
+        assert_eq!(arr.value(0), "miss");
+    }
+
+    #[test]
+    fn expired_entry_triggers_refetch() {
+        let mut cfg = HttpEnrichConfig::new("id", "http://invalid.test/{key}", "e");
+        cfg.ttl = Duration::from_millis(1);
+        cfg.timeout = Duration::from_millis(100);
+        let mut proc = HttpEnrichProcessor::new(cfg).unwrap();
+
+        // Seed with an expired entry.
+        {
+            let mut cache = proc.cache.lock().expect("lock");
+            cache.insert(
+                "old".to_owned(),
+                CacheEntry {
+                    result: LookupResult::Hit("stale".to_owned()),
+                    inserted_at: Instant::now() - Duration::from_secs(10),
+                },
+            );
+        }
+
+        // Processing should re-fetch (and fail since host is invalid).
+        let batch = make_batch(&[Some("old")]);
+        let out = proc.process(batch, &test_meta()).expect("process");
+
+        use arrow::array::AsArray;
+        let status_col = out[0].column_by_name("e_status").expect("e_status");
+        let arr = status_col.as_string::<i32>();
+        assert!(
+            arr.value(0).starts_with("error"),
+            "expected error status, got: {}",
+            arr.value(0)
+        );
+    }
+
+    #[test]
+    fn deduplicates_keys_within_batch() {
+        let cfg = HttpEnrichConfig::new("id", "http://invalid.test/{key}", "e");
+        let mut proc = HttpEnrichProcessor::new(cfg).unwrap();
+
+        // Seed cache with "dup" so we can verify dedup without hitting network.
+        {
+            let mut cache = proc.cache.lock().expect("lock");
+            cache.insert(
+                "dup".to_owned(),
+                CacheEntry {
+                    result: LookupResult::Hit(r#"{"v":1}"#.to_owned()),
+                    inserted_at: Instant::now(),
+                },
+            );
+        }
+
+        let batch = make_batch(&[Some("dup"), Some("dup"), Some("dup")]);
+        let out = proc.process(batch, &test_meta()).expect("process");
+        assert_eq!(out[0].num_rows(), 3);
+
+        use arrow::array::AsArray;
+        let json_col = out[0].column_by_name("e_json").expect("e_json");
+        let arr = json_col.as_string::<i32>();
+        for i in 0..3 {
+            assert!(arr.value(i).contains("v"), "row {i} should have enrichment");
+        }
+    }
+
+    #[test]
+    fn null_keys_get_miss_status() {
+        let cfg = HttpEnrichConfig::new("id", "http://localhost/{key}", "e");
+        let mut proc = HttpEnrichProcessor::new(cfg).unwrap();
+
+        let batch = make_batch(&[None, None]);
+        let out = proc.process(batch, &test_meta()).expect("process");
+
+        use arrow::array::AsArray;
+        let status_col = out[0].column_by_name("e_status").expect("e_status");
+        let arr = status_col.as_string::<i32>();
+        assert_eq!(arr.value(0), "miss");
+        assert_eq!(arr.value(1), "miss");
+    }
+
+    #[test]
+    fn missing_source_column_yields_miss_status() {
+        let cfg = HttpEnrichConfig::new("customer_id", "http://localhost/{key}", "e");
+        let mut proc = HttpEnrichProcessor::new(cfg).unwrap();
+
+        let schema = Arc::new(Schema::new(vec![Field::new("other", DataType::Utf8, true)]));
+        let arr: arrow::array::StringArray = vec![Some("val1")].into_iter().collect();
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).expect("valid batch");
+
+        let out = proc.process(batch, &test_meta()).expect("process");
+        assert_eq!(out[0].num_rows(), 1);
+
+        use arrow::array::AsArray;
+        let status_col = out[0].column_by_name("e_status").expect("e_status");
+        let arr = status_col.as_string::<i32>();
+        assert_eq!(arr.value(0), "miss");
+    }
+
+    #[test]
+    fn eviction_makes_room_for_new_entries() {
+        let mut cfg = HttpEnrichConfig::new("id", "http://localhost/{key}", "e");
+        cfg.max_entries = 3;
+        let proc = HttpEnrichProcessor::new(cfg).unwrap();
+
+        // Fill cache to capacity.
+        {
+            let mut cache = proc.cache.lock().expect("lock");
+            for (i, key) in ["a", "b", "c"].iter().enumerate() {
+                cache.insert(
+                    key.to_string(),
+                    CacheEntry {
+                        result: LookupResult::Hit(format!("val{i}")),
+                        inserted_at: Instant::now() - Duration::from_secs(100 - i as u64),
+                    },
+                );
+            }
+        }
+
+        // Insert a new batch of results — eviction should make room.
+        proc.cache_put_batch(&[("d".to_owned(), LookupResult::Hit("new".to_owned()))]);
+
+        let cache = proc.cache.lock().expect("lock");
+        assert!(
+            cache.contains_key("d"),
+            "new entry must be in cache after eviction"
+        );
+        assert!(
+            cache.len() <= 3,
+            "cache should not exceed max_entries: {}",
+            cache.len()
+        );
+    }
+}

--- a/crates/logfwd-runtime/src/processor/http_enrich.rs
+++ b/crates/logfwd-runtime/src/processor/http_enrich.rs
@@ -237,7 +237,7 @@ impl HttpEnrichProcessor {
                     match resp
                         .into_body()
                         .as_reader()
-                        .take(limit + 1)
+                        .take(limit.saturating_add(1))
                         .read_to_string(&mut buf)
                     {
                         Ok(n) if n as u64 > limit => LookupResult::Error(format!(

--- a/crates/logfwd-runtime/src/processor/http_enrich.rs
+++ b/crates/logfwd-runtime/src/processor/http_enrich.rs
@@ -177,23 +177,26 @@ impl HttpEnrichProcessor {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
 
-        // If more results than capacity, only keep the newest ones.
-        let results = if results.len() > self.config.max_entries {
-            &results[results.len() - self.config.max_entries..]
-        } else {
-            results
-        };
-
-        // Evict if we would exceed capacity after inserting.
-        // Only count cacheable entries (non-Error) for headroom since errors
-        // are skipped below.
-        let cacheable_count = results
+        // Filter to cacheable results first (errors are transient, not cached).
+        let cacheable: Vec<&(String, LookupResult)> = results
             .iter()
             .filter(|(_, r)| !matches!(r, LookupResult::Error(_)))
+            .collect();
+
+        // If more cacheable results than capacity, only keep the newest ones.
+        let cacheable = if cacheable.len() > self.config.max_entries {
+            &cacheable[cacheable.len() - self.config.max_entries..]
+        } else {
+            &cacheable[..]
+        };
+
+        // Count only net-new keys (not already in cache) for eviction sizing.
+        let net_new = cacheable
+            .iter()
+            .filter(|(k, _)| !cache.contains_key(k))
             .count();
-        if cache.len() + cacheable_count > self.config.max_entries {
-            let evict_target = (cache.len() + cacheable_count)
-                .saturating_sub(self.config.max_entries)
+        if cache.len() + net_new > self.config.max_entries {
+            let evict_target = (cache.len() + net_new).saturating_sub(self.config.max_entries)
                 + self.config.max_entries / 10;
             let mut entries: Vec<(Instant, String)> = cache
                 .iter()
@@ -206,11 +209,7 @@ impl HttpEnrichProcessor {
         }
 
         let now = Instant::now();
-        for (key, result) in results {
-            // Only cache Hit/Miss — errors are transient and should be retried.
-            if matches!(result, LookupResult::Error(_)) {
-                continue;
-            }
+        for (key, result) in cacheable {
             cache.insert(
                 key.clone(),
                 CacheEntry {

--- a/crates/logfwd-runtime/src/processor/mod.rs
+++ b/crates/logfwd-runtime/src/processor/mod.rs
@@ -3,10 +3,16 @@ use logfwd_output::BatchMetadata;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 
+/// Blocklist-based enrichment processor: marks rows whose source column
+/// value appears in a preloaded CSV blocklist.
 pub mod blocklist;
+/// HTTP enrichment processor: per-key HTTP lookups with caching and
+/// concurrency control.
 pub mod http_enrich;
 
+/// Processor that annotates records using a preloaded blocklist.
 pub use blocklist::BlocklistProcessor;
+/// Configuration and processor for per-row HTTP enrichment.
 pub use http_enrich::{HttpEnrichConfig, HttpEnrichProcessor};
 
 /// Error types for processor operations.

--- a/crates/logfwd-runtime/src/processor/mod.rs
+++ b/crates/logfwd-runtime/src/processor/mod.rs
@@ -3,6 +3,12 @@ use logfwd_output::BatchMetadata;
 use smallvec::SmallVec;
 use std::fmt::Debug;
 
+pub mod blocklist;
+pub mod http_enrich;
+
+pub use blocklist::BlocklistProcessor;
+pub use http_enrich::{HttpEnrichConfig, HttpEnrichProcessor};
+
 /// Error types for processor operations.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/crates/logfwd-runtime/src/transform.rs
+++ b/crates/logfwd-runtime/src/transform.rs
@@ -11,6 +11,7 @@ pub mod udf {
     pub mod geo_lookup {
         pub use logfwd_transform::udf::geo_lookup::MmdbDatabase;
     }
+    pub use logfwd_transform::udf::CsvRangeDatabase;
 }
 
 #[cfg(not(feature = "datafusion"))]

--- a/crates/logfwd-transform/src/enrichment.rs
+++ b/crates/logfwd-transform/src/enrichment.rs
@@ -610,6 +610,818 @@ pub trait GeoDatabase: Send + Sync {
 }
 
 // ---------------------------------------------------------------------------
+// Reloadable geo database
+// ---------------------------------------------------------------------------
+
+/// Wraps a [`GeoDatabase`] with an atomic hot-swap handle.
+///
+/// The hot path takes a cheap shared read lock.  The reload task takes an
+/// exclusive write lock only to swap the `Arc` pointer — the critical section
+/// is a pointer copy, never an I/O operation.
+///
+/// ```rust,ignore
+/// let db = Arc::new(MmdbDatabase::open(path)?);
+/// let reloadable = Arc::new(ReloadableGeoDb::new(db));
+/// let handle = reloadable.reload_handle();
+///
+/// tokio::spawn(async move {
+///     let mut ticker = tokio::time::interval(Duration::from_secs(interval));
+///     ticker.tick().await; // skip first immediate tick
+///     loop {
+///         ticker.tick().await;
+///         if let Ok(new_db) = MmdbDatabase::open(&path) {
+///             handle.replace(Arc::new(new_db));
+///         }
+///     }
+/// });
+/// ```
+pub struct ReloadableGeoDb {
+    inner: Arc<RwLock<Arc<dyn GeoDatabase>>>,
+}
+
+impl ReloadableGeoDb {
+    /// Wrap an existing database.
+    pub fn new(db: Arc<dyn GeoDatabase>) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(db)),
+        }
+    }
+
+    /// Return a lightweight handle for driving background reloads.
+    pub fn reload_handle(&self) -> GeoReloadHandle {
+        GeoReloadHandle {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl GeoDatabase for ReloadableGeoDb {
+    fn lookup(&self, ip: &str) -> Option<GeoResult> {
+        self.inner
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .lookup(ip)
+    }
+}
+
+/// A cloneable handle used to atomically replace the active database.
+#[derive(Clone)]
+pub struct GeoReloadHandle {
+    inner: Arc<RwLock<Arc<dyn GeoDatabase>>>,
+}
+
+impl GeoReloadHandle {
+    /// Atomically swap in a new database.  Safe to call from any thread.
+    pub fn replace(&self, db: Arc<dyn GeoDatabase>) {
+        *self
+            .inner
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = db;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Environment variable enrichment table
+// ---------------------------------------------------------------------------
+
+/// A one-row enrichment table populated from environment variables matching a
+/// name prefix.  The prefix is stripped and the remainder lower-cased to form
+/// column names.
+///
+/// Useful for injecting deployment metadata that is already baked into the pod
+/// environment without needing a separate config file.
+///
+/// ```yaml
+/// enrichment:
+///   - type: env_vars
+///     table_name: deploy_meta
+///     prefix: LOGFWD_META_
+/// ```
+///
+/// With `LOGFWD_META_CLUSTER=prod` and `LOGFWD_META_REGION=us-east-1` set,
+/// the table exposes `cluster` and `region` columns.
+///
+/// SQL: `SELECT logs.*, m.cluster, m.region FROM logs CROSS JOIN deploy_meta AS m`
+pub struct EnvTable {
+    table_name: String,
+    batch: RecordBatch,
+}
+
+impl EnvTable {
+    /// Build the table from all environment variables whose names begin with
+    /// `prefix`.
+    ///
+    /// Returns an error if no matching variables are found, since an empty
+    /// table would be misleading to wire into the pipeline.
+    pub fn from_prefix(
+        table_name: impl Into<String>,
+        prefix: &str,
+    ) -> Result<Self, TransformError> {
+        let mut pairs: Vec<(String, String)> = std::env::vars()
+            .filter_map(|(k, v)| {
+                k.strip_prefix(prefix)
+                    .map(|stripped| (stripped.to_lowercase(), v))
+            })
+            .collect();
+        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+
+        if pairs.is_empty() {
+            return Err(TransformError::Enrichment(format!(
+                "EnvTable: no environment variables found with prefix '{prefix}'"
+            )));
+        }
+
+        // Reject duplicate column names after lowercase normalization (e.g.
+        // FOO and foo both present would create duplicate Arrow columns).
+        pairs.dedup_by(|a, b| {
+            if a.0 == b.0 {
+                // Keep first occurrence, drop duplicate.
+                true
+            } else {
+                false
+            }
+        });
+
+        let fields: Vec<Field> = pairs
+            .iter()
+            .map(|(k, _)| Field::new(k.as_str(), DataType::Utf8, false))
+            .collect();
+        let schema = Arc::new(Schema::new(fields));
+        let columns: Vec<Arc<dyn arrow::array::Array>> = pairs
+            .iter()
+            .map(|(_, v)| Arc::new(StringArray::from(vec![v.as_str()])) as _)
+            .collect();
+        let batch = RecordBatch::try_new(schema, columns).map_err(TransformError::Arrow)?;
+
+        Ok(EnvTable {
+            table_name: table_name.into(),
+            batch,
+        })
+    }
+}
+
+impl EnrichmentTable for EnvTable {
+    fn name(&self) -> &str {
+        &self.table_name
+    }
+
+    fn snapshot(&self) -> Option<RecordBatch> {
+        Some(self.batch.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Process info (agent self-metadata, resolved once at startup)
+// ---------------------------------------------------------------------------
+
+/// Agent self-metadata table.  One row, resolved at construction time.
+///
+/// Columns: `agent_name`, `agent_version`, `pid`, `start_time`
+/// Note: `start_time` captures the moment this table is constructed
+/// (during pipeline startup), not the exact process start time.
+///
+/// ```yaml
+/// enrichment:
+///   - type: process_info
+/// ```
+///
+/// SQL: `SELECT l.*, a.agent_version FROM logs l CROSS JOIN process_info a`
+pub struct ProcessInfoTable {
+    batch: RecordBatch,
+}
+
+impl Default for ProcessInfoTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProcessInfoTable {
+    pub fn new() -> Self {
+        let agent_name = "logfwd";
+        let agent_version = env!("CARGO_PKG_VERSION");
+        let pid = std::process::id().to_string();
+        let start_time = {
+            use std::time::{SystemTime, UNIX_EPOCH};
+            let dur = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default();
+            // ISO 8601 UTC — good enough without pulling in chrono.
+            let secs = dur.as_secs();
+            let days = secs / 86400;
+            let rem = secs % 86400;
+            let hours = rem / 3600;
+            let mins = (rem % 3600) / 60;
+            let s = rem % 60;
+            // Epoch day 0 = 1970-01-01. Simple civil-date conversion.
+            let (y, m, d) = epoch_days_to_ymd(days as i64);
+            format!("{y:04}-{m:02}-{d:02}T{hours:02}:{mins:02}:{s:02}Z")
+        };
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("agent_name", DataType::Utf8, false),
+            Field::new("agent_version", DataType::Utf8, false),
+            Field::new("pid", DataType::Utf8, false),
+            Field::new("start_time", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![agent_name])),
+                Arc::new(StringArray::from(vec![agent_version])),
+                Arc::new(StringArray::from(vec![pid.as_str()])),
+                Arc::new(StringArray::from(vec![start_time.as_str()])),
+            ],
+        )
+        .expect("process_info schema mismatch");
+
+        ProcessInfoTable { batch }
+    }
+}
+
+impl EnrichmentTable for ProcessInfoTable {
+    fn name(&self) -> &'static str {
+        "process_info"
+    }
+
+    fn snapshot(&self) -> Option<RecordBatch> {
+        Some(self.batch.clone())
+    }
+}
+
+/// Convert days since Unix epoch to (year, month, day).
+fn epoch_days_to_ymd(days: i64) -> (i64, u32, u32) {
+    // Algorithm from Howard Hinnant's chrono-compatible date library.
+    let z = days + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+// ---------------------------------------------------------------------------
+// Key-value file enrichment table
+// ---------------------------------------------------------------------------
+
+/// A one-row enrichment table populated from a `KEY=value` properties file.
+///
+/// Supported syntax:
+/// - `KEY=value` — unquoted value (leading/trailing whitespace stripped)
+/// - `KEY="quoted value"` — double-quoted value (quotes removed)
+/// - `KEY='quoted value'` — single-quoted value (quotes removed)
+/// - `# comment` and blank lines are ignored
+///
+/// Column names are the keys, lower-cased.  Reloadable via `reload()`.
+///
+/// ```yaml
+/// enrichment:
+///   - type: kv_file
+///     table_name: os_release
+///     path: /etc/os-release
+///     refresh_interval: 3600
+/// ```
+pub struct KvFileTable {
+    table_name: String,
+    path: PathBuf,
+    data: Arc<RwLock<Option<RecordBatch>>>,
+}
+
+impl KvFileTable {
+    pub fn new(table_name: impl Into<String>, path: &Path) -> Self {
+        KvFileTable {
+            table_name: table_name.into(),
+            path: path.to_path_buf(),
+            data: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// (Re)load the file from disk.  Returns the number of columns parsed.
+    pub fn reload(&self) -> Result<usize, TransformError> {
+        let pairs = parse_kv_file(&self.path)?;
+        if pairs.is_empty() {
+            return Err(TransformError::Enrichment(format!(
+                "KvFileTable '{}': no key-value pairs found in '{}'",
+                self.table_name,
+                self.path.display()
+            )));
+        }
+        let n = pairs.len();
+        let batch = kv_pairs_to_batch(&pairs)?;
+        *self
+            .data
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(batch);
+        Ok(n)
+    }
+}
+
+impl EnrichmentTable for KvFileTable {
+    fn name(&self) -> &str {
+        &self.table_name
+    }
+
+    fn snapshot(&self) -> Option<RecordBatch> {
+        self.data
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+/// Parse a `KEY=value` file into sorted key-value pairs.
+fn parse_kv_file(path: &Path) -> Result<Vec<(String, String)>, TransformError> {
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        TransformError::Enrichment(format!("failed to read '{}': {e}", path.display()))
+    })?;
+    let mut pairs = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        if let Some((key, raw_val)) = trimmed.split_once('=') {
+            let key = key.trim().to_lowercase();
+            if key.is_empty() {
+                continue;
+            }
+            let val = raw_val.trim();
+            let val = if val.len() > 1
+                && ((val.starts_with('"') && val.ends_with('"'))
+                    || (val.starts_with('\'') && val.ends_with('\'')))
+            {
+                &val[1..val.len() - 1]
+            } else {
+                val
+            };
+            pairs.push((key, val.to_string()));
+        }
+    }
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    for window in pairs.windows(2) {
+        if window[0].0 == window[1].0 {
+            return Err(TransformError::Enrichment(format!(
+                "duplicate key '{}' in '{}'",
+                window[0].0,
+                path.display()
+            )));
+        }
+    }
+    Ok(pairs)
+}
+
+/// Build a one-row RecordBatch from key-value pairs.
+fn kv_pairs_to_batch(pairs: &[(String, String)]) -> Result<RecordBatch, TransformError> {
+    let fields: Vec<Field> = pairs
+        .iter()
+        .map(|(k, _)| Field::new(k.as_str(), DataType::Utf8, false))
+        .collect();
+    let schema = Arc::new(Schema::new(fields));
+    let columns: Vec<Arc<dyn arrow::array::Array>> = pairs
+        .iter()
+        .map(|(_, v)| Arc::new(StringArray::from(vec![v.as_str()])) as _)
+        .collect();
+    RecordBatch::try_new(schema, columns).map_err(TransformError::Arrow)
+}
+
+// ---------------------------------------------------------------------------
+// Network info (resolved once at startup)
+// ---------------------------------------------------------------------------
+
+/// Network interface metadata.  One row, resolved at construction time.
+///
+/// Columns: `hostname`, `primary_ipv4`, `primary_ipv6`, `all_ipv4`, `all_ipv6`
+///
+/// IP addresses are discovered from `/proc/net/fib_trie` (IPv4) and
+/// `/proc/net/if_inet6` (IPv6) on Linux.  On non-Linux systems the table
+/// still provides `hostname` and empty IP columns.
+///
+/// ```yaml
+/// enrichment:
+///   - type: network_info
+/// ```
+pub struct NetworkInfoTable {
+    batch: RecordBatch,
+}
+
+impl Default for NetworkInfoTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NetworkInfoTable {
+    pub fn new() -> Self {
+        let hostname = gethostname::gethostname().to_string_lossy().into_owned();
+
+        let (ipv4_addrs, ipv6_addrs) = discover_local_ips();
+
+        let primary_ipv4 = ipv4_addrs.first().cloned().unwrap_or_default();
+        let primary_ipv6 = ipv6_addrs.first().cloned().unwrap_or_default();
+        let all_ipv4 = ipv4_addrs.join(",");
+        let all_ipv6 = ipv6_addrs.join(",");
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("hostname", DataType::Utf8, false),
+            Field::new("primary_ipv4", DataType::Utf8, false),
+            Field::new("primary_ipv6", DataType::Utf8, false),
+            Field::new("all_ipv4", DataType::Utf8, false),
+            Field::new("all_ipv6", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![hostname.as_str()])),
+                Arc::new(StringArray::from(vec![primary_ipv4.as_str()])),
+                Arc::new(StringArray::from(vec![primary_ipv6.as_str()])),
+                Arc::new(StringArray::from(vec![all_ipv4.as_str()])),
+                Arc::new(StringArray::from(vec![all_ipv6.as_str()])),
+            ],
+        )
+        .expect("network_info schema mismatch");
+
+        NetworkInfoTable { batch }
+    }
+}
+
+impl EnrichmentTable for NetworkInfoTable {
+    fn name(&self) -> &'static str {
+        "network_info"
+    }
+
+    fn snapshot(&self) -> Option<RecordBatch> {
+        Some(self.batch.clone())
+    }
+}
+
+/// Discover non-loopback IPv4 and IPv6 addresses from procfs.
+/// Returns `(ipv4_addrs, ipv6_addrs)`, each sorted.
+fn discover_local_ips() -> (Vec<String>, Vec<String>) {
+    let mut v4 = discover_ipv4_from_proc();
+    let mut v6 = discover_ipv6_from_proc();
+    v4.sort();
+    v4.dedup();
+    v6.sort();
+    v6.dedup();
+    (v4, v6)
+}
+
+/// Read IPv4 addresses from `/proc/net/fib_trie`.
+///
+/// We look for `/32 host LOCAL` entries and filter out `127.*`.
+fn discover_ipv4_from_proc() -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string("/proc/net/fib_trie") else {
+        return Vec::new();
+    };
+    let mut addrs = Vec::new();
+    let mut prev_line = "";
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == "/32 host LOCAL" {
+            // The previous line has the IP like "  |-- 10.0.0.1"
+            if let Some(ip) = prev_line.trim().strip_prefix("|-- ")
+                && !ip.starts_with("127.")
+            {
+                addrs.push(ip.to_string());
+            }
+        }
+        prev_line = trimmed;
+    }
+    addrs
+}
+
+/// Read IPv6 addresses from `/proc/net/if_inet6`.
+///
+/// Format: `<hex32> <idx> <prefix_len> <scope> <flags> <iface>`
+/// Scope 0x20 = link-local; we skip those and loopback (::1).
+fn discover_ipv6_from_proc() -> Vec<String> {
+    let Ok(content) = std::fs::read_to_string("/proc/net/if_inet6") else {
+        return Vec::new();
+    };
+    let mut addrs = Vec::new();
+    for line in content.lines() {
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 4 {
+            continue;
+        }
+        let hex = parts[0];
+        let scope = parts[3];
+        // Skip link-local (scope 20) and loopback (scope 10)
+        if scope == "20" || scope == "10" {
+            continue;
+        }
+        if hex.len() == 32
+            && let Some(formatted) = format_ipv6_hex(hex)
+        {
+            addrs.push(formatted);
+        }
+    }
+    addrs
+}
+
+/// Format 32-char hex string into standard IPv6 notation.
+fn format_ipv6_hex(hex: &str) -> Option<String> {
+    if hex.len() != 32 {
+        return None;
+    }
+    let mut groups = Vec::with_capacity(8);
+    for i in 0..8 {
+        let start = i * 4;
+        let group = &hex[start..start + 4];
+        // Strip leading zeros for compactness
+        let stripped = group.trim_start_matches('0');
+        groups.push(if stripped.is_empty() {
+            "0".to_string()
+        } else {
+            stripped.to_string()
+        });
+    }
+    Some(groups.join(":"))
+}
+
+// ---------------------------------------------------------------------------
+// Container info (resolved once at startup)
+// ---------------------------------------------------------------------------
+
+/// Container runtime detection.  One row, resolved at construction time.
+///
+/// Columns: `container_id`, `container_runtime`
+///
+/// Detection sources:
+/// - `/.dockerenv` presence → runtime = "docker"
+/// - `/proc/self/cgroup` parsing for container ID
+/// - `/run/containerd/` presence → runtime = "containerd"
+///
+/// Possible `container_runtime` values: `docker`, `containerd`, `cri-o`,
+/// `kubernetes` (kubepods without specific runtime), `unknown`, or empty
+/// string (not in a container).
+///
+/// ```yaml
+/// enrichment:
+///   - type: container_info
+/// ```
+pub struct ContainerInfoTable {
+    batch: RecordBatch,
+}
+
+impl Default for ContainerInfoTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ContainerInfoTable {
+    pub fn new() -> Self {
+        let (container_id, container_runtime) = detect_container();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("container_id", DataType::Utf8, false),
+            Field::new("container_runtime", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![container_id.as_str()])),
+                Arc::new(StringArray::from(vec![container_runtime.as_str()])),
+            ],
+        )
+        .expect("container_info schema mismatch");
+
+        ContainerInfoTable { batch }
+    }
+}
+
+impl EnrichmentTable for ContainerInfoTable {
+    fn name(&self) -> &'static str {
+        "container_info"
+    }
+
+    fn snapshot(&self) -> Option<RecordBatch> {
+        Some(self.batch.clone())
+    }
+}
+
+/// Detect container runtime and extract container ID.
+/// Returns `(container_id, runtime)`.
+fn detect_container() -> (String, String) {
+    // Try /proc/self/cgroup (works for cgroup v1 and hybrid v2)
+    if let Ok(content) = std::fs::read_to_string("/proc/self/cgroup")
+        && let Some((id, runtime)) = parse_cgroup_for_container(&content)
+    {
+        return (id, runtime);
+    }
+
+    // Try /proc/self/mountinfo for cgroup v2 pure mode
+    if let Ok(content) = std::fs::read_to_string("/proc/self/mountinfo")
+        && let Some((id, runtime)) = parse_mountinfo_for_container(&content)
+    {
+        return (id, runtime);
+    }
+
+    // Fallback: check for /.dockerenv
+    if Path::new("/.dockerenv").exists() {
+        return (String::new(), "docker".to_string());
+    }
+
+    (String::new(), String::new())
+}
+
+/// Parse cgroup file for container ID.
+/// Cgroup v1 lines look like: `12:memory:/docker/<container-id>`
+/// Cgroup v2 lines look like: `0::/system.slice/containerd-<id>.scope`
+fn parse_cgroup_for_container(content: &str) -> Option<(String, String)> {
+    for line in content.lines() {
+        let path = line.rsplit_once(':').map(|(_, p)| p);
+        let Some(path) = path else { continue };
+
+        // Docker: /docker/<64-hex-chars> or /docker/buildkit/...
+        if let Some(rest) = path.strip_prefix("/docker/") {
+            let id = rest.split('/').next().unwrap_or("");
+            if is_hex_container_id(id) {
+                return Some((id.to_string(), "docker".to_string()));
+            }
+        }
+
+        // Containerd (K8s): /kubepods/...<64-hex-chars> or containerd-<id>.scope
+        if (path.contains("/kubepods") || path.contains("containerd-"))
+            && let Some(id) = extract_hex_id_from_path(path)
+        {
+            let runtime = if path.contains("containerd") {
+                "containerd"
+            } else {
+                "kubernetes"
+            };
+            return Some((id, runtime.to_string()));
+        }
+
+        // CRI-O: /crio-<64-hex-chars>
+        if let Some(rest) = path
+            .strip_prefix("/crio-")
+            .or_else(|| path.rsplit_once("/crio-").map(|(_, r)| r))
+        {
+            let id = rest.split('.').next().unwrap_or(rest);
+            if is_hex_container_id(id) {
+                return Some((id.to_string(), "cri-o".to_string()));
+            }
+        }
+    }
+    None
+}
+
+/// Parse mountinfo for container ID in cgroup v2 pure mode.
+fn parse_mountinfo_for_container(content: &str) -> Option<(String, String)> {
+    for line in content.lines() {
+        if !line.contains("cgroup") {
+            continue;
+        }
+        if let Some(id) = extract_hex_id_from_path(line) {
+            let runtime = if line.contains("docker") {
+                "docker"
+            } else if line.contains("containerd") {
+                "containerd"
+            } else if line.contains("crio") {
+                "cri-o"
+            } else {
+                "unknown"
+            };
+            return Some((id, runtime.to_string()));
+        }
+    }
+    None
+}
+
+/// Check if a string looks like a 64-char hex container ID.
+fn is_hex_container_id(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Extract a 64-char hex ID from anywhere in a path string.
+fn extract_hex_id_from_path(path: &str) -> Option<String> {
+    // Walk through segments separated by / or -
+    for segment in path.split(['/', '-']) {
+        let segment = segment.split('.').next().unwrap_or(segment);
+        if is_hex_container_id(segment) {
+            return Some(segment.to_string());
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// K8s cluster info (resolved once at startup from downward API)
+// ---------------------------------------------------------------------------
+
+/// Kubernetes cluster metadata from the downward API and mounted secrets.
+///
+/// Columns: `namespace`, `pod_name`, `node_name`, `service_account`,
+/// `cluster_name`
+///
+/// Detection sources:
+/// - `KUBERNETES_SERVICE_HOST` env var (presence confirms K8s)
+/// - `/var/run/secrets/kubernetes.io/serviceaccount/namespace`
+/// - `HOSTNAME` env var (pod name in K8s)
+/// - `K8S_NODE_NAME`, `NODE_NAME` env vars (set via downward API fieldRef)
+/// - `K8S_CLUSTER_NAME`, `CLUSTER_NAME` env vars
+///
+/// If not running in Kubernetes, all columns are empty strings.
+///
+/// ```yaml
+/// enrichment:
+///   - type: k8s_cluster_info
+/// ```
+pub struct K8sClusterInfoTable {
+    batch: RecordBatch,
+}
+
+impl Default for K8sClusterInfoTable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl K8sClusterInfoTable {
+    pub fn new() -> Self {
+        let in_k8s = std::env::var("KUBERNETES_SERVICE_HOST").is_ok();
+
+        let namespace = if in_k8s {
+            std::fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        } else {
+            String::new()
+        };
+
+        let pod_name = if in_k8s {
+            std::env::var("HOSTNAME").unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        let node_name = if in_k8s {
+            std::env::var("K8S_NODE_NAME")
+                .or_else(|_| std::env::var("NODE_NAME"))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        let service_account = if in_k8s {
+            // Try the standard downward API env vars.
+            std::env::var("K8S_SERVICE_ACCOUNT")
+                .or_else(|_| std::env::var("SERVICE_ACCOUNT"))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        let cluster_name = if in_k8s {
+            std::env::var("K8S_CLUSTER_NAME")
+                .or_else(|_| std::env::var("CLUSTER_NAME"))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("namespace", DataType::Utf8, false),
+            Field::new("pod_name", DataType::Utf8, false),
+            Field::new("node_name", DataType::Utf8, false),
+            Field::new("service_account", DataType::Utf8, false),
+            Field::new("cluster_name", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![namespace.as_str()])),
+                Arc::new(StringArray::from(vec![pod_name.as_str()])),
+                Arc::new(StringArray::from(vec![node_name.as_str()])),
+                Arc::new(StringArray::from(vec![service_account.as_str()])),
+                Arc::new(StringArray::from(vec![cluster_name.as_str()])),
+            ],
+        )
+        .expect("k8s_cluster_info schema mismatch");
+
+        K8sClusterInfoTable { batch }
+    }
+}
+
+impl EnrichmentTable for K8sClusterInfoTable {
+    fn name(&self) -> &'static str {
+        "k8s_cluster_info"
+    }
+
+    fn snapshot(&self) -> Option<RecordBatch> {
+        Some(self.batch.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -1054,4 +1866,433 @@ mod tests {
         // Final state should have data.
         assert!(table.snapshot().is_some());
     }
+}
+
+// -- ReloadableGeoDb ----------------------------------------------------
+
+#[allow(dead_code)]
+struct FixedGeoDb(GeoResult);
+impl GeoDatabase for FixedGeoDb {
+    fn lookup(&self, _ip: &str) -> Option<GeoResult> {
+        Some(self.0.clone())
+    }
+}
+
+#[test]
+fn reloadable_geo_db_initial_lookup() {
+    let result = GeoResult {
+        country_code: Some("US".to_string()),
+        ..Default::default()
+    };
+    let db = Arc::new(FixedGeoDb(result));
+    let reloadable = Arc::new(ReloadableGeoDb::new(db));
+    let got = reloadable.lookup("1.2.3.4").unwrap();
+    assert_eq!(got.country_code.as_deref(), Some("US"));
+}
+
+#[test]
+fn reloadable_geo_db_swap_replaces_backend() {
+    let first = Arc::new(FixedGeoDb(GeoResult {
+        country_code: Some("US".to_string()),
+        ..Default::default()
+    }));
+    let reloadable = Arc::new(ReloadableGeoDb::new(first));
+    let handle = reloadable.reload_handle();
+
+    let second = Arc::new(FixedGeoDb(GeoResult {
+        country_code: Some("DE".to_string()),
+        ..Default::default()
+    }));
+    handle.replace(second);
+
+    let got = reloadable.lookup("1.2.3.4").unwrap();
+    assert_eq!(got.country_code.as_deref(), Some("DE"));
+}
+
+#[test]
+fn reloadable_geo_db_concurrent_reads() {
+    let db = Arc::new(FixedGeoDb(GeoResult {
+        country_code: Some("AU".to_string()),
+        ..Default::default()
+    }));
+    let reloadable = Arc::new(ReloadableGeoDb::new(db));
+    let handle = reloadable.reload_handle();
+
+    let reader = Arc::clone(&reloadable);
+    let reader_thread = std::thread::spawn(move || {
+        for _ in 0..100 {
+            let _ = reader.lookup("8.8.8.8");
+        }
+    });
+
+    // Swap pointer while reader is running.
+    handle.replace(Arc::new(FixedGeoDb(GeoResult {
+        country_code: Some("GB".to_string()),
+        ..Default::default()
+    })));
+
+    reader_thread.join().unwrap();
+}
+
+// -- EnvTable -----------------------------------------------------------
+
+#[test]
+fn env_table_reads_prefix() {
+    // SAFETY: test sets and clears env vars; must not run in parallel with other
+    // tests that read the same vars.
+    unsafe {
+        std::env::set_var("LOGFWD_TEST_CLUSTER", "prod");
+        std::env::set_var("LOGFWD_TEST_REGION", "us-east-1");
+    }
+
+    let table = EnvTable::from_prefix("deploy", "LOGFWD_TEST_").expect("should succeed");
+    assert_eq!(table.name(), "deploy");
+    let batch = table.snapshot().unwrap();
+    assert_eq!(batch.num_rows(), 1);
+
+    // Columns exist for the two vars we set (plus any pre-existing matches).
+    assert!(batch.column_by_name("cluster").is_some());
+    assert!(batch.column_by_name("region").is_some());
+
+    let cluster = batch
+        .column_by_name("cluster")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(cluster.value(0), "prod");
+
+    unsafe {
+        std::env::remove_var("LOGFWD_TEST_CLUSTER");
+        std::env::remove_var("LOGFWD_TEST_REGION");
+    }
+}
+
+#[test]
+fn env_table_no_match_returns_error() {
+    let result = EnvTable::from_prefix("nothing", "LOGFWD_NONEXISTENT_PREFIX_XYZZY_12345_");
+    assert!(result.is_err());
+}
+
+// -- ProcessInfoTable -------------------------------------------------------
+
+#[test]
+fn process_info_has_expected_columns() {
+    let table = ProcessInfoTable::new();
+    let batch = table.snapshot().expect("should have snapshot");
+    assert_eq!(batch.num_rows(), 1);
+    assert!(batch.column_by_name("agent_name").is_some());
+    assert!(batch.column_by_name("agent_version").is_some());
+    assert!(batch.column_by_name("pid").is_some());
+    assert!(batch.column_by_name("start_time").is_some());
+
+    let name_col = batch
+        .column_by_name("agent_name")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(name_col.value(0), "logfwd");
+
+    let pid_col = batch
+        .column_by_name("pid")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let pid: u32 = pid_col.value(0).parse().expect("pid should be numeric");
+    assert!(pid > 0);
+}
+
+#[test]
+fn process_info_start_time_is_iso8601() {
+    let table = ProcessInfoTable::new();
+    let batch = table.snapshot().unwrap();
+    let ts = batch
+        .column_by_name("start_time")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .value(0)
+        .to_string();
+    // Should look like "2026-04-12T06:20:13Z"
+    assert!(ts.ends_with('Z'), "expected UTC: {ts}");
+    assert_eq!(ts.len(), 20, "expected ISO 8601 length: {ts}");
+}
+
+#[test]
+fn process_info_table_name() {
+    let table = ProcessInfoTable::new();
+    assert_eq!(table.name(), "process_info");
+}
+
+// -- epoch_days_to_ymd -------------------------------------------------------
+
+#[test]
+fn epoch_days_known_dates() {
+    // Unix epoch: 1970-01-01
+    assert_eq!(epoch_days_to_ymd(0), (1970, 1, 1));
+    // 2000-01-01 is day 10957
+    assert_eq!(epoch_days_to_ymd(10957), (2000, 1, 1));
+    // 2024-02-29 (leap day) is day 19782
+    assert_eq!(epoch_days_to_ymd(19782), (2024, 2, 29));
+}
+
+// -- KvFileTable -------------------------------------------------------
+
+#[test]
+fn kv_file_parses_os_release_format() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("os-release");
+    std::fs::write(
+        &path,
+        r#"# This is a comment
+NAME="Ubuntu"
+VERSION_ID="22.04"
+ID=ubuntu
+PRETTY_NAME="Ubuntu 22.04.3 LTS"
+"#,
+    )
+    .unwrap();
+
+    let table = KvFileTable::new("os", &path);
+    let n = table.reload().unwrap();
+    assert_eq!(n, 4);
+
+    let batch = table.snapshot().unwrap();
+    assert_eq!(batch.num_rows(), 1);
+
+    let name_col = batch
+        .column_by_name("name")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(name_col.value(0), "Ubuntu");
+
+    let id_col = batch
+        .column_by_name("id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    assert_eq!(id_col.value(0), "ubuntu");
+}
+
+#[test]
+fn kv_file_handles_single_quotes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.env");
+    std::fs::write(&path, "KEY='single quoted'\n").unwrap();
+
+    let table = KvFileTable::new("test", &path);
+    table.reload().unwrap();
+    let batch = table.snapshot().unwrap();
+    let val = batch
+        .column_by_name("key")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .value(0);
+    assert_eq!(val, "single quoted");
+}
+
+#[test]
+fn kv_file_handles_single_char_quoted_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.env");
+    // A single quote character as the entire value — previously panicked.
+    std::fs::write(&path, "KEY=\"\nOTHER=ok\n").unwrap();
+
+    let table = KvFileTable::new("test", &path);
+    table.reload().unwrap();
+    let batch = table.snapshot().unwrap();
+    // The single `"` should be kept as-is (not stripped).
+    let val = batch
+        .column_by_name("key")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .value(0);
+    assert_eq!(val, "\"");
+}
+
+#[test]
+fn kv_file_empty_file_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.env");
+    std::fs::write(&path, "# only comments\n\n").unwrap();
+
+    let table = KvFileTable::new("empty", &path);
+    assert!(table.reload().is_err());
+}
+
+#[test]
+fn kv_file_missing_file_returns_error() {
+    let table = KvFileTable::new("missing", Path::new("/nonexistent/file.env"));
+    assert!(table.reload().is_err());
+}
+
+#[test]
+fn kv_file_reload_updates_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("update.env");
+    std::fs::write(&path, "VERSION=1\n").unwrap();
+
+    let table = KvFileTable::new("ver", &path);
+    table.reload().unwrap();
+    let v1 = table
+        .snapshot()
+        .unwrap()
+        .column_by_name("version")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .value(0)
+        .to_string();
+    assert_eq!(v1, "1");
+
+    std::fs::write(&path, "VERSION=2\n").unwrap();
+    table.reload().unwrap();
+    let v2 = table
+        .snapshot()
+        .unwrap()
+        .column_by_name("version")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .value(0)
+        .to_string();
+    assert_eq!(v2, "2");
+}
+
+// -- NetworkInfoTable -------------------------------------------------------
+
+#[test]
+fn network_info_has_expected_columns() {
+    let table = NetworkInfoTable::new();
+    let batch = table.snapshot().expect("should have snapshot");
+    assert_eq!(batch.num_rows(), 1);
+    assert!(batch.column_by_name("hostname").is_some());
+    assert!(batch.column_by_name("primary_ipv4").is_some());
+    assert!(batch.column_by_name("primary_ipv6").is_some());
+    assert!(batch.column_by_name("all_ipv4").is_some());
+    assert!(batch.column_by_name("all_ipv6").is_some());
+
+    // Hostname should be non-empty on any real system
+    let hostname = batch
+        .column_by_name("hostname")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap()
+        .value(0);
+    assert!(!hostname.is_empty());
+}
+
+#[test]
+fn network_info_table_name() {
+    let table = NetworkInfoTable::new();
+    assert_eq!(table.name(), "network_info");
+}
+
+// -- format_ipv6_hex -------------------------------------------------------
+
+#[test]
+fn format_ipv6_hex_known_address() {
+    // 2001:0db8:0000:0000:0000:0000:0000:0001
+    let hex = "20010db8000000000000000000000001";
+    let formatted = format_ipv6_hex(hex).unwrap();
+    assert_eq!(formatted, "2001:db8:0:0:0:0:0:1");
+}
+
+#[test]
+fn format_ipv6_hex_all_zeros() {
+    let hex = "00000000000000000000000000000000";
+    let formatted = format_ipv6_hex(hex).unwrap();
+    assert_eq!(formatted, "0:0:0:0:0:0:0:0");
+}
+
+#[test]
+fn format_ipv6_hex_wrong_length() {
+    assert!(format_ipv6_hex("abc").is_none());
+}
+
+// -- ContainerInfoTable -----------------------------------------------------
+
+#[test]
+fn container_info_has_expected_columns() {
+    let table = ContainerInfoTable::new();
+    let batch = table.snapshot().expect("should have snapshot");
+    assert_eq!(batch.num_rows(), 1);
+    assert!(batch.column_by_name("container_id").is_some());
+    assert!(batch.column_by_name("container_runtime").is_some());
+}
+
+#[test]
+fn container_info_table_name() {
+    let table = ContainerInfoTable::new();
+    assert_eq!(table.name(), "container_info");
+}
+
+#[test]
+fn parse_cgroup_docker_format() {
+    let content =
+        "12:memory:/docker/abc123def456abc123def456abc123def456abc123def456abc123def456abc1\n";
+    let result = parse_cgroup_for_container(content);
+    assert!(result.is_some());
+    let (id, runtime) = result.unwrap();
+    assert_eq!(runtime, "docker");
+    assert_eq!(id.len(), 64);
+}
+
+#[test]
+fn parse_cgroup_not_container() {
+    let content = "0::/init.scope\n";
+    let result = parse_cgroup_for_container(content);
+    assert!(result.is_none());
+}
+
+// -- K8sClusterInfoTable ----------------------------------------------------
+
+#[test]
+fn k8s_cluster_info_has_expected_columns() {
+    let table = K8sClusterInfoTable::new();
+    let batch = table.snapshot().expect("should have snapshot");
+    assert_eq!(batch.num_rows(), 1);
+    assert!(batch.column_by_name("namespace").is_some());
+    assert!(batch.column_by_name("pod_name").is_some());
+    assert!(batch.column_by_name("node_name").is_some());
+    assert!(batch.column_by_name("service_account").is_some());
+    assert!(batch.column_by_name("cluster_name").is_some());
+}
+
+#[test]
+fn k8s_cluster_info_table_name() {
+    let table = K8sClusterInfoTable::new();
+    assert_eq!(table.name(), "k8s_cluster_info");
+}
+
+// -- is_hex_container_id ----------------------------------------------------
+
+#[test]
+fn hex_container_id_valid() {
+    let id = "a".repeat(64);
+    assert!(is_hex_container_id(&id));
+}
+
+#[test]
+fn hex_container_id_too_short() {
+    assert!(!is_hex_container_id("abc123"));
+}
+
+#[test]
+fn hex_container_id_non_hex() {
+    let id = "g".repeat(64);
+    assert!(!is_hex_container_id(&id));
 }

--- a/crates/logfwd-transform/src/enrichment.rs
+++ b/crates/logfwd-transform/src/enrichment.rs
@@ -1254,9 +1254,10 @@ fn parse_cgroup_for_container(content: &str) -> Option<(String, String)> {
                     .extension()
                     .is_some_and(|ext| ext.eq_ignore_ascii_case("scope"))
         }) {
+            // Strip prefix and extension case-insensitively via rsplit_once.
             let inner = seg
                 .strip_prefix("docker-")
-                .and_then(|s| s.strip_suffix(".scope"))
+                .and_then(|s| s.rsplit_once('.').map(|(base, _)| base))
                 .unwrap_or("");
             if is_hex_container_id(inner) {
                 return Some((inner.to_string(), "docker".to_string()));
@@ -1882,463 +1883,462 @@ mod tests {
         // Final state should have data.
         assert!(table.snapshot().is_some());
     }
-}
 
-// -- ReloadableGeoDb ----------------------------------------------------
+    // -- ReloadableGeoDb ----------------------------------------------------
 
-#[allow(dead_code)]
-struct FixedGeoDb(GeoResult);
-impl GeoDatabase for FixedGeoDb {
-    fn lookup(&self, _ip: &str) -> Option<GeoResult> {
-        Some(self.0.clone())
-    }
-}
-
-#[test]
-fn reloadable_geo_db_initial_lookup() {
-    let result = GeoResult {
-        country_code: Some("US".to_string()),
-        ..Default::default()
-    };
-    let db = Arc::new(FixedGeoDb(result));
-    let reloadable = Arc::new(ReloadableGeoDb::new(db));
-    let got = reloadable.lookup("1.2.3.4").unwrap();
-    assert_eq!(got.country_code.as_deref(), Some("US"));
-}
-
-#[test]
-fn reloadable_geo_db_swap_replaces_backend() {
-    let first = Arc::new(FixedGeoDb(GeoResult {
-        country_code: Some("US".to_string()),
-        ..Default::default()
-    }));
-    let reloadable = Arc::new(ReloadableGeoDb::new(first));
-    let handle = reloadable.reload_handle();
-
-    let second = Arc::new(FixedGeoDb(GeoResult {
-        country_code: Some("DE".to_string()),
-        ..Default::default()
-    }));
-    handle.replace(second);
-
-    let got = reloadable.lookup("1.2.3.4").unwrap();
-    assert_eq!(got.country_code.as_deref(), Some("DE"));
-}
-
-#[test]
-fn reloadable_geo_db_concurrent_reads() {
-    let db = Arc::new(FixedGeoDb(GeoResult {
-        country_code: Some("AU".to_string()),
-        ..Default::default()
-    }));
-    let reloadable = Arc::new(ReloadableGeoDb::new(db));
-    let handle = reloadable.reload_handle();
-
-    let reader = Arc::clone(&reloadable);
-    let reader_thread = std::thread::spawn(move || {
-        for _ in 0..100 {
-            let _ = reader.lookup("8.8.8.8");
+    struct FixedGeoDb(GeoResult);
+    impl GeoDatabase for FixedGeoDb {
+        fn lookup(&self, _ip: &str) -> Option<GeoResult> {
+            Some(self.0.clone())
         }
-    });
-
-    // Swap pointer while reader is running.
-    handle.replace(Arc::new(FixedGeoDb(GeoResult {
-        country_code: Some("GB".to_string()),
-        ..Default::default()
-    })));
-
-    reader_thread.join().unwrap();
-}
-
-// -- EnvTable -----------------------------------------------------------
-
-#[test]
-fn env_table_reads_prefix() {
-    // SAFETY: test sets and clears env vars; must not run in parallel with other
-    // tests that read the same vars.
-    unsafe {
-        std::env::set_var("LOGFWD_TEST_CLUSTER", "prod");
-        std::env::set_var("LOGFWD_TEST_REGION", "us-east-1");
     }
 
-    let table = EnvTable::from_prefix("deploy", "LOGFWD_TEST_").expect("should succeed");
-    assert_eq!(table.name(), "deploy");
-    let batch = table.snapshot().unwrap();
-    assert_eq!(batch.num_rows(), 1);
-
-    // Columns exist for the two vars we set (plus any pre-existing matches).
-    assert!(batch.column_by_name("cluster").is_some());
-    assert!(batch.column_by_name("region").is_some());
-
-    let cluster = batch
-        .column_by_name("cluster")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
-    assert_eq!(cluster.value(0), "prod");
-
-    unsafe {
-        std::env::remove_var("LOGFWD_TEST_CLUSTER");
-        std::env::remove_var("LOGFWD_TEST_REGION");
+    #[test]
+    fn reloadable_geo_db_initial_lookup() {
+        let result = GeoResult {
+            country_code: Some("US".to_string()),
+            ..Default::default()
+        };
+        let db = Arc::new(FixedGeoDb(result));
+        let reloadable = Arc::new(ReloadableGeoDb::new(db));
+        let got = reloadable.lookup("1.2.3.4").unwrap();
+        assert_eq!(got.country_code.as_deref(), Some("US"));
     }
-}
 
-#[test]
-fn env_table_no_match_returns_error() {
-    let result = EnvTable::from_prefix("nothing", "LOGFWD_NONEXISTENT_PREFIX_XYZZY_12345_");
-    assert!(result.is_err());
-}
+    #[test]
+    fn reloadable_geo_db_swap_replaces_backend() {
+        let first = Arc::new(FixedGeoDb(GeoResult {
+            country_code: Some("US".to_string()),
+            ..Default::default()
+        }));
+        let reloadable = Arc::new(ReloadableGeoDb::new(first));
+        let handle = reloadable.reload_handle();
 
-#[test]
-fn env_table_rejects_duplicate_columns_after_lowercasing() {
-    // Set env vars that collide after lowercasing the suffix.
-    // SAFETY: test is run single-threaded (--test-threads=1).
-    unsafe {
-        std::env::set_var("LOGFWD_DUPTEST_FOO", "a");
-        std::env::set_var("LOGFWD_DUPTEST_foo", "b");
+        let second = Arc::new(FixedGeoDb(GeoResult {
+            country_code: Some("DE".to_string()),
+            ..Default::default()
+        }));
+        handle.replace(second);
+
+        let got = reloadable.lookup("1.2.3.4").unwrap();
+        assert_eq!(got.country_code.as_deref(), Some("DE"));
     }
-    let result = EnvTable::from_prefix("dup_test", "LOGFWD_DUPTEST_");
-    // Clean up before asserting.
-    unsafe {
-        std::env::remove_var("LOGFWD_DUPTEST_FOO");
-        std::env::remove_var("LOGFWD_DUPTEST_foo");
+
+    #[test]
+    fn reloadable_geo_db_concurrent_reads() {
+        let db = Arc::new(FixedGeoDb(GeoResult {
+            country_code: Some("AU".to_string()),
+            ..Default::default()
+        }));
+        let reloadable = Arc::new(ReloadableGeoDb::new(db));
+        let handle = reloadable.reload_handle();
+
+        let reader = Arc::clone(&reloadable);
+        let reader_thread = std::thread::spawn(move || {
+            for _ in 0..100 {
+                let _ = reader.lookup("8.8.8.8");
+            }
+        });
+
+        // Swap pointer while reader is running.
+        handle.replace(Arc::new(FixedGeoDb(GeoResult {
+            country_code: Some("GB".to_string()),
+            ..Default::default()
+        })));
+
+        reader_thread.join().unwrap();
     }
-    assert!(result.is_err());
-    let msg = format!("{}", result.err().unwrap());
-    assert!(msg.contains("duplicate column name"), "got: {msg}");
-}
 
-// -- ProcessInfoTable -------------------------------------------------------
+    // -- EnvTable -----------------------------------------------------------
 
-#[test]
-fn process_info_has_expected_columns() {
-    let table = ProcessInfoTable::new();
-    let batch = table.snapshot().expect("should have snapshot");
-    assert_eq!(batch.num_rows(), 1);
-    assert!(batch.column_by_name("agent_name").is_some());
-    assert!(batch.column_by_name("agent_version").is_some());
-    assert!(batch.column_by_name("pid").is_some());
-    assert!(batch.column_by_name("start_time").is_some());
+    #[test]
+    fn env_table_reads_prefix() {
+        // SAFETY: test sets and clears env vars; must not run in parallel with other
+        // tests that read the same vars.
+        unsafe {
+            std::env::set_var("LOGFWD_TEST_CLUSTER", "prod");
+            std::env::set_var("LOGFWD_TEST_REGION", "us-east-1");
+        }
 
-    let name_col = batch
-        .column_by_name("agent_name")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
+        let table = EnvTable::from_prefix("deploy", "LOGFWD_TEST_").expect("should succeed");
+        assert_eq!(table.name(), "deploy");
+        let batch = table.snapshot().unwrap();
+        assert_eq!(batch.num_rows(), 1);
+
+        // Columns exist for the two vars we set (plus any pre-existing matches).
+        assert!(batch.column_by_name("cluster").is_some());
+        assert!(batch.column_by_name("region").is_some());
+
+        let cluster = batch
+            .column_by_name("cluster")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(cluster.value(0), "prod");
+
+        unsafe {
+            std::env::remove_var("LOGFWD_TEST_CLUSTER");
+            std::env::remove_var("LOGFWD_TEST_REGION");
+        }
+    }
+
+    #[test]
+    fn env_table_no_match_returns_error() {
+        let result = EnvTable::from_prefix("nothing", "LOGFWD_NONEXISTENT_PREFIX_XYZZY_12345_");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn env_table_rejects_duplicate_columns_after_lowercasing() {
+        // Set env vars that collide after lowercasing the suffix.
+        // SAFETY: test is run single-threaded (--test-threads=1).
+        unsafe {
+            std::env::set_var("LOGFWD_DUPTEST_FOO", "a");
+            std::env::set_var("LOGFWD_DUPTEST_foo", "b");
+        }
+        let result = EnvTable::from_prefix("dup_test", "LOGFWD_DUPTEST_");
+        // Clean up before asserting.
+        unsafe {
+            std::env::remove_var("LOGFWD_DUPTEST_FOO");
+            std::env::remove_var("LOGFWD_DUPTEST_foo");
+        }
+        assert!(result.is_err());
+        let msg = format!("{}", result.err().unwrap());
+        assert!(msg.contains("duplicate column name"), "got: {msg}");
+    }
+
+    // -- ProcessInfoTable -------------------------------------------------------
+
+    #[test]
+    fn process_info_has_expected_columns() {
+        let table = ProcessInfoTable::new();
+        let batch = table.snapshot().expect("should have snapshot");
+        assert_eq!(batch.num_rows(), 1);
+        assert!(batch.column_by_name("agent_name").is_some());
+        assert!(batch.column_by_name("agent_version").is_some());
+        assert!(batch.column_by_name("pid").is_some());
+        assert!(batch.column_by_name("start_time").is_some());
+
+        let name_col = batch
+            .column_by_name("agent_name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(name_col.value(0), "logfwd");
+
+        let pid_col = batch
+            .column_by_name("pid")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let pid: u32 = pid_col.value(0).parse().expect("pid should be numeric");
+        assert!(pid > 0);
+    }
+
+    #[test]
+    fn process_info_start_time_is_iso8601() {
+        let table = ProcessInfoTable::new();
+        let batch = table.snapshot().unwrap();
+        let ts = batch
+            .column_by_name("start_time")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0)
+            .to_string();
+        // Should look like "2026-04-12T06:20:13Z"
+        assert!(ts.ends_with('Z'), "expected UTC: {ts}");
+        assert_eq!(ts.len(), 20, "expected ISO 8601 length: {ts}");
+    }
+
+    #[test]
+    fn process_info_table_name() {
+        let table = ProcessInfoTable::new();
+        assert_eq!(table.name(), "process_info");
+    }
+
+    // -- epoch_days_to_ymd -------------------------------------------------------
+
+    #[test]
+    fn epoch_days_known_dates() {
+        // Unix epoch: 1970-01-01
+        assert_eq!(epoch_days_to_ymd(0), (1970, 1, 1));
+        // 2000-01-01 is day 10957
+        assert_eq!(epoch_days_to_ymd(10957), (2000, 1, 1));
+        // 2024-02-29 (leap day) is day 19782
+        assert_eq!(epoch_days_to_ymd(19782), (2024, 2, 29));
+    }
+
+    // -- KvFileTable -------------------------------------------------------
+
+    #[test]
+    fn kv_file_parses_os_release_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("os-release");
+        std::fs::write(
+            &path,
+            r#"# This is a comment
+    NAME="Ubuntu"
+    VERSION_ID="22.04"
+    ID=ubuntu
+    PRETTY_NAME="Ubuntu 22.04.3 LTS"
+    "#,
+        )
         .unwrap();
-    assert_eq!(name_col.value(0), "logfwd");
 
-    let pid_col = batch
-        .column_by_name("pid")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
-    let pid: u32 = pid_col.value(0).parse().expect("pid should be numeric");
-    assert!(pid > 0);
-}
+        let table = KvFileTable::new("os", &path);
+        let n = table.reload().unwrap();
+        assert_eq!(n, 4);
 
-#[test]
-fn process_info_start_time_is_iso8601() {
-    let table = ProcessInfoTable::new();
-    let batch = table.snapshot().unwrap();
-    let ts = batch
-        .column_by_name("start_time")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap()
-        .value(0)
-        .to_string();
-    // Should look like "2026-04-12T06:20:13Z"
-    assert!(ts.ends_with('Z'), "expected UTC: {ts}");
-    assert_eq!(ts.len(), 20, "expected ISO 8601 length: {ts}");
-}
+        let batch = table.snapshot().unwrap();
+        assert_eq!(batch.num_rows(), 1);
 
-#[test]
-fn process_info_table_name() {
-    let table = ProcessInfoTable::new();
-    assert_eq!(table.name(), "process_info");
-}
+        let name_col = batch
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(name_col.value(0), "Ubuntu");
 
-// -- epoch_days_to_ymd -------------------------------------------------------
+        let id_col = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(id_col.value(0), "ubuntu");
+    }
 
-#[test]
-fn epoch_days_known_dates() {
-    // Unix epoch: 1970-01-01
-    assert_eq!(epoch_days_to_ymd(0), (1970, 1, 1));
-    // 2000-01-01 is day 10957
-    assert_eq!(epoch_days_to_ymd(10957), (2000, 1, 1));
-    // 2024-02-29 (leap day) is day 19782
-    assert_eq!(epoch_days_to_ymd(19782), (2024, 2, 29));
-}
+    #[test]
+    fn kv_file_handles_single_quotes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.env");
+        std::fs::write(&path, "KEY='single quoted'\n").unwrap();
 
-// -- KvFileTable -------------------------------------------------------
+        let table = KvFileTable::new("test", &path);
+        table.reload().unwrap();
+        let batch = table.snapshot().unwrap();
+        let val = batch
+            .column_by_name("key")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0);
+        assert_eq!(val, "single quoted");
+    }
 
-#[test]
-fn kv_file_parses_os_release_format() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("os-release");
-    std::fs::write(
-        &path,
-        r#"# This is a comment
-NAME="Ubuntu"
-VERSION_ID="22.04"
-ID=ubuntu
-PRETTY_NAME="Ubuntu 22.04.3 LTS"
-"#,
-    )
-    .unwrap();
+    #[test]
+    fn kv_file_handles_single_char_quoted_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.env");
+        // A single quote character as the entire value — previously panicked.
+        std::fs::write(&path, "KEY=\"\nOTHER=ok\n").unwrap();
 
-    let table = KvFileTable::new("os", &path);
-    let n = table.reload().unwrap();
-    assert_eq!(n, 4);
+        let table = KvFileTable::new("test", &path);
+        table.reload().unwrap();
+        let batch = table.snapshot().unwrap();
+        // The single `"` should be kept as-is (not stripped).
+        let val = batch
+            .column_by_name("key")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0);
+        assert_eq!(val, "\"");
+    }
 
-    let batch = table.snapshot().unwrap();
-    assert_eq!(batch.num_rows(), 1);
+    #[test]
+    fn kv_file_empty_file_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.env");
+        std::fs::write(&path, "# only comments\n\n").unwrap();
 
-    let name_col = batch
-        .column_by_name("name")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
-    assert_eq!(name_col.value(0), "Ubuntu");
+        let table = KvFileTable::new("empty", &path);
+        assert!(table.reload().is_err());
+    }
 
-    let id_col = batch
-        .column_by_name("id")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap();
-    assert_eq!(id_col.value(0), "ubuntu");
-}
+    #[test]
+    fn kv_file_missing_file_returns_error() {
+        let table = KvFileTable::new("missing", Path::new("/nonexistent/file.env"));
+        assert!(table.reload().is_err());
+    }
 
-#[test]
-fn kv_file_handles_single_quotes() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("test.env");
-    std::fs::write(&path, "KEY='single quoted'\n").unwrap();
+    #[test]
+    fn kv_file_reload_updates_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("update.env");
+        std::fs::write(&path, "VERSION=1\n").unwrap();
 
-    let table = KvFileTable::new("test", &path);
-    table.reload().unwrap();
-    let batch = table.snapshot().unwrap();
-    let val = batch
-        .column_by_name("key")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap()
-        .value(0);
-    assert_eq!(val, "single quoted");
-}
+        let table = KvFileTable::new("ver", &path);
+        table.reload().unwrap();
+        let v1 = table
+            .snapshot()
+            .unwrap()
+            .column_by_name("version")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0)
+            .to_string();
+        assert_eq!(v1, "1");
 
-#[test]
-fn kv_file_handles_single_char_quoted_value() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("test.env");
-    // A single quote character as the entire value — previously panicked.
-    std::fs::write(&path, "KEY=\"\nOTHER=ok\n").unwrap();
+        std::fs::write(&path, "VERSION=2\n").unwrap();
+        table.reload().unwrap();
+        let v2 = table
+            .snapshot()
+            .unwrap()
+            .column_by_name("version")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0)
+            .to_string();
+        assert_eq!(v2, "2");
+    }
 
-    let table = KvFileTable::new("test", &path);
-    table.reload().unwrap();
-    let batch = table.snapshot().unwrap();
-    // The single `"` should be kept as-is (not stripped).
-    let val = batch
-        .column_by_name("key")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap()
-        .value(0);
-    assert_eq!(val, "\"");
-}
+    // -- NetworkInfoTable -------------------------------------------------------
 
-#[test]
-fn kv_file_empty_file_returns_error() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("empty.env");
-    std::fs::write(&path, "# only comments\n\n").unwrap();
+    #[test]
+    fn network_info_has_expected_columns() {
+        let table = NetworkInfoTable::new();
+        let batch = table.snapshot().expect("should have snapshot");
+        assert_eq!(batch.num_rows(), 1);
+        assert!(batch.column_by_name("hostname").is_some());
+        assert!(batch.column_by_name("primary_ipv4").is_some());
+        assert!(batch.column_by_name("primary_ipv6").is_some());
+        assert!(batch.column_by_name("all_ipv4").is_some());
+        assert!(batch.column_by_name("all_ipv6").is_some());
 
-    let table = KvFileTable::new("empty", &path);
-    assert!(table.reload().is_err());
-}
+        // Hostname should be non-empty on any real system
+        let hostname = batch
+            .column_by_name("hostname")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap()
+            .value(0);
+        assert!(!hostname.is_empty());
+    }
 
-#[test]
-fn kv_file_missing_file_returns_error() {
-    let table = KvFileTable::new("missing", Path::new("/nonexistent/file.env"));
-    assert!(table.reload().is_err());
-}
+    #[test]
+    fn network_info_table_name() {
+        let table = NetworkInfoTable::new();
+        assert_eq!(table.name(), "network_info");
+    }
 
-#[test]
-fn kv_file_reload_updates_snapshot() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("update.env");
-    std::fs::write(&path, "VERSION=1\n").unwrap();
+    // -- format_ipv6_hex -------------------------------------------------------
 
-    let table = KvFileTable::new("ver", &path);
-    table.reload().unwrap();
-    let v1 = table
-        .snapshot()
-        .unwrap()
-        .column_by_name("version")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap()
-        .value(0)
-        .to_string();
-    assert_eq!(v1, "1");
+    #[test]
+    fn format_ipv6_hex_known_address() {
+        // 2001:0db8:0000:0000:0000:0000:0000:0001
+        let hex = "20010db8000000000000000000000001";
+        let formatted = format_ipv6_hex(hex).unwrap();
+        assert_eq!(formatted, "2001:db8:0:0:0:0:0:1");
+    }
 
-    std::fs::write(&path, "VERSION=2\n").unwrap();
-    table.reload().unwrap();
-    let v2 = table
-        .snapshot()
-        .unwrap()
-        .column_by_name("version")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap()
-        .value(0)
-        .to_string();
-    assert_eq!(v2, "2");
-}
+    #[test]
+    fn format_ipv6_hex_all_zeros() {
+        let hex = "00000000000000000000000000000000";
+        let formatted = format_ipv6_hex(hex).unwrap();
+        assert_eq!(formatted, "0:0:0:0:0:0:0:0");
+    }
 
-// -- NetworkInfoTable -------------------------------------------------------
+    #[test]
+    fn format_ipv6_hex_wrong_length() {
+        assert!(format_ipv6_hex("abc").is_none());
+    }
 
-#[test]
-fn network_info_has_expected_columns() {
-    let table = NetworkInfoTable::new();
-    let batch = table.snapshot().expect("should have snapshot");
-    assert_eq!(batch.num_rows(), 1);
-    assert!(batch.column_by_name("hostname").is_some());
-    assert!(batch.column_by_name("primary_ipv4").is_some());
-    assert!(batch.column_by_name("primary_ipv6").is_some());
-    assert!(batch.column_by_name("all_ipv4").is_some());
-    assert!(batch.column_by_name("all_ipv6").is_some());
+    // -- ContainerInfoTable -----------------------------------------------------
 
-    // Hostname should be non-empty on any real system
-    let hostname = batch
-        .column_by_name("hostname")
-        .unwrap()
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .unwrap()
-        .value(0);
-    assert!(!hostname.is_empty());
-}
+    #[test]
+    fn container_info_has_expected_columns() {
+        let table = ContainerInfoTable::new();
+        let batch = table.snapshot().expect("should have snapshot");
+        assert_eq!(batch.num_rows(), 1);
+        assert!(batch.column_by_name("container_id").is_some());
+        assert!(batch.column_by_name("container_runtime").is_some());
+    }
 
-#[test]
-fn network_info_table_name() {
-    let table = NetworkInfoTable::new();
-    assert_eq!(table.name(), "network_info");
-}
+    #[test]
+    fn container_info_table_name() {
+        let table = ContainerInfoTable::new();
+        assert_eq!(table.name(), "container_info");
+    }
 
-// -- format_ipv6_hex -------------------------------------------------------
+    #[test]
+    fn parse_cgroup_docker_format() {
+        let content =
+            "12:memory:/docker/abc123def456abc123def456abc123def456abc123def456abc123def456abc1\n";
+        let result = parse_cgroup_for_container(content);
+        assert!(result.is_some());
+        let (id, runtime) = result.unwrap();
+        assert_eq!(runtime, "docker");
+        assert_eq!(id.len(), 64);
+    }
 
-#[test]
-fn format_ipv6_hex_known_address() {
-    // 2001:0db8:0000:0000:0000:0000:0000:0001
-    let hex = "20010db8000000000000000000000001";
-    let formatted = format_ipv6_hex(hex).unwrap();
-    assert_eq!(formatted, "2001:db8:0:0:0:0:0:1");
-}
+    #[test]
+    fn parse_cgroup_docker_scope_v2() {
+        let id_hex = "a1b2c3d4".repeat(8); // 64 hex chars
+        let content = format!("0::/system.slice/docker-{id_hex}.scope\n");
+        let result = parse_cgroup_for_container(&content);
+        assert!(result.is_some());
+        let (id, runtime) = result.unwrap();
+        assert_eq!(runtime, "docker");
+        assert_eq!(id, id_hex);
+    }
 
-#[test]
-fn format_ipv6_hex_all_zeros() {
-    let hex = "00000000000000000000000000000000";
-    let formatted = format_ipv6_hex(hex).unwrap();
-    assert_eq!(formatted, "0:0:0:0:0:0:0:0");
-}
+    #[test]
+    fn parse_cgroup_not_container() {
+        let content = "0::/init.scope\n";
+        let result = parse_cgroup_for_container(content);
+        assert!(result.is_none());
+    }
 
-#[test]
-fn format_ipv6_hex_wrong_length() {
-    assert!(format_ipv6_hex("abc").is_none());
-}
+    // -- K8sClusterInfoTable ----------------------------------------------------
 
-// -- ContainerInfoTable -----------------------------------------------------
+    #[test]
+    fn k8s_cluster_info_has_expected_columns() {
+        let table = K8sClusterInfoTable::new();
+        let batch = table.snapshot().expect("should have snapshot");
+        assert_eq!(batch.num_rows(), 1);
+        assert!(batch.column_by_name("namespace").is_some());
+        assert!(batch.column_by_name("pod_name").is_some());
+        assert!(batch.column_by_name("node_name").is_some());
+        assert!(batch.column_by_name("service_account").is_some());
+        assert!(batch.column_by_name("cluster_name").is_some());
+    }
 
-#[test]
-fn container_info_has_expected_columns() {
-    let table = ContainerInfoTable::new();
-    let batch = table.snapshot().expect("should have snapshot");
-    assert_eq!(batch.num_rows(), 1);
-    assert!(batch.column_by_name("container_id").is_some());
-    assert!(batch.column_by_name("container_runtime").is_some());
-}
+    #[test]
+    fn k8s_cluster_info_table_name() {
+        let table = K8sClusterInfoTable::new();
+        assert_eq!(table.name(), "k8s_cluster_info");
+    }
 
-#[test]
-fn container_info_table_name() {
-    let table = ContainerInfoTable::new();
-    assert_eq!(table.name(), "container_info");
-}
+    // -- is_hex_container_id ----------------------------------------------------
 
-#[test]
-fn parse_cgroup_docker_format() {
-    let content =
-        "12:memory:/docker/abc123def456abc123def456abc123def456abc123def456abc123def456abc1\n";
-    let result = parse_cgroup_for_container(content);
-    assert!(result.is_some());
-    let (id, runtime) = result.unwrap();
-    assert_eq!(runtime, "docker");
-    assert_eq!(id.len(), 64);
-}
+    #[test]
+    fn hex_container_id_valid() {
+        let id = "a".repeat(64);
+        assert!(is_hex_container_id(&id));
+    }
 
-#[test]
-fn parse_cgroup_docker_scope_v2() {
-    let id_hex = "a1b2c3d4".repeat(8); // 64 hex chars
-    let content = format!("0::/system.slice/docker-{id_hex}.scope\n");
-    let result = parse_cgroup_for_container(&content);
-    assert!(result.is_some());
-    let (id, runtime) = result.unwrap();
-    assert_eq!(runtime, "docker");
-    assert_eq!(id, id_hex);
-}
+    #[test]
+    fn hex_container_id_too_short() {
+        assert!(!is_hex_container_id("abc123"));
+    }
 
-#[test]
-fn parse_cgroup_not_container() {
-    let content = "0::/init.scope\n";
-    let result = parse_cgroup_for_container(content);
-    assert!(result.is_none());
-}
-
-// -- K8sClusterInfoTable ----------------------------------------------------
-
-#[test]
-fn k8s_cluster_info_has_expected_columns() {
-    let table = K8sClusterInfoTable::new();
-    let batch = table.snapshot().expect("should have snapshot");
-    assert_eq!(batch.num_rows(), 1);
-    assert!(batch.column_by_name("namespace").is_some());
-    assert!(batch.column_by_name("pod_name").is_some());
-    assert!(batch.column_by_name("node_name").is_some());
-    assert!(batch.column_by_name("service_account").is_some());
-    assert!(batch.column_by_name("cluster_name").is_some());
-}
-
-#[test]
-fn k8s_cluster_info_table_name() {
-    let table = K8sClusterInfoTable::new();
-    assert_eq!(table.name(), "k8s_cluster_info");
-}
-
-// -- is_hex_container_id ----------------------------------------------------
-
-#[test]
-fn hex_container_id_valid() {
-    let id = "a".repeat(64);
-    assert!(is_hex_container_id(&id));
-}
-
-#[test]
-fn hex_container_id_too_short() {
-    assert!(!is_hex_container_id("abc123"));
-}
-
-#[test]
-fn hex_container_id_non_hex() {
-    let id = "g".repeat(64);
-    assert!(!is_hex_container_id(&id));
+    #[test]
+    fn hex_container_id_non_hex() {
+        let id = "g".repeat(64);
+        assert!(!is_hex_container_id(&id));
+    }
 }

--- a/crates/logfwd-transform/src/enrichment.rs
+++ b/crates/logfwd-transform/src/enrichment.rs
@@ -732,15 +732,15 @@ impl EnvTable {
         }
 
         // Reject duplicate column names after lowercase normalization (e.g.
-        // FOO and foo both present would create duplicate Arrow columns).
-        pairs.dedup_by(|a, b| {
-            if a.0 == b.0 {
-                // Keep first occurrence, drop duplicate.
-                true
-            } else {
-                false
+        // LOGFWD_META_REGION and LOGFWD_META_region both present would collide).
+        for w in pairs.windows(2) {
+            if w[0].0 == w[1].0 {
+                return Err(TransformError::Enrichment(format!(
+                    "EnvTable: duplicate column name '{}' after lowercasing (prefix '{prefix}')",
+                    w[0].0
+                )));
             }
-        });
+        }
 
         let fields: Vec<Field> = pairs
             .iter()
@@ -1244,6 +1244,22 @@ fn parse_cgroup_for_container(content: &str) -> Option<(String, String)> {
             let id = rest.split('/').next().unwrap_or("");
             if is_hex_container_id(id) {
                 return Some((id.to_string(), "docker".to_string()));
+            }
+        }
+
+        // Docker cgroup v2: docker-<id>.scope (e.g. /system.slice/docker-<id>.scope)
+        if let Some(seg) = path.rsplit('/').find(|s| {
+            s.starts_with("docker-")
+                && Path::new(s)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("scope"))
+        }) {
+            let inner = seg
+                .strip_prefix("docker-")
+                .and_then(|s| s.strip_suffix(".scope"))
+                .unwrap_or("");
+            if is_hex_container_id(inner) {
+                return Some((inner.to_string(), "docker".to_string()));
             }
         }
 
@@ -1974,6 +1990,25 @@ fn env_table_no_match_returns_error() {
     assert!(result.is_err());
 }
 
+#[test]
+fn env_table_rejects_duplicate_columns_after_lowercasing() {
+    // Set env vars that collide after lowercasing the suffix.
+    // SAFETY: test is run single-threaded (--test-threads=1).
+    unsafe {
+        std::env::set_var("LOGFWD_DUPTEST_FOO", "a");
+        std::env::set_var("LOGFWD_DUPTEST_foo", "b");
+    }
+    let result = EnvTable::from_prefix("dup_test", "LOGFWD_DUPTEST_");
+    // Clean up before asserting.
+    unsafe {
+        std::env::remove_var("LOGFWD_DUPTEST_FOO");
+        std::env::remove_var("LOGFWD_DUPTEST_foo");
+    }
+    assert!(result.is_err());
+    let msg = format!("{}", result.err().unwrap());
+    assert!(msg.contains("duplicate column name"), "got: {msg}");
+}
+
 // -- ProcessInfoTable -------------------------------------------------------
 
 #[test]
@@ -2249,6 +2284,17 @@ fn parse_cgroup_docker_format() {
     let (id, runtime) = result.unwrap();
     assert_eq!(runtime, "docker");
     assert_eq!(id.len(), 64);
+}
+
+#[test]
+fn parse_cgroup_docker_scope_v2() {
+    let id_hex = "a1b2c3d4".repeat(8); // 64 hex chars
+    let content = format!("0::/system.slice/docker-{id_hex}.scope\n");
+    let result = parse_cgroup_for_container(&content);
+    assert!(result.is_some());
+    let (id, runtime) = result.unwrap();
+    assert_eq!(runtime, "docker");
+    assert_eq!(id, id_hex);
 }
 
 #[test]

--- a/crates/logfwd-transform/src/enrichment.rs
+++ b/crates/logfwd-transform/src/enrichment.rs
@@ -107,6 +107,7 @@ impl Default for HostInfoTable {
 }
 
 impl HostInfoTable {
+    /// Snapshot host metadata at construction time: hostname, OS type, architecture.
     pub fn new() -> Self {
         let hostname = gethostname::gethostname().to_string_lossy().into_owned();
         let os_type = std::env::consts::OS.to_string();
@@ -167,6 +168,8 @@ pub struct K8sPodEntry {
 }
 
 impl K8sPathTable {
+    /// Create an empty K8s path table. Call [`update_from_paths`](Self::update_from_paths)
+    /// to populate with CRI log paths.
     pub fn new(table_name: impl Into<String>) -> Self {
         let table_name = table_name.into();
         // Start with an empty batch so SQL queries don't fail with "table not found".
@@ -459,6 +462,7 @@ pub struct JsonLinesFileTable {
 }
 
 impl JsonLinesFileTable {
+    /// Create a JSONL file table. Call [`reload`](Self::reload) to load data from disk.
     pub fn new(table_name: impl Into<String>, path: impl Into<PathBuf>) -> Self {
         JsonLinesFileTable {
             table_name: table_name.into(),
@@ -657,10 +661,14 @@ impl ReloadableGeoDb {
 
 impl GeoDatabase for ReloadableGeoDb {
     fn lookup(&self, ip: &str) -> Option<GeoResult> {
-        self.inner
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .lookup(ip)
+        let db = Arc::clone(
+            &self
+                .inner
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        // Lock is dropped here; the lookup runs without blocking writers.
+        db.lookup(ip)
     }
 }
 
@@ -720,6 +728,7 @@ impl EnvTable {
         let mut pairs: Vec<(String, String)> = std::env::vars()
             .filter_map(|(k, v)| {
                 k.strip_prefix(prefix)
+                    .filter(|s| !s.is_empty()) // skip exact prefix match (empty column name)
                     .map(|stripped| (stripped.to_lowercase(), v))
             })
             .collect();
@@ -797,6 +806,7 @@ impl Default for ProcessInfoTable {
 }
 
 impl ProcessInfoTable {
+    /// Snapshot agent self-metadata: name ("logfwd"), version, PID, start time.
     pub fn new() -> Self {
         let agent_name = "logfwd";
         let agent_version = env!("CARGO_PKG_VERSION");
@@ -893,6 +903,7 @@ pub struct KvFileTable {
 }
 
 impl KvFileTable {
+    /// Create a KV file table. Call [`reload`](Self::reload) to load data from disk.
     pub fn new(table_name: impl Into<String>, path: &Path) -> Self {
         KvFileTable {
             table_name: table_name.into(),
@@ -1016,6 +1027,11 @@ impl Default for NetworkInfoTable {
 }
 
 impl NetworkInfoTable {
+    /// Snapshot network metadata: hostname, IP addresses (sorted lexicographically).
+    ///
+    /// `primary_ipv4` / `primary_ipv6` are the lexicographically first non-loopback
+    /// addresses. On multihomed hosts this may not match the default-route interface;
+    /// use `all_ipv4` / `all_ipv6` if you need full coverage.
     pub fn new() -> Self {
         let hostname = gethostname::gethostname().to_string_lossy().into_owned();
 
@@ -1176,6 +1192,7 @@ impl Default for ContainerInfoTable {
 }
 
 impl ContainerInfoTable {
+    /// Detect container runtime and ID from `/proc/self/cgroup` and `/proc/self/mountinfo`.
     pub fn new() -> Self {
         let (container_id, container_runtime) = detect_container();
 
@@ -1362,6 +1379,8 @@ impl Default for K8sClusterInfoTable {
 }
 
 impl K8sClusterInfoTable {
+    /// Read Kubernetes cluster metadata from the downward API environment variables
+    /// and service account token path.
     pub fn new() -> Self {
         let in_k8s = std::env::var("KUBERNETES_SERVICE_HOST").is_ok();
 
@@ -1990,6 +2009,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)] // Windows env vars are case-insensitive; both names map to one var.
     fn env_table_rejects_duplicate_columns_after_lowercasing() {
         // Set env vars that collide after lowercasing the suffix.
         // SAFETY: test is run single-threaded (--test-threads=1).

--- a/crates/logfwd-transform/src/enrichment.rs
+++ b/crates/logfwd-transform/src/enrichment.rs
@@ -725,11 +725,14 @@ impl EnvTable {
         table_name: impl Into<String>,
         prefix: &str,
     ) -> Result<Self, TransformError> {
-        let mut pairs: Vec<(String, String)> = std::env::vars()
+        let mut pairs: Vec<(String, String)> = std::env::vars_os()
             .filter_map(|(k, v)| {
-                k.strip_prefix(prefix)
+                let k_str = k.to_str()?; // skip non-UTF8 keys
+                let v_str = v.to_str()?; // skip non-UTF8 values
+                k_str
+                    .strip_prefix(prefix)
                     .filter(|s| !s.is_empty()) // skip exact prefix match (empty column name)
-                    .map(|stripped| (stripped.to_lowercase(), v))
+                    .map(|stripped| (stripped.to_lowercase(), v_str.to_owned()))
             })
             .collect();
         pairs.sort_by(|a, b| a.0.cmp(&b.0));

--- a/crates/logfwd-transform/src/udf/csv_range_geo.rs
+++ b/crates/logfwd-transform/src/udf/csv_range_geo.rs
@@ -171,6 +171,17 @@ impl CsvRangeDatabase {
         // Sort by start address for binary search.
         ranges.sort_unstable_by_key(|e| e.start);
 
+        // Reject overlapping ranges — they cause ambiguous lookups with binary search.
+        for pair in ranges.windows(2) {
+            if pair[0].end >= pair[1].start {
+                return Err(TransformError::Enrichment(format!(
+                    "CSV geo database contains overlapping IP ranges: range ending at {} overlaps range starting at {}",
+                    u128_to_ip_string(pair[0].end),
+                    u128_to_ip_string(pair[1].start),
+                )));
+            }
+        }
+
         Ok(CsvRangeDatabase { ranges })
     }
 
@@ -234,6 +245,17 @@ fn ip_to_u128(addr: IpAddr) -> u128 {
 /// Parse an IP string to `u128`, accepting both IPv4 and IPv6.
 fn parse_ip_to_u128(s: &str) -> Option<u128> {
     IpAddr::from_str(s.trim()).ok().map(ip_to_u128)
+}
+
+/// Convert a `u128` back to an IP string for error messages.
+///
+/// Values in the IPv4-mapped range (`::ffff:0:0/96`) are rendered as IPv4.
+fn u128_to_ip_string(val: u128) -> String {
+    let addr = std::net::Ipv6Addr::from(val);
+    match addr.to_ipv4_mapped() {
+        Some(v4) => v4.to_string(),
+        None => addr.to_string(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -341,5 +363,36 @@ ip_range_start,ip_range_end,country_code,country_name,city,stateprov,latitude,lo
         let csv = b"ip_range_start,ip_range_end,country_code\n";
         let db = CsvRangeDatabase::load_from_reader(&csv[..]).unwrap();
         assert!(db.is_empty());
+    }
+
+    #[test]
+    fn overlapping_ranges_rejected() {
+        let csv = b"ip_range_start,ip_range_end,country_code\n\
+            1.0.0.0,1.0.0.255,AU\n\
+            1.0.0.128,1.0.1.255,NZ\n";
+        let result = CsvRangeDatabase::load_from_reader(&csv[..]);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("overlapping"),
+            "expected overlap error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn adjacent_ranges_accepted() {
+        let csv = b"ip_range_start,ip_range_end,country_code\n\
+            1.0.0.0,1.0.0.127,AU\n\
+            1.0.0.128,1.0.0.255,NZ\n";
+        let db = CsvRangeDatabase::load_from_reader(&csv[..]).unwrap();
+        assert_eq!(db.len(), 2);
+        assert_eq!(
+            db.lookup("1.0.0.1").unwrap().country_code.as_deref(),
+            Some("AU")
+        );
+        assert_eq!(
+            db.lookup("1.0.0.200").unwrap().country_code.as_deref(),
+            Some("NZ")
+        );
     }
 }

--- a/crates/logfwd-transform/src/udf/csv_range_geo.rs
+++ b/crates/logfwd-transform/src/udf/csv_range_geo.rs
@@ -1,0 +1,345 @@
+//! CSV IP-range geo-IP backend.
+//!
+//! A drop-in replacement for [`super::geo_lookup::MmdbDatabase`] that reads a plain CSV file
+//! instead of a MaxMind `.mmdb` binary.  Compatible with the free
+//! [DB-IP Lite](https://db-ip.com/db/lite/ip-to-location) exports and any
+//! similar CSV with `ip_range_start` / `ip_range_end` header columns.
+//!
+//! ## CSV column mapping
+//!
+//! | CSV header (case-insensitive) | [`GeoResult`] field |
+//! |-------------------------------|---------------------|
+//! | `ip_range_start` or `start_ip`| *(range key)*       |
+//! | `ip_range_end`   or `end_ip`  | *(range key)*       |
+//! | `country_code`                | `country_code`      |
+//! | `country_name`                | `country_name`      |
+//! | `city`                        | `city`              |
+//! | `stateprov` or `region`       | `region`            |
+//! | `latitude`                    | `latitude`          |
+//! | `longitude`                   | `longitude`         |
+//! | `asn`                         | `asn`               |
+//! | `org` or `organization`       | `org`               |
+//!
+//! Unrecognised columns are silently ignored.
+//!
+//! ## Lookup algorithm
+//!
+//! Ranges are stored in a sorted `Vec` keyed on the start address as a `u128`
+//! (IPv4 addresses use the IPv4-mapped IPv6 representation).  A binary search
+//! locates the last entry whose start ≤ lookup IP; if its end ≥ lookup IP the
+//! entry is a hit.
+//!
+//! ## Example (YAML config)
+//!
+//! ```yaml
+//! enrichment:
+//!   - type: geo_database
+//!     format: csv_range
+//!     path: /etc/logfwd/dbip-city-lite.csv
+//! ```
+
+use std::io;
+use std::net::IpAddr;
+use std::path::Path;
+use std::str::FromStr;
+
+use crate::TransformError;
+use crate::enrichment::{GeoDatabase, GeoResult};
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct RangeEntry {
+    start: u128,
+    end: u128,
+    result: GeoResult,
+}
+
+// ---------------------------------------------------------------------------
+// CsvRangeDatabase
+// ---------------------------------------------------------------------------
+
+/// Geo-IP database backed by a CSV file of IP ranges.
+///
+/// See the [module-level documentation](self) for the expected CSV format.
+#[derive(Debug)]
+pub struct CsvRangeDatabase {
+    ranges: Vec<RangeEntry>,
+}
+
+impl CsvRangeDatabase {
+    /// Load from a CSV reader.
+    pub fn load_from_reader<R: io::Read>(reader: R) -> Result<Self, TransformError> {
+        let mut csv = csv::ReaderBuilder::new().flexible(true).from_reader(reader);
+
+        let headers: Vec<String> = csv
+            .headers()
+            .map_err(|e| TransformError::Enrichment(format!("CSV header error: {e}")))?
+            .iter()
+            .map(|h| h.trim().to_lowercase())
+            .collect();
+
+        // Locate required and optional column indices.
+        let start_idx = headers
+            .iter()
+            .position(|h| h == "ip_range_start" || h == "start_ip")
+            .ok_or_else(|| {
+                TransformError::Enrichment(
+                    "CSV missing required column 'ip_range_start' or 'start_ip'".to_string(),
+                )
+            })?;
+
+        let end_idx = headers
+            .iter()
+            .position(|h| h == "ip_range_end" || h == "end_ip")
+            .ok_or_else(|| {
+                TransformError::Enrichment(
+                    "CSV missing required column 'ip_range_end' or 'end_ip'".to_string(),
+                )
+            })?;
+
+        let country_code_idx = headers.iter().position(|h| h == "country_code");
+        let country_name_idx = headers.iter().position(|h| h == "country_name");
+        let city_idx = headers.iter().position(|h| h == "city");
+        let region_idx = headers
+            .iter()
+            .position(|h| h == "stateprov" || h == "region");
+        let lat_idx = headers.iter().position(|h| h == "latitude");
+        let lon_idx = headers.iter().position(|h| h == "longitude");
+        let asn_idx = headers.iter().position(|h| h == "asn");
+        let org_idx = headers
+            .iter()
+            .position(|h| h == "org" || h == "organization");
+
+        let mut ranges: Vec<RangeEntry> = Vec::new();
+
+        for (row_num, record) in (1_u64..).zip(csv.records()) {
+            let record = record.map_err(|e| {
+                TransformError::Enrichment(format!("CSV parse error at row {row_num}: {e}"))
+            })?;
+
+            let get = |idx: usize| -> &str { record.get(idx).unwrap_or("").trim() };
+
+            let start_str = get(start_idx);
+            let end_str = get(end_idx);
+
+            let start = parse_ip_to_u128(start_str).ok_or_else(|| {
+                TransformError::Enrichment(format!(
+                    "CSV row {row_num}: invalid start IP '{start_str}'"
+                ))
+            })?;
+            let end = parse_ip_to_u128(end_str).ok_or_else(|| {
+                TransformError::Enrichment(format!("CSV row {row_num}: invalid end IP '{end_str}'"))
+            })?;
+
+            if end < start {
+                // Skip malformed rows silently — they are common in raw exports.
+                continue;
+            }
+
+            let result = GeoResult {
+                country_code: country_code_idx
+                    .map(&get)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned),
+                country_name: country_name_idx
+                    .map(&get)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned),
+                city: city_idx
+                    .map(&get)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned),
+                region: region_idx
+                    .map(&get)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned),
+                latitude: lat_idx.and_then(|i| get(i).parse::<f64>().ok()),
+                longitude: lon_idx.and_then(|i| get(i).parse::<f64>().ok()),
+                asn: asn_idx.and_then(|i| get(i).trim_start_matches("AS").parse::<i64>().ok()),
+                org: org_idx
+                    .map(get)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_owned),
+            };
+
+            ranges.push(RangeEntry { start, end, result });
+        }
+
+        // Sort by start address for binary search.
+        ranges.sort_unstable_by_key(|e| e.start);
+
+        Ok(CsvRangeDatabase { ranges })
+    }
+
+    /// Load from a file path.
+    pub fn open(path: &Path) -> Result<Self, TransformError> {
+        let file = std::fs::File::open(path).map_err(|e| {
+            TransformError::Enrichment(format!(
+                "failed to open CSV geo database '{}': {e}",
+                path.display()
+            ))
+        })?;
+        Self::load_from_reader(io::BufReader::new(file))
+    }
+
+    /// Number of IP ranges loaded.
+    pub fn len(&self) -> usize {
+        self.ranges.len()
+    }
+
+    /// Returns `true` if no ranges were loaded.
+    pub fn is_empty(&self) -> bool {
+        self.ranges.is_empty()
+    }
+}
+
+impl GeoDatabase for CsvRangeDatabase {
+    fn lookup(&self, ip: &str) -> Option<GeoResult> {
+        let addr = IpAddr::from_str(ip.trim()).ok()?;
+        let key = ip_to_u128(addr);
+
+        // Find the last entry whose start ≤ key.
+        let idx = self
+            .ranges
+            .partition_point(|e| e.start <= key)
+            .checked_sub(1)?;
+
+        let entry = &self.ranges[idx];
+        if entry.end >= key {
+            Some(entry.result.clone())
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert an [`IpAddr`] to a comparable `u128`.
+///
+/// IPv4 addresses are mapped to `::ffff:0:0/96` so they sort before IPv6
+/// addresses and are comparable with IPv4-mapped ranges in the CSV.
+fn ip_to_u128(addr: IpAddr) -> u128 {
+    match addr {
+        IpAddr::V4(v4) => u128::from(v4.to_ipv6_mapped()),
+        IpAddr::V6(v6) => u128::from(v6),
+    }
+}
+
+/// Parse an IP string to `u128`, accepting both IPv4 and IPv6.
+fn parse_ip_to_u128(s: &str) -> Option<u128> {
+    IpAddr::from_str(s.trim()).ok().map(ip_to_u128)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SIMPLE_CSV: &[u8] = b"\
+ip_range_start,ip_range_end,country_code,country_name,city,stateprov,latitude,longitude,asn,org\n\
+1.0.0.0,1.0.0.255,AU,Australia,,,,,7545,Optus\n\
+8.8.8.0,8.8.8.255,US,United States,Mountain View,California,37.386,-122.084,15169,Google LLC\n\
+2001:4860::,2001:4860:ffff:ffff:ffff:ffff:ffff:ffff,US,United States,,,,,,\n\
+";
+
+    #[test]
+    fn load_from_reader_parses_rows() {
+        let db = CsvRangeDatabase::load_from_reader(SIMPLE_CSV).unwrap();
+        assert_eq!(db.len(), 3);
+    }
+
+    #[test]
+    fn lookup_ipv4_hit() {
+        let db = CsvRangeDatabase::load_from_reader(SIMPLE_CSV).unwrap();
+        let result = db.lookup("8.8.8.8").unwrap();
+        assert_eq!(result.country_code.as_deref(), Some("US"));
+        assert_eq!(result.city.as_deref(), Some("Mountain View"));
+        assert_eq!(result.asn, Some(15169));
+        assert_eq!(result.org.as_deref(), Some("Google LLC"));
+        assert!((result.latitude.unwrap() - 37.386).abs() < 0.001);
+    }
+
+    #[test]
+    fn lookup_ipv4_first_range() {
+        let db = CsvRangeDatabase::load_from_reader(SIMPLE_CSV).unwrap();
+        let result = db.lookup("1.0.0.1").unwrap();
+        assert_eq!(result.country_code.as_deref(), Some("AU"));
+        assert_eq!(result.org.as_deref(), Some("Optus"));
+    }
+
+    #[test]
+    fn lookup_ipv4_miss() {
+        let db = CsvRangeDatabase::load_from_reader(SIMPLE_CSV).unwrap();
+        assert!(db.lookup("5.5.5.5").is_none()); // not in any range
+    }
+
+    #[test]
+    fn lookup_ipv6_hit() {
+        let db = CsvRangeDatabase::load_from_reader(SIMPLE_CSV).unwrap();
+        let result = db.lookup("2001:4860::1").unwrap();
+        assert_eq!(result.country_code.as_deref(), Some("US"));
+    }
+
+    #[test]
+    fn lookup_private_ip_miss() {
+        let db = CsvRangeDatabase::load_from_reader(SIMPLE_CSV).unwrap();
+        assert!(db.lookup("192.168.1.1").is_none());
+        assert!(db.lookup("10.0.0.1").is_none());
+    }
+
+    #[test]
+    fn lookup_malformed_ip_returns_none() {
+        let db = CsvRangeDatabase::load_from_reader(SIMPLE_CSV).unwrap();
+        assert!(db.lookup("not-an-ip").is_none());
+        assert!(db.lookup("").is_none());
+    }
+
+    #[test]
+    fn range_boundaries_inclusive() {
+        let db = CsvRangeDatabase::load_from_reader(SIMPLE_CSV).unwrap();
+        // Exact start and end of the AU range.
+        assert!(db.lookup("1.0.0.0").is_some());
+        assert!(db.lookup("1.0.0.255").is_some());
+        assert!(db.lookup("1.0.1.0").is_none());
+    }
+
+    #[test]
+    fn missing_start_column_returns_error() {
+        let bad = b"ip_range_end,country_code\n1.0.0.255,AU\n";
+        let result = CsvRangeDatabase::load_from_reader(&bad[..]);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("ip_range_start"));
+    }
+
+    #[test]
+    fn asn_with_as_prefix_parsed() {
+        let csv = b"ip_range_start,ip_range_end,country_code,asn\n1.2.3.0,1.2.3.255,US,AS12345\n";
+        let db = CsvRangeDatabase::load_from_reader(&csv[..]).unwrap();
+        let result = db.lookup("1.2.3.1").unwrap();
+        assert_eq!(result.asn, Some(12345));
+    }
+
+    #[test]
+    fn start_ip_end_ip_aliases() {
+        let csv = b"start_ip,end_ip,country_code\n9.9.9.0,9.9.9.255,FR\n";
+        let db = CsvRangeDatabase::load_from_reader(&csv[..]).unwrap();
+        let result = db.lookup("9.9.9.9").unwrap();
+        assert_eq!(result.country_code.as_deref(), Some("FR"));
+    }
+
+    #[test]
+    fn is_empty_before_any_rows() {
+        let csv = b"ip_range_start,ip_range_end,country_code\n";
+        let db = CsvRangeDatabase::load_from_reader(&csv[..]).unwrap();
+        assert!(db.is_empty());
+    }
+}

--- a/crates/logfwd-transform/src/udf/mod.rs
+++ b/crates/logfwd-transform/src/udf/mod.rs
@@ -2,12 +2,14 @@
 //!
 //! These are registered in `SqlTransform::execute()` and available in user SQL.
 
+pub mod csv_range_geo;
 pub mod geo_lookup;
 pub mod grok;
 pub mod hash;
 pub mod json_extract;
 pub mod regexp_extract;
 
+pub use csv_range_geo::CsvRangeDatabase;
 pub use geo_lookup::GeoLookupUdf;
 pub use grok::GrokUdf;
 pub use hash::HashUdf;

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1331,6 +1331,16 @@ fn validate_pipeline_read_only(
                                     })?;
                                 Arc::new(mmdb)
                             }
+                            GeoDatabaseFormat::CsvRange => {
+                                let csv = logfwd::transform::udf::CsvRangeDatabase::open(&path)
+                                    .map_err(|e| {
+                                        format!(
+                                            "failed to open CSV range geo database '{}': {e}",
+                                            path.display()
+                                        )
+                                    })?;
+                                Arc::new(csv)
+                            }
                             _ => {
                                 return Err(format!(
                                     "unsupported geo database format: {:?}",
@@ -1392,6 +1402,52 @@ fn validate_pipeline_read_only(
                         .reload()
                         .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
                     enrichment_tables.push(table);
+                }
+                EnrichmentConfig::EnvVars(cfg) => {
+                    let table = Arc::new(
+                        logfwd::transform::enrichment::EnvTable::from_prefix(
+                            &cfg.table_name,
+                            &cfg.prefix,
+                        )
+                        .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?,
+                    );
+                    enrichment_tables.push(table);
+                }
+                EnrichmentConfig::ProcessInfo(_) => {
+                    enrichment_tables.push(Arc::new(
+                        logfwd::transform::enrichment::ProcessInfoTable::new(),
+                    ));
+                }
+                EnrichmentConfig::KvFile(cfg) => {
+                    let mut path = PathBuf::from(&cfg.path);
+                    if path.is_relative()
+                        && let Some(base) = base_path
+                    {
+                        path = base.join(path);
+                    }
+                    let table = Arc::new(logfwd::transform::enrichment::KvFileTable::new(
+                        &cfg.table_name,
+                        &path,
+                    ));
+                    table
+                        .reload()
+                        .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
+                    enrichment_tables.push(table);
+                }
+                EnrichmentConfig::NetworkInfo(_) => {
+                    enrichment_tables.push(Arc::new(
+                        logfwd::transform::enrichment::NetworkInfoTable::new(),
+                    ));
+                }
+                EnrichmentConfig::ContainerInfo(_) => {
+                    enrichment_tables.push(Arc::new(
+                        logfwd::transform::enrichment::ContainerInfoTable::new(),
+                    ));
+                }
+                EnrichmentConfig::K8sClusterInfo(_) => {
+                    enrichment_tables.push(Arc::new(
+                        logfwd::transform::enrichment::K8sClusterInfoTable::new(),
+                    ));
                 }
             }
         }

--- a/crates/logfwd/src/transform.rs
+++ b/crates/logfwd/src/transform.rs
@@ -11,6 +11,7 @@ pub mod udf {
     pub mod geo_lookup {
         pub use logfwd_transform::udf::geo_lookup::MmdbDatabase;
     }
+    pub use logfwd_transform::udf::CsvRangeDatabase;
 }
 
 #[cfg(not(feature = "datafusion"))]

--- a/dev-docs/research/README.md
+++ b/dev-docs/research/README.md
@@ -22,6 +22,7 @@ Point-in-time investigations that informed architecture decisions.
 - [checkpoint-snapshot-design.md](checkpoint-snapshot-design.md)
 - [columnar-batch-builder.md](columnar-batch-builder.md)
 - [crate-restructure-plan.md](crate-restructure-plan.md)
+- [enrichment-architecture-plan-2026-04.md](enrichment-architecture-plan-2026-04.md)
 - [file-tailing-audit.md](file-tailing-audit.md)
 - [linearizability-porcupine-plan.md](linearizability-porcupine-plan.md)
 - [per-input-sql-analysis.md](per-input-sql-analysis.md)

--- a/dev-docs/research/enrichment-architecture-plan-2026-04.md
+++ b/dev-docs/research/enrichment-architecture-plan-2026-04.md
@@ -1,0 +1,380 @@
+# Enrichment Architecture Plan
+
+> **Status:** Active
+> **Date:** 2026-04-12
+> **Context:** Evaluate enrichment architecture for mixed local and live lookups, prototype-friendly experiments, and a phased implementation plan.
+
+## Summary
+
+The current pipeline already supports two enrichment shapes:
+
+- SQL-visible snapshot data via enrichment tables and UDFs
+- post-transform processors with synchronous contracts and room for internal background tasks
+
+That makes the architecture decision clearer than it first appears:
+
+- **pure local, deterministic, snapshot-backed enrichment** belongs in SQL
+- **live, remotely refreshed, rate-limited, or failure-prone enrichment** belongs in a dedicated enrichment processor stage, not in SQL
+
+The near-term goal should not be "pick one enrichment system for everything." It should be to separate enrichment into two execution classes and run focused experiments against both.
+
+## Existing Surfaces
+
+### Snapshot enrichment already in SQL
+
+Current pipeline build wires enrichment into every `SqlTransform` at pipeline construction time.
+
+- Geo database is attached as a UDF backend: [crates/logfwd-runtime/src/pipeline/build.rs](../../crates/logfwd-runtime/src/pipeline/build.rs)
+- Enrichment tables are registered as DataFusion MemTables: [crates/logfwd-transform/src/sql_transform.rs](../../crates/logfwd-transform/src/sql_transform.rs)
+- Geo lookup UDF is synchronous and per-row: [crates/logfwd-transform/src/udf/geo_lookup.rs](../../crates/logfwd-transform/src/udf/geo_lookup.rs)
+- Enrichment tables expose snapshots behind `Arc<RwLock<Option<RecordBatch>>>`: [crates/logfwd-transform/src/enrichment.rs](../../crates/logfwd-transform/src/enrichment.rs)
+
+### A processor seam already exists for non-SQL work
+
+The `Processor` contract is synchronous, but it explicitly allows internal async work via background tasks and channels.
+
+- Processor contract: [crates/logfwd-runtime/src/processor/mod.rs](../../crates/logfwd-runtime/src/processor/mod.rs)
+
+This is the most important design fact for future live enrichment. We do not need to force async into DataFusion. We already have a pipeline seam that can host an async-backed enrichment stage while preserving batch-level pipeline semantics.
+
+## Enrichment Categories We Should Plan For
+
+### 1. Pure local snapshot lookups
+
+Properties:
+
+- loaded from disk or config
+- bounded lookup cost
+- no network I/O
+- deterministic for a given snapshot
+- safe to use in `WHERE`, projection, and grouping
+
+Examples:
+
+- MMDB geo lookup
+- DB-IP Lite or other CSV range-backed geo/ASN database
+- static labels
+- host info
+- K8s path metadata
+- CSV/JSONL reference tables
+- local ASN or threat-list snapshots
+
+**Recommended execution surface:** SQL UDF or SQL JOIN table
+
+### 2. Reloadable local snapshot lookups
+
+Properties:
+
+- still local and deterministic per snapshot
+- need periodic reload / swap semantics
+- stale-vs-fresh semantics matter operationally
+- should never block the hot path during reload
+
+Examples:
+
+- geo database with `refresh_interval`
+- reloaded CSV/JSONL watchlists
+- rotating asset inventory snapshot
+- refreshed ASN mapping files
+
+**Recommended execution surface:** still SQL-visible, but backed by atomic snapshot swap outside DataFusion planning
+
+### 3. Live cached service lookups
+
+Properties:
+
+- require network I/O
+- can fail, timeout, retry, throttle, and partially succeed
+- usually need caching and batching
+- should expose enrichment status and fallback behavior explicitly
+
+Examples:
+
+- customer/account metadata from a service
+- IP reputation / threat intel API
+- CMDB / asset inventory API
+- user directory / org lookup service
+- feature-flag or tenant policy service
+- live geo provider API
+
+**Recommended execution surface:** async enrichment processor stage before SQL
+
+### 4. Stateful/derived enrichments
+
+Properties:
+
+- depend on prior batches, timers, or local state
+- may need heartbeats and flush semantics
+- not naturally modeled as SQL UDFs
+
+Examples:
+
+- trace/session correlation
+- dedupe / suppression
+- rolling counters / rate buckets
+- delayed join against pending side-channel data
+
+**Recommended execution surface:** processor stage only
+
+## Core Decision
+
+We should not design "enrichment" as a single mechanism.
+
+We should define two first-class execution classes:
+
+1. `snapshot enrichment`
+2. `live enrichment`
+
+### Snapshot enrichment
+
+Characteristics:
+
+- SQL-safe
+- deterministic over a single snapshot
+- may be exposed as UDFs or joinable tables
+- can be replayed with clear stale/fresh semantics
+
+### Live enrichment
+
+Characteristics:
+
+- SQL-unsafe
+- async-backed
+- cache-aware
+- must surface operational policy explicitly
+- materializes columns before SQL runs
+
+This split matches current code reality better than forcing everything through either DataFusion or processors alone.
+
+## Experiment Matrix
+
+The right next step is to prototype a small number of enrichment archetypes, not to prematurely generalize every future use case.
+
+| Experiment | Enrichment type | Execution surface | Main question | Success criteria |
+|---|---|---|---|---|
+| A | MMDB geo with reload | SQL UDF + atomic snapshot swap | Can we preserve current SQL ergonomics while implementing reload safely? | no blocking in lookup path, explicit reload metrics, deterministic tests |
+| B | CSV range geo/ASN | SQL table or SQL-safe lookup backend | Do we want a non-MaxMind open backend without changing the model? | acceptable lookup cost, acceptable memory, simple config parity |
+| C | Static/local metadata join | Enrichment table JOIN | Are table-based enrichments enough for most local metadata? | cheap registration, stable schemas, straightforward docs |
+| D | Live HTTP enrichment with cache | Processor stage | What batch/concurrency/cache shape fits the pipeline contract? | bounded latency impact, explicit miss/error columns, no async leakage into SQL |
+| E | Replay semantics comparison | SQL snapshot vs live processor | How do pre/post-transform queues interact with enrichment freshness? | documented guarantees and queue-mode-specific behavior |
+
+## Recommended Experiments
+
+### Experiment A: Reloadable MMDB without changing the UDF model
+
+Goal:
+
+- keep `geo_lookup()` in SQL
+- move reload responsibility outside UDF execution
+- atomically swap current database snapshot
+
+Sketch:
+
+- change `GeoDatabase` backing from fixed `Arc<MmdbDatabase>` to a reloadable shared handle
+- background task watches file timestamp or timer
+- load new DB off-path
+- swap pointer only after successful load
+- lookups always see a complete old or complete new snapshot
+
+Questions to answer:
+
+- what is the cheapest concurrency primitive for read-mostly lookups?
+- how do we expose generation/version and reload failures to diagnostics?
+- what should happen if the DB disappears or reload parse fails?
+
+Why this experiment matters:
+
+It solves the current contract drift around `refresh_interval` without dragging async behavior into SQL execution.
+
+### Experiment B: CSV/IP-range backend for open GeoIP/ASN data
+
+Goal:
+
+- support a non-MaxMind local backend such as DB-IP Lite
+- test whether a second local backend still fits the SQL-safe enrichment model
+
+Sketch:
+
+- extend `GeoDatabaseFormat`
+- build a new local backend with preprocessed ranges or interval search
+- present same `GeoDatabase` trait to UDF layer
+
+Questions to answer:
+
+- do we keep one logical `geo_lookup()` result schema across backends?
+- do we split geo and ASN into separate backends or one composite config?
+- is lookup cost acceptable at target throughput?
+
+Why this experiment matters:
+
+It tells us whether backend diversity is just an implementation detail or whether the current trait/schema is too tightly shaped around MMDB.
+
+### Experiment C: Generic async enrichment processor
+
+Goal:
+
+- prove the processor seam can host live enrichers without forcing SQL or output layers to handle network semantics
+
+Sketch:
+
+- define a processor that reads configured source columns from each `RecordBatch`
+- deduplicates keys within batch
+- checks local cache
+- batches misses to a background worker pool
+- materializes enrichment columns plus status columns back into the batch
+
+Minimum output columns:
+
+- `<prefix>.*` enrichment result columns
+- `<prefix>_status` with values like `hit`, `miss`, `timeout`, `error`, `partial`
+- optional `<prefix>_generation` or `<prefix>_source`
+
+Questions to answer:
+
+- do we block batch progression until misses resolve, or emit partial columns with miss status?
+- what retry model belongs here versus upstream service behavior?
+- how do checkpoint semantics work if enrichment fails transiently?
+
+Why this experiment matters:
+
+If this shape works, we can safely support future remote enrichers without turning SQL into an I/O runtime.
+
+## Proposed Architectural Rules
+
+### Rule 1: No live I/O in SQL
+
+SQL transforms may use:
+
+- UDFs over local snapshots
+- joins against local snapshot tables
+- pure transforms over already-materialized columns
+
+SQL transforms may not own:
+
+- network calls
+- retry logic
+- service throttling
+- request batching
+- cache fill behavior
+
+### Rule 2: Live enrichment must materialize explicit status
+
+Every live enricher should produce both value columns and operational status columns.
+
+This avoids silent NULLs that are ambiguous between:
+
+- no match
+- timeout
+- upstream failure
+- throttling
+- temporary cache miss
+
+### Rule 3: Reloadable local data must remain snapshot-safe
+
+Reloaded local enrichment should never expose partial reload state. The hot path should only read complete snapshots.
+
+### Rule 4: Queue semantics must document enrichment freshness
+
+The current persistence docs already call out that enrichment can be query-time or ingest-time dependent in different queue modes.
+
+- [book/src/content/docs/architecture/pipeline.md](../../book/src/content/docs/architecture/pipeline.md)
+
+Future live enrichment must define whether it is:
+
+- replay-time enrichment
+- ingest-time baked enrichment
+- or unsupported in certain queue modes
+
+## Candidate Trait Split
+
+A useful target model is:
+
+```rust
+trait SnapshotEnricher: Send + Sync {
+    fn name(&self) -> &str;
+}
+
+trait SnapshotLookup: Send + Sync {
+    type Output;
+    fn lookup(&self, key: &str) -> Option<Self::Output>;
+}
+
+trait LiveEnricher: Send + Sync {
+    fn name(&self) -> &str;
+    fn enrich_batch(&mut self, batch: RecordBatch, meta: &BatchMetadata)
+        -> Result<SmallVec<[RecordBatch; 1]>, ProcessorError>;
+}
+```
+
+This does not need to be implemented literally as-is, but it captures the key architectural split:
+
+- snapshot enrichers compose into SQL
+- live enrichers compose into processors
+
+## Phased Plan
+
+### Phase 1: Stabilize snapshot enrichment model
+
+Scope:
+
+- document snapshot-vs-live split
+- fix `geo_database.refresh_interval` contract drift
+- decide whether to reject unsupported reload or implement it
+- prototype reloadable MMDB handle
+
+Deliverables:
+
+- design doc in `dev-docs/`
+- issue tree for snapshot reload + open backend support
+- tests for reload semantics
+- docs updates for queue freshness guarantees
+
+### Phase 2: Add second local backend
+
+Scope:
+
+- choose DB-IP Lite or equivalent CSV range backend
+- preserve `geo_lookup()` result schema when possible
+- benchmark lookup cost and memory
+
+Deliverables:
+
+- backend implementation
+- config validation
+- perf note
+- fallback/unsupported feature documentation
+
+### Phase 3: Prototype live enrichment processor
+
+Scope:
+
+- build one real live enrichment example
+- add cache, batching, concurrency cap, metrics, and status columns
+- decide checkpoint/error policy before broadening API
+
+Recommended first live prototype:
+
+- a simple HTTP-backed key lookup with small bounded response schema
+
+Deliverables:
+
+- one processor implementation
+- one diagnostics panel/metric story
+- one replay/queue semantics note
+
+## What We Should Not Do Yet
+
+- do not generalize all enrichment behind a single magical abstraction now
+- do not move current MMDB geo lookup out of SQL prematurely
+- do not add live network-backed UDFs to DataFusion
+- do not support both SQL and processor implementations of the same enrichment until we have a proven need
+
+## Recommended Near-Term Decision
+
+1. Treat current geo/MMDB as **snapshot enrichment**.
+2. Fix reload semantics as a snapshot-management problem, not a SQL problem.
+3. Add one non-MaxMind local backend experiment.
+4. Prototype one live enrichment processor separately.
+5. Document the split as a first-class architecture rule.
+
+That path keeps current value, avoids forcing async into SQL, and gives us a clean growth path for the larger enrichment roadmap.

--- a/examples/use-cases/app-with-metadata-enrichment-to-otlp.yaml
+++ b/examples/use-cases/app-with-metadata-enrichment-to-otlp.yaml
@@ -1,0 +1,51 @@
+# logfwd example
+# Use case: Application logs with ConfigMap-mounted metadata enrichment
+#
+# Uses kv_file and env_vars to inject deployment metadata into every log line.
+# This pattern is common in Kubernetes where operational metadata lives in
+# ConfigMaps mounted as files and environment variables set via fieldRef.
+#
+# Mount a ConfigMap as /etc/logfwd/metadata.env with contents like:
+#   TEAM=platform
+#   SERVICE=payment-api
+#   ONCALL=https://pagerduty.com/services/ABC123
+#
+# Set environment variables in the pod spec:
+#   LOGFWD_META_DEPLOY_SHA=abc123
+#   LOGFWD_META_DEPLOY_TIME=2026-04-01T12:00:00Z
+
+pipelines:
+  app-logs:
+    inputs:
+      - type: file
+        path: /var/log/app/*.log
+        format: json
+
+    # Uncomment the kv_file and env_vars blocks after creating the files and
+    # setting the environment variables described at the top of this file.
+    # Then update the SQL below to join and select from the metadata/deploy tables:
+    #   CROSS JOIN metadata m → m.team, m.service
+    #   CROSS JOIN deploy d   → d.deploy_sha, d.deploy_time
+    enrichment:
+      # - type: kv_file
+      #   table_name: metadata
+      #   path: /etc/logfwd/metadata.env
+      #   refresh_interval: 300
+      # - type: env_vars
+      #   table_name: deploy
+      #   prefix: LOGFWD_META_
+      - type: process_info
+      - type: host_info
+
+    transform: |
+      SELECT
+        l.*,
+        p.agent_version,
+        h.hostname
+      FROM logs l
+      CROSS JOIN process_info p
+      CROSS JOIN host_info h
+
+    outputs:
+      - type: otlp
+        endpoint: https://otel-collector:4318/v1/logs

--- a/examples/use-cases/kubernetes-enriched-to-otlp.yaml
+++ b/examples/use-cases/kubernetes-enriched-to-otlp.yaml
@@ -1,0 +1,58 @@
+# logfwd example
+# Use case: Kubernetes CRI logs with full resource enrichment to OTLP
+#
+# Enriches every log line with host, container, K8s, and OS metadata.
+# Most enrichment tables are one-row snapshot tables resolved at startup;
+# k8s_path is a multi-row lookup table resolved per log file path.
+#
+# Prerequisites:
+#   - Deploy logfwd as a DaemonSet
+#   - Expose K8S_NODE_NAME via fieldRef in the pod spec
+#   - Set K8S_CLUSTER_NAME as a plain env var or via ConfigMap
+#   - Mount /etc/os-release from the host (already available in most images)
+
+pipelines:
+  k8s-logs:
+    inputs:
+      - type: file
+        path: /var/log/containers/*.log
+        format: cri
+
+    enrichment:
+      - type: host_info
+      - type: process_info
+      - type: network_info
+      - type: container_info
+      - type: k8s_cluster_info
+      - type: k8s_path
+      - type: kv_file
+        table_name: os_release
+        path: /etc/os-release
+      - type: static
+        table_name: labels
+        labels:
+          environment: production
+
+    transform: |
+      SELECT
+        l.*,
+        h.hostname,
+        h.os_type,
+        n.primary_ipv4 AS host_ip,
+        c.container_runtime,
+        k.namespace    AS k8s_namespace,
+        k.node_name    AS k8s_node,
+        k.cluster_name AS k8s_cluster,
+        os.pretty_name AS os_name,
+        lbl.environment
+      FROM logs l
+      CROSS JOIN host_info h
+      CROSS JOIN network_info n
+      CROSS JOIN container_info c
+      CROSS JOIN k8s_cluster_info k
+      CROSS JOIN os_release os
+      CROSS JOIN labels lbl
+
+    outputs:
+      - type: otlp
+        endpoint: https://otel-collector:4318/v1/logs

--- a/examples/use-cases/kubernetes-enriched-to-otlp.yaml
+++ b/examples/use-cases/kubernetes-enriched-to-otlp.yaml
@@ -40,7 +40,8 @@ pipelines:
         h.os_type,
         n.primary_ipv4 AS host_ip,
         c.container_runtime,
-        k.namespace    AS k8s_namespace,
+        -- k8s_cluster_info is collector-scoped (logfwd's own pod).
+        -- For per-log pod namespace, use k8s_path.namespace instead.
         k.node_name    AS k8s_node,
         k.cluster_name AS k8s_cluster,
         os.pretty_name AS os_name,

--- a/examples/use-cases/nginx-geo-enriched-to-otlp.yaml
+++ b/examples/use-cases/nginx-geo-enriched-to-otlp.yaml
@@ -1,0 +1,43 @@
+# logfwd example
+# Use case: Web access logs with GeoIP enrichment to OTLP
+#
+# Parses Nginx/Apache access logs, enriches client IPs with geographic
+# location using a MaxMind GeoLite2-City database, and ships to an OTLP
+# collector. The geo database reloads daily without restart.
+#
+# Prerequisites:
+#   - Download GeoLite2-City.mmdb from https://dev.maxmind.com/geoip
+#   - Place at /data/GeoLite2-City.mmdb (or update path below)
+
+pipelines:
+  access-logs:
+    inputs:
+      - type: file
+        path: /var/log/nginx/access.log
+        format: json
+
+    # Uncomment the geo_database and csv blocks after placing the required files,
+    # then update the SQL below to use geo_lookup() and join known_bots:
+    #   geo_lookup(l.remote_addr).country_code AS geo_country,
+    #   LEFT JOIN known_bots b ON l.http_user_agent = b.user_agent
+    enrichment:
+      # - type: geo_database
+      #   format: mmdb
+      #   path: /data/GeoLite2-City.mmdb
+      #   refresh_interval: 86400
+      - type: host_info
+      # - type: csv
+      #   table_name: known_bots
+      #   path: /etc/logfwd/known-bots.csv
+      #   refresh_interval: 3600
+
+    transform: |
+      SELECT
+        l.*,
+        h.hostname
+      FROM logs l
+      CROSS JOIN host_info h
+
+    outputs:
+      - type: otlp
+        endpoint: https://otel-collector:4318/v1/logs


### PR DESCRIPTION
## ⚠️ Do Not Merge — Work In Progress

### Summary

Adds a comprehensive enrichment system to logfwd: 12 enrichment table types and 2 processor-stage enrichers, bringing logfwd to parity with Vector/OTel Collector/Fluent Bit enrichment capabilities.

### Enrichment tables (snapshot, joined via SQL)

| Type | Description |
|------|-------------|
| `static` | Fixed key-value labels |
| `env_vars` | Environment variables (with optional prefix filter) |
| `csv` / `jsonl` | File-backed lookup tables with refresh |
| `geo_database` | MaxMind MMDB + CSV-range GeoIP |
| `k8s_path` | K8s metadata from log file path |
| `host_info` | OS type, arch, hostname, CPU count |
| `process_info` | Agent name/version, PID, start time |
| `network_info` | Hostname, IPv4/IPv6 from procfs |
| `container_info` | Container ID and runtime from cgroup |
| `k8s_cluster_info` | Namespace, pod, node, cluster from downward API |
| `kv_file` | Generic KEY=VALUE file parser (e.g. /etc/os-release) |

### Processors (batch-blocking, run before SQL)

- **BlocklistProcessor** — tags rows matching a CSV blocklist (zero per-row allocation)
- **HttpEnrichProcessor** — per-row HTTP lookup with local cache, bounded concurrency via `std::thread::scope`, batch-blocking (no "pending" rows)

### Documentation & examples

- Expanded `reference.mdx` enrichment section from 3 to 12 documented types
- 3 new example configs: K8s enrichment, GeoIP, ConfigMap metadata

### Key design decisions

- Snapshot enrichment tables registered as DataFusion MemTables, joined via SQL
- No live I/O inside DataFusion SQL — network calls in Processor layer only
- HttpEnrichProcessor uses batch-blocking model: deduplicate keys → check cache → concurrent fetch misses → wait for completion → build batch. Every row exits fully enriched.
- Reloadable tables use `Arc<RwLock<Option<RecordBatch>>>` with background refresh tasks

### Test plan

- 24 new enrichment table tests (logfwd-transform)
- 11 new http_enrich processor tests
- Existing blocklist tests maintained
- `just test` passes (1322 tests), `just clippy` zero warnings

### What remains

- [ ] Wire BlocklistProcessor and HttpEnrichProcessor into config system
- [ ] Integration tests with real HTTP server (e.g. wiremock)
- [ ] Performance benchmarking of batch-blocking HTTP enrichment
- [ ] CloudInfo enrichment (AWS/GCP/Azure instance metadata)

Closes #TBD


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CSV-range geo lookup, blocklist and HTTP enrichment processors, and new enrichment table types
> - Adds `CsvRangeDatabase`, a CSV-backed `GeoDatabase` that resolves IPv4/IPv6 addresses to `GeoResult` records via inclusive binary-search range matching; overlapping ranges are rejected at load time.
> - Adds a `BlocklistProcessor` that appends `{prefix}_match` (Boolean) and `{prefix}_category` (Utf8) columns per batch from a CSV blocklist loaded at construction.
> - Adds an `HttpEnrichProcessor` that performs cached, concurrent HTTP GET lookups per batch, appending `{prefix}_json` and `{prefix}_status` columns; supports TTL eviction, concurrency cap, and body-size limits.
> - Extends `EnrichmentConfig` with six new variants: `EnvVars`, `ProcessInfo`, `KvFile`, `NetworkInfo`, `ContainerInfo`, and `K8sClusterInfo`, each backed by a corresponding enrichment table implementation.
> - Adds `ReloadableGeoDb` to enable hot-swapping the active geo database at runtime without restarting the pipeline; CSV/JSONL/KV enrichment tables also gain optional `refresh_interval` for periodic background reloads.
> - Risk: background reload tasks are spawned on the current Tokio runtime; a misconfigured interval or failing reload logs a warning but does not surface as a pipeline error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b767f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->