### PR TITLE
test: add journald e2e integration tests and fix native backend flags

### DIFF
--- a/crates/logfwd-io/src/journal_ffi.rs
+++ b/crates/logfwd-io/src/journal_ffi.rs
@@ -62,6 +62,7 @@ type FnSeekTail = unsafe extern "C" fn(*mut SdJournal) -> i32;
 type FnSeekCursor = unsafe extern "C" fn(*mut SdJournal, *const libc::c_char) -> i32;
 
 type FnGetCursor = unsafe extern "C" fn(*mut SdJournal, *mut *mut libc::c_char) -> i32;
+type FnTestCursor = unsafe extern "C" fn(*mut SdJournal, *const libc::c_char) -> i32;
 type FnGetData =
     unsafe extern "C" fn(*mut SdJournal, *const libc::c_char, *mut *const u8, *mut usize) -> i32;
 type FnEnumerateData = unsafe extern "C" fn(*mut SdJournal, *mut *const u8, *mut usize) -> i32;
@@ -93,6 +94,7 @@ struct LibSystemd {
     seek_tail: FnSeekTail,
     seek_cursor: FnSeekCursor,
     get_cursor: FnGetCursor,
+    test_cursor: FnTestCursor,
     get_data: FnGetData,
     enumerate_data: FnEnumerateData,
     restart_data: FnRestartData,
@@ -156,6 +158,7 @@ impl LibSystemd {
                 seek_tail: sym!(b"sd_journal_seek_tail\0", FnSeekTail),
                 seek_cursor: sym!(b"sd_journal_seek_cursor\0", FnSeekCursor),
                 get_cursor: sym!(b"sd_journal_get_cursor\0", FnGetCursor),
+                test_cursor: sym!(b"sd_journal_test_cursor\0", FnTestCursor),
                 get_data: sym!(b"sd_journal_get_data\0", FnGetData),
                 enumerate_data: sym!(b"sd_journal_enumerate_data\0", FnEnumerateData),
                 restart_data: sym!(b"sd_journal_restart_data\0", FnRestartData),
@@ -345,6 +348,24 @@ impl Journal {
             libc::free(raw.cast());
         }
         Ok(cursor)
+    }
+
+    /// Test whether the current journal position matches the given cursor.
+    ///
+    /// Returns `true` if the cursor matches, `false` otherwise. Useful after
+    /// [`seek_cursor`](Self::seek_cursor) to determine whether the cursor entry
+    /// still exists or if the journal positioned on the next closest entry.
+    pub fn test_cursor(&mut self, cursor: &str) -> io::Result<bool> {
+        let c_cursor =
+            CString::new(cursor).map_err(|_| io::Error::other("cursor contains null byte"))?;
+        // SAFETY: `self.handle` is valid. `c_cursor` is a valid NUL-terminated
+        // C string that remains live for the duration of this call.
+        let ret = unsafe { (self.lib.test_cursor)(self.handle, c_cursor.as_ptr()) };
+        if ret < 0 {
+            Err(sd_err(ret))
+        } else {
+            Ok(ret > 0)
+        }
     }
 
     /// Get the value of a specific field from the current entry.

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -414,14 +414,30 @@ fn native_reader_loop(
                 if let Some(ref cursor) = last_cursor {
                     match journal.seek_cursor(cursor) {
                         Ok(()) => {
-                            // If the cursor entry still exists, we're
-                            // positioned ON it (already emitted) and must
-                            // skip past it. If it was rotated out,
-                            // seek_cursor positioned us on the next closest
-                            // entry which hasn't been emitted yet — don't
-                            // skip it.
-                            if journal.test_cursor(cursor).unwrap_or(false) {
-                                let _ = journal.next();
+                            // seek_cursor sets up position but does NOT land
+                            // on an entry — must call next() first, which
+                            // returns the cursor entry (if it still exists)
+                            // or the next closest entry.
+                            match journal.next() {
+                                Ok(true) => {
+                                    if journal.test_cursor(cursor).unwrap_or(false) {
+                                        // On the cursor entry (already
+                                        // emitted). The drain loop's next()
+                                        // will advance to new entries.
+                                    } else {
+                                        // Cursor was rotated out; we landed
+                                        // on the first unread entry. Back up
+                                        // so the drain loop's next() returns
+                                        // it instead of skipping it.
+                                        let _ = journal.previous();
+                                    }
+                                }
+                                Ok(false) => {
+                                    // No entries at or after cursor.
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "sd_journal_next error during invalidate recovery");
+                                }
                             }
                         }
                         Err(e) => {

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -360,11 +360,6 @@ fn native_reader_loop(
 
             match journal.next() {
                 Ok(true) => {
-                    // Save cursor before reading data (cheap string copy).
-                    if let Ok(c) = journal.cursor() {
-                        last_cursor = Some(c);
-                    }
-
                     // Build JSON from entry fields.
                     match entry_to_json(&mut journal, &exclude_units, &mut json_buf) {
                         Ok(Some(())) => {
@@ -394,7 +389,14 @@ fn native_reader_loop(
                         }
                     }
                 }
-                Ok(false) => break, // No more entries; wait.
+                Ok(false) => {
+                    // Save cursor once per drain cycle (not per-entry) to
+                    // avoid an allocation on every entry in the hot path.
+                    if let Ok(c) = journal.cursor() {
+                        last_cursor = Some(c);
+                    }
+                    break; // No more entries; wait.
+                }
                 Err(e) => {
                     tracing::warn!(error = %e, "sd_journal_next error");
                     break;
@@ -409,13 +411,17 @@ fn native_reader_loop(
                 // handle state may be stale, causing next() to return false
                 // even when new entries exist. Re-seek to restore position.
                 if let Some(ref cursor) = last_cursor {
-                    if let Err(e) = journal.seek_cursor(cursor) {
-                        tracing::warn!(error = %e, "failed to re-seek after journal invalidate");
+                    match journal.seek_cursor(cursor) {
+                        Ok(()) => {
+                            // seek_cursor positions ON the cursor entry (already
+                            // emitted). Advance past it so the drain loop reads
+                            // only new entries.
+                            let _ = journal.next();
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, "failed to re-seek after journal invalidate");
+                        }
                     }
-                    // seek_cursor positions ON the cursor entry (already
-                    // emitted). Advance past it so the drain loop reads
-                    // only new entries.
-                    let _ = journal.next();
                 } else {
                     // No entries read yet — restore initial seek position.
                     if let Err(e) = seek_start(&mut journal, config) {

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -432,7 +432,9 @@ fn native_reader_loop(
 
 /// Open a journal handle with the appropriate flags/directory/namespace.
 fn open_native_journal(config: &JournaldConfig) -> io::Result<journal_ffi::Journal> {
-    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
+    // SD_JOURNAL_LOCAL_ONLY reads both system and user journals from the
+    // local machine, matching the default behavior of `journalctl --follow`.
+    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY;
 
     let mut journal = if let Some(ref dir) = config.journal_directory {
         // sd_journal_open_directory only accepts 0 or SD_JOURNAL_OS_ROOT.

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -20,7 +20,7 @@ use crossbeam_channel::{Receiver, TrySendError, bounded};
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 
 use crate::input::{InputEvent, InputSource};
-use crate::journal_ffi;
+use crate::journal_ffi::{self, SD_JOURNAL_INVALIDATE};
 
 /// Channel capacity between the reader thread and `poll()`.
 const CHANNEL_CAPACITY: usize = 4096;
@@ -343,6 +343,11 @@ fn native_reader_loop(
     // Reusable buffer for JSON serialization.
     let mut json_buf = Vec::with_capacity(4096);
 
+    // Track the last-read cursor so we can recover after INVALIDATE.
+    // Seed it with the current position (from seek_start) so since_now
+    // recovery works even before the first entry is processed.
+    let mut last_cursor: Option<String> = journal.cursor().ok();
+
     loop {
         if !running.load(Ordering::Acquire) {
             return;
@@ -356,6 +361,11 @@ fn native_reader_loop(
 
             match journal.next() {
                 Ok(true) => {
+                    // Save cursor before reading data (cheap string copy).
+                    if let Ok(c) = journal.cursor() {
+                        last_cursor = Some(c);
+                    }
+
                     // Build JSON from entry fields.
                     match entry_to_json(&mut journal, &exclude_units, &mut json_buf) {
                         Ok(Some(())) => {
@@ -395,7 +405,20 @@ fn native_reader_loop(
 
         // Wait for new entries (with periodic timeout to check running flag).
         match journal.wait(NATIVE_WAIT_USEC) {
-            Ok(_) => {} // NOP, APPEND, or INVALIDATE — all handled by next loop iteration
+            Ok(SD_JOURNAL_INVALIDATE) => {
+                // Journal files were rotated/added/removed. The internal file
+                // handle state may be stale, causing next() to return false
+                // even when new entries exist. Re-seek to our saved cursor so
+                // the drain loop's next() call picks up new entries.
+                if let Some(ref cursor) = last_cursor {
+                    if let Err(e) = journal.seek_cursor(cursor) {
+                        tracing::warn!(error = %e, "failed to re-seek after journal invalidate");
+                    }
+                    // Don't call next() here — the drain loop will call it,
+                    // advancing past the cursor entry to the first new one.
+                }
+            }
+            Ok(_) => {} // NOP or APPEND — next loop iteration will drain.
             Err(e) => {
                 tracing::warn!(error = %e, "sd_journal_wait error");
                 health.store(HEALTH_DEGRADED, Ordering::Release);

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -363,6 +363,14 @@ fn native_reader_loop(
                     // Build JSON from entry fields.
                     match entry_to_json(&mut journal, &exclude_units, &mut json_buf) {
                         Ok(Some(())) => {
+                            // Save cursor of this entry before sending. We do
+                            // this per-entry (not at drain-loop exit) because
+                            // cursor() is only reliable while positioned on a
+                            // valid entry (next()→true).
+                            if let Ok(c) = journal.cursor() {
+                                last_cursor = Some(c);
+                            }
+
                             json_buf.push(b'\n');
                             // Move the buffer to avoid cloning; allocate a
                             // fresh one for the next entry.
@@ -389,14 +397,7 @@ fn native_reader_loop(
                         }
                     }
                 }
-                Ok(false) => {
-                    // Save cursor once per drain cycle (not per-entry) to
-                    // avoid an allocation on every entry in the hot path.
-                    if let Ok(c) = journal.cursor() {
-                        last_cursor = Some(c);
-                    }
-                    break; // No more entries; wait.
-                }
+                Ok(false) => break, // No more entries; wait.
                 Err(e) => {
                     tracing::warn!(error = %e, "sd_journal_next error");
                     break;
@@ -413,10 +414,15 @@ fn native_reader_loop(
                 if let Some(ref cursor) = last_cursor {
                     match journal.seek_cursor(cursor) {
                         Ok(()) => {
-                            // seek_cursor positions ON the cursor entry (already
-                            // emitted). Advance past it so the drain loop reads
-                            // only new entries.
-                            let _ = journal.next();
+                            // If the cursor entry still exists, we're
+                            // positioned ON it (already emitted) and must
+                            // skip past it. If it was rotated out,
+                            // seek_cursor positioned us on the next closest
+                            // entry which hasn't been emitted yet — don't
+                            // skip it.
+                            if journal.test_cursor(cursor).unwrap_or(false) {
+                                let _ = journal.next();
+                            }
                         }
                         Err(e) => {
                             tracing::warn!(error = %e, "failed to re-seek after journal invalidate");

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -344,9 +344,8 @@ fn native_reader_loop(
     let mut json_buf = Vec::with_capacity(4096);
 
     // Track the last-read cursor so we can recover after INVALIDATE.
-    // Seed it with the current position (from seek_start) so since_now
-    // recovery works even before the first entry is processed.
-    let mut last_cursor: Option<String> = journal.cursor().ok();
+    // Starts as None — only set after actually emitting an entry.
+    let mut last_cursor: Option<String> = None;
 
     loop {
         if !running.load(Ordering::Acquire) {
@@ -408,14 +407,20 @@ fn native_reader_loop(
             Ok(SD_JOURNAL_INVALIDATE) => {
                 // Journal files were rotated/added/removed. The internal file
                 // handle state may be stale, causing next() to return false
-                // even when new entries exist. Re-seek to our saved cursor so
-                // the drain loop's next() call picks up new entries.
+                // even when new entries exist. Re-seek to restore position.
                 if let Some(ref cursor) = last_cursor {
                     if let Err(e) = journal.seek_cursor(cursor) {
                         tracing::warn!(error = %e, "failed to re-seek after journal invalidate");
                     }
-                    // Don't call next() here — the drain loop will call it,
-                    // advancing past the cursor entry to the first new one.
+                    // seek_cursor positions ON the cursor entry (already
+                    // emitted). Advance past it so the drain loop reads
+                    // only new entries.
+                    let _ = journal.next();
+                } else {
+                    // No entries read yet — restore initial seek position.
+                    if let Err(e) = seek_start(&mut journal, config) {
+                        tracing::warn!(error = %e, "failed to re-seek after journal invalidate");
+                    }
                 }
             }
             Ok(_) => {} // NOP or APPEND — next loop iteration will drain.

--- a/crates/logfwd-io/tests/it/journald_e2e.rs
+++ b/crates/logfwd-io/tests/it/journald_e2e.rs
@@ -33,7 +33,11 @@ fn journald_available() -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
-        && Command::new("logger").arg("--version").output().is_ok()
+        && Command::new("logger")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
 }
 
 /// Write `n` test entries to the journal with a unique tag and message prefix.
@@ -159,14 +163,9 @@ fn subprocess_reads_journal_entries() {
         return;
     }
 
-    let tag = unique_tag("subprocess-basic");
-    write_journal_entries(&tag, 5);
-
-    // Small sleep to let journal flush.
-    std::thread::sleep(Duration::from_millis(200));
-
     let config = JournaldConfig {
         backend: JournaldBackendPref::Subprocess,
+        since_now: true,
         current_boot_only: true,
         ..Default::default()
     };
@@ -176,15 +175,21 @@ fn subprocess_reads_journal_entries() {
 
     assert_eq!(input.backend(), JournaldBackend::Subprocess);
 
-    let lines = poll_until_lines(&mut input, 1, Duration::from_secs(10));
+    // Write entries AFTER creating the input in since_now mode.
+    std::thread::sleep(Duration::from_millis(500));
+    let tag = unique_tag("subprocess-basic");
+    write_journal_entries(&tag, 5);
 
+    let lines = poll_until_match(&mut input, &tag, Duration::from_secs(10));
+
+    let our_entries: Vec<&String> = lines.iter().filter(|l| l.contains(&tag)).collect();
     assert!(
-        !lines.is_empty(),
-        "expected at least one journal entry via subprocess backend"
+        !our_entries.is_empty(),
+        "expected entries with tag={tag} via subprocess backend"
     );
 
     // Verify output is valid JSON.
-    for line in &lines {
+    for line in &our_entries {
         let parsed: serde_json::Value = serde_json::from_str(line)
             .unwrap_or_else(|e| panic!("invalid JSON: {e}\nline: {line}"));
         assert!(parsed.is_object(), "expected JSON object, got {parsed}");
@@ -308,7 +313,13 @@ fn subprocess_since_now_skips_history() {
     );
 }
 
-/// Exclude units filter works.
+/// Exclude units filter works — entries from excluded systemd units are dropped.
+///
+/// Note: `logger(1)` entries typically have no `_SYSTEMD_UNIT` field, so we
+/// verify the filter doesn't suppress our test entries (positive case) and
+/// that the underlying filter mechanism is wired up. The exclude_units logic
+/// operates on `_SYSTEMD_UNIT`, which is set by systemd for service-managed
+/// processes.
 #[test]
 #[ignore]
 fn subprocess_exclude_units_filters() {
@@ -317,26 +328,35 @@ fn subprocess_exclude_units_filters() {
         return;
     }
 
+    // Exclude a common system unit. Our logger entries don't carry
+    // _SYSTEMD_UNIT, so they should always pass through regardless.
     let config = JournaldConfig {
         backend: JournaldBackendPref::Subprocess,
         since_now: true,
         current_boot_only: true,
-        // Exclude sshd — a commonly noisy unit on the test host.
-        exclude_units: vec!["sshd".to_string()],
+        exclude_units: vec!["ssh.service".to_string()],
         ..Default::default()
     };
 
     let mut input = JournaldInput::new("test-exclude", config, make_stats())
         .expect("failed to create journald input");
 
-    // Write an entry that should appear (logger goes to user/syslog, not sshd).
+    // Write entries that should NOT be excluded (logger → no _SYSTEMD_UNIT).
+    std::thread::sleep(Duration::from_millis(500));
     let tag = unique_tag("subprocess-excl");
-    write_journal_entries(&tag, 2);
+    write_journal_entries(&tag, 3);
 
-    let lines = poll_until_lines(&mut input, 1, Duration::from_secs(10));
+    let lines = poll_until_match(&mut input, &tag, Duration::from_secs(10));
 
-    // Verify no sshd entries snuck through.
-    let sshd_entries: Vec<&String> = lines
+    // Our logger entries must pass through the exclude filter.
+    let our_entries: Vec<&String> = lines.iter().filter(|l| l.contains(&tag)).collect();
+    assert!(
+        !our_entries.is_empty(),
+        "logger entries should not be excluded (tag={tag})"
+    );
+
+    // Verify no ssh.service entries snuck through (if any were generated).
+    let excluded_entries: Vec<&String> = lines
         .iter()
         .filter(|l| {
             serde_json::from_str::<serde_json::Value>(l)
@@ -346,15 +366,15 @@ fn subprocess_exclude_units_filters() {
                         .and_then(|u| u.as_str())
                         .map(String::from)
                 })
-                .map(|u| u.contains("sshd"))
+                .map(|u| u.contains("ssh"))
                 .unwrap_or(false)
         })
         .collect();
 
     assert!(
-        sshd_entries.is_empty(),
-        "exclude_units should filter sshd entries, found {} sshd lines",
-        sshd_entries.len()
+        excluded_entries.is_empty(),
+        "exclude_units should filter ssh.service entries, found {} lines",
+        excluded_entries.len()
     );
 }
 
@@ -413,7 +433,7 @@ fn subprocess_drop_stops_reader() {
     // Capture the backend confirmation.
     assert_eq!(input.backend(), JournaldBackend::Subprocess);
 
-    // Drop should kill the child process and join the reader thread.
+    // Drop signals the reader thread to stop (via the running flag / child kill).
     drop(input);
 
     // If we reach here without hanging, the reader thread exited cleanly.
@@ -436,12 +456,9 @@ fn native_reads_journal_entries() {
         return;
     }
 
-    let tag = unique_tag("native-basic");
-    write_journal_entries(&tag, 5);
-    std::thread::sleep(Duration::from_millis(200));
-
     let config = JournaldConfig {
         backend: JournaldBackendPref::Native,
+        since_now: true,
         current_boot_only: true,
         ..Default::default()
     };
@@ -451,15 +468,21 @@ fn native_reads_journal_entries() {
 
     assert_eq!(input.backend(), JournaldBackend::Native);
 
-    let lines = poll_until_lines(&mut input, 1, Duration::from_secs(10));
+    // Write entries AFTER creating the input in since_now mode.
+    std::thread::sleep(Duration::from_millis(500));
+    let tag = unique_tag("native-basic");
+    write_journal_entries(&tag, 5);
 
+    let lines = poll_until_match(&mut input, &tag, Duration::from_secs(10));
+
+    let our_entries: Vec<&String> = lines.iter().filter(|l| l.contains(&tag)).collect();
     assert!(
-        !lines.is_empty(),
-        "expected at least one journal entry via native backend"
+        !our_entries.is_empty(),
+        "expected entries with tag={tag} via native backend"
     );
 
     // Verify output is valid JSON.
-    for line in &lines {
+    for line in &our_entries {
         let parsed: serde_json::Value = serde_json::from_str(line)
             .unwrap_or_else(|e| panic!("invalid JSON: {e}\nline: {line}"));
         assert!(parsed.is_object(), "expected JSON object");

--- a/crates/logfwd-io/tests/it/journald_e2e.rs
+++ b/crates/logfwd-io/tests/it/journald_e2e.rs
@@ -1,0 +1,849 @@
+//! End-to-end integration tests for the journald input source.
+//!
+//! These tests exercise both the subprocess and native backends against the
+//! real systemd journal on the host. They write test entries via `logger(1)`,
+//! then verify the input reads them back with correct field mapping.
+//!
+//! All tests are `#[ignore]` because they require:
+//! - Linux with systemd/journald running
+//! - `logger` and `journalctl` in PATH
+//! - libsystemd.so.0 for native backend tests
+//!
+//! CI runs them in the "Test (network integration)" job via `--run-ignored all`.
+
+use std::process::Command;
+use std::sync::Arc;
+use std::time::Duration;
+
+use logfwd_io::input::{InputEvent, InputSource};
+use logfwd_io::journal_ffi;
+use logfwd_io::journald_input::{JournaldBackend, JournaldBackendPref, JournaldConfig, JournaldInput};
+use logfwd_types::diagnostics::ComponentStats;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if systemd-journald is running and `logger` is available.
+fn journald_available() -> bool {
+    Command::new("journalctl")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+        && Command::new("logger")
+            .arg("--version")
+            .output()
+            .is_ok()
+}
+
+/// Write `n` test entries to the journal with a unique tag and message prefix.
+/// Returns the tag used so callers can filter on it.
+fn write_journal_entries(tag: &str, n: usize) -> String {
+    for i in 0..n {
+        let status = Command::new("logger")
+            .arg("-t")
+            .arg(tag)
+            .arg(format!("test-entry-{i}"))
+            .status()
+            .expect("failed to run logger");
+        assert!(status.success(), "logger exited with {status}");
+    }
+    tag.to_string()
+}
+
+/// Poll `input` until at least `expected` bytes of data arrive or `timeout`
+/// elapses. Returns all collected raw bytes.
+fn poll_until_bytes(input: &mut dyn InputSource, expected: usize, timeout: Duration) -> Vec<u8> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut backoff = Duration::from_millis(10);
+    let max_backoff = Duration::from_millis(200);
+    let mut all = Vec::new();
+
+    while std::time::Instant::now() < deadline {
+        for event in input.poll().unwrap() {
+            if let InputEvent::Data { bytes, .. } = event {
+                all.extend_from_slice(&bytes);
+            }
+        }
+        if all.len() >= expected {
+            // One more drain pass.
+            std::thread::sleep(Duration::from_millis(50));
+            for event in input.poll().unwrap() {
+                if let InputEvent::Data { bytes, .. } = event {
+                    all.extend_from_slice(&bytes);
+                }
+            }
+            return all;
+        }
+        std::thread::sleep(backoff);
+        backoff = (backoff * 2).min(max_backoff);
+    }
+    all
+}
+
+/// Poll `input` until we've collected at least `min_lines` newline-delimited
+/// JSON entries, or `timeout` elapses. Returns the parsed lines.
+fn poll_until_lines(
+    input: &mut dyn InputSource,
+    min_lines: usize,
+    timeout: Duration,
+) -> Vec<String> {
+    let raw = poll_until_bytes(input, min_lines * 20, timeout);
+    let text = String::from_utf8_lossy(&raw);
+    text.lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
+}
+
+/// Poll `input` until at least one line containing `needle` is found, or
+/// `timeout` elapses. Returns all collected lines.
+fn poll_until_match(
+    input: &mut dyn InputSource,
+    needle: &str,
+    timeout: Duration,
+) -> Vec<String> {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut all_bytes = Vec::new();
+
+    while std::time::Instant::now() < deadline {
+        for event in input.poll().unwrap() {
+            if let InputEvent::Data { bytes, .. } = event {
+                all_bytes.extend_from_slice(&bytes);
+            }
+        }
+        let text = String::from_utf8_lossy(&all_bytes);
+        if text.contains(needle) {
+            // Drain once more to collect any trailing entries.
+            std::thread::sleep(Duration::from_millis(100));
+            for event in input.poll().unwrap() {
+                if let InputEvent::Data { bytes, .. } = event {
+                    all_bytes.extend_from_slice(&bytes);
+                }
+            }
+            let text = String::from_utf8_lossy(&all_bytes);
+            return text
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| l.to_string())
+                .collect();
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    let text = String::from_utf8_lossy(&all_bytes);
+    text.lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
+}
+
+/// Create a unique tag for this test to avoid cross-test contamination.
+fn unique_tag(test_name: &str) -> String {
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("logfwd-test-{test_name}-{ts}")
+}
+
+fn make_stats() -> Arc<ComponentStats> {
+    Arc::new(ComponentStats::new())
+}
+
+// ---------------------------------------------------------------------------
+// Subprocess backend tests
+// ---------------------------------------------------------------------------
+
+/// Happy path: write entries, read them back via subprocess backend.
+#[test]
+#[ignore]
+fn subprocess_reads_journal_entries() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+
+    let tag = unique_tag("subprocess-basic");
+    write_journal_entries(&tag, 5);
+
+    // Small sleep to let journal flush.
+    std::thread::sleep(Duration::from_millis(200));
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Subprocess,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let mut input = JournaldInput::new("test-sub", config, make_stats())
+        .expect("failed to create journald input");
+
+    assert_eq!(input.backend(), JournaldBackend::Subprocess);
+
+    let lines = poll_until_lines(&mut input, 1, Duration::from_secs(10));
+
+    assert!(
+        !lines.is_empty(),
+        "expected at least one journal entry via subprocess backend"
+    );
+
+    // Verify output is valid JSON.
+    for line in &lines {
+        let parsed: serde_json::Value =
+            serde_json::from_str(line).unwrap_or_else(|e| panic!("invalid JSON: {e}\nline: {line}"));
+        assert!(parsed.is_object(), "expected JSON object, got {parsed}");
+    }
+}
+
+/// Verify entries contain expected fields from the journal export format.
+#[test]
+#[ignore]
+fn subprocess_entries_contain_standard_fields() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Subprocess,
+        since_now: true,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let mut input = JournaldInput::new("test-fields", config, make_stats())
+        .expect("failed to create journald input");
+
+    // Write entries AFTER creating the input (since_now only sees new entries).
+    std::thread::sleep(Duration::from_millis(500));
+    let tag = unique_tag("subprocess-fields");
+    write_journal_entries(&tag, 3);
+
+    let lines = poll_until_match(&mut input, &tag, Duration::from_secs(10));
+    assert!(!lines.is_empty(), "expected journal entries");
+
+    // Find our tagged entries.
+    let our_entries: Vec<serde_json::Value> = lines
+        .iter()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .filter(|v: &serde_json::Value| {
+            v.get("SYSLOG_IDENTIFIER")
+                .and_then(|s| s.as_str())
+                .map(|s| s == tag)
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert!(
+        !our_entries.is_empty(),
+        "expected to find entries with tag={tag} in {} total lines",
+        lines.len()
+    );
+
+    // Every entry should have these standard journal fields.
+    for entry in &our_entries {
+        assert!(
+            entry.get("MESSAGE").is_some(),
+            "entry missing MESSAGE field: {entry}"
+        );
+        assert!(
+            entry.get("PRIORITY").is_some(),
+            "entry missing PRIORITY field: {entry}"
+        );
+        assert!(
+            entry.get("_PID").is_some(),
+            "entry missing _PID field: {entry}"
+        );
+        assert!(
+            entry.get("_HOSTNAME").is_some(),
+            "entry missing _HOSTNAME field: {entry}"
+        );
+    }
+
+    // Verify our message content.
+    let messages: Vec<&str> = our_entries
+        .iter()
+        .filter_map(|e| e.get("MESSAGE").and_then(|m| m.as_str()))
+        .collect();
+    assert!(
+        messages.iter().any(|m| m.contains("test-entry-0")),
+        "expected test-entry-0 in messages: {messages:?}"
+    );
+}
+
+/// Since-now mode skips historical entries.
+#[test]
+#[ignore]
+fn subprocess_since_now_skips_history() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+
+    let old_tag = unique_tag("subprocess-old");
+    write_journal_entries(&old_tag, 3);
+    std::thread::sleep(Duration::from_millis(200));
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Subprocess,
+        since_now: true,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let mut input = JournaldInput::new("test-since-now", config, make_stats())
+        .expect("failed to create journald input");
+
+    // Wait a bit, then write new entries.
+    std::thread::sleep(Duration::from_millis(500));
+    let new_tag = unique_tag("subprocess-new");
+    write_journal_entries(&new_tag, 2);
+
+    let lines = poll_until_match(&mut input, &new_tag, Duration::from_secs(10));
+
+    // We should see the new entries but not the old ones.
+    let has_new = lines.iter().any(|l| l.contains(&new_tag));
+    let has_old = lines.iter().any(|l| l.contains(&old_tag));
+
+    assert!(has_new, "expected new entries (tag={new_tag}) in output");
+    assert!(!has_old, "since_now should skip old entries (tag={old_tag})");
+}
+
+/// Exclude units filter works.
+#[test]
+#[ignore]
+fn subprocess_exclude_units_filters() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Subprocess,
+        since_now: true,
+        current_boot_only: true,
+        // Exclude sshd — a commonly noisy unit on the test host.
+        exclude_units: vec!["sshd".to_string()],
+        ..Default::default()
+    };
+
+    let mut input = JournaldInput::new("test-exclude", config, make_stats())
+        .expect("failed to create journald input");
+
+    // Write an entry that should appear (logger goes to user/syslog, not sshd).
+    let tag = unique_tag("subprocess-excl");
+    write_journal_entries(&tag, 2);
+
+    let lines = poll_until_lines(&mut input, 1, Duration::from_secs(10));
+
+    // Verify no sshd entries snuck through.
+    let sshd_entries: Vec<&String> = lines
+        .iter()
+        .filter(|l| {
+            serde_json::from_str::<serde_json::Value>(l)
+                .ok()
+                .and_then(|v| v.get("_SYSTEMD_UNIT").and_then(|u| u.as_str()).map(String::from))
+                .map(|u| u.contains("sshd"))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert!(
+        sshd_entries.is_empty(),
+        "exclude_units should filter sshd entries, found {} sshd lines",
+        sshd_entries.len()
+    );
+}
+
+/// Input reports healthy after startup.
+#[test]
+#[ignore]
+fn subprocess_health_becomes_healthy() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Subprocess,
+        since_now: true,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let mut input = JournaldInput::new("test-health", config, make_stats())
+        .expect("failed to create journald input");
+
+    // Write an entry to trigger the reader thread to emit data.
+    let tag = unique_tag("subprocess-health");
+    write_journal_entries(&tag, 1);
+
+    // Poll until data arrives — health should transition from Starting to OK.
+    let _ = poll_until_lines(&mut input, 1, Duration::from_secs(10));
+
+    let health = input.health();
+    assert!(
+        matches!(
+            health,
+            logfwd_types::diagnostics::ComponentHealth::Healthy
+        ),
+        "expected Healthy after receiving data, got {health:?}"
+    );
+}
+
+/// Drop stops the reader thread cleanly.
+#[test]
+#[ignore]
+fn subprocess_drop_stops_reader() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Subprocess,
+        since_now: true,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let input = JournaldInput::new("test-drop", config, make_stats())
+        .expect("failed to create journald input");
+
+    // Capture the backend confirmation.
+    assert_eq!(input.backend(), JournaldBackend::Subprocess);
+
+    // Drop should kill the child process and join the reader thread.
+    drop(input);
+
+    // If we reach here without hanging, the reader thread exited cleanly.
+}
+
+// ---------------------------------------------------------------------------
+// Native backend tests
+// ---------------------------------------------------------------------------
+
+/// Happy path: read entries via native sd_journal API.
+#[test]
+#[ignore]
+fn native_reads_journal_entries() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+    if !journal_ffi::is_native_available() {
+        eprintln!("SKIP: libsystemd.so.0 not available");
+        return;
+    }
+
+    let tag = unique_tag("native-basic");
+    write_journal_entries(&tag, 5);
+    std::thread::sleep(Duration::from_millis(200));
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Native,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let mut input = JournaldInput::new("test-native", config, make_stats())
+        .expect("failed to create journald input");
+
+    assert_eq!(input.backend(), JournaldBackend::Native);
+
+    let lines = poll_until_lines(&mut input, 1, Duration::from_secs(10));
+
+    assert!(
+        !lines.is_empty(),
+        "expected at least one journal entry via native backend"
+    );
+
+    // Verify output is valid JSON.
+    for line in &lines {
+        let parsed: serde_json::Value =
+            serde_json::from_str(line).unwrap_or_else(|e| panic!("invalid JSON: {e}\nline: {line}"));
+        assert!(parsed.is_object(), "expected JSON object");
+    }
+}
+
+/// Native backend entries have the same field contract as subprocess.
+#[test]
+#[ignore]
+fn native_entries_contain_standard_fields() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+    if !journal_ffi::is_native_available() {
+        eprintln!("SKIP: libsystemd.so.0 not available");
+        return;
+    }
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Native,
+        since_now: true,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let mut input = JournaldInput::new("test-native-fields", config, make_stats())
+        .expect("failed to create journald input");
+
+    // Write entries AFTER creating the input (since_now only sees new entries).
+    std::thread::sleep(Duration::from_millis(500));
+    let tag = unique_tag("native-fields");
+    write_journal_entries(&tag, 3);
+
+    let lines = poll_until_match(&mut input, &tag, Duration::from_secs(10));
+    assert!(!lines.is_empty(), "expected journal entries");
+
+    let our_entries: Vec<serde_json::Value> = lines
+        .iter()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .filter(|v: &serde_json::Value| {
+            v.get("SYSLOG_IDENTIFIER")
+                .and_then(|s| s.as_str())
+                .map(|s| s == tag)
+                .unwrap_or(false)
+        })
+        .collect();
+
+    assert!(
+        !our_entries.is_empty(),
+        "expected entries with tag={tag}"
+    );
+
+    for entry in &our_entries {
+        assert!(entry.get("MESSAGE").is_some(), "missing MESSAGE");
+        assert!(entry.get("PRIORITY").is_some(), "missing PRIORITY");
+        assert!(entry.get("_PID").is_some(), "missing _PID");
+        assert!(entry.get("_HOSTNAME").is_some(), "missing _HOSTNAME");
+    }
+}
+
+/// Native backend since_now mode.
+#[test]
+#[ignore]
+fn native_since_now_skips_history() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+    if !journal_ffi::is_native_available() {
+        eprintln!("SKIP: libsystemd.so.0 not available");
+        return;
+    }
+
+    let old_tag = unique_tag("native-old");
+    write_journal_entries(&old_tag, 3);
+    std::thread::sleep(Duration::from_millis(200));
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Native,
+        since_now: true,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let mut input = JournaldInput::new("test-native-since", config, make_stats())
+        .expect("failed to create journald input");
+
+    std::thread::sleep(Duration::from_millis(500));
+    let new_tag = unique_tag("native-new");
+    write_journal_entries(&new_tag, 2);
+
+    let lines = poll_until_match(&mut input, &new_tag, Duration::from_secs(10));
+
+    let has_new = lines.iter().any(|l| l.contains(&new_tag));
+    let has_old = lines.iter().any(|l| l.contains(&old_tag));
+
+    assert!(has_new, "expected new entries (tag={new_tag}) in output");
+    assert!(!has_old, "since_now should skip old entries (tag={old_tag})");
+}
+
+// ---------------------------------------------------------------------------
+// Auto-fallback backend test
+// ---------------------------------------------------------------------------
+
+/// Auto backend selects native when libsystemd is available.
+#[test]
+#[ignore]
+fn auto_backend_selects_native_when_available() {
+    if !journald_available() {
+        eprintln!("SKIP: journald not available");
+        return;
+    }
+
+    let config = JournaldConfig {
+        backend: JournaldBackendPref::Auto,
+        since_now: true,
+        current_boot_only: true,
+        ..Default::default()
+    };
+
+    let input = JournaldInput::new("test-auto", config, make_stats())
+        .expect("failed to create journald input");
+
+    let expected = if journal_ffi::is_native_available() {
+        JournaldBackend::Native
+    } else {
+        JournaldBackend::Subprocess
+    };
+
+    assert_eq!(
+        input.backend(),
+        expected,
+        "auto backend should select {expected:?} based on libsystemd availability"
+    );
+}
+
+/// Debug: exhaustive test of recovery strategies
+#[test]
+#[ignore]
+fn debug_native_recovery_strategies() {
+    if !journal_ffi::is_native_available() {
+        eprintln!("SKIP");
+        return;
+    }
+    
+    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
+    let mut j = journal_ffi::Journal::open(flags).expect("open");
+    
+    // Apply boot filter like production code does
+    let boot_id = std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+        .unwrap().trim().replace('-', "");
+    j.add_match(format!("_BOOT_ID={boot_id}").as_bytes()).unwrap();
+    
+    j.seek_tail().unwrap();
+    let prev = j.previous().unwrap();
+    eprintln!("previous: {prev}");
+    
+    let cursor = if prev { Some(j.cursor().unwrap()) } else { None };
+    eprintln!("cursor: {cursor:?}");
+    
+    // Drain any entries
+    loop { if !j.next().unwrap() { break; } }
+    
+    // Write entries
+    let tag = unique_tag("recovery");
+    write_journal_entries(&tag, 3);
+    eprintln!("wrote 3 entries with tag: {tag}");
+    
+    // Try multiple wait + next cycles
+    for attempt in 0..10 {
+        let w = j.wait(500_000).unwrap_or(-1); // 500ms
+        eprintln!("attempt {attempt}: wait={w}");
+        
+        let mut found = 0;
+        loop {
+            match j.next() {
+                Ok(true) => {
+                    found += 1;
+                    // Check if it's our entry
+                    j.restart_data();
+                    let mut is_ours = false;
+                    while let Ok(Some(field)) = j.enumerate_data() {
+                        let s = String::from_utf8_lossy(field);
+                        if s.contains(&tag) {
+                            is_ours = true;
+                            eprintln!("  found our entry: {}", &s[..s.len().min(80)]);
+                        }
+                    }
+                    if is_ours {
+                        eprintln!("SUCCESS on attempt {attempt}!");
+                        return;
+                    }
+                }
+                Ok(false) => break,
+                Err(e) => { eprintln!("  next error: {e}"); break; }
+            }
+        }
+        eprintln!("  found {found} entries, none ours");
+        
+        // Try seek_cursor recovery on attempt 5
+        if attempt == 5 {
+            if let Some(ref c) = cursor {
+                eprintln!("  trying seek_cursor recovery");
+                j.seek_cursor(c).unwrap();
+            }
+        }
+    }
+    eprintln!("FAILED: never found our entries");
+    panic!("native recovery failed");
+}
+
+/// Debug: minimal native since_now test without any filters
+#[test]
+#[ignore]
+fn debug_native_no_filter() {
+    if !journal_ffi::is_native_available() {
+        eprintln!("SKIP");
+        return;
+    }
+    
+    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
+    let mut j = journal_ffi::Journal::open(flags).expect("open");
+    
+    // NO match filters - just open + seek_tail + previous
+    j.seek_tail().unwrap();
+    let _ = j.previous().unwrap();
+    
+    // Drain
+    loop { if !j.next().unwrap() { break; } }
+    
+    let tag = unique_tag("nofilter");
+    write_journal_entries(&tag, 2);
+    eprintln!("wrote: {tag}");
+    
+    for i in 0..10 {
+        let w = j.wait(500_000).unwrap_or(-1);
+        let mut found = false;
+        loop {
+            match j.next() {
+                Ok(true) => {
+                    j.restart_data();
+                    while let Ok(Some(f)) = j.enumerate_data() {
+                        let s = String::from_utf8_lossy(f);
+                        if s.contains(&tag) {
+                            eprintln!("FOUND on iter {i}: {}", &s[..s.len().min(100)]);
+                            found = true;
+                        }
+                    }
+                }
+                Ok(false) => break,
+                Err(_) => break,
+            }
+        }
+        if found { return; }
+        eprintln!("iter {i}: wait={w}, not found yet");
+    }
+    panic!("never found entries");
+}
+
+/// Debug: seek_head + drain all + then follow new entries
+#[test]
+#[ignore]
+fn debug_native_drain_then_follow() {
+    if !journal_ffi::is_native_available() {
+        eprintln!("SKIP");
+        return;
+    }
+    
+    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
+    let mut j = journal_ffi::Journal::open(flags).expect("open");
+    
+    // Seek to head and drain ALL existing entries
+    j.seek_head().unwrap();
+    let mut count = 0u64;
+    loop {
+        match j.next() {
+            Ok(true) => count += 1,
+            _ => break,
+        }
+    }
+    eprintln!("drained {count} existing entries");
+    
+    // Now write new entries
+    let tag = unique_tag("drain-follow");
+    write_journal_entries(&tag, 2);
+    eprintln!("wrote: {tag}");
+    
+    // Follow
+    for i in 0..10 {
+        let w = j.wait(500_000).unwrap_or(-1);
+        let mut found = false;
+        loop {
+            match j.next() {
+                Ok(true) => {
+                    j.restart_data();
+                    while let Ok(Some(f)) = j.enumerate_data() {
+                        let s = String::from_utf8_lossy(f);
+                        if s.contains(&tag) {
+                            eprintln!("FOUND on iter {i}: {}", &s[..s.len().min(100)]);
+                            found = true;
+                        }
+                    }
+                }
+                Ok(false) => break,
+                Err(_) => break,
+            }
+        }
+        if found { return; }
+        eprintln!("iter {i}: wait={w}, not found");
+    }
+    panic!("never found");
+}
+
+/// Debug: fresh journal handle opened AFTER entries are written
+#[test]
+#[ignore]
+fn debug_native_fresh_handle() {
+    if !journal_ffi::is_native_available() {
+        eprintln!("SKIP");
+        return;
+    }
+    
+    // Write entries first
+    let tag = unique_tag("fresh");
+    write_journal_entries(&tag, 2);
+    std::thread::sleep(Duration::from_millis(500));
+    
+    // Open a fresh handle
+    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
+    let mut j = journal_ffi::Journal::open(flags).expect("open");
+    
+    j.seek_tail().unwrap();
+    
+    // Go back 10 entries from tail
+    for _ in 0..10 {
+        if !j.previous().unwrap() { break; }
+    }
+    
+    // Now try to find our entries
+    let mut found = false;
+    for _ in 0..100 {
+        match j.next() {
+            Ok(true) => {
+                j.restart_data();
+                while let Ok(Some(f)) = j.enumerate_data() {
+                    let s = String::from_utf8_lossy(f);
+                    if s.contains(&tag) {
+                        eprintln!("FOUND: {}", &s[..s.len().min(100)]);
+                        found = true;
+                    }
+                }
+            }
+            _ => break,
+        }
+    }
+    assert!(found, "entries should be visible in a fresh handle");
+    
+    // Now write MORE entries and see if wait+next works
+    let tag2 = unique_tag("fresh2");
+    write_journal_entries(&tag2, 2);
+    eprintln!("wrote tag2: {tag2}");
+    
+    for i in 0..10 {
+        let w = j.wait(500_000).unwrap_or(-1);
+        let mut found2 = false;
+        loop {
+            match j.next() {
+                Ok(true) => {
+                    j.restart_data();
+                    while let Ok(Some(f)) = j.enumerate_data() {
+                        let s = String::from_utf8_lossy(f);
+                        if s.contains(&tag2) {
+                            eprintln!("FOUND tag2 on iter {i}: {}", &s[..s.len().min(100)]);
+                            found2 = true;
+                        }
+                    }
+                }
+                _ => break,
+            }
+        }
+        if found2 { return; }
+        eprintln!("iter {i}: wait={w}, tag2 not found");
+    }
+    panic!("tag2 never found in follow mode");
+}

--- a/crates/logfwd-io/tests/it/journald_e2e.rs
+++ b/crates/logfwd-io/tests/it/journald_e2e.rs
@@ -366,7 +366,7 @@ fn subprocess_exclude_units_filters() {
                         .and_then(|u| u.as_str())
                         .map(String::from)
                 })
-                .map(|u| u.contains("ssh"))
+                .map(|u| u == "ssh.service")
                 .unwrap_or(false)
         })
         .collect();

--- a/crates/logfwd-io/tests/it/journald_e2e.rs
+++ b/crates/logfwd-io/tests/it/journald_e2e.rs
@@ -17,7 +17,9 @@ use std::time::Duration;
 
 use logfwd_io::input::{InputEvent, InputSource};
 use logfwd_io::journal_ffi;
-use logfwd_io::journald_input::{JournaldBackend, JournaldBackendPref, JournaldConfig, JournaldInput};
+use logfwd_io::journald_input::{
+    JournaldBackend, JournaldBackendPref, JournaldConfig, JournaldInput,
+};
 use logfwd_types::diagnostics::ComponentStats;
 
 // ---------------------------------------------------------------------------
@@ -31,10 +33,7 @@ fn journald_available() -> bool {
         .output()
         .map(|o| o.status.success())
         .unwrap_or(false)
-        && Command::new("logger")
-            .arg("--version")
-            .output()
-            .is_ok()
+        && Command::new("logger").arg("--version").output().is_ok()
 }
 
 /// Write `n` test entries to the journal with a unique tag and message prefix.
@@ -99,11 +98,7 @@ fn poll_until_lines(
 
 /// Poll `input` until at least one line containing `needle` is found, or
 /// `timeout` elapses. Returns all collected lines.
-fn poll_until_match(
-    input: &mut dyn InputSource,
-    needle: &str,
-    timeout: Duration,
-) -> Vec<String> {
+fn poll_until_match(input: &mut dyn InputSource, needle: &str, timeout: Duration) -> Vec<String> {
     let deadline = std::time::Instant::now() + timeout;
     let mut all_bytes = Vec::new();
 
@@ -190,8 +185,8 @@ fn subprocess_reads_journal_entries() {
 
     // Verify output is valid JSON.
     for line in &lines {
-        let parsed: serde_json::Value =
-            serde_json::from_str(line).unwrap_or_else(|e| panic!("invalid JSON: {e}\nline: {line}"));
+        let parsed: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("invalid JSON: {e}\nline: {line}"));
         assert!(parsed.is_object(), "expected JSON object, got {parsed}");
     }
 }
@@ -307,7 +302,10 @@ fn subprocess_since_now_skips_history() {
     let has_old = lines.iter().any(|l| l.contains(&old_tag));
 
     assert!(has_new, "expected new entries (tag={new_tag}) in output");
-    assert!(!has_old, "since_now should skip old entries (tag={old_tag})");
+    assert!(
+        !has_old,
+        "since_now should skip old entries (tag={old_tag})"
+    );
 }
 
 /// Exclude units filter works.
@@ -343,7 +341,11 @@ fn subprocess_exclude_units_filters() {
         .filter(|l| {
             serde_json::from_str::<serde_json::Value>(l)
                 .ok()
-                .and_then(|v| v.get("_SYSTEMD_UNIT").and_then(|u| u.as_str()).map(String::from))
+                .and_then(|v| {
+                    v.get("_SYSTEMD_UNIT")
+                        .and_then(|u| u.as_str())
+                        .map(String::from)
+                })
                 .map(|u| u.contains("sshd"))
                 .unwrap_or(false)
         })
@@ -384,10 +386,7 @@ fn subprocess_health_becomes_healthy() {
 
     let health = input.health();
     assert!(
-        matches!(
-            health,
-            logfwd_types::diagnostics::ComponentHealth::Healthy
-        ),
+        matches!(health, logfwd_types::diagnostics::ComponentHealth::Healthy),
         "expected Healthy after receiving data, got {health:?}"
     );
 }
@@ -461,8 +460,8 @@ fn native_reads_journal_entries() {
 
     // Verify output is valid JSON.
     for line in &lines {
-        let parsed: serde_json::Value =
-            serde_json::from_str(line).unwrap_or_else(|e| panic!("invalid JSON: {e}\nline: {line}"));
+        let parsed: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("invalid JSON: {e}\nline: {line}"));
         assert!(parsed.is_object(), "expected JSON object");
     }
 }
@@ -509,10 +508,7 @@ fn native_entries_contain_standard_fields() {
         })
         .collect();
 
-    assert!(
-        !our_entries.is_empty(),
-        "expected entries with tag={tag}"
-    );
+    assert!(!our_entries.is_empty(), "expected entries with tag={tag}");
 
     for entry in &our_entries {
         assert!(entry.get("MESSAGE").is_some(), "missing MESSAGE");
@@ -559,7 +555,10 @@ fn native_since_now_skips_history() {
     let has_old = lines.iter().any(|l| l.contains(&old_tag));
 
     assert!(has_new, "expected new entries (tag={new_tag}) in output");
-    assert!(!has_old, "since_now should skip old entries (tag={old_tag})");
+    assert!(
+        !has_old,
+        "since_now should skip old entries (tag={old_tag})"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -596,254 +595,4 @@ fn auto_backend_selects_native_when_available() {
         expected,
         "auto backend should select {expected:?} based on libsystemd availability"
     );
-}
-
-/// Debug: exhaustive test of recovery strategies
-#[test]
-#[ignore]
-fn debug_native_recovery_strategies() {
-    if !journal_ffi::is_native_available() {
-        eprintln!("SKIP");
-        return;
-    }
-    
-    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
-    let mut j = journal_ffi::Journal::open(flags).expect("open");
-    
-    // Apply boot filter like production code does
-    let boot_id = std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
-        .unwrap().trim().replace('-', "");
-    j.add_match(format!("_BOOT_ID={boot_id}").as_bytes()).unwrap();
-    
-    j.seek_tail().unwrap();
-    let prev = j.previous().unwrap();
-    eprintln!("previous: {prev}");
-    
-    let cursor = if prev { Some(j.cursor().unwrap()) } else { None };
-    eprintln!("cursor: {cursor:?}");
-    
-    // Drain any entries
-    loop { if !j.next().unwrap() { break; } }
-    
-    // Write entries
-    let tag = unique_tag("recovery");
-    write_journal_entries(&tag, 3);
-    eprintln!("wrote 3 entries with tag: {tag}");
-    
-    // Try multiple wait + next cycles
-    for attempt in 0..10 {
-        let w = j.wait(500_000).unwrap_or(-1); // 500ms
-        eprintln!("attempt {attempt}: wait={w}");
-        
-        let mut found = 0;
-        loop {
-            match j.next() {
-                Ok(true) => {
-                    found += 1;
-                    // Check if it's our entry
-                    j.restart_data();
-                    let mut is_ours = false;
-                    while let Ok(Some(field)) = j.enumerate_data() {
-                        let s = String::from_utf8_lossy(field);
-                        if s.contains(&tag) {
-                            is_ours = true;
-                            eprintln!("  found our entry: {}", &s[..s.len().min(80)]);
-                        }
-                    }
-                    if is_ours {
-                        eprintln!("SUCCESS on attempt {attempt}!");
-                        return;
-                    }
-                }
-                Ok(false) => break,
-                Err(e) => { eprintln!("  next error: {e}"); break; }
-            }
-        }
-        eprintln!("  found {found} entries, none ours");
-        
-        // Try seek_cursor recovery on attempt 5
-        if attempt == 5 {
-            if let Some(ref c) = cursor {
-                eprintln!("  trying seek_cursor recovery");
-                j.seek_cursor(c).unwrap();
-            }
-        }
-    }
-    eprintln!("FAILED: never found our entries");
-    panic!("native recovery failed");
-}
-
-/// Debug: minimal native since_now test without any filters
-#[test]
-#[ignore]
-fn debug_native_no_filter() {
-    if !journal_ffi::is_native_available() {
-        eprintln!("SKIP");
-        return;
-    }
-    
-    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
-    let mut j = journal_ffi::Journal::open(flags).expect("open");
-    
-    // NO match filters - just open + seek_tail + previous
-    j.seek_tail().unwrap();
-    let _ = j.previous().unwrap();
-    
-    // Drain
-    loop { if !j.next().unwrap() { break; } }
-    
-    let tag = unique_tag("nofilter");
-    write_journal_entries(&tag, 2);
-    eprintln!("wrote: {tag}");
-    
-    for i in 0..10 {
-        let w = j.wait(500_000).unwrap_or(-1);
-        let mut found = false;
-        loop {
-            match j.next() {
-                Ok(true) => {
-                    j.restart_data();
-                    while let Ok(Some(f)) = j.enumerate_data() {
-                        let s = String::from_utf8_lossy(f);
-                        if s.contains(&tag) {
-                            eprintln!("FOUND on iter {i}: {}", &s[..s.len().min(100)]);
-                            found = true;
-                        }
-                    }
-                }
-                Ok(false) => break,
-                Err(_) => break,
-            }
-        }
-        if found { return; }
-        eprintln!("iter {i}: wait={w}, not found yet");
-    }
-    panic!("never found entries");
-}
-
-/// Debug: seek_head + drain all + then follow new entries
-#[test]
-#[ignore]
-fn debug_native_drain_then_follow() {
-    if !journal_ffi::is_native_available() {
-        eprintln!("SKIP");
-        return;
-    }
-    
-    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
-    let mut j = journal_ffi::Journal::open(flags).expect("open");
-    
-    // Seek to head and drain ALL existing entries
-    j.seek_head().unwrap();
-    let mut count = 0u64;
-    loop {
-        match j.next() {
-            Ok(true) => count += 1,
-            _ => break,
-        }
-    }
-    eprintln!("drained {count} existing entries");
-    
-    // Now write new entries
-    let tag = unique_tag("drain-follow");
-    write_journal_entries(&tag, 2);
-    eprintln!("wrote: {tag}");
-    
-    // Follow
-    for i in 0..10 {
-        let w = j.wait(500_000).unwrap_or(-1);
-        let mut found = false;
-        loop {
-            match j.next() {
-                Ok(true) => {
-                    j.restart_data();
-                    while let Ok(Some(f)) = j.enumerate_data() {
-                        let s = String::from_utf8_lossy(f);
-                        if s.contains(&tag) {
-                            eprintln!("FOUND on iter {i}: {}", &s[..s.len().min(100)]);
-                            found = true;
-                        }
-                    }
-                }
-                Ok(false) => break,
-                Err(_) => break,
-            }
-        }
-        if found { return; }
-        eprintln!("iter {i}: wait={w}, not found");
-    }
-    panic!("never found");
-}
-
-/// Debug: fresh journal handle opened AFTER entries are written
-#[test]
-#[ignore]
-fn debug_native_fresh_handle() {
-    if !journal_ffi::is_native_available() {
-        eprintln!("SKIP");
-        return;
-    }
-    
-    // Write entries first
-    let tag = unique_tag("fresh");
-    write_journal_entries(&tag, 2);
-    std::thread::sleep(Duration::from_millis(500));
-    
-    // Open a fresh handle
-    let flags = journal_ffi::SD_JOURNAL_LOCAL_ONLY | journal_ffi::SD_JOURNAL_SYSTEM;
-    let mut j = journal_ffi::Journal::open(flags).expect("open");
-    
-    j.seek_tail().unwrap();
-    
-    // Go back 10 entries from tail
-    for _ in 0..10 {
-        if !j.previous().unwrap() { break; }
-    }
-    
-    // Now try to find our entries
-    let mut found = false;
-    for _ in 0..100 {
-        match j.next() {
-            Ok(true) => {
-                j.restart_data();
-                while let Ok(Some(f)) = j.enumerate_data() {
-                    let s = String::from_utf8_lossy(f);
-                    if s.contains(&tag) {
-                        eprintln!("FOUND: {}", &s[..s.len().min(100)]);
-                        found = true;
-                    }
-                }
-            }
-            _ => break,
-        }
-    }
-    assert!(found, "entries should be visible in a fresh handle");
-    
-    // Now write MORE entries and see if wait+next works
-    let tag2 = unique_tag("fresh2");
-    write_journal_entries(&tag2, 2);
-    eprintln!("wrote tag2: {tag2}");
-    
-    for i in 0..10 {
-        let w = j.wait(500_000).unwrap_or(-1);
-        let mut found2 = false;
-        loop {
-            match j.next() {
-                Ok(true) => {
-                    j.restart_data();
-                    while let Ok(Some(f)) = j.enumerate_data() {
-                        let s = String::from_utf8_lossy(f);
-                        if s.contains(&tag2) {
-                            eprintln!("FOUND tag2 on iter {i}: {}", &s[..s.len().min(100)]);
-                            found2 = true;
-                        }
-                    }
-                }
-                _ => break,
-            }
-        }
-        if found2 { return; }
-        eprintln!("iter {i}: wait={w}, tag2 not found");
-    }
-    panic!("tag2 never found in follow mode");
 }

--- a/crates/logfwd-io/tests/it/main.rs
+++ b/crates/logfwd-io/tests/it/main.rs
@@ -1,5 +1,6 @@
 mod checkpoint_state_machine;
 mod file_boundary_contract;
+mod journald_e2e;
 mod otlp_receiver_contract;
 mod support;
 mod transport_e2e;


### PR DESCRIPTION
## Summary

Adds 10 end-to-end integration tests for the journald input source, exercising both subprocess and native (sd_journal) backends against the real systemd journal. Also fixes a bug in the native backend that prevented it from reading user journal entries.

Relates to #1477

## Changes

### Bug fix: native backend journal flags
- **Root cause**: `open_native_journal()` used `SD_JOURNAL_LOCAL_ONLY | SD_JOURNAL_SYSTEM`, which opens **only** the system journal. Entries from non-root users (via `logger`) go to the user journal and were invisible to the native backend.
- **Fix**: Use `SD_JOURNAL_LOCAL_ONLY` alone, which reads both system and user journals — matching `journalctl --follow` default behavior and the subprocess backend.

### Bug fix: INVALIDATE recovery
- After `sd_journal_wait()` returns `SD_JOURNAL_INVALIDATE` (journal rotation), `sd_journal_next()` could return stale `false` even with new entries available.
- Added cursor tracking and re-seek on INVALIDATE to recover correctly.

### Integration tests (10 tests)
All tests use `#[ignore]` and require Linux with systemd running.

**Subprocess backend (6 tests):**
- `subprocess_reads_journal_entries` — happy path read
- `subprocess_entries_contain_standard_fields` — field mapping (MESSAGE, PRIORITY, _PID, _HOSTNAME)
- `subprocess_since_now_skips_history` — since_now mode
- `subprocess_exclude_units_filters` — unit exclusion
- `subprocess_health_becomes_healthy` — health state transitions
- `subprocess_drop_stops_reader` — clean shutdown

**Native backend (3 tests):**
- `native_reads_journal_entries` — happy path
- `native_entries_contain_standard_fields` — field parity with subprocess
- `native_since_now_skips_history` — since_now with native API

**Auto backend (1 test):**
- `auto_backend_selects_native_when_available` — backend selection logic

### Test infrastructure
- `poll_until_match()` helper: polls input until a specific needle string appears, avoiding false positives from unrelated journal noise
- `unique_tag()`: per-test syslog tags with nanosecond timestamps for isolation
- `write_journal_entries()`: writes test entries via `logger(1)`

## Test plan
- All 10 journald e2e tests pass locally (`cargo test -p logfwd-io --test it journald_e2e -- --ignored`)
- All 1489 unit tests pass (`just test`)
- `just clippy` clean, `just fmt` applied

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add journald e2e integration tests and fix native backend journal flags
> - Adds a new end-to-end integration test suite in [journald_e2e.rs](https://github.com/strawgate/memagent/pull/1976/files#diff-e92f34bafb30ab2eb80080e59331252f0853caf08332d95ce673550595484eed) covering subprocess and native backends, including field contracts, `since_now` behavior, exclude units, health transitions, drop behavior, and auto backend selection.
> - Fixes [open_native_journal](https://github.com/strawgate/memagent/pull/1976/files#diff-30b3cf26707fa9d4720331157effe15b59edaa0698b619b56a594cca6b570543) to open with `SD_JOURNAL_LOCAL_ONLY` only (dropping `SD_JOURNAL_SYSTEM`), so the native backend reads both system and user journals, matching `journalctl`'s default follow behavior.
> - Adds `SD_JOURNAL_INVALIDATE` handling in the native reader loop: on invalidation, it re-seeks to the last-read cursor using the new `Journal::test_cursor` method and adjusts position to avoid skipping or duplicating entries.
> - Adds `Journal::test_cursor` in [journal_ffi.rs](https://github.com/strawgate/memagent/pull/1976/files#diff-95f6e9fb2b25ff566a5bc92dab488cb650f8df85af4def9e2fb8760e2f858b61) by resolving and wrapping `sd_journal_test_cursor` as an `io::Result<bool>`.
> - Behavioral Change: the native journal now includes user journal entries that were previously excluded by `SD_JOURNAL_SYSTEM`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f67661b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->