### PR TITLE
fix: retry IoError and timeouts indefinitely in worker pool

### DIFF
--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -2086,16 +2086,18 @@ pipelines:
         let config = logfwd_config::Config::load_str(&yaml).unwrap();
         let pipe_cfg = &config.pipelines["default"];
         let mut pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter(), None).unwrap();
-        // always-failing: fails every call — pool exhausts retries and the
+        // always-failing: fails every call — workers retry indefinitely and the
         // pipeline must hold checkpoint progress instead of rejecting it.
         pipeline = pipeline.with_sink(Box::new(FailingSink::new(u32::MAX)));
         pipeline.batch_timeout = Duration::from_millis(20);
+        // Short drain timeout so pool cancels workers promptly on shutdown.
+        pipeline.set_pool_drain_timeout(Duration::from_secs(1));
 
         let shutdown = CancellationToken::new();
         let sd = shutdown.clone();
 
         tokio::spawn(async move {
-            // Give pool time to exhaust retries (4 attempts × ~100ms backoff ≈ 700ms)
+            // Give workers time to start retrying.
             tokio::time::sleep(Duration::from_millis(1500)).await;
             sd.cancel();
         });
@@ -2619,6 +2621,8 @@ output:
 
         let mut pipeline = pipeline_with_sink(&log_path, Box::new(FailingSink::new(u32::MAX)));
         pipeline.set_batch_timeout(Duration::from_millis(10));
+        // Short drain timeout so pool cancels indefinitely-retrying workers promptly.
+        pipeline.set_pool_drain_timeout(Duration::from_secs(1));
 
         let shutdown = CancellationToken::new();
         let sd = shutdown.clone();

--- a/crates/logfwd-runtime/src/worker_pool/pool.rs
+++ b/crates/logfwd-runtime/src/worker_pool/pool.rs
@@ -1527,7 +1527,7 @@ mod tests {
             Some(&"503".to_string())
         );
         assert!(
-            capture.contains_event_message("worker_pool: transient error, retrying with jitter"),
+            capture.contains_event_message("worker_pool: transient error, retrying"),
             "expected retry log event"
         );
         assert!(

--- a/crates/logfwd-runtime/src/worker_pool/worker.rs
+++ b/crates/logfwd-runtime/src/worker_pool/worker.rs
@@ -206,6 +206,17 @@ pub(super) async fn recv_with_idle_timeout(
 /// Returns `(outcome, send_latency_ns, retries)` where `send_latency_ns` is
 /// cumulative wall time inside `sink.send_batch()` across all attempts
 /// (excludes backoff sleep).
+///
+/// Retries indefinitely for transient failures (`IoError`, `RetryAfter`,
+/// timeouts) using exponential backoff capped at `max_retry_delay`. The
+/// worker blocks on its current batch, which propagates backpressure
+/// through the bounded worker channels to the pipeline and ultimately to
+/// inputs — matching Filebeat's delivery model. The only exits are:
+///
+/// - `Delivered` — batch was sent successfully
+/// - `Rejected` — sink permanently rejected the data (4xx, schema error)
+/// - `PoolClosed` — shutdown cancellation was observed
+/// - `InternalFailure` — unknown `SendResult` variant
 pub(super) async fn process_item(
     worker_id: usize,
     sink: &mut dyn Sink,
@@ -217,22 +228,22 @@ pub(super) async fn process_item(
 ) -> (DeliveryOutcome, u64, usize) {
     sink.begin_batch();
 
-    // Retry budget for transient IoError failures. When exhausted the worker
-    // reports RetryExhausted so the pipeline can hold tickets and initiate an
-    // orderly shutdown (checkpoints do not advance past undelivered data).
-    // RetryAfter (server-specified backoff) resets the cycle and retries
-    // indefinitely until cancellation since the server explicitly asked to wait.
-    const RETRY_BUDGET: usize = 3;
     const BATCH_TIMEOUT_SECS: u64 = 60;
 
-    let mut backoff = ExponentialBuilder::default()
-        .with_min_delay(Duration::from_millis(100))
-        .with_max_delay(max_retry_delay)
-        .with_factor(2.0)
-        .with_max_times(RETRY_BUDGET)
-        .with_jitter()
-        .build();
+    /// Build a fresh exponential backoff iterator.
+    fn new_backoff(max_retry_delay: Duration) -> backon::ExponentialBackoff {
+        ExponentialBuilder::default()
+            .with_min_delay(Duration::from_millis(100))
+            .with_max_delay(max_retry_delay)
+            .with_factor(2.0)
+            // Large per-cycle count; we reset the cycle when exhausted so
+            // the worker retries indefinitely until cancellation.
+            .with_max_times(10)
+            .with_jitter()
+            .build()
+    }
 
+    let mut backoff = new_backoff(max_retry_delay);
     let mut send_latency_ns: u64 = 0;
     let mut retries_count = 0;
 
@@ -256,13 +267,31 @@ pub(super) async fn process_item(
 
         match result {
             Err(_elapsed) => {
-                tracing::error!(
+                // Timeout — treat like a transient error: back off and retry.
+                // A hung send doesn't mean the output is permanently dead.
+                retries_count += 1;
+                let delay = backoff.next().unwrap_or_else(|| {
+                    backoff = new_backoff(max_retry_delay);
+                    backoff
+                        .next()
+                        .expect("fresh backoff yields at least one delay")
+                });
+                output_health.apply_worker_event(worker_id, OutputHealthEvent::Retrying);
+                tracing::warn!(
                     worker_id,
                     timeout_secs = BATCH_TIMEOUT_SECS,
-                    "worker_pool: batch send timed out"
+                    retries = retries_count,
+                    sleep_ms = delay.as_millis() as u64,
+                    "worker_pool: batch send timed out, retrying"
                 );
-                output_health.apply_worker_event(worker_id, OutputHealthEvent::FatalFailure);
-                return (DeliveryOutcome::TimedOut, send_latency_ns, retries_count);
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => {
+                        tracing::warn!(worker_id, "worker_pool: cancellation observed during timeout backoff");
+                        return (DeliveryOutcome::PoolClosed, send_latency_ns, retries_count);
+                    }
+                    () = tokio::time::sleep(delay) => {}
+                }
             }
             Ok(SendResult::Ok) => {
                 output_health.apply_worker_event(worker_id, OutputHealthEvent::DeliverySucceeded);
@@ -280,26 +309,19 @@ pub(super) async fn process_item(
                 );
             }
             Ok(SendResult::RetryAfter(retry_dur)) => {
-                // Server specified delay — consume a backoff slot but use
-                // the server's delay (capped at max_retry_delay).
+                // Server specified delay — use the server's delay (capped).
                 if backoff.next().is_none() {
-                    tracing::warn!(
-                        worker_id,
-                        retry_budget = RETRY_BUDGET,
-                        "worker_pool: retry budget exhausted under RetryAfter; continuing until cancellation"
-                    );
-                    backoff = ExponentialBuilder::default()
-                        .with_min_delay(Duration::from_millis(100))
-                        .with_max_delay(max_retry_delay)
-                        .with_factor(2.0)
-                        .with_max_times(RETRY_BUDGET)
-                        .with_jitter()
-                        .build();
+                    backoff = new_backoff(max_retry_delay);
                 }
                 retries_count += 1;
                 let sleep_for = retry_dur.min(max_retry_delay);
                 output_health.apply_worker_event(worker_id, OutputHealthEvent::Retrying);
-                tracing::warn!(worker_id, ?sleep_for, "worker_pool: rate-limited, retrying");
+                tracing::warn!(
+                    worker_id,
+                    ?sleep_for,
+                    retries = retries_count,
+                    "worker_pool: rate-limited, retrying"
+                );
                 tokio::select! {
                     biased;
                     () = cancel.cancelled() => {
@@ -309,40 +331,34 @@ pub(super) async fn process_item(
                     () = tokio::time::sleep(sleep_for) => {}
                 }
             }
-            Ok(SendResult::IoError(e)) => match backoff.next() {
-                Some(delay) => {
-                    retries_count += 1;
-                    output_health.apply_worker_event(worker_id, OutputHealthEvent::Retrying);
-                    tracing::warn!(
-                        worker_id,
-                        sleep_ms = delay.as_millis() as u64,
-                        error = %e,
-                        "worker_pool: transient error, retrying with jitter"
-                    );
-                    tokio::select! {
-                        biased;
-                        () = cancel.cancelled() => {
-                            tracing::warn!(worker_id, "worker_pool: cancellation observed during jitter backoff");
-                            return (DeliveryOutcome::PoolClosed, send_latency_ns, retries_count);
-                        }
-                        () = tokio::time::sleep(delay) => {}
+            Ok(SendResult::IoError(e)) => {
+                // Transient I/O error — retry indefinitely with backoff.
+                // Backpressure propagates naturally: while this worker blocks,
+                // the pipeline cannot submit new batches to it, slowing inputs.
+                retries_count += 1;
+                let delay = backoff.next().unwrap_or_else(|| {
+                    backoff = new_backoff(max_retry_delay);
+                    backoff
+                        .next()
+                        .expect("fresh backoff yields at least one delay")
+                });
+                output_health.apply_worker_event(worker_id, OutputHealthEvent::Retrying);
+                tracing::warn!(
+                    worker_id,
+                    sleep_ms = delay.as_millis() as u64,
+                    retries = retries_count,
+                    error = %e,
+                    "worker_pool: transient error, retrying"
+                );
+                tokio::select! {
+                    biased;
+                    () = cancel.cancelled() => {
+                        tracing::warn!(worker_id, "worker_pool: cancellation observed during retry backoff");
+                        return (DeliveryOutcome::PoolClosed, send_latency_ns, retries_count);
                     }
+                    () = tokio::time::sleep(delay) => {}
                 }
-                None => {
-                    tracing::error!(
-                        worker_id,
-                        retry_budget = RETRY_BUDGET,
-                        error = %e,
-                        "worker_pool: retry budget exhausted on transient error"
-                    );
-                    output_health.apply_worker_event(worker_id, OutputHealthEvent::FatalFailure);
-                    return (
-                        DeliveryOutcome::RetryExhausted,
-                        send_latency_ns,
-                        retries_count,
-                    );
-                }
-            },
+            }
             // Future SendResult variants (#[non_exhaustive]) — treat as failure.
             Ok(_) => {
                 output_health.apply_worker_event(worker_id, OutputHealthEvent::FatalFailure);

--- a/crates/logfwd-runtime/src/worker_pool/worker.rs
+++ b/crates/logfwd-runtime/src/worker_pool/worker.rs
@@ -229,18 +229,29 @@ pub(super) async fn process_item(
     sink.begin_batch();
 
     const BATCH_TIMEOUT_SECS: u64 = 60;
+    /// After this many retries, downgrade repeated warnings to debug level
+    /// to avoid unbounded log volume during extended outages.
+    const WARN_RETRY_LIMIT: usize = 5;
 
-    /// Build a fresh exponential backoff iterator.
+    /// Build a fresh exponential backoff iterator. Once exhausted the caller
+    /// should fall back to `max_retry_delay` directly (stay at cap) rather
+    /// than resetting to min — this avoids sawtooth retry spikes against an
+    /// unhealthy sink.
     fn new_backoff(max_retry_delay: Duration) -> backon::ExponentialBackoff {
+        let min_delay = Duration::from_millis(100).min(max_retry_delay);
         ExponentialBuilder::default()
-            .with_min_delay(Duration::from_millis(100))
+            .with_min_delay(min_delay)
             .with_max_delay(max_retry_delay)
             .with_factor(2.0)
-            // Large per-cycle count; we reset the cycle when exhausted so
-            // the worker retries indefinitely until cancellation.
             .with_max_times(10)
             .with_jitter()
             .build()
+    }
+
+    /// Get the next backoff delay, staying at `max_retry_delay` once the
+    /// iterator is exhausted (no panic, no cycle reset).
+    fn next_delay(backoff: &mut backon::ExponentialBackoff, max_retry_delay: Duration) -> Duration {
+        backoff.next().unwrap_or(max_retry_delay)
     }
 
     let mut backoff = new_backoff(max_retry_delay);
@@ -270,20 +281,25 @@ pub(super) async fn process_item(
                 // Timeout — treat like a transient error: back off and retry.
                 // A hung send doesn't mean the output is permanently dead.
                 retries_count += 1;
-                let delay = backoff.next().unwrap_or_else(|| {
-                    backoff = new_backoff(max_retry_delay);
-                    backoff
-                        .next()
-                        .expect("fresh backoff yields at least one delay")
-                });
+                let delay = next_delay(&mut backoff, max_retry_delay);
                 output_health.apply_worker_event(worker_id, OutputHealthEvent::Retrying);
-                tracing::warn!(
-                    worker_id,
-                    timeout_secs = BATCH_TIMEOUT_SECS,
-                    retries = retries_count,
-                    sleep_ms = delay.as_millis() as u64,
-                    "worker_pool: batch send timed out, retrying"
-                );
+                if retries_count <= WARN_RETRY_LIMIT {
+                    tracing::warn!(
+                        worker_id,
+                        timeout_secs = BATCH_TIMEOUT_SECS,
+                        retries = retries_count,
+                        sleep_ms = delay.as_millis() as u64,
+                        "worker_pool: batch send timed out, retrying"
+                    );
+                } else {
+                    tracing::debug!(
+                        worker_id,
+                        timeout_secs = BATCH_TIMEOUT_SECS,
+                        retries = retries_count,
+                        sleep_ms = delay.as_millis() as u64,
+                        "worker_pool: batch send timed out, retrying"
+                    );
+                }
                 tokio::select! {
                     biased;
                     () = cancel.cancelled() => {
@@ -310,9 +326,7 @@ pub(super) async fn process_item(
             }
             Ok(SendResult::RetryAfter(retry_dur)) => {
                 // Server specified delay — use the server's delay (capped).
-                if backoff.next().is_none() {
-                    backoff = new_backoff(max_retry_delay);
-                }
+                // Don't advance the backoff iterator; server controls timing.
                 retries_count += 1;
                 let sleep_for = retry_dur.min(max_retry_delay);
                 output_health.apply_worker_event(worker_id, OutputHealthEvent::Retrying);
@@ -336,20 +350,25 @@ pub(super) async fn process_item(
                 // Backpressure propagates naturally: while this worker blocks,
                 // the pipeline cannot submit new batches to it, slowing inputs.
                 retries_count += 1;
-                let delay = backoff.next().unwrap_or_else(|| {
-                    backoff = new_backoff(max_retry_delay);
-                    backoff
-                        .next()
-                        .expect("fresh backoff yields at least one delay")
-                });
+                let delay = next_delay(&mut backoff, max_retry_delay);
                 output_health.apply_worker_event(worker_id, OutputHealthEvent::Retrying);
-                tracing::warn!(
-                    worker_id,
-                    sleep_ms = delay.as_millis() as u64,
-                    retries = retries_count,
-                    error = %e,
-                    "worker_pool: transient error, retrying"
-                );
+                if retries_count <= WARN_RETRY_LIMIT {
+                    tracing::warn!(
+                        worker_id,
+                        sleep_ms = delay.as_millis() as u64,
+                        retries = retries_count,
+                        error = %e,
+                        "worker_pool: transient error, retrying"
+                    );
+                } else {
+                    tracing::debug!(
+                        worker_id,
+                        sleep_ms = delay.as_millis() as u64,
+                        retries = retries_count,
+                        error = %e,
+                        "worker_pool: transient error, retrying"
+                    );
+                }
                 tokio::select! {
                     biased;
                     () = cancel.cancelled() => {

--- a/crates/logfwd/tests/turmoil_sim/bug_hunt.rs
+++ b/crates/logfwd/tests/turmoil_sim/bug_hunt.rs
@@ -620,8 +620,11 @@ fn panic_after_initial_success_does_not_advance_checkpoint_past_gap() {
 // - later batches may still deliver,
 // - durable checkpoint never reaches end-of-input because failed gap is held.
 
+/// Transient IoError failures are retried indefinitely. After a burst of
+/// errors the worker eventually succeeds, all batches deliver, and the
+/// checkpoint advances to cover the full input — no data is held or lost.
 #[test]
-fn retry_exhausted_gap_blocks_checkpoint_even_after_later_successes() {
+fn transient_io_errors_retry_until_delivery_succeeds() {
     let mut sim = super::build_sim(90, 1);
 
     let factory = Arc::new(InstrumentedSinkFactory::new(vec![vec![
@@ -665,7 +668,7 @@ fn retry_exhausted_gap_blocks_checkpoint_even_after_later_successes() {
     let run_result = sim.run();
     assert!(
         run_result.is_ok(),
-        "pipeline must terminate under retry-exhaustion path; got {run_result:?}"
+        "pipeline must terminate cleanly; got {run_result:?}"
     );
 
     let delivered = delivered_counter.load(Ordering::Relaxed);
@@ -674,19 +677,15 @@ fn retry_exhausted_gap_blocks_checkpoint_even_after_later_successes() {
 
     assert!(
         calls >= 6,
-        "expected retry-exhaustion attempts plus later sends; calls={calls}"
+        "expected retry attempts plus successful sends; calls={calls}"
     );
     assert!(
-        delivered >= 2,
-        "expected first and later batches to deliver around retry-exhausted gap; delivered={delivered}"
+        delivered >= 3,
+        "all batches should eventually deliver after transient errors; delivered={delivered}"
     );
     assert!(
-        durable.is_some(),
-        "first successful batch should commit checkpoint progress"
-    );
-    assert!(
-        durable.unwrap_or_default() < input_total_bytes,
-        "checkpoint must remain behind full input because retry-exhausted gap is held; durable={durable:?} input_total_bytes={input_total_bytes}"
+        durable.unwrap_or_default() >= input_total_bytes,
+        "checkpoint should advance past all input once every batch delivers; durable={durable:?} input_total_bytes={input_total_bytes}"
     );
     ckpt_handle.assert_monotonic(1);
     ckpt_handle.assert_durable_not_ahead_of_updates(1);

--- a/crates/logfwd/tests/turmoil_sim/network_sim.rs
+++ b/crates/logfwd/tests/turmoil_sim/network_sim.rs
@@ -462,17 +462,17 @@ fn tcp_server_crash_preserves_pre_crash_delivery() {
     let total_received = server_handle_check.received_lines.load(Ordering::Relaxed);
 
     // The server received some data before the crash.
-    // After crash+bounce, more data may have been delivered.
-    // At minimum, pre-crash data must exist (it was already counted).
     assert!(
         pre_crash > 0,
         "expected data delivered before server crash, got 0"
     );
 
-    // Crash/bounce must not corrupt pre-crash data.
+    // With indefinite retry the worker keeps trying through the
+    // crash/bounce window. Pre-crash data is never lost, and
+    // additional data may arrive once the server is back up.
     assert!(
         total_received >= pre_crash,
-        "crash should not corrupt pre-crash data: total ({total_received}) < pre_crash ({pre_crash})"
+        "crash should not lose pre-crash data: total ({total_received}) < pre_crash ({pre_crash})"
     );
 }
 


### PR DESCRIPTION
## Summary

Workers now retry transient failures (`IoError`, send timeouts) **indefinitely** with capped exponential backoff, instead of giving up after 3 attempts (~2 seconds). This matches Filebeat's delivery model and fixes the root cause of pipeline death on transient network blips.

Closes #1799
Closes #1800

## Problem

The worker pool had a `RETRY_BUDGET` of 3 with exponential backoff totaling ~2 seconds. Any network disruption longer than that exhausted retries → `RetryExhausted` → `Hold` → pipeline immediately cancels and stops ingesting data. This made logfwd unable to survive routine output restarts, DNS hiccups, or brief network partitions.

## Solution

**Make `IoError` and timeout retries indefinite**, relying on bounded channel backpressure instead of finite retry budgets:

1. **Workers block on retries** — exponential backoff cycles reset after each cycle (10 retries per cycle, capped at `max_retry_delay`)
2. **Backpressure propagates naturally**: worker stuck → worker channel full → `pool.submit()` blocks → pipeline stops pulling → input channels fill → inputs pause reading
3. **Cancellation token** checked every retry iteration ensures TLA+ liveness: every batch eventually delivers OR the pipeline shuts down
4. **Timeouts now retry** instead of returning `TimedOut` — a hung send doesn't mean the output is permanently dead

### What's unchanged
- `RetryAfter` (server-specified backoff) — already retried indefinitely
- Worker panic handling — still causes worker exit and Hold (correct: sink in unknown state)
- `Rejected` — permanent sink rejection, no retry

### Delivery model comparison

| Collector | On retry exhaustion | Backpressure? |
|---|---|---|
| **Filebeat** | Retries forever | Yes (queue fills → inputs pause) |
| Vector | Drops batch | Optional disk buffer |
| **logfwd (before)** | Hold → pipeline dies | Broken |
| **logfwd (after)** | Retries forever | Yes (channels fill → inputs pause) |

## Test plan

- [x] `just fmt && just clippy` — zero warnings
- [x] `just test` — 1454 tests pass
- [x] Turmoil simulation — 62 tests pass (including crash/bounce, partition, chaos scenarios)
- [x] Updated `retry_exhausted_gap` test → `transient_io_errors_retry_until_delivery_succeeds` (verifies all batches deliver after burst of IoErrors)
- [x] Updated crash/bounce test comment to reflect indefinite retry behavior

## Files changed

- `crates/logfwd-runtime/src/worker_pool/worker.rs` — core fix: indefinite retry loop
- `crates/logfwd/tests/turmoil_sim/bug_hunt.rs` — updated test for new behavior  
- `crates/logfwd/tests/turmoil_sim/network_sim.rs` — updated crash/bounce comment

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry IoError and timeouts indefinitely in worker pool with exponential backoff
> - Workers in [`worker.rs`](https://github.com/strawgate/memagent/pull/1932/files#diff-5c15f5bfaac602f49cae801d69a266493a44601112a1dac378304ede61bf45cb) now retry transient failures (I/O errors and per-batch timeouts) indefinitely using exponential backoff capped at `max_retry_delay`, instead of exhausting a fixed `RETRY_BUDGET`.
> - Timeouts from `tokio::time::timeout` are now treated as transient and retried rather than producing a `TimedOut`/`FatalFailure` outcome.
> - Log verbosity for repeated retries downgrades from WARN to DEBUG after a threshold (`WARN_RETRY_LIMIT`) to limit log volume.
> - Workers only exit on success, permanent rejection, cancellation, or an unknown `SendResult`.
> - Behavioral Change: `IoError` no longer produces `RetryExhausted` and timeouts no longer produce `TimedOut`; both now retry until cancellation or success.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 1c14bc7. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->