### PR TITLE
fix: tolerate held batches without halting pipeline ingestion

### DIFF
--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -41,7 +41,11 @@ pub(crate) const DEFAULT_POOL_DRAIN_TIMEOUT: Duration = Duration::from_secs(60);
 /// accumulate — this allows recovery when the failure is transient (e.g.,
 /// downstream bounce). Only when the held count exceeds this limit does the
 /// pipeline stop accepting new input to bound memory growth.
-pub(crate) const DEFAULT_MAX_HELD_BATCHES: usize = 100;
+///
+/// At 10 batches with typical retry backoff (~2-3 seconds per batch), persistent
+/// failures are detected within ~30 seconds while transient blips (1-3 holds)
+/// recover naturally.
+pub(crate) const DEFAULT_MAX_HELD_BATCHES: usize = 10;
 
 impl Pipeline {
     /// Construct a pipeline from parsed YAML config.

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -34,6 +34,15 @@ pub(crate) const DEFAULT_CHECKPOINT_FLUSH_INTERVAL: Duration = Duration::from_se
 /// Default maximum time to wait for worker-pool drain before cancellation.
 pub(crate) const DEFAULT_POOL_DRAIN_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// Maximum number of held (undeliverable) batches before ingestion stops.
+///
+/// Held batches arise from transient failures (retry exhaustion, worker panics,
+/// timeouts). The pipeline continues processing new batches while held tickets
+/// accumulate — this allows recovery when the failure is transient (e.g.,
+/// downstream bounce). Only when the held count exceeds this limit does the
+/// pipeline stop accepting new input to bound memory growth.
+pub(crate) const DEFAULT_MAX_HELD_BATCHES: usize = 100;
+
 impl Pipeline {
     /// Construct a pipeline from parsed YAML config.
     pub fn from_config(
@@ -378,6 +387,7 @@ impl Pipeline {
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store,
             held_tickets: Vec::new(),
+            max_held_batches: DEFAULT_MAX_HELD_BATCHES,
             last_checkpoint_flush: tokio::time::Instant::now(),
             checkpoint_flush_interval: DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
             pool_drain_timeout: DEFAULT_POOL_DRAIN_TIMEOUT,

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -2869,6 +2869,9 @@ output:
         let log_path = dir.path().join("held-pool-ack.log");
         std::fs::write(&log_path, "").unwrap();
         let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        // Set threshold to 1 so a single hold triggers shutdown (tests the
+        // safety-valve mechanism with the lowest possible threshold).
+        pipeline.max_held_batches = 1;
         let machine = pipeline.machine.as_mut().unwrap();
         let ticket = machine.create_batch(SourceId(42), 1000);
         let ticket = machine.begin_send(ticket);
@@ -2891,7 +2894,7 @@ output:
 
         assert!(
             should_stop,
-            "held worker outcomes must terminalize ingestion instead of accumulating tickets"
+            "held count reaching max_held_batches must request terminal shutdown"
         );
         assert_eq!(pipeline.held_tickets.len(), 1);
         assert_eq!(

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -153,7 +153,16 @@ pub struct Pipeline {
     /// The runtime cannot requeue these without also retaining payload ownership,
     /// but it must keep the queued ticket alive so the lifecycle machine keeps
     /// the batch unresolved and checkpoints do not advance past undelivered data.
+    ///
+    /// The pipeline continues processing new batches while held tickets
+    /// accumulate. Only when the held count exceeds `max_held_batches` does the
+    /// pipeline stop ingestion to bound memory growth. On shutdown, held batches
+    /// are abandoned via `force_stop` and replayed from the last committed
+    /// checkpoint on restart.
     held_tickets: Vec<logfwd_types::pipeline::BatchTicket<logfwd_types::pipeline::Queued, u64>>,
+    /// Safety valve: stop ingestion when held tickets exceed this count.
+    /// Prevents unbounded memory growth from persistent sink failures.
+    max_held_batches: usize,
     /// Throttle checkpoint flushes to at most once per this interval.
     /// Uses tokio::time::Instant so the throttle works correctly under
     /// both real and simulated (Turmoil) time.
@@ -328,6 +337,7 @@ impl Pipeline {
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store: None,
             held_tickets: Vec::new(),
+            max_held_batches: build::DEFAULT_MAX_HELD_BATCHES,
             last_checkpoint_flush: tokio::time::Instant::now(),
             checkpoint_flush_interval: build::DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
             pool_drain_timeout: Duration::from_secs(60),
@@ -364,6 +374,7 @@ impl Pipeline {
             machine: Some(PipelineMachine::new().start()),
             checkpoint_store: None,
             held_tickets: Vec::new(),
+            max_held_batches: build::DEFAULT_MAX_HELD_BATCHES,
             last_checkpoint_flush: tokio::time::Instant::now(),
             checkpoint_flush_interval: build::DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
             pool_drain_timeout: Duration::from_secs(60),
@@ -678,6 +689,11 @@ impl Pipeline {
     /// Apply a pool `AckItem` at the worker/checkpoint seam.
     ///
     /// Called from the `select!` loop when a pool worker finishes a batch.
+    /// Returns `true` only when the held-ticket safety valve is tripped
+    /// (held count exceeds `max_held_batches`), signaling the pipeline to
+    /// stop ingestion. Transient holds (retry exhaustion, worker panics)
+    /// do NOT stop ingestion — the pipeline continues processing new batches
+    /// so that recovery is possible when the underlying failure resolves.
     #[allow(clippy::unused_async)] // async required for turmoil barrier await
     async fn apply_pool_ack(&mut self, ack: AckItem) -> bool {
         let batch_id = ack.batch_id;
@@ -729,7 +745,22 @@ impl Pipeline {
             },
         )
         .await;
-        has_held
+
+        // Only stop ingestion when the held-ticket safety valve is tripped.
+        // Individual holds are tolerated — the pipeline continues accepting new
+        // batches so that subsequent sends can succeed after transient failures
+        // (downstream bounce, worker panic recovery). Checkpoints are still
+        // blocked past held batches, so at-least-once delivery is preserved
+        // via replay on restart.
+        if has_held && self.held_tickets.len() >= self.max_held_batches {
+            tracing::error!(
+                held = self.held_tickets.len(),
+                max = self.max_held_batches,
+                "pipeline: held-ticket safety valve tripped; stopping ingestion"
+            );
+            return true;
+        }
+        false
     }
 
     /// Finalize Sending tickets and apply receipts to the machine when present.
@@ -780,7 +811,10 @@ impl Pipeline {
         if held > 0 {
             tracing::warn!(
                 held_tickets = held,
-                "pipeline: terminal hold requested; stopping ingestion so checkpoints do not advance past undelivered data"
+                total_held = self.held_tickets.len(),
+                max_held = self.max_held_batches,
+                "pipeline: batch held — checkpoint blocked past undelivered data, \
+                 pipeline continues processing new batches"
             );
         }
         // Flush to disk at most once per checkpoint_flush_interval to amortize fsync cost.
@@ -2685,7 +2719,7 @@ output:
         let (has_held, _advances) = pipeline.ack_all_tickets(vec![ticket], TicketDisposition::Hold);
         assert!(
             has_held,
-            "hold disposition must request terminal shutdown to bound held-ticket growth"
+            "hold disposition must signal that a batch was held"
         );
 
         let machine = pipeline.machine.as_ref().unwrap();
@@ -2700,6 +2734,99 @@ output:
             1,
             "hold must retain a failed queued ticket instead of dropping the sending ticket"
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn apply_pool_ack_continues_below_held_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("hold_continue.log");
+        std::fs::write(&log_path, b"").unwrap();
+
+        let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        pipeline.max_held_batches = 5; // low threshold for testing
+        let machine = pipeline.machine.as_mut().unwrap();
+        let source = SourceId(42);
+
+        // Hold 1 batch — below threshold, apply_pool_ack must return false.
+        let ticket = machine.create_batch(source, 1000);
+        let ticket = machine.begin_send(ticket);
+        pipeline
+            .metrics
+            .inflight_batches
+            .store(1, Ordering::Relaxed);
+        let should_stop = pipeline
+            .apply_pool_ack(AckItem {
+                tickets: vec![ticket],
+                outcome: crate::worker_pool::DeliveryOutcome::RetryExhausted,
+                num_rows: 10,
+                submitted_at: tokio::time::Instant::now(),
+                scan_ns: 0,
+                transform_ns: 0,
+                output_ns: 0,
+                queue_wait_ns: 0,
+                send_latency_ns: 0,
+                batch_id: 1,
+                output_name: "test".to_string(),
+            })
+            .await;
+        assert!(
+            !should_stop,
+            "pipeline must continue when held count ({}) < max ({})",
+            pipeline.held_tickets.len(),
+            pipeline.max_held_batches,
+        );
+        assert_eq!(pipeline.held_tickets.len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn apply_pool_ack_stops_at_held_threshold() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("hold_stop.log");
+        std::fs::write(&log_path, b"").unwrap();
+
+        let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
+        pipeline.max_held_batches = 2; // very low threshold for testing
+
+        // Hold 2 batches to reach the threshold.
+        for i in 0..2u64 {
+            let machine = pipeline.machine.as_mut().unwrap();
+            let ticket = machine.create_batch(SourceId(42), (i + 1) * 1000);
+            let ticket = machine.begin_send(ticket);
+            pipeline
+                .metrics
+                .inflight_batches
+                .store(1, Ordering::Relaxed);
+            let should_stop = pipeline
+                .apply_pool_ack(AckItem {
+                    tickets: vec![ticket],
+                    outcome: crate::worker_pool::DeliveryOutcome::RetryExhausted,
+                    num_rows: 10,
+                    submitted_at: tokio::time::Instant::now(),
+                    scan_ns: 0,
+                    transform_ns: 0,
+                    output_ns: 0,
+                    queue_wait_ns: 0,
+                    send_latency_ns: 0,
+                    batch_id: i + 1,
+                    output_name: "test".to_string(),
+                })
+                .await;
+
+            if i < 1 {
+                assert!(
+                    !should_stop,
+                    "pipeline must continue below threshold (held={})",
+                    pipeline.held_tickets.len(),
+                );
+            } else {
+                assert!(
+                    should_stop,
+                    "pipeline must stop at threshold (held={})",
+                    pipeline.held_tickets.len(),
+                );
+            }
+        }
+        assert_eq!(pipeline.held_tickets.len(), 2);
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/logfwd/tests/turmoil_sim/bug_hunt.rs
+++ b/crates/logfwd/tests/turmoil_sim/bug_hunt.rs
@@ -143,11 +143,15 @@ fn worker_panic_does_not_block_drain() {
     let delivered_counter = factory.delivered_counter();
 
     sim.client("pipeline", async move {
-        let lines = generate_json_lines(20);
+        // Use 200 lines with tiny batch target to guarantee multiple batches.
+        // The first batch panics; the pipeline continues and the worker pool
+        // respawns a new worker for subsequent batches.
+        let lines = generate_json_lines(200);
         let input = ChannelInputSource::new("test", SourceId(1), lines);
 
         let mut pipeline = Pipeline::for_simulation_with_factory("sim", factory, 1);
         pipeline.set_batch_timeout(Duration::from_millis(20));
+        pipeline.set_batch_target_bytes(64); // tiny → many batches
         let mut pipeline = pipeline.with_input("test", Box::new(input));
 
         let shutdown = CancellationToken::new();
@@ -171,20 +175,15 @@ fn worker_panic_does_not_block_drain() {
          Error: {result:?}"
     );
 
-    // Some rows may or may not be delivered depending on whether the worker
-    // pool can recover from the panic. Document actual behavior.
+    // With pipeline hold resilience, the pipeline continues accepting batches
+    // after the first hold. The worker pool respawns a new worker on the next
+    // submit, so subsequent batches should be delivered successfully.
     let delivered = delivered_counter.load(Ordering::Relaxed);
-    // NOTE: With 1 worker, if the worker panics and the pool doesn't respawn,
-    // no subsequent batches can be delivered. The key assertion is that the
-    // pipeline COMPLETES (above), not that all rows are delivered.
-    //
-    // If delivered > 0, the pool successfully recovered from the panic.
-    // If delivered == 0, all batches after the panic were also lost (the
-    // single worker died and wasn't replaced).
-    eprintln!(
-        "worker_panic test: {delivered} rows delivered out of 20 \
-         (0 is acceptable if worker pool doesn't respawn after panic)"
+    assert!(
+        delivered > 0,
+        "expected post-panic delivery after worker respawn, got 0 delivered out of 200"
     );
+    eprintln!("worker_panic test: {delivered} rows delivered out of 200");
 }
 
 // ---------------------------------------------------------------------------
@@ -446,8 +445,8 @@ fn panic_first_batch_triggers_terminal_hold_without_checkpoint_advance() {
     let mut sim = super::build_sim(90, 1);
 
     // Factory scripts are popped from the end:
-    // 1st worker => [Panic]. Under the terminal-hold model, the pipeline
-    // shuts down after the panic ack without recycling workers.
+    // 1st worker => [Panic]. Under hold resilience, the pipeline continues
+    // after the panic ack — worker pool respawns and delivers remaining batches.
     let factory = Arc::new(InstrumentedSinkFactory::new(vec![
         vec![],
         vec![FailureAction::Panic],
@@ -489,24 +488,28 @@ fn panic_first_batch_triggers_terminal_hold_without_checkpoint_advance() {
     let delivered = delivered_counter.load(Ordering::Relaxed);
     eprintln!(
         "panic_first_batch test: {delivered} rows delivered, {calls} calls \
-         (terminal-hold model stops ingestion after panic ack)"
+         (hold resilience continues after panic ack)"
     );
 
-    // Under the terminal-hold model, the pipeline shuts down immediately
-    // after the panic ack. The first batch panics and no subsequent batches
-    // are processed because ingestion is stopped — no worker recycling.
-    assert_eq!(
-        calls, 1,
-        "terminal-hold model must issue exactly 1 send call (the panic); calls={calls}"
+    // Under hold resilience, the pipeline continues after the panic ack.
+    // The worker pool respawns a new worker and delivers subsequent batches.
+    // With batch_target_bytes=1, each line is a separate batch (10 batches).
+    // The first batch panics; remaining batches succeed via respawned worker.
+    assert!(
+        calls >= 2,
+        "hold resilience: must issue at least 2 send calls (1 panic + respawned deliveries); calls={calls}"
     );
 
-    // Terminal hold means zero deliveries: the only batch panicked.
-    assert_eq!(
-        delivered, 0,
-        "terminal-hold model must not deliver any rows after panic; delivered={delivered}"
+    // Subsequent batches are delivered after worker respawn.
+    assert!(
+        delivered > 0,
+        "hold resilience: respawned worker must deliver post-panic batches; delivered={delivered}"
     );
 
-    // Held first ticket must block checkpoint advancement entirely.
+    // Critical invariant: held first ticket must block checkpoint advancement.
+    // Even though later batches succeed, the checkpoint cannot advance past
+    // the held gap because at-least-once semantics require replay of the
+    // panicked batch on restart.
     assert!(
         ckpt_handle.durable_offset(1).is_none(),
         "durable checkpoint must remain absent while first failed ticket is held"
@@ -535,8 +538,8 @@ fn panic_first_batch_triggers_terminal_hold_without_checkpoint_advance() {
 fn panic_after_initial_success_does_not_advance_checkpoint_past_gap() {
     let mut sim = super::build_sim(90, 1);
 
-    // First worker: success then panic. Under the terminal-hold model, the
-    // pipeline shuts down after the panic ack without recycling workers.
+    // First worker: success then panic. Under hold resilience, the pipeline
+    // continues after the panic ack — worker pool respawns for remaining batches.
     let factory = Arc::new(InstrumentedSinkFactory::new(vec![
         vec![],
         vec![FailureAction::Succeed, FailureAction::Panic],
@@ -587,11 +590,12 @@ fn panic_after_initial_success_does_not_advance_checkpoint_past_gap() {
         delivered > 0,
         "expected at least some successful deliveries before panic; delivered={delivered}"
     );
-    // Under the terminal-hold model: exactly 1 success + 1 panic = 2 calls.
-    // No recovery calls because ingestion stops after the panic ack.
-    assert_eq!(
-        calls, 2,
-        "terminal-hold model must issue exactly 2 send calls (1 success + 1 panic); calls={calls}"
+    // Under hold resilience, the pipeline continues after the panic ack.
+    // 12 lines with batch_target_bytes=1 → 12 batches. First succeeds,
+    // second panics, remaining succeed via respawned worker.
+    assert!(
+        calls > 2,
+        "hold resilience: must issue more than 2 calls (1 success + 1 panic + respawned); calls={calls}"
     );
     // The first successful batch may or may not have triggered a checkpoint
     // update depending on flush timing. Either way, checkpoint must not

--- a/crates/logfwd/tests/turmoil_sim/network_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/network_sim.rs
@@ -474,6 +474,9 @@ fn tcp_server_crash_preserves_pre_crash_delivery() {
         total_received >= pre_crash,
         "crash should not corrupt pre-crash data: total ({total_received}) < pre_crash ({pre_crash})"
     );
+    // NOTE: Strengthening to `total_received > pre_crash` requires held batch
+    // re-dispatch (#1800), which is a future enhancement. For now, the pipeline
+    // continues running (no deadlock) but already-held batches are not retried.
 }
 
 /// Test: hold/release creates burst delivery after message buffering.


### PR DESCRIPTION
## Summary

Previously, any single held batch (from retry exhaustion, worker panic, or transient output failure) immediately stopped the entire pipeline — cancelling ingestion and preventing all forward progress. This made transient output failures fatal.

Now the pipeline continues processing while held batches accumulate, only stopping when a safety-valve threshold (10 batches) is reached. Held batches still block checkpoint advancement, preserving at-least-once delivery semantics — on restart, data replays from the last checkpoint.

**Why this works:** when the pipeline continues submitting, the worker pool naturally prunes dead workers and spawns fresh ones with new connections. This allows recovery from both worker panics (#1799) and output bounce scenarios (#1800).

**Tradeoff:** batches delivered after a held batch produce duplicates on restart (checkpoint is blocked at the held gap). With threshold=10, this bounds the duplicate window to ~10 batches before the pipeline concludes the output is persistently broken.

## What changed

**Pipeline core** (`logfwd-runtime/src/pipeline/mod.rs`, `build.rs`):
- `apply_pool_ack()` now returns `true` (stop) only when held batch count reaches `max_held_batches` (default 10), rather than on the first hold
- Added `max_held_batches` field to Pipeline struct with safety-valve semantics

**Turmoil simulation tests** (`bug_hunt.rs`, `network_sim.rs`):
- `worker_panic_does_not_block_drain`: uses 200 lines with 64-byte batch target to guarantee multiple batches; now asserts `delivered > 0` (worker pool respawns after panic)
- `panic_first_batch` and `panic_after_initial_success`: updated from terminal-hold assertions to hold-resilience assertions while preserving checkpoint safety invariants
- `held_pool_ack_requests_terminal_shutdown`: sets `max_held_batches=1` to test safety-valve at lowest threshold

## Safety invariants preserved

- Held batches block checkpoint advancement (at-least-once delivery via replay on restart)
- Checkpoint monotonicity and durable-not-ahead-of-updates
- Safety valve at 10 held batches prevents unbounded memory growth

## Future work (separate PRs)

- **Worker-level fresh-sink retry:** create new sink from factory after panic/retry-exhaustion and retry the batch before acking Hold. This would prevent holds entirely for transient failures but requires TLA+ model updates and proptest coverage.
- Make `max_held_batches` configurable via pipeline YAML config.

## Test plan

- `just test` — 1404 tests pass
- `just clippy` — zero warnings
- All 62 turmoil simulation tests pass (including strengthened panic/crash tests)

Closes #1799
Relates to #1800

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow pipeline ingestion to continue until held batches reach a configurable threshold
> - Previously, `Pipeline.apply_pool_ack` stopped ingestion on the first held (undeliverable) batch. It now stops only when `held_tickets.len() >= max_held_batches`, defaulting to 10 via `DEFAULT_MAX_HELD_BATCHES`.
> - An error is logged when the safety valve trips. Warning logs for `ack_all_tickets` are updated to reflect that the pipeline continues processing while checkpoints are blocked.
> - Integration tests in [bug_hunt.rs](https://github.com/strawgate/memagent/pull/1851/files#diff-f70ec9a220356a8d2b23628fe22853c0140bc9cc729445ee2ae2be7ab32e90bc) are updated to assert continued delivery after a worker panic, matching the new behavior.
> - Behavioral Change: pipelines that previously halted ingestion on the first held batch will now continue until 10 batches are held.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 606f388.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->