### PR TITLE
fix(io): use read loop in compute_fingerprint to prevent short-read fingerprint mismatch

### DIFF
--- a/crates/logfwd-io/src/tail/identity.rs
+++ b/crates/logfwd-io/src/tail/identity.rs
@@ -73,7 +73,14 @@ pub(super) fn compute_fingerprint(file: &mut File, max_bytes: usize) -> io::Resu
     file.seek(SeekFrom::Start(0))?;
 
     let mut buf = vec![0u8; max_bytes];
-    let n = file.read(&mut buf)?;
+    let mut total = 0;
+    while total < buf.len() {
+        match file.read(&mut buf[total..])? {
+            0 => break,
+            n => total += n,
+        }
+    }
+    let n = total;
 
     file.seek(SeekFrom::Start(pos))?;
 
@@ -107,8 +114,9 @@ pub(super) fn identify_file(path: &Path, fingerprint_bytes: usize) -> io::Result
 
 #[cfg(test)]
 mod tests {
-    use super::source_id_from_digests;
+    use super::{compute_fingerprint, source_id_from_digests};
     use logfwd_types::pipeline::SourceId;
+    use std::io::Write;
 
     #[test]
     fn source_id_uses_primary_digest_when_nonzero() {
@@ -123,5 +131,33 @@ mod tests {
     #[test]
     fn source_id_uses_nonzero_sentinel_when_both_digests_are_zero() {
         assert_eq!(source_id_from_digests(0, 0), SourceId(1));
+    }
+
+    #[test]
+    fn compute_fingerprint_is_deterministic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            f.write_all(b"hello world, this is a test line\n").unwrap();
+        }
+        let mut file = std::fs::File::open(&path).unwrap();
+        let fp1 = compute_fingerprint(&mut file, 256).unwrap();
+        let fp2 = compute_fingerprint(&mut file, 256).unwrap();
+        assert_eq!(fp1, fp2, "consecutive fingerprint calls must be identical");
+        assert_ne!(
+            fp1, 0,
+            "non-empty file must not produce sentinel fingerprint"
+        );
+    }
+
+    #[test]
+    fn compute_fingerprint_empty_file_returns_sentinel() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.log");
+        std::fs::File::create(&path).unwrap();
+        let mut file = std::fs::File::open(&path).unwrap();
+        let fp = compute_fingerprint(&mut file, 256).unwrap();
+        assert_eq!(fp, 0, "empty file must return sentinel fingerprint 0");
     }
 }


### PR DESCRIPTION
## Summary

- Replace single `file.read()` with a loop that reads until buffer is full or true EOF in `compute_fingerprint`
- Prevents spurious log rotation detection on filesystems that may short-read (NFS, FUSE, overlayfs)

Fixes #1863

## Details

`compute_fingerprint` used a single `file.read(&mut buf)` call. Per the `Read` trait contract, a single `read()` may return fewer bytes than requested even when more data is available. Two calls on the same file could hash different byte counts, producing different fingerprints, causing the tailer to incorrectly detect log rotation and re-read the file from offset 0 (data duplication).

## Test plan

- [x] Added `compute_fingerprint_is_deterministic` test — verifies consecutive calls produce identical fingerprints
- [x] Added `compute_fingerprint_empty_file_returns_sentinel` test — verifies empty files return sentinel 0
- [x] All existing identity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `compute_fingerprint` to use a read loop and prevent short-read fingerprint mismatch
> A single `read` call may return fewer bytes than requested, causing `compute_fingerprint` to hash an incomplete buffer and produce inconsistent fingerprints for the same file. The fix replaces the single read with a loop in [identity.rs](https://github.com/strawgate/memagent/pull/1922/files#diff-fe479143386787db46ce8164546d910581df2a30d28eb38fde96dce7ac5d2b82) that reads until the buffer is full or EOF. Two new tests cover determinism across consecutive calls and the sentinel `0` return for empty files. Risk: files where the first read previously returned fewer bytes than available will now produce a different fingerprint than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bece4c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->