### PR TITLE
refactor: add BatchPlan, FieldHandle, and FieldKind skeleton

### DIFF
--- a/crates/logfwd-arrow/src/columnar/mod.rs
+++ b/crates/logfwd-arrow/src/columnar/mod.rs
@@ -1,9 +1,15 @@
 //! Shared columnar construction engine.
 //!
-//! This module will eventually house the `ColumnarBatchBuilder` and its
-//! supporting types (`BatchPlan`, `FieldHandle`, `FieldKind`).  For now it
-//! contains only the extracted row lifecycle protocol — the state machine
-//! that enforces the begin_batch → begin_row → end_row → finish_batch
-//! call sequence shared by all columnar builders.
+//! This module houses the planning and lifecycle types for the shared
+//! `ColumnarBatchBuilder` direction:
+//!
+//! - [`row_protocol::RowLifecycle`] — batch/row state machine
+//! - [`plan::BatchPlan`] — field registry and handle allocator
+//! - [`plan::FieldHandle`] — stable column reference
+//! - [`plan::FieldKind`] — protocol-agnostic column type
+//!
+//! See `dev-docs/research/columnar-batch-builder.md` for the design intent.
 
+#[allow(dead_code)]
+pub(crate) mod plan;
 pub(crate) mod row_protocol;

--- a/crates/logfwd-arrow/src/columnar/plan.rs
+++ b/crates/logfwd-arrow/src/columnar/plan.rs
@@ -1,0 +1,484 @@
+// plan.rs — BatchPlan, FieldHandle, and FieldKind skeleton.
+//
+// Provides the planning layer for columnar batch construction.  Producers
+// declare fields up front (planned) or discover them dynamically; the plan
+// assigns stable `FieldHandle`s that later map to column indices in the
+// shared builder.
+//
+// See dev-docs/research/columnar-batch-builder.md for the design intent.
+//
+// These types are not yet wired into StreamingBuilder; follow-up issues
+// (#1844, #1845) will integrate them.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// FieldKind — protocol-agnostic column types
+// ---------------------------------------------------------------------------
+
+/// Protocol-agnostic column type for the shared columnar engine.
+///
+/// These are Arrow-level capabilities, not source-specific semantics.
+/// OTLP field numbers, JSON mixed-type conflict logic, and CSV column
+/// indices do not belong here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum FieldKind {
+    /// 64-bit signed integer (`Int64`).
+    Int64,
+    /// 64-bit IEEE 754 float (`Float64`).
+    Float64,
+    /// Boolean.
+    Bool,
+    /// Variable-length UTF-8 string backed by Arrow `StringViewArray`.
+    Utf8View,
+    /// Variable-length binary backed by Arrow `BinaryViewArray`.
+    BinaryView,
+    /// Fixed-size binary (e.g., 16 bytes for UUIDs, trace IDs).
+    FixedBinary(usize),
+}
+
+// ---------------------------------------------------------------------------
+// FieldHandle — stable column reference
+// ---------------------------------------------------------------------------
+
+/// Opaque handle to a column in a `BatchPlan`.
+///
+/// Handles are stable within a plan: the same field always maps to the same
+/// handle regardless of when it was declared or resolved.  Producers store
+/// handles for repeated use across rows without re-resolving by name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct FieldHandle(u32);
+
+impl FieldHandle {
+    /// The underlying column index.
+    #[inline(always)]
+    pub(crate) fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FieldSchemaMode — planned vs dynamic
+// ---------------------------------------------------------------------------
+
+/// How a field's type was established.
+///
+/// Schema-fixed fields have a declared kind that must not change.
+/// Dynamic fields accumulate observed kinds and may develop type conflicts
+/// (like JSON's mixed int/string columns).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FieldSchemaMode {
+    /// Producer declared the field with a fixed kind up front.
+    /// Attempts to write a different kind are rejected (not silently
+    /// promoted to a conflict column).
+    Planned(FieldKind),
+    /// Field was discovered dynamically (e.g., JSON key resolution).
+    /// Multiple observed kinds are tracked; the builder decides whether
+    /// to emit a conflict struct column or a single-type column at
+    /// finalization.
+    Dynamic {
+        /// Set of kinds observed so far.
+        observed: Vec<FieldKind>,
+    },
+}
+
+impl FieldSchemaMode {
+    fn new_planned(kind: FieldKind) -> Self {
+        FieldSchemaMode::Planned(kind)
+    }
+
+    fn new_dynamic(kind: FieldKind) -> Self {
+        FieldSchemaMode::Dynamic {
+            observed: vec![kind],
+        }
+    }
+
+    /// Record an additional observed kind for a dynamic field.
+    /// Returns `true` if this was a new kind (conflict may be needed).
+    fn observe(&mut self, kind: FieldKind) -> bool {
+        match self {
+            FieldSchemaMode::Dynamic { observed } => {
+                if observed.contains(&kind) {
+                    false
+                } else {
+                    observed.push(kind);
+                    true
+                }
+            }
+            FieldSchemaMode::Planned(_) => false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FieldEntry — per-field metadata in the plan
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+struct FieldEntry {
+    name: Arc<str>,
+    handle: FieldHandle,
+    mode: FieldSchemaMode,
+}
+
+// ---------------------------------------------------------------------------
+// BatchPlan — field registry and handle allocator
+// ---------------------------------------------------------------------------
+
+/// Registry of fields for a columnar batch.
+///
+/// A `BatchPlan` collects field declarations (planned or dynamic) and
+/// assigns stable [`FieldHandle`]s.  It does **not** own column storage
+/// or Arrow materialization — that remains the builder's job.
+///
+/// # Planned vs dynamic fields
+///
+/// - **Planned fields** are declared with a fixed [`FieldKind`] before any
+///   rows are written.  The kind is immutable; attempting to write a
+///   different kind through `declare_planned` again returns the existing
+///   handle only if the kinds match, otherwise returns an error.
+///
+/// - **Dynamic fields** are resolved by name + observed kind at write time
+///   (like `StreamingBuilder::resolve_field` for JSON).  Multiple observed
+///   kinds are accumulated and may produce conflict columns.
+pub(crate) struct BatchPlan {
+    /// Ordered field entries (index = handle value).
+    fields: Vec<FieldEntry>,
+    /// Name → handle for O(1) lookup.  Keys share the same `Arc<str>`
+    /// as the corresponding `FieldEntry::name` to avoid double-allocation.
+    index: HashMap<Arc<str>, FieldHandle>,
+}
+
+impl BatchPlan {
+    /// Create an empty plan.
+    pub(crate) fn new() -> Self {
+        BatchPlan {
+            fields: Vec::new(),
+            index: HashMap::new(),
+        }
+    }
+
+    /// Create a plan with pre-allocated capacity.
+    pub(crate) fn with_capacity(cap: usize) -> Self {
+        BatchPlan {
+            fields: Vec::with_capacity(cap),
+            index: HashMap::with_capacity(cap),
+        }
+    }
+
+    /// Number of fields in the plan.
+    pub(crate) fn len(&self) -> usize {
+        self.fields.len()
+    }
+
+    /// Whether the plan is empty.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Declare a schema-fixed field.
+    ///
+    /// If the field already exists as planned with the same kind, returns
+    /// the existing handle (idempotent).  If it exists with a different
+    /// kind or as a dynamic field, returns `Err`.
+    pub(crate) fn declare_planned(
+        &mut self,
+        name: &str,
+        kind: FieldKind,
+    ) -> Result<FieldHandle, PlanError> {
+        if let Some(&handle) = self.index.get(name) {
+            let entry = &self.fields[handle.index()];
+            match &entry.mode {
+                FieldSchemaMode::Planned(existing_kind) if *existing_kind == kind => Ok(handle),
+                FieldSchemaMode::Planned(existing_kind) => Err(PlanError::KindMismatch {
+                    field: name.to_string(),
+                    declared: *existing_kind,
+                    requested: kind,
+                }),
+                FieldSchemaMode::Dynamic { .. } => Err(PlanError::ModeMismatch {
+                    field: name.to_string(),
+                    reason: "field already exists as dynamic",
+                }),
+            }
+        } else {
+            let handle = self.alloc_handle();
+            let shared_name: Arc<str> = Arc::from(name);
+            self.fields.push(FieldEntry {
+                name: Arc::clone(&shared_name),
+                handle,
+                mode: FieldSchemaMode::new_planned(kind),
+            });
+            self.index.insert(shared_name, handle);
+            Ok(handle)
+        }
+    }
+
+    /// Resolve a dynamic field by name and observed kind.
+    ///
+    /// If the field already exists as dynamic, the observed kind is
+    /// accumulated (for conflict detection).  If it exists as planned,
+    /// returns `Err` — planned fields cannot become dynamic.
+    pub(crate) fn resolve_dynamic(
+        &mut self,
+        name: &str,
+        kind: FieldKind,
+    ) -> Result<FieldHandle, PlanError> {
+        if let Some(&handle) = self.index.get(name) {
+            let entry = &mut self.fields[handle.index()];
+            match &mut entry.mode {
+                FieldSchemaMode::Dynamic { .. } => {
+                    entry.mode.observe(kind);
+                    Ok(handle)
+                }
+                FieldSchemaMode::Planned(_) => Err(PlanError::ModeMismatch {
+                    field: name.to_string(),
+                    reason: "field already exists as planned",
+                }),
+            }
+        } else {
+            let handle = self.alloc_handle();
+            let shared_name: Arc<str> = Arc::from(name);
+            self.fields.push(FieldEntry {
+                name: Arc::clone(&shared_name),
+                handle,
+                mode: FieldSchemaMode::new_dynamic(kind),
+            });
+            self.index.insert(shared_name, handle);
+            Ok(handle)
+        }
+    }
+
+    /// Look up a field by name without creating it.
+    pub(crate) fn lookup(&self, name: &str) -> Option<FieldHandle> {
+        self.index.get(name).copied()
+    }
+
+    /// Get the schema mode for a field handle.
+    pub(crate) fn field_mode(&self, handle: FieldHandle) -> Option<&FieldSchemaMode> {
+        self.fields.get(handle.index()).map(|e| &e.mode)
+    }
+
+    /// Get the field name for a handle.
+    pub(crate) fn field_name(&self, handle: FieldHandle) -> Option<&str> {
+        self.fields.get(handle.index()).map(|e| &*e.name)
+    }
+
+    /// Iterate over all fields in declaration order.
+    pub(crate) fn fields(&self) -> impl Iterator<Item = (FieldHandle, &str, &FieldSchemaMode)> {
+        self.fields.iter().map(|e| (e.handle, &*e.name, &e.mode))
+    }
+
+    fn alloc_handle(&self) -> FieldHandle {
+        FieldHandle(
+            u32::try_from(self.fields.len()).expect("BatchPlan field count exceeds u32::MAX"),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PlanError
+// ---------------------------------------------------------------------------
+
+/// Error from `BatchPlan` field declaration or resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PlanError {
+    /// A planned field was re-declared with a different kind.
+    KindMismatch {
+        field: String,
+        declared: FieldKind,
+        requested: FieldKind,
+    },
+    /// A field mode conflict (e.g., planned field resolved as dynamic).
+    ModeMismatch { field: String, reason: &'static str },
+}
+
+impl std::fmt::Display for PlanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PlanError::KindMismatch {
+                field,
+                declared,
+                requested,
+            } => write!(
+                f,
+                "field {field:?} declared as {declared:?}, requested as {requested:?}"
+            ),
+            PlanError::ModeMismatch { field, reason } => {
+                write!(f, "field {field:?}: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PlanError {}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn planned_field_returns_stable_handle() {
+        let mut plan = BatchPlan::new();
+        let h1 = plan.declare_planned("timestamp", FieldKind::Int64).unwrap();
+        let h2 = plan.declare_planned("timestamp", FieldKind::Int64).unwrap();
+        assert_eq!(h1, h2);
+        assert_eq!(h1.index(), 0);
+    }
+
+    #[test]
+    fn planned_field_kind_mismatch_errors() {
+        let mut plan = BatchPlan::new();
+        plan.declare_planned("severity", FieldKind::Int64).unwrap();
+        let err = plan
+            .declare_planned("severity", FieldKind::Utf8View)
+            .unwrap_err();
+        assert!(matches!(err, PlanError::KindMismatch { .. }));
+    }
+
+    #[test]
+    fn dynamic_field_returns_stable_handle() {
+        let mut plan = BatchPlan::new();
+        let h1 = plan.resolve_dynamic("level", FieldKind::Utf8View).unwrap();
+        let h2 = plan.resolve_dynamic("level", FieldKind::Utf8View).unwrap();
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn dynamic_field_accumulates_observed_kinds() {
+        let mut plan = BatchPlan::new();
+        let h = plan.resolve_dynamic("value", FieldKind::Int64).unwrap();
+        plan.resolve_dynamic("value", FieldKind::Utf8View).unwrap();
+
+        let mode = plan.field_mode(h).unwrap();
+        match mode {
+            FieldSchemaMode::Dynamic { observed } => {
+                assert_eq!(observed.len(), 2);
+                assert!(observed.contains(&FieldKind::Int64));
+                assert!(observed.contains(&FieldKind::Utf8View));
+            }
+            _ => panic!("expected Dynamic mode"),
+        }
+    }
+
+    #[test]
+    fn dynamic_field_deduplicates_same_kind() {
+        let mut plan = BatchPlan::new();
+        plan.resolve_dynamic("count", FieldKind::Int64).unwrap();
+        plan.resolve_dynamic("count", FieldKind::Int64).unwrap();
+        plan.resolve_dynamic("count", FieldKind::Int64).unwrap();
+
+        let h = plan.lookup("count").unwrap();
+        match plan.field_mode(h).unwrap() {
+            FieldSchemaMode::Dynamic { observed } => assert_eq!(observed.len(), 1),
+            _ => panic!("expected Dynamic mode"),
+        }
+    }
+
+    #[test]
+    fn planned_field_cannot_become_dynamic() {
+        let mut plan = BatchPlan::new();
+        plan.declare_planned("ts", FieldKind::Int64).unwrap();
+        let err = plan.resolve_dynamic("ts", FieldKind::Int64).unwrap_err();
+        assert!(matches!(err, PlanError::ModeMismatch { .. }));
+    }
+
+    #[test]
+    fn dynamic_field_cannot_become_planned() {
+        let mut plan = BatchPlan::new();
+        plan.resolve_dynamic("msg", FieldKind::Utf8View).unwrap();
+        let err = plan
+            .declare_planned("msg", FieldKind::Utf8View)
+            .unwrap_err();
+        assert!(matches!(err, PlanError::ModeMismatch { .. }));
+    }
+
+    #[test]
+    fn handles_are_sequential() {
+        let mut plan = BatchPlan::new();
+        let h0 = plan.declare_planned("a", FieldKind::Int64).unwrap();
+        let h1 = plan.declare_planned("b", FieldKind::Float64).unwrap();
+        let h2 = plan.resolve_dynamic("c", FieldKind::Utf8View).unwrap();
+        assert_eq!(h0.index(), 0);
+        assert_eq!(h1.index(), 1);
+        assert_eq!(h2.index(), 2);
+        assert_eq!(plan.len(), 3);
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown() {
+        let plan = BatchPlan::new();
+        assert!(plan.lookup("nonexistent").is_none());
+    }
+
+    #[test]
+    fn field_name_round_trips() {
+        let mut plan = BatchPlan::new();
+        let h = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
+        assert_eq!(plan.field_name(h), Some("body"));
+    }
+
+    #[test]
+    fn fields_iterator_in_declaration_order() {
+        let mut plan = BatchPlan::new();
+        plan.declare_planned("z", FieldKind::Bool).unwrap();
+        plan.resolve_dynamic("a", FieldKind::Int64).unwrap();
+        plan.declare_planned("m", FieldKind::Float64).unwrap();
+
+        let names: Vec<&str> = plan.fields().map(|(_, name, _)| name).collect();
+        assert_eq!(names, vec!["z", "a", "m"]);
+    }
+
+    #[test]
+    fn with_capacity_works() {
+        let plan = BatchPlan::with_capacity(64);
+        assert!(plan.is_empty());
+        assert_eq!(plan.len(), 0);
+    }
+
+    #[test]
+    fn fixed_binary_kind() {
+        let mut plan = BatchPlan::new();
+        let h = plan
+            .declare_planned("trace_id", FieldKind::FixedBinary(16))
+            .unwrap();
+        match plan.field_mode(h).unwrap() {
+            FieldSchemaMode::Planned(FieldKind::FixedBinary(16)) => {}
+            other => panic!("expected FixedBinary(16), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fixed_binary_size_mismatch_is_kind_mismatch() {
+        let mut plan = BatchPlan::new();
+        plan.declare_planned("id", FieldKind::FixedBinary(16))
+            .unwrap();
+        let err = plan
+            .declare_planned("id", FieldKind::FixedBinary(32))
+            .unwrap_err();
+        assert!(matches!(err, PlanError::KindMismatch { .. }));
+    }
+
+    #[test]
+    fn plan_error_display() {
+        let err = PlanError::KindMismatch {
+            field: "ts".to_string(),
+            declared: FieldKind::Int64,
+            requested: FieldKind::Float64,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("ts"));
+        assert!(msg.contains("Int64"));
+        assert!(msg.contains("Float64"));
+
+        let err2 = PlanError::ModeMismatch {
+            field: "x".to_string(),
+            reason: "already dynamic",
+        };
+        assert!(err2.to_string().contains("already dynamic"));
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the minimal planning types for the shared columnar builder direction. These types define how producers declare fields and receive stable column handles, without yet wiring them into `StreamingBuilder`.

Closes #1843
Depends on: #1859 (row protocol extraction)

## Changes

### New: `crates/logfwd-arrow/src/columnar/plan.rs`

| Type | Purpose |
|------|---------|
| `FieldKind` | Protocol-agnostic column types: `Int64`, `Float64`, `Bool`, `Utf8View`, `BinaryView`, `FixedBinary(usize)` |
| `FieldHandle` | Opaque stable column reference (wraps `u32` index) |
| `FieldSchemaMode` | `Planned(FieldKind)` for schema-fixed producers, `Dynamic { observed }` for JSON-style discovery |
| `BatchPlan` | Field registry: `declare_planned()` for typed producers, `resolve_dynamic()` for JSON-like discovery |
| `PlanError` | `KindMismatch` and `ModeMismatch` errors |

### Design decisions

- **Planned fields** are idempotent: re-declaring with the same kind returns the same handle
- **Planned fields reject kind changes** — no silent conflict promotion for typed producers
- **Dynamic fields accumulate observed kinds** for conflict detection (like JSON)
- **Planned and dynamic modes are mutually exclusive** per field
- **Handles are sequential** u32 indices in declaration order
- **No OTLP semantics** — field kinds are Arrow-level capabilities only

### Updated: `crates/logfwd-arrow/src/columnar/mod.rs`

Added `plan` module with doc comment updates listing all columnar types.

## Non-goals (per #1843)

- No producer migration (JSON, CSV, OTLP)
- No Arrow materialization from the plan
- No OTLP field names or numbers in logfwd-arrow
- No cross-batch caches

## Test plan

```bash
cargo clippy -p logfwd-arrow --lib -- -D warnings   # zero warnings
cargo test -p logfwd-arrow columnar                   # 26 tests pass (11 row_protocol + 15 plan)
cargo test -p logfwd-arrow                            # all 142+ tests pass
```

## Test coverage (15 plan tests)

- `planned_field_returns_stable_handle` — idempotent re-declaration
- `planned_field_kind_mismatch_errors` — Int64 vs Utf8View
- `dynamic_field_returns_stable_handle` — same handle on re-resolve
- `dynamic_field_accumulates_observed_kinds` — Int64 + Utf8View tracked
- `dynamic_field_deduplicates_same_kind` — same kind observed 3× stays 1
- `planned_field_cannot_become_dynamic` — mode isolation
- `dynamic_field_cannot_become_planned` — mode isolation
- `handles_are_sequential` — 0, 1, 2 in declaration order
- `lookup_returns_none_for_unknown` — missing field
- `field_name_round_trips` — name accessor
- `fields_iterator_in_declaration_order` — z, a, m not sorted
- `with_capacity_works` — empty plan with capacity
- `fixed_binary_kind` — FixedBinary(16) round-trip
- `fixed_binary_size_mismatch_is_kind_mismatch` — 16 vs 32
- `plan_error_display` — error message formatting

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `BatchPlan`, `FieldHandle`, and `FieldKind` skeleton to columnar planning layer
> - Introduces [plan.rs](https://github.com/strawgate/memagent/pull/1861/files#diff-a011956f5010954e5ba04ca64dc46a3c8181c8c7c424cec79b37ae24994631ad) with a field registry (`BatchPlan`) that allocates stable `FieldHandle` references and validates column type declarations.
> - `BatchPlan` distinguishes between planned fields (fixed `FieldKind` at declaration) and dynamic fields (kinds accumulated and de-duplicated at runtime), returning typed `PlanError` on mode or kind mismatches.
> - Exposes the new `plan` submodule from [columnar/mod.rs](https://github.com/strawgate/memagent/pull/1861/files#diff-aeaa764a60fac05e453f27135a8bd5a8b9b084fbe8df24d12269053a2655337a); all new code is currently annotated `#[allow(dead_code)]` as it is not yet wired to any consumer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f95cdcc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->