### PR TITLE
fix(io): gracefully recover from corrupt checkpoint file instead of failing to start

### DIFF
--- a/crates/logfwd-io/src/checkpoint.rs
+++ b/crates/logfwd-io/src/checkpoint.rs
@@ -85,9 +85,17 @@ impl FileCheckpointStore {
         let checkpoints_path = data_dir.join("checkpoints.json");
         let checkpoints = if checkpoints_path.exists() {
             let bytes = std::fs::read(&checkpoints_path)?;
-            let list: Vec<SourceCheckpoint> = serde_json::from_slice(&bytes)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-            list.into_iter().map(|c| (c.source_id, c)).collect()
+            match serde_json::from_slice::<Vec<SourceCheckpoint>>(&bytes) {
+                Ok(list) => list.into_iter().map(|c| (c.source_id, c)).collect(),
+                Err(e) => {
+                    tracing::warn!(
+                        path = %checkpoints_path.display(),
+                        error = %e,
+                        "checkpoint file is corrupt — starting fresh"
+                    );
+                    BTreeMap::new()
+                }
+            }
         } else {
             BTreeMap::new()
         };
@@ -355,6 +363,19 @@ mod tests {
         let parsed: Vec<SourceCheckpoint> = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0].offset, 2048);
+    }
+
+    /// A corrupt checkpoint file should not prevent the store from opening.
+    /// Instead it logs a warning and starts with empty state.
+    #[test]
+    fn test_corrupt_checkpoint_recovers() {
+        let dir = TempDir::new().unwrap();
+        let cp_path = dir.path().join("checkpoints.json");
+        std::fs::write(&cp_path, b"NOT VALID JSON {{{").unwrap();
+
+        let store = FileCheckpointStore::open(dir.path())
+            .expect("open should succeed despite corrupt file");
+        assert!(store.load_all().is_empty(), "should start with empty state");
     }
 
     /// `default_data_dir` returns a non-empty path.


### PR DESCRIPTION
## Summary

- When `checkpoints.json` is corrupt (invalid JSON), log a warning and start with empty state instead of returning an error
- Previously, a corrupt checkpoint file prevented the pipeline from starting entirely
- Crash recovery is still safe: the pipeline starts fresh and re-reads from the configured start position

Fixes #1914

## Test plan

- [x] Added `test_corrupt_checkpoint_recovers` — verifies corrupt file doesn't prevent startup
- [x] All existing checkpoint tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Recover gracefully from a corrupt checkpoint file in `FileCheckpointStore.open`
> Previously, a corrupt `checkpoints.json` caused `FileCheckpointStore.open` to return an error, preventing startup. Now, deserialization failures are caught, a warning is logged with the file path and error, and the store starts with empty state instead.
>
> Behavioral Change: a corrupt checkpoint file no longer blocks startup, but all previously checkpointed source positions are silently discarded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a528425.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->