### PR TITLE
fix(io): handle empty OTLP JSON arrays/kvlists and fix attribute-protocol field ordering

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -273,17 +273,9 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
                     out.push(b',');
                 }
 
-                if let Some(attrs) = record.get("attributes").and_then(|v| v.as_array()) {
-                    for kv in attrs {
-                        if let (Some(key), Some(val)) =
-                            (kv.get("key").and_then(|k| k.as_str()), kv.get("value"))
-                            && write_json_any_value_field_from_json(&mut out, key, val)?
-                        {
-                            out.push(b',');
-                        }
-                    }
-                }
-
+                // Write protocol fields BEFORE log record attributes so that
+                // first-write-wins semantics prevent attributes from shadowing
+                // trace_id, span_id, flags, scope.name, or scope.version.
                 if let Some(tid) = record.get("traceId").and_then(|v| v.as_str()) {
                     if !tid.is_empty() {
                         let normalized_trace_id = normalize_otlp_hex_id(tid, 32, "traceId")?;
@@ -329,6 +321,17 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
                 {
                     write_json_string_field(&mut out, field_names::SCOPE_VERSION, version);
                     out.push(b',');
+                }
+
+                if let Some(attrs) = record.get("attributes").and_then(|v| v.as_array()) {
+                    for kv in attrs {
+                        if let (Some(key), Some(val)) =
+                            (kv.get("key").and_then(|k| k.as_str()), kv.get("value"))
+                            && write_json_any_value_field_from_json(&mut out, key, val)?
+                        {
+                            out.push(b',');
+                        }
+                    }
                 }
 
                 if out.last() == Some(&b',') {
@@ -399,10 +402,14 @@ fn json_any_value_to_string(v: &serde_json::Value) -> Result<Option<String>, Inp
 }
 
 fn json_any_array_to_string(array_value: &serde_json::Value) -> Result<String, InputError> {
-    let values = array_value
-        .get("values")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| InputError::Receiver("invalid OTLP JSON arrayValue".into()))?;
+    // Per protobuf JSON mapping: a missing "values" key means an empty
+    // repeated field (valid). A present-but-non-array "values" is invalid.
+    let values = match array_value.get("values") {
+        None => return Ok("[]".to_string()),
+        Some(v) => v.as_array().ok_or_else(|| {
+            InputError::Receiver("invalid OTLP JSON arrayValue: 'values' is not an array".into())
+        })?,
+    };
 
     let mut out = Vec::with_capacity(values.len());
     for item in values {
@@ -414,10 +421,14 @@ fn json_any_array_to_string(array_value: &serde_json::Value) -> Result<String, I
 }
 
 fn json_any_kvlist_to_string(kvlist_value: &serde_json::Value) -> Result<String, InputError> {
-    let values = kvlist_value
-        .get("values")
-        .and_then(serde_json::Value::as_array)
-        .ok_or_else(|| InputError::Receiver("invalid OTLP JSON kvlistValue".into()))?;
+    // Per protobuf JSON mapping: a missing "values" key means an empty
+    // repeated field (valid). A present-but-non-array "values" is invalid.
+    let values = match kvlist_value.get("values") {
+        None => return Ok("[]".to_string()),
+        Some(v) => v.as_array().ok_or_else(|| {
+            InputError::Receiver("invalid OTLP JSON kvlistValue: 'values' is not an array".into())
+        })?,
+    };
 
     let mut out = Vec::with_capacity(values.len());
     for entry in values {
@@ -547,5 +558,132 @@ mod tests {
 
         assert_eq!(id.as_ref(), "0123456789abcdef0123456789abcdef");
         assert!(matches!(id, Cow::Owned(_)));
+    }
+
+    #[test]
+    fn empty_array_value_without_values_key() {
+        let v: serde_json::Value = serde_json::json!({});
+        let result = json_any_array_to_string(&v).expect("empty arrayValue must succeed");
+        assert_eq!(result, "[]");
+    }
+
+    #[test]
+    fn empty_kvlist_value_without_values_key() {
+        let v: serde_json::Value = serde_json::json!({});
+        let result = json_any_kvlist_to_string(&v).expect("empty kvlistValue must succeed");
+        assert_eq!(result, "[]");
+    }
+
+    #[test]
+    fn any_value_empty_array_value() {
+        let v: serde_json::Value = serde_json::json!({"arrayValue": {}});
+        let result = json_any_value_to_string(&v)
+            .expect("must succeed")
+            .expect("must produce Some");
+        assert_eq!(result, "[]");
+    }
+
+    #[test]
+    fn any_value_empty_kvlist_value() {
+        let v: serde_json::Value = serde_json::json!({"kvlistValue": {}});
+        let result = json_any_value_to_string(&v)
+            .expect("must succeed")
+            .expect("must produce Some");
+        assert_eq!(result, "[]");
+    }
+
+    #[test]
+    fn json_literal_empty_array_value() {
+        let v: serde_json::Value = serde_json::json!({"arrayValue": {}});
+        let result = json_any_value_to_json_literal(&v)
+            .expect("must succeed")
+            .expect("must produce Some");
+        assert_eq!(result, serde_json::json!([]));
+    }
+
+    #[test]
+    fn json_literal_empty_kvlist_value() {
+        let v: serde_json::Value = serde_json::json!({"kvlistValue": {}});
+        let result = json_any_value_to_json_literal(&v)
+            .expect("must succeed")
+            .expect("must produce Some");
+        assert_eq!(result, serde_json::json!([]));
+    }
+
+    #[test]
+    fn protocol_fields_not_shadowed_by_attributes() {
+        use arrow::array::{Array, StringArray, StringViewArray};
+        use arrow::datatypes::DataType;
+
+        fn str_val(col: &dyn Array, row: usize) -> String {
+            match col.data_type() {
+                DataType::Utf8 => col
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .expect("Utf8")
+                    .value(row)
+                    .to_string(),
+                DataType::Utf8View => col
+                    .as_any()
+                    .downcast_ref::<StringViewArray>()
+                    .expect("Utf8View")
+                    .value(row)
+                    .to_string(),
+                other => panic!("expected string column, got {other}"),
+            }
+        }
+
+        let json_body = br#"{
+            "resourceLogs": [{
+                "scopeLogs": [{
+                    "scope": { "name": "real-scope", "version": "1.0" },
+                    "logRecords": [{
+                        "body": { "stringValue": "test" },
+                        "traceId": "0123456789abcdef0123456789abcdef",
+                        "spanId": "0123456789abcdef",
+                        "flags": 1,
+                        "attributes": [
+                            { "key": "trace_id", "value": { "stringValue": "fake-trace" } },
+                            { "key": "span_id", "value": { "stringValue": "fake-span" } },
+                            { "key": "flags", "value": { "intValue": "999" } },
+                            { "key": "scope.name", "value": { "stringValue": "fake-scope" } },
+                            { "key": "scope.version", "value": { "stringValue": "fake-ver" } }
+                        ]
+                    }]
+                }]
+            }]
+        }"#;
+
+        let batch = decode_otlp_json(json_body, field_names::DEFAULT_RESOURCE_PREFIX)
+            .expect("decode must succeed");
+
+        assert_eq!(batch.num_rows(), 1);
+
+        let trace_col = batch
+            .column_by_name(field_names::TRACE_ID)
+            .expect("trace_id column");
+        assert_eq!(
+            str_val(trace_col.as_ref(), 0),
+            "0123456789abcdef0123456789abcdef",
+            "trace_id must be the protocol field, not the attribute"
+        );
+
+        let span_col = batch
+            .column_by_name(field_names::SPAN_ID)
+            .expect("span_id column");
+        assert_eq!(
+            str_val(span_col.as_ref(), 0),
+            "0123456789abcdef",
+            "span_id must be the protocol field, not the attribute"
+        );
+
+        let scope_col = batch
+            .column_by_name(field_names::SCOPE_NAME)
+            .expect("scope.name column");
+        assert_eq!(
+            str_val(scope_col.as_ref(), 0),
+            "real-scope",
+            "scope.name must be the protocol field, not the attribute"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two fixes in the OTLP JSON decode path:

1. **#1867**: `json_any_array_to_string` and `json_any_kvlist_to_string` now treat a missing "values" key as an empty repeated field (valid per protobuf JSON mapping spec) instead of returning an error that rejects the entire batch
2. **#1870**: Protocol fields (trace_id, span_id, flags, scope.name, scope.version) are now written BEFORE log record attributes, so first-write-wins semantics prevent attribute shadowing — matching the protobuf decode path behavior

Fixes #1867, fixes #1870

## Test plan

- [x] Added test for empty arrayValue (no "values" key)
- [x] Added test for empty kvlistValue (no "values" key)
- [x] Added test verifying protocol fields take priority over same-named attributes
- [x] All existing OTLP decode tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OTLP JSON protocol field ordering and handle empty array/kvlist values
> - Reorders field emission in `decode_otlp_logs_json` so protocol fields (`trace_id`, `span_id`, `flags`, `scope.name`, `scope.version`) are written before log record attributes, ensuring first-write-wins consumers retain protocol values when attribute keys conflict.
> - Treats a missing `values` key in `arrayValue` and `kvlistValue` JSON shapes as an empty array instead of an error in `json_any_array_to_string` and `json_any_kvlist_to_string`.
> - Improves error messages when `values` is present but not an array in both functions.
> - Behavioral Change: OTLP JSON records with attributes that share keys with protocol fields will now consistently preserve the protocol field values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00150cb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->