### PR TITLE
fix(io): reject oversized chunks in compress instead of silent u32 truncation

### DIFF
--- a/crates/logfwd-io/src/compress.rs
+++ b/crates/logfwd-io/src/compress.rs
@@ -71,6 +71,20 @@ impl ChunkCompressor {
         cursor.set_position(HEADER_SIZE as u64);
         let compressed_size = self.compressor.compress_to_buffer(raw, &mut cursor)?;
 
+        // Validate that sizes fit in u32 — the wire format only has 4 bytes per field.
+        let raw_size_u32 = u32::try_from(raw_size).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("raw size {raw_size} exceeds u32::MAX"),
+            )
+        })?;
+        let compressed_size_u32 = u32::try_from(compressed_size).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("compressed size {compressed_size} exceeds u32::MAX"),
+            )
+        })?;
+
         // Compute checksum over the compressed payload.
         let checksum =
             xxhash_rust::xxh32::xxh32(&self.out_buf[HEADER_SIZE..HEADER_SIZE + compressed_size], 0);
@@ -79,8 +93,8 @@ impl ChunkCompressor {
         self.out_buf[0..2].copy_from_slice(&MAGIC.to_le_bytes());
         self.out_buf[2] = VERSION;
         self.out_buf[3] = FLAG_ZSTD;
-        self.out_buf[4..8].copy_from_slice(&(compressed_size as u32).to_le_bytes());
-        self.out_buf[8..12].copy_from_slice(&(raw_size as u32).to_le_bytes());
+        self.out_buf[4..8].copy_from_slice(&compressed_size_u32.to_le_bytes());
+        self.out_buf[8..12].copy_from_slice(&raw_size_u32.to_le_bytes());
         self.out_buf[12..16].copy_from_slice(&checksum.to_le_bytes());
 
         // Swap out_buf to give ownership to the caller without cloning.
@@ -92,8 +106,8 @@ impl ChunkCompressor {
 
         Ok(CompressedChunk {
             data,
-            raw_size: raw_size as u32,
-            compressed_size: compressed_size as u32,
+            raw_size: raw_size_u32,
+            compressed_size: compressed_size_u32,
         })
     }
 
@@ -202,5 +216,27 @@ mod tests {
     #[test]
     fn test_truncated_rejected() {
         assert!(decompress_chunk(&[0u8; 4]).is_err());
+    }
+
+    /// Verify that `compress()` rejects raw input larger than `u32::MAX` bytes
+    /// instead of silently truncating the size fields.
+    #[test]
+    fn test_oversized_raw_input_rejected() {
+        // We cannot allocate a 4 GiB+ buffer in a unit test, but we can
+        // exercise the same validation logic by checking the conversion
+        // directly. This mirrors what compress() does internally.
+        let oversized: usize = u32::MAX as usize + 1;
+        let result = u32::try_from(oversized);
+        assert!(
+            result.is_err(),
+            "u32::try_from should fail for values > u32::MAX"
+        );
+
+        // Also verify that the error message format matches what compress() produces.
+        let err = io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("raw size {oversized} exceeds u32::MAX"),
+        );
+        assert!(err.to_string().contains("exceeds u32::MAX"));
     }
 }

--- a/crates/logfwd-io/src/compress.rs
+++ b/crates/logfwd-io/src/compress.rs
@@ -52,7 +52,7 @@ impl ChunkCompressor {
     /// Reuses internal buffers to avoid allocation.
     pub fn compress(&mut self, raw: &[u8]) -> io::Result<CompressedChunk> {
         let raw_size = raw.len();
-        let raw_size_u32 = checked_wire_size("raw size", raw_size)?;
+        let raw_size_u32 = check_wire_size("raw size", raw_size)?;
 
         // Worst case: zstd may expand data. zstd_safe::compress_bound gives the max.
         let max_compressed = zstd::zstd_safe::compress_bound(raw_size);
@@ -74,7 +74,7 @@ impl ChunkCompressor {
 
         // Validate that compressed size fits in u32; the wire format only has
         // 4 bytes per size field.
-        let compressed_size_u32 = checked_wire_size("compressed size", compressed_size)?;
+        let compressed_size_u32 = check_wire_size("compressed size", compressed_size)?;
 
         // Compute checksum over the compressed payload.
         let checksum =
@@ -112,7 +112,7 @@ impl ChunkCompressor {
     }
 }
 
-fn checked_wire_size(name: &str, size: usize) -> io::Result<u32> {
+fn check_wire_size(name: &str, size: usize) -> io::Result<u32> {
     u32::try_from(size).map_err(|_| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -223,13 +223,14 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     fn test_oversized_raw_input_rejected() {
         let oversized: usize = u32::MAX as usize + 1;
-        let result = checked_wire_size("raw size", oversized);
+        let result = check_wire_size("raw size", oversized);
         assert!(
             result.is_err(),
-            "checked_wire_size should fail for values > u32::MAX"
+            "check_wire_size should fail for values > u32::MAX"
         );
 
         let err = result.expect_err("oversized raw input must be rejected");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert!(err.to_string().contains("raw size"));
         assert!(err.to_string().contains("exceeds u32::MAX"));
     }

--- a/crates/logfwd-io/src/compress.rs
+++ b/crates/logfwd-io/src/compress.rs
@@ -52,6 +52,7 @@ impl ChunkCompressor {
     /// Reuses internal buffers to avoid allocation.
     pub fn compress(&mut self, raw: &[u8]) -> io::Result<CompressedChunk> {
         let raw_size = raw.len();
+        let raw_size_u32 = checked_wire_size("raw size", raw_size)?;
 
         // Worst case: zstd may expand data. zstd_safe::compress_bound gives the max.
         let max_compressed = zstd::zstd_safe::compress_bound(raw_size);
@@ -71,19 +72,9 @@ impl ChunkCompressor {
         cursor.set_position(HEADER_SIZE as u64);
         let compressed_size = self.compressor.compress_to_buffer(raw, &mut cursor)?;
 
-        // Validate that sizes fit in u32 — the wire format only has 4 bytes per field.
-        let raw_size_u32 = u32::try_from(raw_size).map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("raw size {raw_size} exceeds u32::MAX"),
-            )
-        })?;
-        let compressed_size_u32 = u32::try_from(compressed_size).map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("compressed size {compressed_size} exceeds u32::MAX"),
-            )
-        })?;
+        // Validate that compressed size fits in u32; the wire format only has
+        // 4 bytes per size field.
+        let compressed_size_u32 = checked_wire_size("compressed size", compressed_size)?;
 
         // Compute checksum over the compressed payload.
         let checksum =
@@ -119,6 +110,15 @@ impl ChunkCompressor {
         }
         chunk.raw_size as f64 / chunk.compressed_size as f64
     }
+}
+
+fn checked_wire_size(name: &str, size: usize) -> io::Result<u32> {
+    u32::try_from(size).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{name} {size} exceeds u32::MAX"),
+        )
+    })
 }
 
 /// Decompress and verify a compressed chunk (for testing / receiver side).
@@ -218,25 +218,19 @@ mod tests {
         assert!(decompress_chunk(&[0u8; 4]).is_err());
     }
 
-    /// Verify that `compress()` rejects raw input larger than `u32::MAX` bytes
-    /// instead of silently truncating the size fields.
+    /// Verify the validation path used by `compress()` for oversized inputs.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_oversized_raw_input_rejected() {
-        // We cannot allocate a 4 GiB+ buffer in a unit test, but we can
-        // exercise the same validation logic by checking the conversion
-        // directly. This mirrors what compress() does internally.
         let oversized: usize = u32::MAX as usize + 1;
-        let result = u32::try_from(oversized);
+        let result = checked_wire_size("raw size", oversized);
         assert!(
             result.is_err(),
-            "u32::try_from should fail for values > u32::MAX"
+            "checked_wire_size should fail for values > u32::MAX"
         );
 
-        // Also verify that the error message format matches what compress() produces.
-        let err = io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("raw size {oversized} exceeds u32::MAX"),
-        );
+        let err = result.expect_err("oversized raw input must be rejected");
+        assert!(err.to_string().contains("raw size"));
         assert!(err.to_string().contains("exceeds u32::MAX"));
     }
 }


### PR DESCRIPTION
## Summary

- Add `u32::try_from()` bounds checks for `raw_size` and `compressed_size` in `ChunkCompressor::compress()`
- Previously, values exceeding `u32::MAX` were silently truncated via `as u32`, producing corrupt wire headers
- Now returns `io::Error(InvalidInput)` with a clear message

Fixes #1871

## Test plan

- [x] Added test verifying the u32 bounds check rejects oversized values
- [x] All existing compress/decompress tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject oversized chunks in `ChunkCompressor.compress` instead of silently truncating to u32
> Previously, raw and compressed sizes larger than `u32::MAX` were silently cast, causing silent overflow in the wire header. A new `check_wire_size` helper in [compress.rs](https://github.com/strawgate/memagent/pull/1924/files#diff-1e8ba5f4086395ee69aa0b7b1bd761bbb9383741b166c6446f5979499082d097) converts `usize` to `u32`, returning `io::ErrorKind::InvalidInput` if the value exceeds `u32::MAX`. Behavioral Change: `compress()` now returns an error for oversized inputs rather than writing a truncated size into the header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28f3104.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->