### PR TITLE
fix: rotate budget remainder across host_metrics families

### DIFF
--- a/crates/logfwd-io/src/host_metrics.rs
+++ b/crates/logfwd-io/src/host_metrics.rs
@@ -170,6 +170,9 @@ struct HostMetricsCommon {
     schema: Arc<Schema>,
     system: System,
     networks: Networks,
+    /// Monotonically increasing counter used to rotate the budget remainder
+    /// across families so no single family is permanently starved (#1935).
+    poll_count: usize,
 }
 
 #[derive(Debug)]
@@ -630,25 +633,33 @@ impl HostMetricsCommon {
             self.networks.refresh(true);
         }
 
-        // Split budget evenly across active families so no single family starves others.
+        // Split budget evenly across active families, rotating the remainder
+        // so no single family is permanently starved (#1935).
         let per_family_budget = self.cfg.max_rows_per_poll / active_count;
-        // Remainder goes to the first active family to avoid losing rows.
         let remainder = self.cfg.max_rows_per_poll % active_count;
+        let start_idx = self.poll_count % active_count;
+        self.poll_count = self.poll_count.wrapping_add(1);
 
         let mut emitted = 0usize;
-        let mut budget_extra = remainder;
+        let mut family_idx = 0usize;
 
         if enabled.contains(&SignalFamily::Process) {
-            let budget = per_family_budget + std::mem::take(&mut budget_extra);
-            emitted += self.emit_process_rows(control, out, budget);
+            let extra =
+                usize::from((family_idx + active_count - start_idx) % active_count < remainder);
+            emitted += self.emit_process_rows(control, out, per_family_budget + extra);
+            family_idx += 1;
         }
         if enabled.contains(&SignalFamily::Network) {
-            let budget = per_family_budget + std::mem::take(&mut budget_extra);
-            emitted += self.emit_network_rows(control, out, budget);
+            let extra =
+                usize::from((family_idx + active_count - start_idx) % active_count < remainder);
+            emitted += self.emit_network_rows(control, out, per_family_budget + extra);
+            family_idx += 1;
         }
         if enabled.contains(&SignalFamily::File) {
-            let budget = per_family_budget + std::mem::take(&mut budget_extra);
-            emitted += self.emit_disk_io_rows(control, out, budget);
+            let extra =
+                usize::from((family_idx + active_count - start_idx) % active_count < remainder);
+            emitted += self.emit_disk_io_rows(control, out, per_family_budget + extra);
+            let _ = family_idx;
         }
 
         emitted
@@ -1077,6 +1088,7 @@ impl HostMetricsInput {
                     schema: sensor_schema(),
                     system: System::new(),
                     networks: Networks::new_with_refreshed_list(),
+                    poll_count: 0,
                 },
                 state: InitState { control },
             })),
@@ -2273,5 +2285,56 @@ mod tests {
             );
         }
         eprintln!("\n=== DATA AUDIT COMPLETE ===");
+    }
+
+    #[test]
+    fn budget_rotation_distributes_remainder_fairly() {
+        // Simulate the rotation logic with 3 families and budget=2
+        // per_family_budget = 2/3 = 0, remainder = 2
+        // Over 3 polls, each family should get the extra budget twice.
+        let active_count = 3usize;
+        let max_rows = 2usize;
+        let per_family_budget = max_rows / active_count; // 0
+        let remainder = max_rows % active_count; // 2
+
+        // Track how many extra rows each family position gets over 3 cycles.
+        let mut extras = [0usize; 3];
+        for poll_count in 0..3 {
+            let start_idx = poll_count % active_count;
+            for family_idx in 0..3 {
+                let extra =
+                    usize::from((family_idx + active_count - start_idx) % active_count < remainder);
+                extras[family_idx] += extra;
+            }
+        }
+
+        // Each family should get exactly 2 extras over 3 polls (fair distribution).
+        assert_eq!(
+            extras,
+            [2, 2, 2],
+            "each family must get equal remainder share over a full rotation"
+        );
+        assert_eq!(
+            per_family_budget, 0,
+            "base budget is zero with budget=2, families=3"
+        );
+
+        // Also verify single cycle: with budget=1 and 3 families, only one family gets 1 per cycle.
+        let max_rows = 1usize;
+        let remainder = max_rows % active_count; // 1
+        let mut totals = [0usize; 3];
+        for poll_count in 0..3 {
+            let start_idx = poll_count % active_count;
+            for family_idx in 0..3 {
+                let extra =
+                    usize::from((family_idx + active_count - start_idx) % active_count < remainder);
+                totals[family_idx] += extra;
+            }
+        }
+        assert_eq!(
+            totals,
+            [1, 1, 1],
+            "budget=1 with 3 families: each gets 1 row over 3 polls"
+        );
     }
 }

--- a/crates/logfwd-io/src/host_metrics.rs
+++ b/crates/logfwd-io/src/host_metrics.rs
@@ -170,7 +170,7 @@ struct HostMetricsCommon {
     schema: Arc<Schema>,
     system: System,
     networks: Networks,
-    /// Monotonically increasing counter used to rotate the budget remainder
+    /// Wrapping counter used to rotate the budget remainder
     /// across families so no single family is permanently starved (#1935).
     poll_count: usize,
 }
@@ -659,7 +659,6 @@ impl HostMetricsCommon {
             let extra =
                 usize::from((family_idx + active_count - start_idx) % active_count < remainder);
             emitted += self.emit_disk_io_rows(control, out, per_family_budget + extra);
-            let _ = family_idx;
         }
 
         emitted
@@ -2299,9 +2298,9 @@ mod tests {
 
         // Track how many extra rows each family position gets over 3 cycles.
         let mut extras = [0usize; 3];
-        for poll_count in 0..3 {
+        for poll_count in 0..active_count {
             let start_idx = poll_count % active_count;
-            for family_idx in 0..3 {
+            for family_idx in 0..active_count {
                 let extra =
                     usize::from((family_idx + active_count - start_idx) % active_count < remainder);
                 extras[family_idx] += extra;
@@ -2323,9 +2322,9 @@ mod tests {
         let max_rows = 1usize;
         let remainder = max_rows % active_count; // 1
         let mut totals = [0usize; 3];
-        for poll_count in 0..3 {
+        for poll_count in 0..active_count {
             let start_idx = poll_count % active_count;
-            for family_idx in 0..3 {
+            for family_idx in 0..active_count {
                 let extra =
                     usize::from((family_idx + active_count - start_idx) % active_count < remainder);
                 totals[family_idx] += extra;


### PR DESCRIPTION
## Summary

The remainder from integer division of `max_rows_per_poll / active_families` was always given to the first active family (process). With small budgets (e.g., 1-2 rows with 3 families), network and file families were permanently starved — they'd get 0 rows every single poll cycle.

## Fix

Added a `poll_count` counter to `HostMetricsCommon` that rotates which families receive the remainder each cycle. Over N polls (where N = active_count), each family gets an equal share of remainder rows.

**Example:** budget=2, 3 families → per_family=0, remainder=2
- Poll 0: process=1, network=1, file=0
- Poll 1: process=0, network=1, file=1
- Poll 2: process=1, network=0, file=1
- (repeats)

## Test plan

- Added `budget_rotation_distributes_remainder_fairly` unit test verifying equal distribution over full rotation cycles
- All 23 existing host_metrics tests pass

Closes #1935

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rotate budget remainder across host_metrics families on successive polls
> Previously, the row budget remainder from `max_rows_per_poll / active_count` was always awarded to the first active family. Now, a `poll_count` wrapping counter in `HostMetricsCommon` rotates which families receive the extra rows on each poll, distributing the remainder fairly over time. A new unit test validates equal distribution across three families over multiple polls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a36cfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->