### PR TITLE
refactor: extract row lifecycle protocol from StreamingBuilder

### DIFF
--- a/crates/logfwd-arrow/src/columnar/mod.rs
+++ b/crates/logfwd-arrow/src/columnar/mod.rs
@@ -1,0 +1,9 @@
+//! Shared columnar construction engine.
+//!
+//! This module will eventually house the `ColumnarBatchBuilder` and its
+//! supporting types (`BatchPlan`, `FieldHandle`, `FieldKind`).  For now it
+//! contains only the extracted row lifecycle protocol — the state machine
+//! that enforces the begin_batch → begin_row → end_row → finish_batch
+//! call sequence shared by all columnar builders.
+
+pub(crate) mod row_protocol;

--- a/crates/logfwd-arrow/src/columnar/row_protocol.rs
+++ b/crates/logfwd-arrow/src/columnar/row_protocol.rs
@@ -1,0 +1,302 @@
+// row_protocol.rs — Row lifecycle state machine for columnar builders.
+//
+// Extracted from StreamingBuilder to isolate the batch/row call-sequence
+// protocol.  This is the first scaffold toward a shared ColumnarBatchBuilder
+// (see dev-docs/research/columnar-batch-builder.md).
+//
+// The protocol enforces:
+//   Idle → begin_batch() → InBatch
+//     InBatch → begin_row() → InRow
+//       InRow → end_row() → InBatch
+//     InBatch → finish_batch() → Idle
+
+use logfwd_core::scanner::BuilderState;
+
+/// Row lifecycle state machine for columnar builders.
+///
+/// Tracks the current batch/row phase, row count, per-row dedup bitmask,
+/// and the per-row line-written flag.  These four fields are the minimal
+/// state needed to enforce the call sequence contract documented on
+/// [`BuilderState`] and [`ScanBuilder`](logfwd_core::scanner::ScanBuilder).
+///
+/// # Why runtime state instead of typestate
+///
+/// The batch/row protocol is driven by the scanner loop which dispatches
+/// `begin_row`/`end_row` dynamically based on input data.  The transitions
+/// cannot be encoded at compile time because the number of rows per batch
+/// is data-dependent and the same builder instance is reused across
+/// batches.  `debug_assert` guards catch illegal transitions in tests
+/// while keeping zero overhead in release builds.
+///
+/// Transition methods are `#[inline(always)]` because they sit on the
+/// scanner hot path and must not introduce call overhead.
+pub(crate) struct RowLifecycle {
+    /// Current phase of the batch build cycle.
+    state: BuilderState,
+    /// Number of rows completed (via `end_row`) in the current batch.
+    row_count: u32,
+    /// Per-row dedup bitmask for fields 0–63.  Reset in `begin_row`.
+    written_bits: u64,
+    /// Whether `append_line` has been called for the current row.
+    line_written_this_row: bool,
+}
+
+impl RowLifecycle {
+    /// Create a new lifecycle in the `Idle` state.
+    pub(crate) fn new() -> Self {
+        RowLifecycle {
+            state: BuilderState::Idle,
+            row_count: 0,
+            written_bits: 0,
+            line_written_this_row: false,
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // State transitions
+    // -----------------------------------------------------------------
+
+    /// Transition to `InBatch`.  Resets row count and dedup state.
+    ///
+    /// # Panics (debug)
+    /// Asserts that we are not currently inside a row.
+    #[inline(always)]
+    pub(crate) fn begin_batch(&mut self) {
+        debug_assert!(
+            matches!(self.state, BuilderState::Idle | BuilderState::InBatch),
+            "begin_batch called while inside a row (missing end_row)"
+        );
+        self.state = BuilderState::InBatch;
+        self.row_count = 0;
+        self.written_bits = 0;
+    }
+
+    /// Transition from `InBatch` to `InRow`.  Resets per-row dedup state.
+    ///
+    /// # Panics (debug)
+    /// Asserts that we are in the `InBatch` state.
+    #[inline(always)]
+    pub(crate) fn begin_row(&mut self) {
+        debug_assert_eq!(
+            self.state,
+            BuilderState::InBatch,
+            "begin_row called outside of a batch (call begin_batch first)"
+        );
+        self.written_bits = 0;
+        self.line_written_this_row = false;
+        self.state = BuilderState::InRow;
+    }
+
+    /// Transition from `InRow` back to `InBatch`.  Increments row count.
+    ///
+    /// # Panics (debug)
+    /// Asserts that we are in the `InRow` state.
+    ///
+    /// # Panics (always)
+    /// Panics if row count would overflow `u32::MAX`.
+    #[inline(always)]
+    pub(crate) fn end_row(&mut self) {
+        debug_assert_eq!(
+            self.state,
+            BuilderState::InRow,
+            "end_row called without a matching begin_row"
+        );
+        self.row_count = self
+            .row_count
+            .checked_add(1)
+            .expect("row_count overflow: batch exceeds u32::MAX rows");
+        self.state = BuilderState::InBatch;
+    }
+
+    /// Transition from `InBatch` to `Idle` after batch finalization.
+    ///
+    /// # Panics (debug)
+    /// Asserts that we are in the `InBatch` state.
+    #[inline(always)]
+    pub(crate) fn finish_batch(&mut self) {
+        debug_assert_eq!(
+            self.state,
+            BuilderState::InBatch,
+            "finish_batch called outside of a batch"
+        );
+        self.state = BuilderState::Idle;
+    }
+
+    // -----------------------------------------------------------------
+    // Accessors — all #[inline(always)] for the hot path
+    // -----------------------------------------------------------------
+
+    /// Current protocol state.
+    #[inline(always)]
+    pub(crate) fn state(&self) -> BuilderState {
+        self.state
+    }
+
+    /// Number of completed rows in the current batch.
+    #[inline(always)]
+    pub(crate) fn row_count(&self) -> u32 {
+        self.row_count
+    }
+
+    /// Mutable reference to the per-row dedup bitmask.
+    #[inline(always)]
+    pub(crate) fn written_bits_mut(&mut self) -> &mut u64 {
+        &mut self.written_bits
+    }
+
+    /// Whether `append_line` has already been called for the current row.
+    #[inline(always)]
+    pub(crate) fn line_written_this_row(&self) -> bool {
+        self.line_written_this_row
+    }
+
+    /// Mark `append_line` as called for the current row.
+    #[inline(always)]
+    pub(crate) fn set_line_written(&mut self) {
+        self.line_written_this_row = true;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_starts_idle() {
+        let lc = RowLifecycle::new();
+        assert_eq!(lc.state(), BuilderState::Idle);
+        assert_eq!(lc.row_count(), 0);
+    }
+
+    #[test]
+    fn normal_lifecycle_transitions() {
+        let mut lc = RowLifecycle::new();
+
+        lc.begin_batch();
+        assert_eq!(lc.state(), BuilderState::InBatch);
+        assert_eq!(lc.row_count(), 0);
+
+        lc.begin_row();
+        assert_eq!(lc.state(), BuilderState::InRow);
+        assert!(!lc.line_written_this_row());
+
+        lc.end_row();
+        assert_eq!(lc.state(), BuilderState::InBatch);
+        assert_eq!(lc.row_count(), 1);
+
+        lc.begin_row();
+        lc.end_row();
+        assert_eq!(lc.row_count(), 2);
+
+        lc.finish_batch();
+        assert_eq!(lc.state(), BuilderState::Idle);
+    }
+
+    #[test]
+    fn begin_row_resets_dedup_state() {
+        let mut lc = RowLifecycle::new();
+        lc.begin_batch();
+
+        // Simulate writing fields in the first row.
+        lc.begin_row();
+        *lc.written_bits_mut() = 0xFF;
+        lc.set_line_written();
+        assert!(lc.line_written_this_row());
+        lc.end_row();
+
+        // Second row starts fresh.
+        lc.begin_row();
+        assert_eq!(*lc.written_bits_mut(), 0);
+        assert!(!lc.line_written_this_row());
+        lc.end_row();
+        lc.finish_batch();
+    }
+
+    #[test]
+    fn begin_batch_resets_row_count() {
+        let mut lc = RowLifecycle::new();
+
+        lc.begin_batch();
+        lc.begin_row();
+        lc.end_row();
+        lc.begin_row();
+        lc.end_row();
+        assert_eq!(lc.row_count(), 2);
+        lc.finish_batch();
+
+        // Second batch starts fresh.
+        lc.begin_batch();
+        assert_eq!(lc.row_count(), 0);
+        lc.finish_batch();
+    }
+
+    #[test]
+    fn empty_batch_allowed() {
+        let mut lc = RowLifecycle::new();
+        lc.begin_batch();
+        assert_eq!(lc.row_count(), 0);
+        lc.finish_batch();
+        assert_eq!(lc.state(), BuilderState::Idle);
+    }
+
+    #[test]
+    fn begin_batch_from_idle_and_in_batch_both_work() {
+        let mut lc = RowLifecycle::new();
+        // From Idle.
+        lc.begin_batch();
+        assert_eq!(lc.state(), BuilderState::InBatch);
+        // From InBatch (restart without finishing — allowed by the protocol).
+        lc.begin_batch();
+        assert_eq!(lc.state(), BuilderState::InBatch);
+        lc.finish_batch();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "begin_row called outside of a batch")]
+    fn begin_row_without_batch_panics() {
+        let mut lc = RowLifecycle::new();
+        lc.begin_row();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "end_row called without a matching begin_row")]
+    fn end_row_without_begin_row_panics() {
+        let mut lc = RowLifecycle::new();
+        lc.begin_batch();
+        lc.end_row();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "begin_batch called while inside a row")]
+    fn begin_batch_inside_row_panics() {
+        let mut lc = RowLifecycle::new();
+        lc.begin_batch();
+        lc.begin_row();
+        lc.begin_batch();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "finish_batch called outside of a batch")]
+    fn finish_batch_from_idle_panics() {
+        let mut lc = RowLifecycle::new();
+        lc.finish_batch();
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "finish_batch called outside of a batch")]
+    fn finish_batch_inside_row_panics() {
+        let mut lc = RowLifecycle::new();
+        lc.begin_batch();
+        lc.begin_row();
+        lc.finish_batch();
+    }
+}

--- a/crates/logfwd-arrow/src/lib.rs
+++ b/crates/logfwd-arrow/src/lib.rs
@@ -4,6 +4,7 @@
 //! Contains `StreamingBuilder` (zero-copy hot path) and the `Scanner`
 //! wrapper type that produces `RecordBatch`.
 
+pub(crate) mod columnar;
 pub mod conflict_schema;
 pub mod materialize;
 pub mod scanner;

--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -24,6 +24,7 @@ use logfwd_core::scanner::BuilderState;
 use logfwd_types::field_names;
 
 use crate::check_dup_bits;
+use crate::columnar::row_protocol::RowLifecycle;
 
 #[cfg(kani)]
 type FieldIndexMap = std::collections::BTreeMap<Vec<u8>, usize>;
@@ -156,10 +157,8 @@ pub struct StreamingBuilder {
     /// `field_index` — bounds `fields.len()` to the high-water mark of unique
     /// fields seen in any *single* batch rather than growing without limit.
     num_active: usize,
-    row_count: u32,
-    /// Tracks which fields (by index) were written in the current row.
-    /// Only covers the first 64 fields (indices 0-63); see `check_dup_bits`.
-    written_bits: u64,
+    /// Row lifecycle state machine: batch/row phase, row count, dedup bits.
+    lifecycle: RowLifecycle,
     /// Reference-counted buffer. Stored here to compute offsets safely
     /// and shared with Arrow StringViewArrays in finish_batch.
     buf: bytes::Bytes,
@@ -172,11 +171,6 @@ pub struct StreamingBuilder {
     /// Line views: (offset_in_buf, len) per row, in row order.
     /// Populated only when `line_field_name` is set.
     line_views: Vec<(u32, u32)>,
-    /// Tracks whether `append_line` has been called for the current row.
-    /// Used for duplicate detection since `line_views` is not indexed by field.
-    line_written_this_row: bool,
-    /// Protocol state — enforced via `debug_assert` in each method.
-    state: BuilderState,
     /// Constant per-row resource attributes emitted as `_resource_*` columns.
     resource_attrs: Vec<(String, String)>,
 }
@@ -193,14 +187,11 @@ impl StreamingBuilder {
             fields: Vec::with_capacity(32),
             field_index: new_field_index(),
             num_active: 0,
-            row_count: 0,
-            written_bits: 0,
+            lifecycle: RowLifecycle::new(),
             buf: bytes::Bytes::new(),
             decoded_buf: Vec::new(),
             line_field_name,
             line_views: Vec::new(),
-            line_written_this_row: false,
-            state: BuilderState::Idle,
             resource_attrs: Vec::new(),
         }
     }
@@ -224,9 +215,11 @@ impl StreamingBuilder {
     /// offsets are stored as u32. Buffers larger than 4 GiB would produce
     /// silently truncated offsets without this guard.
     pub fn begin_batch(&mut self, buf: bytes::Bytes) {
-        debug_assert_ne!(
-            self.state,
-            BuilderState::InRow,
+        debug_assert!(
+            matches!(
+                self.lifecycle.state(),
+                BuilderState::Idle | BuilderState::InBatch
+            ),
             "begin_batch called while inside a row (missing end_row)"
         );
         assert!(
@@ -236,7 +229,7 @@ impl StreamingBuilder {
         );
         self.buf = buf;
         self.decoded_buf.clear();
-        self.row_count = 0;
+        self.lifecycle.begin_batch();
         // Only clear the slots that were active in the previous batch.
         // This preserves the inner-Vec capacity of each FieldColumns for
         // hot-path reuse while still bounding memory under key churn.
@@ -250,39 +243,23 @@ impl StreamingBuilder {
         self.field_index.clear();
         self.num_active = 0;
         self.line_views.clear();
-        self.state = BuilderState::InBatch;
     }
 
     #[inline(always)]
     pub fn begin_row(&mut self) {
-        debug_assert_eq!(
-            self.state,
-            BuilderState::InBatch,
-            "begin_row called outside of a batch (call begin_batch first)"
-        );
-        self.written_bits = 0;
-        self.line_written_this_row = false;
-        self.state = BuilderState::InRow;
+        self.lifecycle.begin_row();
     }
 
     #[inline(always)]
     pub fn end_row(&mut self) {
-        debug_assert_eq!(
-            self.state,
-            BuilderState::InRow,
-            "end_row called without a matching begin_row"
-        );
-        self.row_count = self
-            .row_count
-            .checked_add(1)
-            .expect("row_count overflow: batch exceeds u32::MAX rows");
-        self.state = BuilderState::InBatch;
+        self.lifecycle.end_row();
     }
 
     #[inline]
     pub fn resolve_field(&mut self, key: &[u8]) -> usize {
         debug_assert!(
-            self.state == BuilderState::InBatch || self.state == BuilderState::InRow,
+            self.lifecycle.state() == BuilderState::InBatch
+                || self.lifecycle.state() == BuilderState::InRow,
             "resolve_field called outside of an active batch"
         );
         if let Some(&idx) = self.field_index.get(key) {
@@ -331,14 +308,14 @@ impl StreamingBuilder {
     #[inline(always)]
     pub fn append_str_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_str_by_idx called outside of a row"
         );
-        if check_dup_bits(&mut self.written_bits, idx) {
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
             return;
         }
-        if idx >= u64::BITS as usize && self.fields[idx].last_row == self.row_count {
+        if idx >= u64::BITS as usize && self.fields[idx].last_row == self.lifecycle.row_count() {
             return;
         }
         // StringViewArray requires valid UTF-8.  JSON is always UTF-8 in
@@ -351,12 +328,12 @@ impl StreamingBuilder {
             return;
         };
         if idx >= u64::BITS as usize {
-            self.fields[idx].last_row = self.row_count;
+            self.fields[idx].last_row = self.lifecycle.row_count();
         }
         let offset = self.offset_of(value);
         let fc = &mut self.fields[idx];
         fc.has_str = true;
-        fc.str_views.push((self.row_count, offset, len));
+        fc.str_views.push((self.lifecycle.row_count(), offset, len));
     }
 
     #[inline(always)]
@@ -373,14 +350,14 @@ impl StreamingBuilder {
     #[inline(always)]
     pub fn append_decoded_str_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_decoded_str_by_idx called outside of a row"
         );
-        if check_dup_bits(&mut self.written_bits, idx) {
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
             return;
         }
-        if idx >= u64::BITS as usize && self.fields[idx].last_row == self.row_count {
+        if idx >= u64::BITS as usize && self.fields[idx].last_row == self.lifecycle.row_count() {
             return;
         }
         if std::str::from_utf8(value).is_err() {
@@ -406,12 +383,13 @@ impl StreamingBuilder {
         };
         // All validation passed — safe to update dedup guard and extend decoded_buf.
         if idx >= u64::BITS as usize {
-            self.fields[idx].last_row = self.row_count;
+            self.fields[idx].last_row = self.lifecycle.row_count();
         }
         self.decoded_buf.extend_from_slice(value);
         let fc = &mut self.fields[idx];
         fc.has_str = true;
-        fc.str_views.push((self.row_count, combined_offset, len));
+        fc.str_views
+            .push((self.lifecycle.row_count(), combined_offset, len));
     }
 
     #[inline(always)]
@@ -422,126 +400,126 @@ impl StreamingBuilder {
     #[inline(always)]
     pub fn append_int_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_int_by_idx called outside of a row"
         );
-        if check_dup_bits(&mut self.written_bits, idx) {
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
             return;
         }
         let fc = &mut self.fields[idx];
         if idx >= 64 {
-            if fc.last_row == self.row_count {
+            if fc.last_row == self.lifecycle.row_count() {
                 return;
             }
-            fc.last_row = self.row_count;
+            fc.last_row = self.lifecycle.row_count();
         }
         if let Some(v) = parse_int_fast(value) {
             fc.has_int = true;
-            fc.int_values.push((self.row_count, v));
+            fc.int_values.push((self.lifecycle.row_count(), v));
         }
     }
 
     #[inline(always)]
     pub fn append_i64_value_by_idx(&mut self, idx: usize, value: i64) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_i64_value_by_idx called outside of a row"
         );
-        if check_dup_bits(&mut self.written_bits, idx) {
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
             return;
         }
         let fc = &mut self.fields[idx];
         if idx >= 64 {
-            if fc.last_row == self.row_count {
+            if fc.last_row == self.lifecycle.row_count() {
                 return;
             }
-            fc.last_row = self.row_count;
+            fc.last_row = self.lifecycle.row_count();
         }
         fc.has_int = true;
-        fc.int_values.push((self.row_count, value));
+        fc.int_values.push((self.lifecycle.row_count(), value));
     }
 
     #[inline(always)]
     pub fn append_float_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_float_by_idx called outside of a row"
         );
-        if check_dup_bits(&mut self.written_bits, idx) {
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
             return;
         }
         let fc = &mut self.fields[idx];
         if idx >= 64 {
-            if fc.last_row == self.row_count {
+            if fc.last_row == self.lifecycle.row_count() {
                 return;
             }
-            fc.last_row = self.row_count;
+            fc.last_row = self.lifecycle.row_count();
         }
         if let Some(v) = parse_float_fast(value) {
             fc.has_float = true;
-            fc.float_values.push((self.row_count, v));
+            fc.float_values.push((self.lifecycle.row_count(), v));
         }
     }
 
     #[inline(always)]
     pub fn append_f64_value_by_idx(&mut self, idx: usize, value: f64) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_f64_value_by_idx called outside of a row"
         );
-        if check_dup_bits(&mut self.written_bits, idx) {
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
             return;
         }
         let fc = &mut self.fields[idx];
         if idx >= 64 {
-            if fc.last_row == self.row_count {
+            if fc.last_row == self.lifecycle.row_count() {
                 return;
             }
-            fc.last_row = self.row_count;
+            fc.last_row = self.lifecycle.row_count();
         }
         fc.has_float = true;
-        fc.float_values.push((self.row_count, value));
+        fc.float_values.push((self.lifecycle.row_count(), value));
     }
 
     #[inline(always)]
     pub fn append_bool_by_idx(&mut self, idx: usize, value: bool) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_bool_by_idx called outside of a row"
         );
-        if check_dup_bits(&mut self.written_bits, idx) {
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
             return;
         }
         let fc = &mut self.fields[idx];
         if idx >= 64 {
-            if fc.last_row == self.row_count {
+            if fc.last_row == self.lifecycle.row_count() {
                 return;
             }
-            fc.last_row = self.row_count;
+            fc.last_row = self.lifecycle.row_count();
         }
         fc.has_bool = true;
-        fc.bool_values.push((self.row_count, value));
+        fc.bool_values.push((self.lifecycle.row_count(), value));
     }
 
     #[inline(always)]
     pub fn append_null_by_idx(&mut self, idx: usize) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_null_by_idx called outside of a row"
         );
         // Nulls are represented by gaps -- no value record needed.
         // But mark as written for duplicate-key detection.
-        let _ = check_dup_bits(&mut self.written_bits, idx);
+        let _ = check_dup_bits(self.lifecycle.written_bits_mut(), idx);
 
         let fc = &mut self.fields[idx];
         if idx >= 64 {
-            fc.last_row = self.row_count;
+            fc.last_row = self.lifecycle.row_count();
         }
     }
 
@@ -556,11 +534,11 @@ impl StreamingBuilder {
     #[inline(always)]
     pub fn append_line(&mut self, line: &[u8]) {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InRow,
             "append_line called outside of a row"
         );
-        if self.line_field_name.is_some() && !self.line_written_this_row {
+        if self.line_field_name.is_some() && !self.lifecycle.line_written_this_row() {
             let line_view = if std::str::from_utf8(line).is_ok() {
                 let Ok(line_len) = u32::try_from(line.len()) else {
                     return;
@@ -586,7 +564,7 @@ impl StreamingBuilder {
             if let Some(line_view) = line_view {
                 self.line_views.push(line_view);
             }
-            self.line_written_this_row = true;
+            self.lifecycle.set_line_written();
         }
     }
 
@@ -598,11 +576,11 @@ impl StreamingBuilder {
     /// as separate Arrow StringView blocks to avoid copying the whole input.
     pub fn finish_batch(&mut self) -> Result<RecordBatch, ArrowError> {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InBatch,
             "finish_batch called outside of a batch (call begin_batch first, and ensure all rows are closed with end_row)"
         );
-        let num_rows = self.row_count as usize;
+        let num_rows = self.lifecycle.row_count() as usize;
 
         // StringView offsets use original-buffer offsets for unescaped strings
         // and offsets >= original_buf_len for decoded strings. Keep those as two
@@ -911,7 +889,7 @@ impl StreamingBuilder {
         let schema = Arc::new(Schema::new(schema_fields));
         let opts = RecordBatchOptions::new().with_row_count(Some(num_rows));
         let result = RecordBatch::try_new_with_options(schema, arrays, &opts);
-        self.state = BuilderState::Idle;
+        self.lifecycle.finish_batch();
         result
     }
 
@@ -927,11 +905,11 @@ impl StreamingBuilder {
     /// `StringArray` compresses efficiently via IPC zstd.
     pub fn finish_batch_detached(&mut self) -> Result<RecordBatch, ArrowError> {
         debug_assert_eq!(
-            self.state,
+            self.lifecycle.state(),
             BuilderState::InBatch,
             "finish_batch_detached called outside of a batch"
         );
-        let num_rows = self.row_count as usize;
+        let num_rows = self.lifecycle.row_count() as usize;
         let has_decoded = !self.decoded_buf.is_empty();
 
         let mut schema_fields: Vec<Field> = Vec::with_capacity(self.num_active);
@@ -1177,7 +1155,7 @@ impl StreamingBuilder {
         let schema = Arc::new(Schema::new(schema_fields));
         let opts = RecordBatchOptions::new().with_row_count(Some(num_rows));
         let result = RecordBatch::try_new_with_options(schema, arrays, &opts);
-        self.state = BuilderState::Idle;
+        self.lifecycle.finish_batch();
         result
     }
 
@@ -2762,15 +2740,14 @@ mod verification {
         let mut b = StreamingBuilder::new(Some("line".to_string()));
         b.fields.push(FieldColumns::new(b"x"));
         b.num_active = 1;
-        b.row_count = 7;
         b.line_views.push((1, 2));
         b.decoded_buf.extend_from_slice(b"decoded");
         b.begin_batch(bytes::Bytes::from_static(b"test data pad"));
         assert_eq!(b.num_active, 0);
-        assert_eq!(b.row_count, 0);
+        assert_eq!(b.lifecycle.row_count(), 0);
         assert!(b.line_views.is_empty());
         assert!(b.decoded_buf.is_empty());
-        assert_eq!(b.state, BuilderState::InBatch);
+        assert_eq!(b.lifecycle.state(), BuilderState::InBatch);
         assert_eq!(b.fields.len(), 1);
     }
 
@@ -2787,7 +2764,7 @@ mod verification {
             b.begin_row();
             b.end_row();
         }
-        assert_eq!(b.row_count, num_rows);
+        assert_eq!(b.lifecycle.row_count(), num_rows);
         kani::cover!(num_rows == 0, "empty batch");
         kani::cover!(num_rows > 0, "non-empty batch");
     }


### PR DESCRIPTION
## Summary

Extracts the row lifecycle state machine from `StreamingBuilder` into a new `RowLifecycle` struct in `logfwd-arrow::columnar::row_protocol`. This is the first scaffold toward the shared `ColumnarBatchBuilder` described in `dev-docs/research/columnar-batch-builder.md`.

Closes #1842

## What changed

### New: `crates/logfwd-arrow/src/columnar/row_protocol.rs`

`RowLifecycle` struct owns the four state fields that enforce the batch/row call sequence:

| Field | Purpose |
|-------|---------|
| `state: BuilderState` | Current phase (Idle → InBatch → InRow) |
| `row_count: u32` | Completed rows in current batch |
| `written_bits: u64` | Per-row dedup bitmask (fields 0–63) |
| `line_written_this_row: bool` | Per-row line-capture flag |

Methods: `begin_batch()`, `begin_row()`, `end_row()`, `finish_batch()`, plus inline accessors.

11 focused tests covering:
- Normal lifecycle transitions
- Per-row dedup state reset
- Batch restart row count reset
- Empty batch allowed
- 5 illegal transition panic tests

### Changed: `crates/logfwd-arrow/src/streaming_builder.rs`

`StreamingBuilder` now composes `RowLifecycle` instead of owning the four fields directly:

```rust
pub struct StreamingBuilder {
    lifecycle: RowLifecycle,  // replaces state, row_count, written_bits, line_written_this_row
    fields: Vec<FieldColumns>,
    // ... rest unchanged
}
```

All `self.state`, `self.row_count`, `self.written_bits`, and `self.line_written_this_row` accesses replaced with `self.lifecycle.*()` calls.

### What stays unchanged

- All Arrow materialization, string backing, conflict handling, block storage
- All public API behavior (method signatures, return types)
- All 54 streaming_builder tests pass unchanged
- All 69 scanner conformance tests pass unchanged
- All 7 integration/allocation regression tests pass unchanged

## Non-goals (per #1842)

- No `BatchPlan`, `FieldHandle`, or `FieldKind` (→ #1843)
- No `BlockStore` or string backing extraction (→ #1844)
- No conflict-column changes
- No OTLP projection changes

## Test plan

```bash
cargo clippy -p logfwd-arrow --lib -- -D warnings   # zero warnings
cargo test -p logfwd-arrow                            # 142 tests pass
cargo test -p logfwd-core scanner                     # 69 tests pass
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract row lifecycle state machine from `StreamingBuilder` into `RowLifecycle`
> - Introduces a new `RowLifecycle` struct in [`crates/logfwd-arrow/src/columnar/row_protocol.rs`](https://github.com/strawgate/memagent/pull/1859/files#diff-f7744c06fef7f82d7e96372210884f3a55f873665612965369b4fb6362badeda) that encapsulates the row/batch state fields (`BuilderState`, `row_count`, `written_bits`, `line_written_this_row`) previously scattered across `StreamingBuilder`.
> - `RowLifecycle` exposes typed transition methods (`begin_batch`, `begin_row`, `end_row`, `finish_batch`) with `debug_assert`-guarded protocol correctness checks.
> - `StreamingBuilder` now holds a single `lifecycle: RowLifecycle` field and delegates all state reads and mutations to it; no functional behavior changes.
> - Kani proofs in `streaming_builder.rs` are updated to reference the new lifecycle accessors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cc01f9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->