### PR TITLE
fix: clean up SOCK_OWNERS on failed TCP connects

### DIFF
--- a/crates/logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-kern/src/main.rs
+++ b/crates/logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-kern/src/main.rs
@@ -38,6 +38,7 @@ use sensor_ebpf_common::*;
 const TCP_ESTABLISHED: i32 = 1;
 const TCP_SYN_SENT: i32 = 2;
 const TCP_SYN_RECV: i32 = 3;
+const TCP_CLOSE: i32 = 7;
 
 /// 16 MB ring buffer — ~100ms headroom at high event rate.
 #[map]
@@ -491,7 +492,7 @@ fn try_sock_state(ctx: &TracePointContext) -> Result<(), i64> {
 
     // Outbound connect: SYN_SENT → ESTABLISHED
     if oldstate == TCP_SYN_SENT && newstate == TCP_ESTABLISHED {
-        let skaddr: u64 = unsafe { ctx.read_at(8).unwrap_or(0) }; // SAFETY: fixed ABI offset
+        let skaddr: u64 = unsafe { ctx.read_at(8)? };
 
         let mut entry = match EVENTS.reserve::<TcpConnectEvent>(0) {
             Some(e) => e,
@@ -514,19 +515,23 @@ fn try_sock_state(ctx: &TracePointContext) -> Result<(), i64> {
         entry.submit(0);
     }
 
-    // Failed connect: SYN_SENT → anything other than ESTABLISHED (refused, timeout, reset).
-    // Clean up cached process info so SOCK_OWNERS does not leak entries (#1934).
-    if oldstate == TCP_SYN_SENT && newstate != TCP_ESTABLISHED {
-        // SAFETY: fixed ABI offset for skaddr
-        let skaddr: u64 = unsafe { ctx.read_at(8).unwrap_or(0) };
+    // Failed connect: clean up SOCK_OWNERS on terminal failure states.
+    // Excludes SYN_SENT → SYN_RECV (simultaneous open) and
+    // SYN_SENT → ESTABLISHED (handled above). (#1934)
+    if oldstate == TCP_SYN_SENT
+        && newstate != TCP_ESTABLISHED
+        && newstate != TCP_SYN_RECV
+    {
+        let skaddr: u64 = unsafe { ctx.read_at(8)? };
         SOCK_OWNERS.remove(&skaddr).ok();
     }
 
-    // Safety net: any transition to CLOSE removes stale entries that survived
-    // unexpected state paths (e.g. aborted handshakes, resets after ESTABLISHED).
+    // Safety net: on transition to CLOSE, remove any stale entries that
+    // survived unexpected state paths (e.g. resets after ESTABLISHED).
+    // Only fires for sockets that passed through tcp_v4_connect (kprobe),
+    // so the hashmap lookup is bounded by the connect rate.
     if newstate == TCP_CLOSE && oldstate != TCP_SYN_SENT {
-        // SAFETY: fixed ABI offset for skaddr
-        let skaddr: u64 = unsafe { ctx.read_at(8).unwrap_or(0) };
+        let skaddr: u64 = unsafe { ctx.read_at(8)? };
         SOCK_OWNERS.remove(&skaddr).ok();
     }
 

--- a/crates/logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-kern/src/main.rs
+++ b/crates/logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-kern/src/main.rs
@@ -514,6 +514,22 @@ fn try_sock_state(ctx: &TracePointContext) -> Result<(), i64> {
         entry.submit(0);
     }
 
+    // Failed connect: SYN_SENT → anything other than ESTABLISHED (refused, timeout, reset).
+    // Clean up cached process info so SOCK_OWNERS does not leak entries (#1934).
+    if oldstate == TCP_SYN_SENT && newstate != TCP_ESTABLISHED {
+        // SAFETY: fixed ABI offset for skaddr
+        let skaddr: u64 = unsafe { ctx.read_at(8).unwrap_or(0) };
+        SOCK_OWNERS.remove(&skaddr).ok();
+    }
+
+    // Safety net: any transition to CLOSE removes stale entries that survived
+    // unexpected state paths (e.g. aborted handshakes, resets after ESTABLISHED).
+    if newstate == TCP_CLOSE && oldstate != TCP_SYN_SENT {
+        // SAFETY: fixed ABI offset for skaddr
+        let skaddr: u64 = unsafe { ctx.read_at(8).unwrap_or(0) };
+        SOCK_OWNERS.remove(&skaddr).ok();
+    }
+
     // Inbound accept: SYN_RECV → ESTABLISHED
     if oldstate == TCP_SYN_RECV && newstate == TCP_ESTABLISHED {
         let mut entry = match EVENTS.reserve::<TcpAcceptEvent>(0) {


### PR DESCRIPTION
## Summary

The `SOCK_OWNERS` BPF HashMap caches process info from `tcp_connect` so `inet_sock_set_state` can attribute connections to the right process. Entries were only removed on successful connect (`SYN_SENT → ESTABLISHED`), but failed connects (refused, timeout, reset) left stale entries that leaked until the 8192-entry map was exhausted, causing:

1. **Lost process attribution** — new connections can't insert into a full map
2. **Misattribution** — if a socket address is reused, the stale entry maps a new connection to the wrong process

## Changes

Added two cleanup paths in `try_sock_state`:

- **`* → CLOSE` (excluding SYN_SENT)**: safety net for unexpected state paths (aborted handshakes, resets after ESTABLISHED)

## Test plan

- eBPF kernel code — verified by CI eBPF probe compilation lane
- Logic review: the `remove()` call is idempotent (no-op if key absent), so the safety net path has zero overhead for normal flows

Closes #1934

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `SOCK_OWNERS` cleanup on failed TCP connects in `try_sock_state`
> - Adds cleanup logic in the `inet_sock_set_state` eBPF handler to remove `SOCK_OWNERS` entries when a TCP connection fails (SYN_SENT → non-ESTABLISHED/SYN_RECV) or transitions to CLOSE (excluding SYN_SENT → CLOSE).
> - Adds a `TCP_CLOSE` constant (value `7`) to support the new CLOSE-state cleanup branch.
> - Behavioral Change: reading `skaddr` in the SYN_SENT → ESTABLISHED path now propagates errors instead of silently using `0` as a map key on failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c35889.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->