### PR TITLE
bench: harden OTLP benchmark labels and add profile recipes

### DIFF
--- a/crates/logfwd-bench/README.md
+++ b/crates/logfwd-bench/README.md
@@ -83,8 +83,29 @@ validation in setup only. The timed regions measure just the named stage:
 - `otlp_output_compression` times zstd compression of an already encoded payload.
 - `otlp_e2e_in_process` times decode plus encode in one process, without transport or network effects.
 
-The suite includes the experimental wire-to-Arrow decoder for primitive
-fixtures; it is validated against the prost path before benchmark timing starts.
+The suite includes the experimental projected wire-to-Arrow decoder for
+primitive fixtures; it is validated against the prost path before benchmark
+timing starts. Mode names are aligned between Criterion and the profile binary:
+
+| Decode path | Criterion (decode_materialize) | Criterion (e2e) | Profile binary |
+|-------------|-------------------------------|-----------------|----------------|
+| prost reference | `prost_reference_to_batch` | `prost_reference_to_*_encode` | `prost_reference_to_batch` |
+| production current | `production_current_to_batch` | `production_current_to_*_encode` | `production_current_to_batch` |
+| projected detached | `projected_detached_to_batch` | `projected_detached_to_*_encode` | `projected_detached_to_batch` |
+| projected view | `projected_view_to_batch` | `projected_view_to_*_encode` | `projected_view_to_batch` |
+
+**Timing boundaries:**
+
+- `otlp_input_parser_only` — protobuf decode only (no Arrow materialization).
+- `otlp_input_decode_materialize` — protobuf decode + Arrow batch construction.
+- `otlp_output_encode_only` — OTLP serialization from a prebuilt batch.
+- `otlp_output_compression` — zstd compression of an already-encoded payload.
+- `otlp_e2e_in_process` — decode + encode in one pass, no transport or network.
+
+All fixture synthesis, prost/reference parity checks, and encode-path assertions
+run in setup before any Criterion timer starts. In the profile binary, warmup
+exercises the same code path as the measured loop to pre-size reusable buffers;
+allocation counting begins after warmup completes.
 
 ### Profiling Tools (`src/`)
 
@@ -95,7 +116,7 @@ fixtures; it is validated against the prost path before benchmark timing starts.
 | `bin/cloudtrail_profile.rs` | `cloudtrail_profile` | CloudTrail-like generator profile (NDJSON vs direct RecordBatch generation, cardinality, compression) |
 | `es_throughput.rs` | `es-throughput` | Elasticsearch output throughput with worker scaling |
 | `bin/framed_input_profile.rs` | `framed_input_profile` | FramedInput stage timings, RSS, optional flamegraph, optional dhat allocation report |
-| `bin/otlp_io_profile.rs` | `otlp_io_profile` | Focused OTLP prost/projected/projected-view CPU flamegraphs and allocation counts for decode and in-process decode→encode paths. |
+| `bin/otlp_io_profile.rs` | `otlp_io_profile` | Focused OTLP decode and decode→encode CPU flamegraphs and allocation counts. Mode names match Criterion (`prost_reference_to_batch`, `production_current_to_batch`, `projected_detached_to_batch`, `projected_view_to_batch`, `e2e_*`). |
 | `explore.rs` | *(lib)* | Multi-dimensional exploratory benchmark (CSV output) |
 | `rss.rs` | *(lib)* | Resident set size at each pipeline stage |
 | `sizes.rs` | *(lib)* | Data size analysis: raw → Arrow → IPC → Parquet |

--- a/crates/logfwd-bench/benches/otlp_io.rs
+++ b/crates/logfwd-bench/benches/otlp_io.rs
@@ -332,7 +332,7 @@ fn bench_decode_materialize(c: &mut Criterion) {
 
         if !fixture.profile.has_complex_any {
             group.bench_with_input(
-                BenchmarkId::new("experimental_wire_to_batch", fixture.profile.name),
+                BenchmarkId::new("projected_detached_to_batch", fixture.profile.name),
                 &fixture.payload,
                 |b, payload| {
                     b.iter(|| {
@@ -345,7 +345,7 @@ fn bench_decode_materialize(c: &mut Criterion) {
             );
 
             group.bench_with_input(
-                BenchmarkId::new("experimental_wire_view_to_batch", fixture.profile.name),
+                BenchmarkId::new("projected_view_to_batch", fixture.profile.name),
                 &fixture.payload_bytes,
                 |b, payload| {
                     b.iter(|| {
@@ -399,7 +399,7 @@ fn bench_output_encode_only(c: &mut Criterion) {
 
         if let Some(batch) = fixture.projected_batch.as_ref() {
             group.bench_with_input(
-                BenchmarkId::new("handwritten_projected_detached", fixture.profile.name),
+                BenchmarkId::new("projected_detached_handwritten", fixture.profile.name),
                 batch,
                 |b, batch| {
                     let mut sink = make_otlp_sink(Compression::None);
@@ -413,7 +413,7 @@ fn bench_output_encode_only(c: &mut Criterion) {
 
         if let Some(batch) = fixture.projected_view_batch.as_ref() {
             group.bench_with_input(
-                BenchmarkId::new("handwritten_projected_view", fixture.profile.name),
+                BenchmarkId::new("projected_view_handwritten", fixture.profile.name),
                 batch,
                 |b, batch| {
                     let mut sink = make_otlp_sink(Compression::None);
@@ -474,7 +474,10 @@ fn bench_end_to_end(c: &mut Criterion) {
         group.throughput(Throughput::Elements(fixture.profile.total_rows() as u64));
 
         group.bench_with_input(
-            BenchmarkId::new("decode_to_handwritten_encode", fixture.profile.name),
+            BenchmarkId::new(
+                "prost_reference_to_handwritten_encode",
+                fixture.profile.name,
+            ),
             &fixture.payload,
             |b, payload| {
                 let mut sink = make_otlp_sink(Compression::None);
@@ -488,7 +491,10 @@ fn bench_end_to_end(c: &mut Criterion) {
         );
 
         group.bench_with_input(
-            BenchmarkId::new("decode_to_generated_fast_encode", fixture.profile.name),
+            BenchmarkId::new(
+                "prost_reference_to_generated_fast_encode",
+                fixture.profile.name,
+            ),
             &fixture.payload,
             |b, payload| {
                 let mut sink = make_otlp_sink(Compression::None);
@@ -502,7 +508,10 @@ fn bench_end_to_end(c: &mut Criterion) {
         );
 
         group.bench_with_input(
-            BenchmarkId::new("production_to_handwritten_encode", fixture.profile.name),
+            BenchmarkId::new(
+                "production_current_to_handwritten_encode",
+                fixture.profile.name,
+            ),
             &fixture.payload,
             |b, payload| {
                 let mut sink = make_otlp_sink(Compression::None);
@@ -516,7 +525,10 @@ fn bench_end_to_end(c: &mut Criterion) {
         );
 
         group.bench_with_input(
-            BenchmarkId::new("production_to_generated_fast_encode", fixture.profile.name),
+            BenchmarkId::new(
+                "production_current_to_generated_fast_encode",
+                fixture.profile.name,
+            ),
             &fixture.payload,
             |b, payload| {
                 let mut sink = make_otlp_sink(Compression::None);
@@ -532,7 +544,7 @@ fn bench_end_to_end(c: &mut Criterion) {
         if !fixture.profile.has_complex_any {
             group.bench_with_input(
                 BenchmarkId::new(
-                    "experimental_wire_to_handwritten_encode",
+                    "projected_detached_to_handwritten_encode",
                     fixture.profile.name,
                 ),
                 &fixture.payload,
@@ -549,10 +561,7 @@ fn bench_end_to_end(c: &mut Criterion) {
             );
 
             group.bench_with_input(
-                BenchmarkId::new(
-                    "experimental_wire_view_to_handwritten_encode",
-                    fixture.profile.name,
-                ),
+                BenchmarkId::new("projected_view_to_handwritten_encode", fixture.profile.name),
                 &fixture.payload_bytes,
                 |b, payload| {
                     let mut sink = make_otlp_sink(Compression::None);

--- a/crates/logfwd-bench/src/bin/otlp_io_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_io_profile.rs
@@ -61,11 +61,11 @@ impl FixtureProfile {
 #[derive(Clone, Copy)]
 enum Mode {
     ProstReferenceToBatch,
-    ProductionToBatch,
-    ProjectedDetachedDecode,
-    ProjectedViewDecode,
+    ProductionCurrentToBatch,
+    ProjectedDetachedToBatch,
+    ProjectedViewToBatch,
     E2eProstReference,
-    E2eProduction,
+    E2eProductionCurrent,
     E2eProjectedDetached,
     E2eProjectedView,
 }
@@ -73,11 +73,11 @@ enum Mode {
 impl Mode {
     const ALL: [Mode; 8] = [
         Mode::ProstReferenceToBatch,
-        Mode::ProductionToBatch,
-        Mode::ProjectedDetachedDecode,
-        Mode::ProjectedViewDecode,
+        Mode::ProductionCurrentToBatch,
+        Mode::ProjectedDetachedToBatch,
+        Mode::ProjectedViewToBatch,
         Mode::E2eProstReference,
-        Mode::E2eProduction,
+        Mode::E2eProductionCurrent,
         Mode::E2eProjectedDetached,
         Mode::E2eProjectedView,
     ];
@@ -85,11 +85,11 @@ impl Mode {
     fn name(self) -> &'static str {
         match self {
             Mode::ProstReferenceToBatch => "prost_reference_to_batch",
-            Mode::ProductionToBatch => "production_to_batch",
-            Mode::ProjectedDetachedDecode => "projected_detached_decode",
-            Mode::ProjectedViewDecode => "projected_view_decode",
+            Mode::ProductionCurrentToBatch => "production_current_to_batch",
+            Mode::ProjectedDetachedToBatch => "projected_detached_to_batch",
+            Mode::ProjectedViewToBatch => "projected_view_to_batch",
             Mode::E2eProstReference => "e2e_prost_reference",
-            Mode::E2eProduction => "e2e_production",
+            Mode::E2eProductionCurrent => "e2e_production_current",
             Mode::E2eProjectedDetached => "e2e_projected_detached",
             Mode::E2eProjectedView => "e2e_projected_view",
         }
@@ -97,14 +97,22 @@ impl Mode {
 
     fn by_name(name: &str) -> Self {
         match name {
-            "prost_decode" | "prost_reference_to_batch" => Mode::ProstReferenceToBatch,
-            "production_to_batch" => Mode::ProductionToBatch,
-            "projected_detached_decode" => Mode::ProjectedDetachedDecode,
-            "projected_view_decode" => Mode::ProjectedViewDecode,
-            "e2e_prost" | "e2e_prost_reference" => Mode::E2eProstReference,
-            "e2e_production" => Mode::E2eProduction,
+            // canonical names
+            "prost_reference_to_batch" => Mode::ProstReferenceToBatch,
+            "production_current_to_batch" => Mode::ProductionCurrentToBatch,
+            "projected_detached_to_batch" => Mode::ProjectedDetachedToBatch,
+            "projected_view_to_batch" => Mode::ProjectedViewToBatch,
+            "e2e_prost_reference" => Mode::E2eProstReference,
+            "e2e_production_current" => Mode::E2eProductionCurrent,
             "e2e_projected_detached" => Mode::E2eProjectedDetached,
             "e2e_projected_view" => Mode::E2eProjectedView,
+            // deprecated aliases from earlier naming
+            "prost_decode" => Mode::ProstReferenceToBatch,
+            "production_to_batch" => Mode::ProductionCurrentToBatch,
+            "projected_detached_decode" => Mode::ProjectedDetachedToBatch,
+            "projected_view_decode" => Mode::ProjectedViewToBatch,
+            "e2e_prost" => Mode::E2eProstReference,
+            "e2e_production" => Mode::E2eProductionCurrent,
             _ => panic!("unknown mode {name}; run with --help to list supported modes"),
         }
     }
@@ -220,9 +228,13 @@ fn print_usage() {
     for mode in Mode::ALL {
         eprintln!("  {}", mode.name());
     }
-    eprintln!("Aliases:");
+    eprintln!("Deprecated aliases:");
     eprintln!("  prost_decode => prost_reference_to_batch");
+    eprintln!("  production_to_batch => production_current_to_batch");
+    eprintln!("  projected_detached_decode => projected_detached_to_batch");
+    eprintln!("  projected_view_decode => projected_view_to_batch");
     eprintln!("  e2e_prost => e2e_prost_reference");
+    eprintln!("  e2e_production => e2e_production_current");
 }
 
 fn run_with_flamegraph(
@@ -253,14 +265,14 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
     if matches!(
         mode,
         Mode::E2eProstReference
-            | Mode::E2eProduction
+            | Mode::E2eProductionCurrent
             | Mode::E2eProjectedDetached
             | Mode::E2eProjectedView
     ) {
         let batch = match mode {
             Mode::E2eProstReference => decode_protobuf_to_batch_prost_reference(&fixture.payload)
                 .expect("warmup prost reference decode"),
-            Mode::E2eProduction => {
+            Mode::E2eProductionCurrent => {
                 decode_protobuf_to_batch(&fixture.payload).expect("warmup production decode")
             }
             Mode::E2eProjectedDetached => {
@@ -272,9 +284,9 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
             )
             .expect("warmup projected view decode"),
             Mode::ProstReferenceToBatch
-            | Mode::ProductionToBatch
-            | Mode::ProjectedDetachedDecode
-            | Mode::ProjectedViewDecode => unreachable!("decode-only modes are not warmed here"),
+            | Mode::ProductionCurrentToBatch
+            | Mode::ProjectedDetachedToBatch
+            | Mode::ProjectedViewToBatch => unreachable!("decode-only modes are not warmed here"),
         };
         sink.encode_batch(&batch, &metadata);
     }
@@ -289,17 +301,17 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
                     decode_protobuf_to_batch_prost_reference(&fixture.payload).expect("prost");
                 black_box(batch.num_rows());
             }
-            Mode::ProductionToBatch => {
+            Mode::ProductionCurrentToBatch => {
                 let batch = decode_protobuf_to_batch(&fixture.payload).expect("production");
                 black_box(batch.num_rows());
             }
-            Mode::ProjectedDetachedDecode => {
+            Mode::ProjectedDetachedToBatch => {
                 let batch =
                     decode_protobuf_to_batch_projected_detached_experimental(&fixture.payload)
                         .expect("projected detached");
                 black_box(batch.num_rows());
             }
-            Mode::ProjectedViewDecode => {
+            Mode::ProjectedViewToBatch => {
                 let batch = decode_protobuf_bytes_to_batch_projected_only_experimental(
                     fixture.payload_bytes.clone(),
                 )
@@ -312,7 +324,7 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
                 sink.encode_batch(&batch, &metadata);
                 black_box(sink.encoded_payload().len());
             }
-            Mode::E2eProduction => {
+            Mode::E2eProductionCurrent => {
                 let batch = decode_protobuf_to_batch(&fixture.payload).expect("production");
                 sink.encode_batch(&batch, &metadata);
                 black_box(sink.encoded_payload().len());

--- a/justfile
+++ b/justfile
@@ -566,6 +566,22 @@ profile-otlp-local lines="500000" seconds="6":
         exit 1
     fi
 
+# Run OTLP I/O Criterion benchmarks (stage-separated: parser, decode, encode, compression, e2e).
+bench-otlp-io *ARGS:
+    cargo bench -p logfwd-bench --bench otlp_io -- {{ARGS}}
+
+# Run OTLP I/O benchmarks with fast local iteration settings.
+bench-otlp-io-fast *ARGS:
+    cargo bench -p logfwd-bench --bench otlp_io -- --warm-up-time 1 --measurement-time 2 --sample-size 10 {{ARGS}}
+
+# Profile OTLP decode/encode CPU with the normal allocator (flamegraph, per-mode timings).
+profile-otlp-io *ARGS:
+    cargo run -p logfwd-bench --release --bin otlp_io_profile -- {{ARGS}}
+
+# Profile OTLP decode/encode allocation counts with stats_alloc instrumentation.
+profile-otlp-io-alloc *ARGS:
+    cargo run -p logfwd-bench --release --features otlp-profile-alloc --bin otlp_io_profile -- {{ARGS}}
+
 # Generate microbenchmark report (markdown)
 bench-report:
     cargo run -p logfwd-bench


### PR DESCRIPTION
## Summary

Harden the OTLP benchmark/profile harness so mode names are unambiguous and
timing boundaries are documented.

Closes #1840

## Changes

### Mode name alignment

Renamed modes so Criterion benchmarks and `otlp_io_profile` binary use matching
names that describe exactly what is timed:

| Decode path | Criterion | Profile binary |
|-------------|-----------|----------------|
| prost reference | `prost_reference_to_batch` | `prost_reference_to_batch` |
| production current | `production_current_to_batch` | `production_current_to_batch` |
| projected detached | `projected_detached_to_batch` | `projected_detached_to_batch` |
| projected view | `projected_view_to_batch` | `projected_view_to_batch` |

E2E modes follow the same pattern: `e2e_prost_reference`, `e2e_production_current`,
`e2e_projected_detached`, `e2e_projected_view`.

Backward-compatible aliases (`prost_decode`, `production_to_batch`,
`projected_detached_decode`, `projected_view_decode`, `e2e_production`) are
preserved in the profile binary.

### Missing justfile recipes

Added `bench-otlp-io`, `bench-otlp-io-fast`, `profile-otlp-io`, and
`profile-otlp-io-alloc` recipes referenced in the bench README.

### README timing boundary docs

Updated the benchmark README with a mode name alignment table and explicit
timing boundary documentation for each Criterion group.

## Baseline Numbers

**attrs-heavy** (40 attrs/record, 2000 rows, 10 iterations):

| Mode | ns/row | allocs/row | B/row alloc |
|------|--------|------------|-------------|
| `prost_reference_to_batch` | 13,107 | 71.5 | 7,295 |
| `production_current_to_batch` | 13,307 | 71.5 | 7,295 |
| `projected_detached_to_batch` | 6,428 | 1.5 | 4,589 |
| `projected_view_to_batch` | 6,143 | 1.4 | 3,933 |
| `e2e_prost_reference` | 15,575 | 72.5 | 9,554 |
| `e2e_production_current` | 15,228 | 72.5 | 9,554 |
| `e2e_projected_detached` | 8,497 | 2.5 | 6,848 |
| `e2e_projected_view` | 7,826 | 2.5 | 6,192 |

**wide-10k** (20 attrs/record, 10000 rows, 3 iterations):

| Mode | ns/row |
|------|--------|
| `prost_reference_to_batch` | 6,250 |
| `production_current_to_batch` | 6,390 |
| `projected_detached_to_batch` | 3,874 |
| `projected_view_to_batch` | 3,765 |
| `e2e_prost_reference` | 8,045 |
| `e2e_production_current` | 7,538 |
| `e2e_projected_detached` | 4,822 |
| `e2e_projected_view` | 5,020 |

### Key findings

- **Projected decode is ~2× faster** than prost/production decode (both cases).
- **Projected allocations are ~48× fewer** (1.4-1.5 vs 71.5 allocs/row for attrs-heavy).
- **E2E encode does NOT erase the decode win**: projected e2e is ~1.8-2× faster.
- **Projected view vs detached** are comparable; view is slightly faster for decode-only,
  detached is slightly faster for e2e on wide-10k.

## Verification

```bash
git diff --check                                                    # ✓
cargo fmt --check                                                   # ✓
cargo clippy -p logfwd-bench --bench otlp_io -- -D warnings         # ✓
cargo clippy -p logfwd-bench --bin otlp_io_profile -- -D warnings   # ✓
cargo clippy -p logfwd-bench --features otlp-profile-alloc --bin otlp_io_profile -- -D warnings  # ✓
```

Smoke profiles pass for both `attrs-heavy` and `wide-10k` cases.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename OTLP benchmark labels to canonical names and add profiling recipes
> - Renames benchmark IDs in [`benches/otlp_io.rs`](https://github.com/strawgate/memagent/pull/1852/files#diff-2b94a188409548d0ab41bdf5b456128dcd109a21ff082e68a68470abfa9e0bb0) to canonical forms (e.g. `projected_detached_to_batch`, `prost_reference_to_handwritten_encode`) replacing prior `experimental_*` and mixed-order names.
> - Renames `Mode` enum variants and updates `name()`/`by_name()` in [`src/bin/otlp_io_profile.rs`](https://github.com/strawgate/memagent/pull/1852/files#diff-4632d75c09da49be46a9a165529e968a190a39e9350a1addcfdbd702e225cc71) to match; old names are accepted as deprecated aliases.
> - Adds four `just` recipes in [`justfile`](https://github.com/strawgate/memagent/pull/1852/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1): `bench-otlp-io`, `bench-otlp-io-fast`, `profile-otlp-io`, and `profile-otlp-io-alloc`.
> - Behavioral Change: any tooling or scripts that match on old Criterion benchmark IDs or profiler mode names will need to be updated to the new canonical names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c17822.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->