### PR TITLE
fix(transform): fix NULL pattern handling, quote trimming, and array group_index in UDFs

### DIFF
--- a/crates/logfwd-transform/src/udf/grok.rs
+++ b/crates/logfwd-transform/src/udf/grok.rs
@@ -183,9 +183,16 @@ impl ScalarUDFImpl for GrokUdf {
             | ColumnarValue::Scalar(datafusion::common::ScalarValue::LargeUtf8(Some(s))) => {
                 s.clone()
             }
-            ColumnarValue::Scalar(s) => {
-                let s = s.to_string();
-                s.trim_matches('"').trim_matches('\'').to_string()
+            // NULL pattern -> NULL propagation: return scalar Utf8 NULL.
+            ColumnarValue::Scalar(s) if s.is_null() => {
+                return Ok(ColumnarValue::Scalar(
+                    datafusion::common::ScalarValue::Utf8(None),
+                ));
+            }
+            ColumnarValue::Scalar(_) => {
+                return Err(datafusion::error::DataFusionError::Execution(
+                    "grok() pattern argument must be a scalar string literal".to_string(),
+                ));
             }
             ColumnarValue::Array(_) => {
                 return Err(datafusion::error::DataFusionError::Execution(
@@ -331,14 +338,20 @@ impl ScalarUDFImpl for GrokUdf {
                 // Treat SQL NULL input the same as no match: return a Struct
                 // with all-null fields. This avoids matching against "NULL" —
                 // the string that ScalarValue::Utf8(None).to_string() produces.
-                let raw = if scalar.is_null() {
+                // Extract the inner string directly from ScalarValue to avoid
+                // trim_matches corruption on values with boundary quotes.
+                let raw: Option<String> = if scalar.is_null() {
                     None
                 } else {
-                    Some(scalar.to_string())
+                    match scalar {
+                        datafusion::common::ScalarValue::Utf8(Some(s))
+                        | datafusion::common::ScalarValue::Utf8View(Some(s))
+                        | datafusion::common::ScalarValue::LargeUtf8(Some(s)) => Some(s.clone()),
+                        other => Some(other.to_string()),
+                    }
                 };
                 let matches = raw
                     .as_deref()
-                    .map(|s| s.trim_matches('"').trim_matches('\''))
                     .and_then(|s| compiled.pattern.match_against(s));
 
                 let fields: Vec<Field> = compiled
@@ -668,5 +681,26 @@ mod tests {
             msg.contains("pattern argument must be a scalar string literal"),
             "unexpected error: {msg}"
         );
+    }
+
+    /// Regression (#1891/#1908): NULL pattern must return NULL.
+    #[test]
+    fn test_null_pattern_returns_null() {
+        let batch = make_access_log_batch();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            "SELECT grok(message, CAST(NULL AS VARCHAR)) AS parsed FROM logs",
+        ));
+        let col = result.column_by_name("parsed").unwrap();
+        for row in 0..result.num_rows() {
+            assert!(
+                col.is_null(row),
+                "row {row}: NULL pattern must propagate NULL"
+            );
+        }
     }
 }

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -128,9 +128,16 @@ impl ScalarUDFImpl for RegexpExtractUdf {
             | ColumnarValue::Scalar(datafusion::common::ScalarValue::LargeUtf8(Some(s))) => {
                 s.clone()
             }
-            ColumnarValue::Scalar(s) => {
-                let s = s.to_string();
-                s.trim_matches('"').trim_matches('\'').to_string()
+            // NULL pattern -> NULL propagation: return all-null result.
+            ColumnarValue::Scalar(s) if s.is_null() => {
+                return Ok(ColumnarValue::Scalar(
+                    datafusion::common::ScalarValue::Utf8(None),
+                ));
+            }
+            ColumnarValue::Scalar(_) => {
+                return Err(datafusion::error::DataFusionError::Execution(
+                    "regexp_extract() pattern argument must be a scalar string literal".to_string(),
+                ));
             }
             ColumnarValue::Array(_) => {
                 return Err(datafusion::error::DataFusionError::Execution(
@@ -173,13 +180,10 @@ impl ScalarUDFImpl for RegexpExtractUdf {
                     0
                 }
             }
-            ColumnarValue::Array(arr) => {
-                let int_arr = arr.as_primitive::<arrow::datatypes::Int64Type>();
-                if int_arr.is_empty() || int_arr.is_null(0) {
-                    0
-                } else {
-                    int_arr.value(0) as usize
-                }
+            ColumnarValue::Array(_) => {
+                return Err(datafusion::error::DataFusionError::Execution(
+                    "regexp_extract() group_index argument must be a scalar integer literal, not an array column".to_string(),
+                ));
             }
         };
 
@@ -254,9 +258,15 @@ impl ScalarUDFImpl for RegexpExtractUdf {
                         datafusion::common::ScalarValue::Utf8(None),
                     ));
                 }
-                let val = scalar.to_string();
-                let val = val.trim_matches('"').trim_matches('\'');
-                match re.captures(val) {
+                // Extract the inner string directly from ScalarValue to avoid
+                // trim_matches corruption on values with boundary quotes.
+                let val = match scalar {
+                    datafusion::common::ScalarValue::Utf8(Some(s))
+                    | datafusion::common::ScalarValue::Utf8View(Some(s))
+                    | datafusion::common::ScalarValue::LargeUtf8(Some(s)) => s.clone(),
+                    other => other.to_string(),
+                };
+                match re.captures(&val) {
                     Some(caps) => match caps.get(idx) {
                         Some(m) => Ok(ColumnarValue::Scalar(
                             datafusion::common::ScalarValue::Utf8(Some(m.as_str().to_string())),
@@ -595,6 +605,83 @@ mod tests {
         let msg = err.to_string();
         assert!(
             msg.contains("pattern argument must be a scalar string literal"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    /// Regression (#1891): NULL pattern must return NULL, not compile "NULL" as regex.
+    #[test]
+    fn test_null_pattern_returns_null() {
+        let batch = make_batch();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            "SELECT regexp_extract(msg, CAST(NULL AS VARCHAR), 1) AS extracted FROM logs",
+        ));
+        let col = result.column_by_name("extracted").unwrap();
+        for row in 0..result.num_rows() {
+            assert!(
+                col.is_null(row),
+                "row {row}: NULL pattern must propagate NULL"
+            );
+        }
+    }
+
+    /// Regression (#1901): scalar input with boundary quotes must not be corrupted.
+    #[test]
+    fn test_scalar_input_preserves_boundary_quotes() {
+        let schema = Arc::new(Schema::new(vec![Field::new("msg", DataType::Utf8, true)]));
+        let msgs: Arc<dyn Array> = Arc::new(StringArray::from(vec![Some("dummy")]));
+        let batch = RecordBatch::try_new(schema, vec![msgs]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(run_sql(
+            batch,
+            r#"SELECT regexp_extract('"hello"', '(".*")', 1) AS extracted FROM logs"#,
+        ));
+        let col = result
+            .column_by_name("extracted")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(
+            col.value(0),
+            "\"hello\"",
+            "boundary quotes must be preserved"
+        );
+    }
+
+    /// Regression (#1889): array group_index must be rejected.
+    #[test]
+    fn test_rejects_array_group_index() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("msg", DataType::Utf8, true),
+            Field::new("idx", DataType::Int64, true),
+        ]));
+        let msg: Arc<dyn Array> = Arc::new(StringArray::from(vec![Some("status=200")]));
+        let idx: Arc<dyn Array> = Arc::new(Int64Array::from(vec![Some(1)]));
+        let batch = RecordBatch::try_new(schema, vec![msg, idx]).unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let err = rt
+            .block_on(run_sql_result(
+                batch,
+                "SELECT regexp_extract(msg, 'status=(\\d+)', idx) AS status FROM logs",
+            ))
+            .expect_err("array group_index must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("group_index argument must be a scalar integer literal"),
             "unexpected error: {msg}"
         );
     }


### PR DESCRIPTION
## Summary

Three fixes across `regexp_extract` and `grok` UDFs:

1. **#1891 + #1908**: NULL pattern argument now returns NULL for all rows instead of compiling the literal string "NULL" as a regex/grok pattern
2. **#1901**: Scalar string input extraction uses direct ScalarValue matching instead of `to_string()` + `trim_matches('"')` which corrupted values with boundary quotes
3. **#1889**: Array `group_index` argument now rejected with a clear error instead of silently using only row 0's value for all rows

Fixes #1889, fixes #1891, fixes #1901, fixes #1908

## Test plan

- [x] Added test for NULL pattern → NULL result in regexp_extract
- [x] Added test for NULL pattern → NULL result in grok
- [x] Added test for array group_index rejection
- [x] Added test for scalar string with boundary quotes preserved
- [x] All existing UDF tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix NULL pattern handling, quote trimming, and array `group_index` in grok and regexp_extract UDFs
> - NULL patterns in `GrokUdf` and `RegexpExtractUdf` now return a NULL result instead of treating the string `'NULL'` as a valid pattern.
> - Non-string scalar and array patterns now produce an execution error instead of being coerced via `to_string()`.
> - Scalar inputs extract strings directly from `Utf8`/`Utf8View`/`LargeUtf8` variants, removing the `trim_matches` call that stripped legitimate boundary quotes.
> - Array-valued `group_index` in `RegexpExtractUdf` now returns an execution error instead of silently reading the first element.
> - Regression tests added for all four behaviors in [grok.rs](https://github.com/strawgate/memagent/pull/1930/files#diff-b2afb20090fb53f827b886b3db7efac924faa0074a0b78f5ae770f041a8c83a5) and [regexp_extract.rs](https://github.com/strawgate/memagent/pull/1930/files#diff-53b1d1b12e649ff264f98f2e6c0509dbf5b22edfb236111cb2a636bc51516d97).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91f9c7f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->