### PR TITLE
fix(core): harden timestamp and severity parsing

### DIFF
--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -325,12 +325,16 @@ pub fn parse_severity(text: &[u8]) -> (Severity, &[u8]) {
     // Previous version used prefix matching (e.g., any string starting with
     // "I" matched INFO) which caused false positives like "INVALID" → Info.
     let sev = match text.len() {
+        3 if eq_ignore_case_3(text, b"ERR") => Severity::Error,
         4 if eq_ignore_case_4(text, b"INFO") => Severity::Info,
         4 if eq_ignore_case_4(text, b"WARN") => Severity::Warn,
         5 if eq_ignore_case_5(text, b"DEBUG") => Severity::Debug,
         5 if eq_ignore_case_5(text, b"TRACE") => Severity::Trace,
         5 if eq_ignore_case_5(text, b"ERROR") => Severity::Error,
         5 if eq_ignore_case_5(text, b"FATAL") => Severity::Fatal,
+        6 if eq_ignore_case_6(text, b"NOTICE") => Severity::Info,
+        7 if eq_ignore_case_7(text, b"WARNING") => Severity::Warn,
+        8 if eq_ignore_case_8(text, b"CRITICAL") => Severity::Fatal,
         _ => Severity::Unspecified,
     };
     if matches!(sev, Severity::Unspecified) {
@@ -345,6 +349,12 @@ pub fn parse_severity(text: &[u8]) -> (Severity, &[u8]) {
 #[cfg(kani)]
 fn eq_ignore_case_match(a: &[u8], b: &[u8]) -> bool {
     a.len() == b.len() && a.iter().zip(b.iter()).all(|(x, y)| x | 0x20 == y | 0x20)
+}
+
+/// Case-insensitive 3-byte comparison.
+#[inline(always)]
+fn eq_ignore_case_3(a: &[u8], b: &[u8]) -> bool {
+    a[0] | 0x20 == b[0] | 0x20 && a[1] | 0x20 == b[1] | 0x20 && a[2] | 0x20 == b[2] | 0x20
 }
 
 /// Case-insensitive 4-byte comparison. Uses `|0x20` which maps uppercase
@@ -367,6 +377,42 @@ fn eq_ignore_case_5(a: &[u8], b: &[u8]) -> bool {
         && a[2] | 0x20 == b[2] | 0x20
         && a[3] | 0x20 == b[3] | 0x20
         && a[4] | 0x20 == b[4] | 0x20
+}
+
+/// Case-insensitive 6-byte comparison.
+#[inline(always)]
+fn eq_ignore_case_6(a: &[u8], b: &[u8]) -> bool {
+    a[0] | 0x20 == b[0] | 0x20
+        && a[1] | 0x20 == b[1] | 0x20
+        && a[2] | 0x20 == b[2] | 0x20
+        && a[3] | 0x20 == b[3] | 0x20
+        && a[4] | 0x20 == b[4] | 0x20
+        && a[5] | 0x20 == b[5] | 0x20
+}
+
+/// Case-insensitive 7-byte comparison.
+#[inline(always)]
+fn eq_ignore_case_7(a: &[u8], b: &[u8]) -> bool {
+    a[0] | 0x20 == b[0] | 0x20
+        && a[1] | 0x20 == b[1] | 0x20
+        && a[2] | 0x20 == b[2] | 0x20
+        && a[3] | 0x20 == b[3] | 0x20
+        && a[4] | 0x20 == b[4] | 0x20
+        && a[5] | 0x20 == b[5] | 0x20
+        && a[6] | 0x20 == b[6] | 0x20
+}
+
+/// Case-insensitive 8-byte comparison.
+#[inline(always)]
+fn eq_ignore_case_8(a: &[u8], b: &[u8]) -> bool {
+    a[0] | 0x20 == b[0] | 0x20
+        && a[1] | 0x20 == b[1] | 0x20
+        && a[2] | 0x20 == b[2] | 0x20
+        && a[3] | 0x20 == b[3] | 0x20
+        && a[4] | 0x20 == b[4] | 0x20
+        && a[5] | 0x20 == b[5] | 0x20
+        && a[6] | 0x20 == b[6] | 0x20
+        && a[7] | 0x20 == b[7] | 0x20
 }
 
 // JSON field extraction (extract_json_fields, JsonFields, key_eq_ignore_case)
@@ -401,6 +447,39 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
     let sec = parse_2digits(ts, 17) as u64;
 
     if year == 0 || month == 0 || month > 12 || day == 0 || day > 31 {
+        return None;
+    }
+
+    // Validate separator characters: YYYY-MM-DDThh:mm:ss
+    if ts[4] != b'-'
+        || ts[7] != b'-'
+        || (ts[10] != b'T' && ts[10] != b't' && ts[10] != b' ')
+        || ts[13] != b':'
+        || ts[16] != b':'
+    {
+        return None;
+    }
+
+    // Validate that date/time digit positions are actually ASCII digits.
+    // parse_2digits silently returns 0 for non-digits, which is valid for
+    // hour/min/sec and would let garbage through as 00:00:00. (#1875)
+    if !ts[5].is_ascii_digit()
+        || !ts[6].is_ascii_digit()
+        || !ts[8].is_ascii_digit()
+        || !ts[9].is_ascii_digit()
+        || !ts[11].is_ascii_digit()
+        || !ts[12].is_ascii_digit()
+        || !ts[14].is_ascii_digit()
+        || !ts[15].is_ascii_digit()
+        || !ts[17].is_ascii_digit()
+        || !ts[18].is_ascii_digit()
+    {
+        return None;
+    }
+
+    // Month-specific day validation (#1874). Reject invalid dates like Feb 31.
+    let max_day = days_in_month(year, month);
+    if day > max_day {
         return None;
     }
 
@@ -520,6 +599,29 @@ fn parse_2digits(s: &[u8], off: usize) -> u8 {
     (a - b'0') * 10 + (b - b'0')
 }
 
+/// Returns `true` if `year` is a leap year (Gregorian calendar).
+#[inline(always)]
+fn is_leap_year(year: i64) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+}
+
+/// Returns the number of days in the given month (1-12) for the given year.
+#[inline(always)]
+fn days_in_month(year: i64, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            if is_leap_year(year) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => 0,
+    }
+}
+
 /// Days from 1970-01-01 to the given civil date. Algorithm from Howard Hinnant.
 #[cfg_attr(kani, kani::requires(
     year >= 1 && year <= 2553 && month >= 1 && month <= 12 && day >= 1 && day <= 31
@@ -625,6 +727,26 @@ mod tests {
             parse_severity(b"unknown").0,
             Severity::Unspecified
         ));
+    }
+
+    #[test]
+    fn test_parse_severity_aliases() {
+        // WARNING -> Warn (#1866)
+        assert!(matches!(parse_severity(b"WARNING").0, Severity::Warn));
+        assert!(matches!(parse_severity(b"warning").0, Severity::Warn));
+        assert!(matches!(parse_severity(b"Warning").0, Severity::Warn));
+        // ERR -> Error (#1866)
+        assert!(matches!(parse_severity(b"ERR").0, Severity::Error));
+        assert!(matches!(parse_severity(b"err").0, Severity::Error));
+        assert!(matches!(parse_severity(b"Err").0, Severity::Error));
+        // NOTICE -> Info (#1912)
+        assert!(matches!(parse_severity(b"NOTICE").0, Severity::Info));
+        assert!(matches!(parse_severity(b"notice").0, Severity::Info));
+        assert!(matches!(parse_severity(b"Notice").0, Severity::Info));
+        // CRITICAL -> Fatal (#1912)
+        assert!(matches!(parse_severity(b"CRITICAL").0, Severity::Fatal));
+        assert!(matches!(parse_severity(b"critical").0, Severity::Fatal));
+        assert!(matches!(parse_severity(b"Critical").0, Severity::Fatal));
     }
 
     #[test]
@@ -752,6 +874,34 @@ mod tests {
         assert_eq!(parse_timestamp_nanos(b"2024-01-01T23:60:00Z"), None);
         // Invalid second (leap second 60 is allowed, 61 is not)
         assert_eq!(parse_timestamp_nanos(b"2024-01-01T23:59:61Z"), None);
+    }
+
+    #[test]
+    fn parse_timestamp_rejects_invalid_calendar_dates() {
+        assert_eq!(parse_timestamp_nanos(b"2024-02-31T00:00:00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-02-30T00:00:00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2023-02-29T00:00:00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-04-31T00:00:00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-06-31T00:00:00Z"), None);
+        assert!(parse_timestamp_nanos(b"2024-02-29T00:00:00Z").is_some());
+        assert_eq!(parse_timestamp_nanos(b"1900-02-29T00:00:00Z"), None);
+        assert!(parse_timestamp_nanos(b"2000-02-29T00:00:00Z").is_some());
+    }
+
+    #[test]
+    fn parse_timestamp_rejects_non_digit_time_fields() {
+        assert_eq!(parse_timestamp_nanos(b"2024-01-15TXX:30:00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-01-15T10:XX:00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-01-15T10:30:XXZ"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-XX-15T10:30:00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-01-XXT10:30:00Z"), None);
+    }
+
+    #[test]
+    fn parse_timestamp_rejects_bad_separators() {
+        assert_eq!(parse_timestamp_nanos(b"2024/01/15T10:30:00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-01-15T10-30-00Z"), None);
+        assert_eq!(parse_timestamp_nanos(b"2024-01-15X10:30:00Z"), None);
     }
 
     #[test]
@@ -1095,6 +1245,16 @@ mod verification {
         assert!(matches!(parse_severity(b"trace").0, Severity::Trace));
         assert!(matches!(parse_severity(b"fatal").0, Severity::Fatal));
 
+        // Aliases -- uppercase and lowercase (#1866, #1912)
+        assert!(matches!(parse_severity(b"ERR").0, Severity::Error));
+        assert!(matches!(parse_severity(b"err").0, Severity::Error));
+        assert!(matches!(parse_severity(b"NOTICE").0, Severity::Info));
+        assert!(matches!(parse_severity(b"notice").0, Severity::Info));
+        assert!(matches!(parse_severity(b"WARNING").0, Severity::Warn));
+        assert!(matches!(parse_severity(b"warning").0, Severity::Warn));
+        assert!(matches!(parse_severity(b"CRITICAL").0, Severity::Fatal));
+        assert!(matches!(parse_severity(b"critical").0, Severity::Fatal));
+
         // Empty / unknown
         assert!(matches!(parse_severity(b"").0, Severity::Unspecified));
         assert!(matches!(parse_severity(b"X").0, Severity::Unspecified));
@@ -1111,23 +1271,26 @@ mod verification {
         assert!(matches!(parse_severity(b"Trace").0, Severity::Trace));
         assert!(matches!(parse_severity(b"Fatal").0, Severity::Fatal));
 
+        // Mixed case aliases
+        assert!(matches!(parse_severity(b"Err").0, Severity::Error));
+        assert!(matches!(parse_severity(b"Notice").0, Severity::Info));
+        assert!(matches!(parse_severity(b"Warning").0, Severity::Warn));
+        assert!(matches!(parse_severity(b"Critical").0, Severity::Fatal));
+
         // Exact length required — no prefix matching
         assert!(matches!(
             parse_severity(b"INFORMATION").0,
-            Severity::Unspecified
-        ));
-        assert!(matches!(
-            parse_severity(b"WARNING").0,
             Severity::Unspecified
         ));
         assert!(matches!(parse_severity(b"TRAMP").0, Severity::Unspecified));
         assert!(matches!(parse_severity(b"INF").0, Severity::Unspecified));
     }
 
-    /// Prove parse_severity ONLY returns non-Unspecified for the 6
-    /// standard level strings (any case). No false positives.
+    /// Prove parse_severity ONLY returns non-Unspecified for the 10
+    /// recognized level strings (6 standard + 4 aliases, any case).
+    /// No false positives.
     #[kani::proof]
-    #[kani::unwind(6)] // eq_ignore_case_match: Zip over ≤5-byte targets + 1 terminator
+    #[kani::unwind(9)] // eq_ignore_case_match: Zip over ≤8-byte targets + 1 terminator
     fn verify_parse_severity_no_false_positives() {
         let bytes: [u8; 8] = kani::any();
         let len: usize = kani::any_where(|&l: &usize| l <= 8);
@@ -1135,14 +1298,18 @@ mod verification {
         let (sev, _) = parse_severity(text);
 
         if !matches!(sev, Severity::Unspecified) {
-            // Must be exactly one of the 6 standard levels
+            // Must be exactly one of the 10 recognized levels
             assert!(
                 eq_ignore_case_match(text, b"TRACE")
                     || eq_ignore_case_match(text, b"DEBUG")
                     || eq_ignore_case_match(text, b"INFO")
                     || eq_ignore_case_match(text, b"WARN")
                     || eq_ignore_case_match(text, b"ERROR")
-                    || eq_ignore_case_match(text, b"FATAL"),
+                    || eq_ignore_case_match(text, b"FATAL")
+                    || eq_ignore_case_match(text, b"ERR")
+                    || eq_ignore_case_match(text, b"NOTICE")
+                    || eq_ignore_case_match(text, b"WARNING")
+                    || eq_ignore_case_match(text, b"CRITICAL"),
                 "matched a non-standard level"
             );
         }

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -321,7 +321,8 @@ pub enum Severity {
 /// Fast severity lookup from first byte + length. No string comparison needed.
 #[inline(always)]
 pub fn parse_severity(text: &[u8]) -> (Severity, &[u8]) {
-    // Exact case-insensitive match against the 6 standard severity strings.
+    // Exact case-insensitive match against the 6 standard severity strings
+    // plus common aliases used by syslog and application logs.
     // Previous version used prefix matching (e.g., any string starting with
     // "I" matched INFO) which caused false positives like "INVALID" → Info.
     let sev = match text.len() {
@@ -735,7 +736,7 @@ mod tests {
         assert!(matches!(parse_severity(b"WARNING").0, Severity::Warn));
         assert!(matches!(parse_severity(b"warning").0, Severity::Warn));
         assert!(matches!(parse_severity(b"Warning").0, Severity::Warn));
-        // ERR -> Error (#1866)
+        // ERR -> Error (#1912)
         assert!(matches!(parse_severity(b"ERR").0, Severity::Error));
         assert!(matches!(parse_severity(b"err").0, Severity::Error));
         assert!(matches!(parse_severity(b"Err").0, Severity::Error));


### PR DESCRIPTION
## Summary

Four parsing fixes in `crates/logfwd-core/src/otlp.rs`:

1. **#1866 + #1912**: Add severity aliases — WARNING→Warn, ERR→Error, NOTICE→Info, CRITICAL→Fatal (with new `eq_ignore_case_3/6/7/8` helpers)
2. **#1874**: Reject invalid calendar dates (e.g., Feb 31) via `days_in_month` helper with leap year support
3. **#1875**: Validate separator characters (`-`, `T`/`t`/` `, `:`) and ensure time-of-day fields are ASCII digits

Fixes #1866, fixes #1874, fixes #1875, fixes #1912

## Details

`parse_severity` previously only matched 4-letter (INFO, WARN) and 5-letter (DEBUG, TRACE, ERROR, FATAL) strings. Many logging frameworks use longer names: Python uses "WARNING", syslog uses "NOTICE" and "CRITICAL", etc.

`parse_timestamp_nanos` accepted invalid dates like `2024-02-31` (wrapping to March) and non-digit time fields like `2024-01-15TXX:00:00Z` (treating non-digits as 0).

## Test plan

- [x] Tests for all 10 severity string aliases (case-insensitive)
- [x] Tests for invalid calendar dates (Feb 30, Apr 31, Feb 29 in non-leap year)
- [x] Tests for non-digit rejection in time fields
- [x] Tests for separator character validation
- [x] Updated Kani proofs for the expanded severity set
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden timestamp and severity parsing in `otlp` log forwarding core
> - `parse_severity` now recognizes `ERR`, `NOTICE`, `WARNING`, and `CRITICAL` (case-insensitive) in addition to standard level names, mapping them to `Error`, `Info`, `Warn`, and `Fatal` respectively. New fixed-length helpers (`eq_ignore_case_3/6/7/8`) handle comparisons via bitwise `|0x20`.
> - `parse_timestamp_nanos` now validates separator characters at expected positions, checks that all digit positions are ASCII digits, and rejects calendar-invalid dates (e.g. Feb 31, or Feb 29 in non-leap years) using new `is_leap_year` and `days_in_month` helpers.
> - New unit tests and updated Kani proofs cover the alias mappings, bad separators, non-digit fields, and invalid calendar dates.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45069af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->