### PR TITLE
docs: interactive backpressure and checkpoint ordering experiences

### DIFF
--- a/book/astro.config.mjs
+++ b/book/astro.config.mjs
@@ -32,6 +32,8 @@ export default defineConfig({
             { label: "Scanner Deep Dive", slug: "how-it-works/scanner" },
             { label: "Why Tailing Is Hard", slug: "how-it-works/tailing" },
             { label: "Why Columnar Matters", slug: "how-it-works/columnar" },
+            { label: "Backpressure in Action", slug: "how-it-works/backpressure" },
+            { label: "Checkpoint Ordering", slug: "how-it-works/checkpoints" },
             { label: "Performance", slug: "how-it-works/performance" },
           ],
         },

--- a/book/src/components/BackpressureSim.astro
+++ b/book/src/components/BackpressureSim.astro
@@ -183,7 +183,7 @@
     transform: translateX(-50%); z-index: 10;
     padding: 0.35rem 0.55rem; border-radius: 6px;
     font-size: 0.62rem; font-weight: 600; line-height: 1.35;
-    white-space: nowrap; max-width: 220px; white-space: normal;
+    max-width: 220px; white-space: normal;
     pointer-events: none;
     animation: bp-alert-in 0.3s ease-out forwards;
     box-shadow: 0 2px 8px rgba(0,0,0,0.15);
@@ -484,7 +484,7 @@
   }
 
   function updateStats() {
-    var throughput = (outputSpeed / 100) * OUT_MAX_RATE;
+    var throughput = (outputSpeed / 100) * OUT_MAX_RATE * 4; // 4 ticks/s (250ms interval)
     var latClass = '';
     var latVal = '';
     if (outputSpeed === 0) { latVal = '\u221E'; latClass = 'red'; }
@@ -658,12 +658,35 @@
   updateStats();
   addLog('Pipeline started \u2014 drag the slider or click a preset', 'ok');
 
-  // Start animation
-  var interval = setInterval(simTick, 250);
+  // Start animation (pause when tab is hidden to save CPU/battery)
+  var interval = null;
+
+  function startSimulation() {
+    if (interval !== null || document.hidden) return;
+    interval = setInterval(simTick, 250);
+  }
+
+  function stopSimulation() {
+    if (interval === null) return;
+    clearInterval(interval);
+    interval = null;
+  }
+
+  function handleVisibilityChange() {
+    if (document.hidden) {
+      stopSimulation();
+    } else {
+      startSimulation();
+    }
+  }
+
+  startSimulation();
+  document.addEventListener('visibilitychange', handleVisibilityChange);
 
   // Cleanup on page nav (Starlight SPA)
   document.addEventListener('astro:before-swap', function() {
-    clearInterval(interval);
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    stopSimulation();
     running = false;
   }, { once: true });
 })();

--- a/book/src/components/BackpressureSim.astro
+++ b/book/src/components/BackpressureSim.astro
@@ -1,0 +1,545 @@
+---
+// Interactive backpressure cascade simulator.
+// Shows how slowing the output causes pressure to build backward through the pipeline.
+---
+
+<div class="bp" id="backpressure-sim"></div>
+
+<style is:global>
+  .bp {
+    --bp-bg: var(--sl-color-bg-sidebar);
+    --bp-border: var(--sl-color-hairline);
+    --bp-accent: var(--sl-color-accent);
+    --bp-text: var(--sl-color-text);
+    --bp-muted: var(--sl-color-gray-3);
+    --bp-green: #22c55e;
+    --bp-amber: #f59e0b;
+    --bp-red: #ef4444;
+    --bp-blue: #60a5fa;
+    --bp-purple: #a78bfa;
+    margin: 1.5rem 0;
+  }
+  .bp * { margin-top: 0 !important; }
+
+  /* Control bar */
+  .bp-controls {
+    display: flex; align-items: center; gap: 0.75rem;
+    padding: 0.6rem 0.85rem; background: var(--bp-bg);
+    border: 1px solid var(--bp-border); border-radius: 8px;
+    margin-bottom: 0.75rem; flex-wrap: wrap;
+  }
+  .bp-label {
+    font-size: 0.72rem; font-weight: 600; color: var(--bp-text);
+    white-space: nowrap;
+  }
+  .bp-slider-wrap {
+    display: flex; align-items: center; gap: 0.4rem; flex: 1; min-width: 160px;
+  }
+  .bp-slider {
+    flex: 1; height: 4px; -webkit-appearance: none; appearance: none;
+    background: var(--bp-border); border-radius: 2px; outline: none;
+    cursor: pointer;
+  }
+  .bp-slider::-webkit-slider-thumb {
+    -webkit-appearance: none; width: 14px; height: 14px; border-radius: 50%;
+    background: var(--bp-accent); border: none; cursor: pointer;
+  }
+  .bp-slider::-moz-range-thumb {
+    width: 14px; height: 14px; border-radius: 50%;
+    background: var(--bp-accent); border: none; cursor: pointer;
+  }
+  .bp-speed-val {
+    font-family: var(--sl-font-mono, monospace); font-size: 0.7rem;
+    font-weight: 700; min-width: 40px; text-align: right;
+  }
+  .bp-btns { display: flex; gap: 0.3rem; }
+  .bp-btn {
+    padding: 0.2rem 0.55rem; border-radius: 4px; border: 1px solid var(--bp-border);
+    background: transparent; color: var(--bp-text); font-size: 0.65rem;
+    cursor: pointer; font-weight: 600;
+  }
+  .bp-btn:hover { border-color: var(--bp-accent); }
+  .bp-btn.active { border-color: var(--bp-accent); background: var(--bp-accent); color: white; }
+
+  /* Pipeline stages */
+  .bp-pipeline {
+    display: flex; gap: 0; align-items: stretch;
+    margin-bottom: 0.6rem; overflow-x: auto;
+  }
+  .bp-stage {
+    flex: 1; min-width: 120px; padding: 0.5rem;
+    border: 1.5px solid var(--bp-border); background: var(--bp-bg);
+    border-radius: 8px; position: relative;
+    transition: border-color 0.4s, background 0.4s;
+  }
+  .bp-stage.pressured {
+    border-color: var(--bp-amber);
+    background: color-mix(in srgb, var(--bp-amber) 5%, var(--bp-bg));
+  }
+  .bp-stage.blocked {
+    border-color: var(--bp-red);
+    background: color-mix(in srgb, var(--bp-red) 7%, var(--bp-bg));
+  }
+  .bp-stage-head {
+    display: flex; justify-content: space-between; align-items: center;
+    margin-bottom: 0.3rem;
+  }
+  .bp-stage-name {
+    font-size: 0.72rem; font-weight: 700; color: var(--bp-text);
+  }
+  .bp-stage-tag {
+    font-size: 0.5rem; font-weight: 700; padding: 0.1rem 0.3rem;
+    border-radius: 3px; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .bp-tag-ok { background: color-mix(in srgb, var(--bp-green) 15%, transparent); color: var(--bp-green); }
+  .bp-tag-slow { background: color-mix(in srgb, var(--bp-amber) 15%, transparent); color: var(--bp-amber); }
+  .bp-tag-blocked { background: color-mix(in srgb, var(--bp-red) 15%, transparent); color: var(--bp-red); }
+
+  .bp-stage-desc {
+    font-size: 0.58rem; color: var(--bp-muted); margin-bottom: 0.4rem;
+  }
+
+  /* Queue visualization */
+  .bp-queue {
+    display: flex; gap: 2px; height: 18px; margin-bottom: 0.3rem;
+  }
+  .bp-slot {
+    flex: 1; border-radius: 2px; border: 1px solid var(--bp-border);
+    transition: background 0.3s, border-color 0.3s;
+    position: relative;
+  }
+  .bp-slot.filled {
+    background: var(--bp-green); border-color: var(--bp-green);
+  }
+  .bp-slot.filling {
+    background: var(--bp-amber); border-color: var(--bp-amber);
+  }
+  .bp-slot.full {
+    background: var(--bp-red); border-color: var(--bp-red);
+  }
+  .bp-queue-label {
+    font-size: 0.5rem; color: var(--bp-muted); text-align: center;
+    font-family: var(--sl-font-mono, monospace);
+  }
+
+  /* Arrow connectors */
+  .bp-arrow {
+    display: flex; align-items: center; justify-content: center;
+    width: 28px; min-width: 28px; color: var(--bp-muted);
+    font-size: 1rem; transition: color 0.3s;
+  }
+  .bp-arrow.pressured { color: var(--bp-amber); }
+  .bp-arrow.blocked { color: var(--bp-red); }
+
+  /* Stats row */
+  .bp-stats {
+    display: flex; gap: 0.75rem; flex-wrap: wrap;
+    font-size: 0.68rem; padding: 0.4rem 0;
+  }
+  .bp-stat { display: flex; flex-direction: column; }
+  .bp-stat-label {
+    font-size: 0.5rem; color: var(--bp-muted);
+    text-transform: uppercase; letter-spacing: 0.03em;
+  }
+  .bp-stat-val {
+    font-weight: 700; font-family: var(--sl-font-mono, monospace);
+  }
+  .bp-stat-val.green { color: var(--bp-green); }
+  .bp-stat-val.amber { color: var(--bp-amber); }
+  .bp-stat-val.red { color: var(--bp-red); }
+
+  /* Event log */
+  .bp-log {
+    max-height: 110px; overflow-y: auto;
+    border: 1px solid var(--bp-border); border-radius: 6px;
+    padding: 0.3rem 0.5rem; margin-top: 0.4rem;
+  }
+  .bp-log-entry {
+    font-size: 0.6rem; line-height: 1.6;
+    font-family: var(--sl-font-mono, monospace);
+    animation: bp-fadein 0.3s ease-out;
+  }
+  @keyframes bp-fadein { from { opacity: 0; } to { opacity: 1; } }
+  .bp-log-entry .ts { color: var(--bp-muted); }
+  .bp-log-entry .warn { color: var(--bp-amber); font-weight: 600; }
+  .bp-log-entry .err { color: var(--bp-red); font-weight: 600; }
+  .bp-log-entry .ok { color: var(--bp-green); }
+
+  /* Explanation panel */
+  .bp-explain {
+    padding: 0.55rem 0.75rem; background: var(--bp-bg);
+    border: 1px solid var(--bp-border); border-radius: 7px;
+    margin-top: 0.5rem; font-size: 0.75rem; line-height: 1.5;
+    transition: border-color 0.3s;
+  }
+  .bp-explain.warn { border-color: var(--bp-amber); }
+  .bp-explain.err { border-color: var(--bp-red); }
+  .bp-explain b { display: block; font-size: 0.78rem; margin-bottom: 0.1rem; }
+
+  /* Batch particles */
+  .bp-batch {
+    position: absolute; width: 8px; height: 8px; border-radius: 2px;
+    background: var(--bp-blue); opacity: 0.9;
+    transition: left 0.3s linear, opacity 0.2s;
+    top: 50%; transform: translateY(-50%);
+    z-index: 2;
+  }
+</style>
+
+<script>
+(function() {
+  var root = document.getElementById('backpressure-sim');
+  if (!root) return;
+
+  function el(tag, cls) { var e = document.createElement(tag); if (cls) e.className = cls; return e; }
+
+  // --- State ---
+  var outputSpeed = 100; // 0-100 percent of max throughput
+  var running = true;
+  var tick = 0;
+
+  // Queue capacities (matching real code)
+  var IO_CPU_CAP = 4;
+  var PIPELINE_CAP = 16;
+  var WORKER_CAP = 1; // per-worker channel capacity = 1
+  var NUM_WORKERS = 3;
+
+  // Queue fill levels
+  var ioCpuFill = 0;
+  var pipelineFill = 0;
+  var workerFills = [0, 0, 0];
+
+  // Production rates per tick
+  var IO_RATE = 2.0; // chunks/tick from I/O
+  var CPU_RATE = 1.8; // batches/tick from CPU
+  var PIPELINE_RATE = 1.5; // batches/tick pipeline throughput
+
+  // Stats
+  var totalProduced = 0;
+  var totalDelivered = 0;
+  var ioBlocked = false;
+  var cpuBlocked = false;
+
+  // --- Build DOM ---
+  var controls = el('div', 'bp-controls');
+  var lbl = el('span', 'bp-label'); lbl.textContent = 'Output Speed';
+  var sliderWrap = el('div', 'bp-slider-wrap');
+  var slider = el('input', 'bp-slider');
+  slider.type = 'range'; slider.min = '0'; slider.max = '100'; slider.value = '100';
+  var speedVal = el('span', 'bp-speed-val'); speedVal.textContent = '100%';
+  sliderWrap.appendChild(slider);
+  sliderWrap.appendChild(speedVal);
+
+  var btns = el('div', 'bp-btns');
+  var btnFast = el('button', 'bp-btn active'); btnFast.textContent = 'Fast';
+  var btnSlow = el('button', 'bp-btn'); btnSlow.textContent = 'Slow';
+  var btnDown = el('button', 'bp-btn'); btnDown.textContent = 'Outage';
+  btns.appendChild(btnFast); btns.appendChild(btnSlow); btns.appendChild(btnDown);
+
+  controls.appendChild(lbl);
+  controls.appendChild(sliderWrap);
+  controls.appendChild(btns);
+  root.appendChild(controls);
+
+  // Pipeline stages
+  var pipeline = el('div', 'bp-pipeline');
+
+  function makeStage(name, desc, cap, queueLabel) {
+    var s = el('div', 'bp-stage');
+    var head = el('div', 'bp-stage-head');
+    var nm = el('span', 'bp-stage-name'); nm.textContent = name;
+    var tag = el('span', 'bp-stage-tag bp-tag-ok'); tag.textContent = 'OK';
+    head.appendChild(nm); head.appendChild(tag);
+    s.appendChild(head);
+
+    var d = el('div', 'bp-stage-desc'); d.textContent = desc;
+    s.appendChild(d);
+
+    var q = el('div', 'bp-queue');
+    var slots = [];
+    for (var i = 0; i < cap; i++) {
+      var slot = el('div', 'bp-slot');
+      q.appendChild(slot);
+      slots.push(slot);
+    }
+    s.appendChild(q);
+
+    var ql = el('div', 'bp-queue-label'); ql.textContent = queueLabel;
+    s.appendChild(ql);
+
+    return { el: s, tag: tag, slots: slots, qlabel: ql };
+  }
+
+  function makeArrow() {
+    var a = el('div', 'bp-arrow'); a.textContent = '\u25B6';
+    return a;
+  }
+
+  var ioStage = makeStage('I/O Worker', 'poll() \u2192 read bytes', IO_CPU_CAP, '0/' + IO_CPU_CAP + ' slots');
+  var arrow1 = makeArrow();
+  var cpuStage = makeStage('CPU Worker', 'scan \u2192 SQL transform', PIPELINE_CAP, '0/' + PIPELINE_CAP + ' slots');
+  var arrow2 = makeArrow();
+  var outStage = makeStage('Output Pool', NUM_WORKERS + ' workers \u00D7 MRU dispatch', NUM_WORKERS, '0/' + NUM_WORKERS + ' busy');
+
+  pipeline.appendChild(ioStage.el);
+  pipeline.appendChild(arrow1);
+  pipeline.appendChild(cpuStage.el);
+  pipeline.appendChild(arrow2);
+  pipeline.appendChild(outStage.el);
+  root.appendChild(pipeline);
+
+  // Stats
+  var statsEl = el('div', 'bp-stats');
+  root.appendChild(statsEl);
+
+  // Event log
+  var logEl = el('div', 'bp-log');
+  root.appendChild(logEl);
+
+  // Explanation
+  var explainEl = el('div', 'bp-explain');
+  explainEl.innerHTML = '<b>Normal operation</b>All queues are draining faster than they fill. Data flows smoothly from files through SQL transforms to your collector.';
+  root.appendChild(explainEl);
+
+  // --- Preset buttons ---
+  var presets = [btnFast, btnSlow, btnDown];
+  function setPreset(idx) {
+    presets.forEach(function(b, i) { b.className = 'bp-btn' + (i === idx ? ' active' : ''); });
+    if (idx === 0) { slider.value = '100'; outputSpeed = 100; }
+    else if (idx === 1) { slider.value = '30'; outputSpeed = 30; }
+    else { slider.value = '0'; outputSpeed = 0; }
+    speedVal.textContent = outputSpeed + '%';
+  }
+  btnFast.onclick = function() { setPreset(0); };
+  btnSlow.onclick = function() { setPreset(1); };
+  btnDown.onclick = function() { setPreset(2); };
+
+  slider.oninput = function() {
+    outputSpeed = parseInt(slider.value);
+    speedVal.textContent = outputSpeed + '%';
+    presets.forEach(function(b) { b.className = 'bp-btn'; });
+    if (outputSpeed === 100) btnFast.className = 'bp-btn active';
+    else if (outputSpeed === 0) btnDown.className = 'bp-btn active';
+  };
+
+  // --- Log helper ---
+  var logCount = 0;
+  function addLog(msg, cls) {
+    logCount++;
+    var entry = el('div', 'bp-log-entry');
+    var ts = tick.toString().padStart(4, '0');
+    entry.innerHTML = '<span class="ts">t=' + ts + '</span> ' + (cls ? '<span class="' + cls + '">' + msg + '</span>' : msg);
+    logEl.appendChild(entry);
+    if (logEl.children.length > 40) logEl.removeChild(logEl.firstChild);
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+
+  // --- Update visuals ---
+  function updateStage(stage, fill, cap, label) {
+    var pct = fill / cap;
+    for (var i = 0; i < stage.slots.length; i++) {
+      if (i < Math.ceil(fill)) {
+        stage.slots[i].className = pct >= 1.0 ? 'bp-slot full' : (pct > 0.6 ? 'bp-slot filling' : 'bp-slot filled');
+      } else {
+        stage.slots[i].className = 'bp-slot';
+      }
+    }
+    stage.qlabel.textContent = Math.ceil(fill) + '/' + cap + ' ' + label;
+
+    if (pct >= 1.0) {
+      stage.el.className = 'bp-stage blocked';
+      stage.tag.className = 'bp-stage-tag bp-tag-blocked'; stage.tag.textContent = 'BLOCKED';
+    } else if (pct > 0.5) {
+      stage.el.className = 'bp-stage pressured';
+      stage.tag.className = 'bp-stage-tag bp-tag-slow'; stage.tag.textContent = 'PRESSURE';
+    } else {
+      stage.el.className = 'bp-stage';
+      stage.tag.className = 'bp-stage-tag bp-tag-ok'; stage.tag.textContent = 'OK';
+    }
+  }
+
+  function updateArrow(arrowEl, pressure) {
+    arrowEl.className = pressure >= 1.0 ? 'bp-arrow blocked' : (pressure > 0.5 ? 'bp-arrow pressured' : 'bp-arrow');
+  }
+
+  function updateStats() {
+    var throughput = (outputSpeed / 100) * PIPELINE_RATE;
+    var latClass = '';
+    var latVal = '';
+    if (outputSpeed === 0) { latVal = '\u221E'; latClass = 'red'; }
+    else if (outputSpeed < 30) { latVal = '>500ms'; latClass = 'red'; }
+    else if (outputSpeed < 70) { latVal = '~200ms'; latClass = 'amber'; }
+    else { latVal = '<50ms'; latClass = 'green'; }
+
+    statsEl.innerHTML = '';
+    var items = [
+      ['Throughput', throughput.toFixed(1) + ' batch/s', throughput < 0.5 ? 'red' : (throughput < 1.0 ? 'amber' : 'green')],
+      ['Latency', latVal, latClass],
+      ['Batches produced', '' + totalProduced, ''],
+      ['Batches delivered', '' + totalDelivered, 'green'],
+      ['I/O worker', ioBlocked ? 'BLOCKED' : 'polling', ioBlocked ? 'red' : 'green'],
+      ['CPU worker', cpuBlocked ? 'BLOCKED' : 'scanning', cpuBlocked ? 'red' : 'green'],
+    ];
+    items.forEach(function(item) {
+      var s = el('div', 'bp-stat');
+      var l = el('div', 'bp-stat-label'); l.textContent = item[0];
+      var v = el('div', 'bp-stat-val' + (item[2] ? ' ' + item[2] : '')); v.textContent = item[1];
+      s.appendChild(l); s.appendChild(v); statsEl.appendChild(s);
+    });
+  }
+
+  function updateExplanation() {
+    var outPct = 1 - (outputSpeed / 100);
+    var workerPressure = Math.max.apply(null, workerFills) / WORKER_CAP;
+    var pipePressure = pipelineFill / PIPELINE_CAP;
+    var ioPressure = ioCpuFill / IO_CPU_CAP;
+
+    if (outputSpeed === 0) {
+      explainEl.className = 'bp-explain err';
+      explainEl.innerHTML = '<b>\u26D4 Output outage \u2014 full cascade</b>' +
+        'The collector is unreachable. Output workers retry with exponential backoff (capped at 60s), blocking their channels. ' +
+        'The pipeline channel fills to 16/16. CPU workers block on <code>blocking_send</code>. ' +
+        'I/O workers block on the bounded(4) channel. File readers naturally back off \u2014 <b>no data is lost</b>, but new logs queue on disk until the outage clears.';
+    } else if (ioPressure >= 1.0) {
+      explainEl.className = 'bp-explain err';
+      explainEl.innerHTML = '<b>\u26A0 I/O worker blocked \u2014 backpressure reached the source</b>' +
+        'The bounded(4) I/O\u2192CPU channel is full. The I/O worker is stuck in <code>blocking_send</code> and cannot call <code>poll()</code>. ' +
+        'The file reader sees no reads and its adaptive poll cadence backs off. Logs accumulate on disk safely \u2014 logfwd will catch up when pressure clears.';
+    } else if (pipePressure > 0.5) {
+      explainEl.className = 'bp-explain warn';
+      explainEl.innerHTML = '<b>\u26A0 Pipeline channel filling \u2014 pressure building</b>' +
+        'Output workers are slower than the CPU worker. The pipeline channel (' + Math.ceil(pipelineFill) + '/16) is backing up. ' +
+        'If it fills completely, the CPU worker will block, and pressure will cascade to the I/O worker. ' +
+        'This is <b>by design</b> \u2014 bounded channels turn slow outputs into backpressure instead of unbounded memory growth.';
+    } else if (workerPressure > 0.5) {
+      explainEl.className = 'bp-explain warn';
+      explainEl.innerHTML = '<b>Output workers busy</b>' +
+        'MRU dispatch is consolidating work onto fewer workers. <code>try_send</code> scans workers front-to-back; ' +
+        'the first with capacity gets the batch. If all ' + NUM_WORKERS + ' workers are full, the pool spawns up to max or async-waits on the front worker.';
+    } else {
+      explainEl.className = 'bp-explain';
+      explainEl.innerHTML = '<b>Normal operation</b>' +
+        'All queues are draining faster than they fill. Data flows smoothly from files through SQL transforms to your collector. ' +
+        'Try dragging the output speed slider to the left, or click <b>Slow</b> or <b>Outage</b> to see backpressure cascade.';
+    }
+  }
+
+  // --- Simulation loop ---
+  var lastLogTick = -10;
+
+  function simTick() {
+    if (!running) return;
+    tick++;
+
+    // Output drain rate depends on speed slider
+    var outDrain = (outputSpeed / 100) * PIPELINE_RATE;
+
+    // Output workers drain
+    var totalWorkerFill = workerFills.reduce(function(a, b) { return a + b; }, 0);
+    var drained = Math.min(totalWorkerFill, outDrain);
+    var remaining = drained;
+    for (var w = 0; w < NUM_WORKERS && remaining > 0; w++) {
+      var take = Math.min(workerFills[w], remaining);
+      workerFills[w] -= take;
+      remaining -= take;
+      if (take > 0) totalDelivered += Math.round(take);
+    }
+
+    // Pipeline drains into workers (MRU dispatch)
+    var pipelineDrain = 0;
+    if (pipelineFill > 0) {
+      for (var w2 = 0; w2 < NUM_WORKERS; w2++) {
+        if (pipelineFill <= 0) break;
+        var space = WORKER_CAP - workerFills[w2];
+        if (space > 0) {
+          var send = Math.min(space, pipelineFill, 0.8);
+          workerFills[w2] += send;
+          pipelineFill -= send;
+          pipelineDrain += send;
+        }
+      }
+    }
+
+    // CPU worker drains I/O queue, fills pipeline
+    cpuBlocked = pipelineFill >= PIPELINE_CAP;
+    if (!cpuBlocked && ioCpuFill > 0) {
+      var cpuDrain = Math.min(ioCpuFill, CPU_RATE, PIPELINE_CAP - pipelineFill);
+      ioCpuFill -= cpuDrain;
+      pipelineFill += cpuDrain;
+      totalProduced += Math.round(cpuDrain);
+    }
+
+    // I/O worker produces into I/O-CPU channel
+    ioBlocked = ioCpuFill >= IO_CPU_CAP;
+    if (!ioBlocked) {
+      var ioProduce = Math.min(IO_RATE, IO_CPU_CAP - ioCpuFill);
+      ioCpuFill += ioProduce;
+    }
+
+    // Clamp values
+    ioCpuFill = Math.max(0, Math.min(IO_CPU_CAP, ioCpuFill));
+    pipelineFill = Math.max(0, Math.min(PIPELINE_CAP, pipelineFill));
+    for (var w3 = 0; w3 < NUM_WORKERS; w3++) {
+      workerFills[w3] = Math.max(0, Math.min(WORKER_CAP, workerFills[w3]));
+    }
+
+    // Log interesting events
+    if (ioBlocked && tick - lastLogTick > 8) {
+      addLog('I/O worker blocked \u2014 bounded(4) channel full', 'warn');
+      lastLogTick = tick;
+    } else if (cpuBlocked && !ioBlocked && tick - lastLogTick > 8) {
+      addLog('CPU worker blocked \u2014 pipeline channel full (' + Math.ceil(pipelineFill) + '/16)', 'warn');
+      lastLogTick = tick;
+    } else if (outputSpeed === 0 && tick - lastLogTick > 12) {
+      addLog('Output unreachable \u2014 workers retrying with backoff', 'err');
+      lastLogTick = tick;
+    } else if (outputSpeed === 100 && pipelineFill < 1 && tick - lastLogTick > 15) {
+      addLog('Pipeline healthy \u2014 ' + totalDelivered + ' batches delivered', 'ok');
+      lastLogTick = tick;
+    }
+
+    // Update visuals
+    var workerBusy = workerFills.filter(function(f) { return f > 0.1; }).length;
+    updateStage(ioStage, ioCpuFill, IO_CPU_CAP, 'slots');
+    updateStage(cpuStage, pipelineFill, PIPELINE_CAP, 'slots');
+    // For output, show busy workers
+    outStage.qlabel.textContent = workerBusy + '/' + NUM_WORKERS + ' busy';
+    for (var i = 0; i < outStage.slots.length; i++) {
+      if (workerFills[i] > 0.5) {
+        outStage.slots[i].className = workerFills[i] >= WORKER_CAP ? 'bp-slot full' : 'bp-slot filling';
+      } else {
+        outStage.slots[i].className = workerFills[i] > 0.1 ? 'bp-slot filled' : 'bp-slot';
+      }
+    }
+    var allWorkersFull = workerFills.every(function(f) { return f >= WORKER_CAP * 0.9; });
+    if (allWorkersFull) {
+      outStage.el.className = 'bp-stage blocked';
+      outStage.tag.className = 'bp-stage-tag bp-tag-blocked'; outStage.tag.textContent = 'FULL';
+    } else if (workerBusy >= 2) {
+      outStage.el.className = 'bp-stage pressured';
+      outStage.tag.className = 'bp-stage-tag bp-tag-slow'; outStage.tag.textContent = 'BUSY';
+    } else {
+      outStage.el.className = 'bp-stage';
+      outStage.tag.className = 'bp-stage-tag bp-tag-ok'; outStage.tag.textContent = 'OK';
+    }
+
+    updateArrow(arrow1, ioCpuFill / IO_CPU_CAP);
+    updateArrow(arrow2, pipelineFill / PIPELINE_CAP);
+    updateStats();
+    updateExplanation();
+  }
+
+  // Initial render
+  updateStats();
+
+  // Start animation
+  var interval = setInterval(simTick, 250);
+
+  // Cleanup on page nav (Starlight SPA)
+  function cleanup() {
+    clearInterval(interval);
+    running = false;
+  }
+  document.addEventListener('astro:before-swap', cleanup, { once: true });
+})();
+</script>

--- a/book/src/components/BackpressureSim.astro
+++ b/book/src/components/BackpressureSim.astro
@@ -292,18 +292,19 @@
 
   // --- Build DOM ---
   var controls = el('div', 'bp-controls');
-  var lbl = el('span', 'bp-label'); lbl.textContent = 'Output Speed';
+  var lbl = el('label', 'bp-label'); lbl.htmlFor = 'bp-output-speed'; lbl.textContent = 'Output Speed';
   var sliderWrap = el('div', 'bp-slider-wrap');
   var slider = el('input', 'bp-slider');
+  slider.id = 'bp-output-speed';
   slider.type = 'range'; slider.min = '0'; slider.max = '100'; slider.value = '100';
   var speedVal = el('span', 'bp-speed-val'); speedVal.textContent = '100%';
   sliderWrap.appendChild(slider);
   sliderWrap.appendChild(speedVal);
 
   var btns = el('div', 'bp-btns');
-  var btnFast = el('button', 'bp-btn active'); btnFast.textContent = 'Fast';
-  var btnSlow = el('button', 'bp-btn'); btnSlow.textContent = 'Slow';
-  var btnDown = el('button', 'bp-btn'); btnDown.textContent = 'Outage';
+  var btnFast = el('button', 'bp-btn active'); btnFast.type = 'button'; btnFast.textContent = 'Fast'; btnFast.setAttribute('aria-pressed', 'true');
+  var btnSlow = el('button', 'bp-btn'); btnSlow.type = 'button'; btnSlow.textContent = 'Slow'; btnSlow.setAttribute('aria-pressed', 'false');
+  var btnDown = el('button', 'bp-btn'); btnDown.type = 'button'; btnDown.textContent = 'Outage'; btnDown.setAttribute('aria-pressed', 'false');
   btns.appendChild(btnFast); btns.appendChild(btnSlow); btns.appendChild(btnDown);
 
   controls.appendChild(lbl);
@@ -378,7 +379,11 @@
   // --- Preset buttons ---
   var presets = [btnFast, btnSlow, btnDown];
   function setPreset(idx) {
-    presets.forEach(function(b, i) { b.className = 'bp-btn' + (i === idx ? ' active' : ''); });
+    presets.forEach(function(b, i) {
+      var active = i === idx;
+      b.className = 'bp-btn' + (active ? ' active' : '');
+      b.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
     if (idx === 0) { slider.value = '100'; outputSpeed = 100; }
     else if (idx === 1) { slider.value = '30'; outputSpeed = 30; }
     else { slider.value = '0'; outputSpeed = 0; }
@@ -389,11 +394,22 @@
   btnDown.onclick = function() { setPreset(2); };
 
   slider.oninput = function() {
-    outputSpeed = parseInt(slider.value);
+    outputSpeed = parseInt(slider.value, 10);
     speedVal.textContent = outputSpeed + '%';
-    presets.forEach(function(b) { b.className = 'bp-btn'; });
-    if (outputSpeed === 100) btnFast.className = 'bp-btn active';
-    else if (outputSpeed === 0) btnDown.className = 'bp-btn active';
+    presets.forEach(function(b) {
+      b.className = 'bp-btn';
+      b.setAttribute('aria-pressed', 'false');
+    });
+    if (outputSpeed === 100) {
+      btnFast.className = 'bp-btn active';
+      btnFast.setAttribute('aria-pressed', 'true');
+    } else if (outputSpeed === 30) {
+      btnSlow.className = 'bp-btn active';
+      btnSlow.setAttribute('aria-pressed', 'true');
+    } else if (outputSpeed === 0) {
+      btnDown.className = 'bp-btn active';
+      btnDown.setAttribute('aria-pressed', 'true');
+    }
   };
 
   // --- Alert system ---

--- a/book/src/components/BackpressureSim.astro
+++ b/book/src/components/BackpressureSim.astro
@@ -106,7 +106,7 @@
   .bp-slot {
     flex: 1; border-radius: 2px; border: 1px solid var(--bp-border);
     transition: background 0.3s, border-color 0.3s;
-    position: relative;
+    position: relative; overflow: hidden;
   }
   .bp-slot.filled {
     background: var(--bp-green); border-color: var(--bp-green);
@@ -122,14 +122,101 @@
     font-family: var(--sl-font-mono, monospace);
   }
 
-  /* Arrow connectors */
+  /* Activity bar — gentle shimmer showing the stage is alive */
+  .bp-activity {
+    height: 3px; border-radius: 1.5px; margin-top: 0.35rem;
+    background: var(--bp-border); overflow: hidden;
+    position: relative;
+  }
+  .bp-activity-fill {
+    position: absolute; inset: 0; border-radius: 1.5px;
+    background: var(--bp-green);
+    transform-origin: left;
+    transition: transform 0.3s ease, background-color 0.4s;
+  }
+  .bp-activity-fill.flowing {
+    animation: bp-flow 1.5s ease-in-out infinite;
+  }
+  .bp-activity-fill.pressured { background: var(--bp-amber); }
+  .bp-activity-fill.blocked {
+    background: var(--bp-red);
+    animation: bp-blocked-pulse 2s ease-in-out infinite;
+  }
+  @keyframes bp-flow {
+    0%   { transform: scaleX(0.15); translate: 0% 0; }
+    50%  { transform: scaleX(0.5); translate: 50% 0; }
+    100% { transform: scaleX(0.15); translate: 85% 0; }
+  }
+  @keyframes bp-blocked-pulse {
+    0%, 100% { opacity: 0.4; }
+    50% { opacity: 1; }
+  }
+
+  /* Arrow connectors with flow animation */
   .bp-arrow {
     display: flex; align-items: center; justify-content: center;
     width: 28px; min-width: 28px; color: var(--bp-muted);
     font-size: 1rem; transition: color 0.3s;
+    position: relative;
   }
   .bp-arrow.pressured { color: var(--bp-amber); }
   .bp-arrow.blocked { color: var(--bp-red); }
+  .bp-arrow-dot {
+    position: absolute; width: 4px; height: 4px; border-radius: 50%;
+    background: var(--bp-green); opacity: 0;
+  }
+  .bp-arrow.flowing .bp-arrow-dot {
+    animation: bp-dot-fly 1.2s ease-in-out infinite;
+  }
+  .bp-arrow.pressured .bp-arrow-dot { background: var(--bp-amber); }
+  .bp-arrow.blocked .bp-arrow-dot { background: var(--bp-red); animation: none; opacity: 0; }
+  @keyframes bp-dot-fly {
+    0%   { opacity: 0; translate: -10px 0; }
+    20%  { opacity: 1; }
+    80%  { opacity: 1; }
+    100% { opacity: 0; translate: 10px 0; }
+  }
+
+  /* Alert callouts — speech bubbles anchored to stages */
+  .bp-alert {
+    position: absolute; bottom: calc(100% + 8px); left: 50%;
+    transform: translateX(-50%); z-index: 10;
+    padding: 0.35rem 0.55rem; border-radius: 6px;
+    font-size: 0.62rem; font-weight: 600; line-height: 1.35;
+    white-space: nowrap; max-width: 220px; white-space: normal;
+    pointer-events: none;
+    animation: bp-alert-in 0.3s ease-out forwards;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  }
+  .bp-alert::after {
+    content: ''; position: absolute; top: 100%; left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+  }
+  .bp-alert.ok {
+    background: var(--bp-green); color: white;
+  }
+  .bp-alert.ok::after { border-top-color: var(--bp-green); }
+  .bp-alert.warn {
+    background: var(--bp-amber); color: #1a1a2e;
+  }
+  .bp-alert.warn::after { border-top-color: var(--bp-amber); }
+  .bp-alert.err {
+    background: var(--bp-red); color: white;
+  }
+  .bp-alert.err::after { border-top-color: var(--bp-red); }
+
+  @keyframes bp-alert-in {
+    from { opacity: 0; translate: 0 4px; }
+    to { opacity: 1; translate: 0 0; }
+  }
+  .bp-alert.exiting {
+    animation: bp-alert-out 0.4s ease-in forwards;
+  }
+  @keyframes bp-alert-out {
+    from { opacity: 1; translate: 0 0; }
+    to { opacity: 0; translate: 0 -4px; }
+  }
 
   /* Stats row */
   .bp-stats {
@@ -150,7 +237,7 @@
 
   /* Event log */
   .bp-log {
-    max-height: 110px; overflow-y: auto;
+    max-height: 90px; overflow-y: auto;
     border: 1px solid var(--bp-border); border-radius: 6px;
     padding: 0.3rem 0.5rem; margin-top: 0.4rem;
   }
@@ -164,26 +251,6 @@
   .bp-log-entry .warn { color: var(--bp-amber); font-weight: 600; }
   .bp-log-entry .err { color: var(--bp-red); font-weight: 600; }
   .bp-log-entry .ok { color: var(--bp-green); }
-
-  /* Explanation panel */
-  .bp-explain {
-    padding: 0.55rem 0.75rem; background: var(--bp-bg);
-    border: 1px solid var(--bp-border); border-radius: 7px;
-    margin-top: 0.5rem; font-size: 0.75rem; line-height: 1.5;
-    transition: border-color 0.3s;
-  }
-  .bp-explain.warn { border-color: var(--bp-amber); }
-  .bp-explain.err { border-color: var(--bp-red); }
-  .bp-explain b { display: block; font-size: 0.78rem; margin-bottom: 0.1rem; }
-
-  /* Batch particles */
-  .bp-batch {
-    position: absolute; width: 8px; height: 8px; border-radius: 2px;
-    background: var(--bp-blue); opacity: 0.9;
-    transition: left 0.3s linear, opacity 0.2s;
-    top: 50%; transform: translateY(-50%);
-    z-index: 2;
-  }
 </style>
 
 <script>
@@ -194,31 +261,34 @@
   function el(tag, cls) { var e = document.createElement(tag); if (cls) e.className = cls; return e; }
 
   // --- State ---
-  var outputSpeed = 100; // 0-100 percent of max throughput
+  var outputSpeed = 100;
   var running = true;
   var tick = 0;
 
-  // Queue capacities (matching real code)
   var IO_CPU_CAP = 4;
   var PIPELINE_CAP = 16;
-  var WORKER_CAP = 1; // per-worker channel capacity = 1
+  var WORKER_CAP = 1;
   var NUM_WORKERS = 3;
 
-  // Queue fill levels
   var ioCpuFill = 0;
   var pipelineFill = 0;
   var workerFills = [0, 0, 0];
 
-  // Production rates per tick
-  var IO_RATE = 2.0; // chunks/tick from I/O
-  var CPU_RATE = 1.8; // batches/tick from CPU
-  var PIPELINE_RATE = 1.5; // batches/tick pipeline throughput
+  // Rates are balanced so 100% output speed drains everything.
+  // The bottleneck is the output — when it slows, pressure builds.
+  var IO_RATE = 1.5;      // chunks/tick from I/O
+  var CPU_RATE = 1.5;     // batches/tick CPU can process
+  var OUT_MAX_RATE = 1.6; // output can drain slightly faster than input at full speed
 
-  // Stats
   var totalProduced = 0;
   var totalDelivered = 0;
   var ioBlocked = false;
   var cpuBlocked = false;
+
+  // Track previous states for transition detection
+  var prevIoState = 'ok';   // ok | pressured | blocked
+  var prevCpuState = 'ok';
+  var prevOutState = 'ok';
 
   // --- Build DOM ---
   var controls = el('div', 'bp-controls');
@@ -267,11 +337,20 @@
     var ql = el('div', 'bp-queue-label'); ql.textContent = queueLabel;
     s.appendChild(ql);
 
-    return { el: s, tag: tag, slots: slots, qlabel: ql };
+    // Activity bar
+    var act = el('div', 'bp-activity');
+    var actFill = el('div', 'bp-activity-fill flowing');
+    act.appendChild(actFill);
+    s.appendChild(act);
+
+    return { el: s, tag: tag, slots: slots, qlabel: ql, actFill: actFill };
   }
 
   function makeArrow() {
-    var a = el('div', 'bp-arrow'); a.textContent = '\u25B6';
+    var a = el('div', 'bp-arrow flowing');
+    a.innerHTML = '\u25B6';
+    var dot = el('div', 'bp-arrow-dot');
+    a.appendChild(dot);
     return a;
   }
 
@@ -296,11 +375,6 @@
   var logEl = el('div', 'bp-log');
   root.appendChild(logEl);
 
-  // Explanation
-  var explainEl = el('div', 'bp-explain');
-  explainEl.innerHTML = '<b>Normal operation</b>All queues are draining faster than they fill. Data flows smoothly from files through SQL transforms to your collector.';
-  root.appendChild(explainEl);
-
   // --- Preset buttons ---
   var presets = [btnFast, btnSlow, btnDown];
   function setPreset(idx) {
@@ -322,10 +396,25 @@
     else if (outputSpeed === 0) btnDown.className = 'bp-btn active';
   };
 
+  // --- Alert system ---
+  function showAlert(stageObj, text, level) {
+    // Remove any existing alert on this stage
+    var old = stageObj.el.querySelector('.bp-alert');
+    if (old) old.remove();
+
+    var a = el('div', 'bp-alert ' + level);
+    a.textContent = text;
+    stageObj.el.appendChild(a);
+
+    // Auto-dismiss after 3.5s
+    setTimeout(function() {
+      a.classList.add('exiting');
+      setTimeout(function() { if (a.parentNode) a.remove(); }, 400);
+    }, 3500);
+  }
+
   // --- Log helper ---
-  var logCount = 0;
   function addLog(msg, cls) {
-    logCount++;
     var entry = el('div', 'bp-log-entry');
     var ts = tick.toString().padStart(4, '0');
     entry.innerHTML = '<span class="ts">t=' + ts + '</span> ' + (cls ? '<span class="' + cls + '">' + msg + '</span>' : msg);
@@ -335,6 +424,13 @@
   }
 
   // --- Update visuals ---
+  function classifyState(fill, cap) {
+    var pct = fill / cap;
+    if (pct >= 1.0) return 'blocked';
+    if (pct > 0.5) return 'pressured';
+    return 'ok';
+  }
+
   function updateStage(stage, fill, cap, label) {
     var pct = fill / cap;
     for (var i = 0; i < stage.slots.length; i++) {
@@ -349,21 +445,30 @@
     if (pct >= 1.0) {
       stage.el.className = 'bp-stage blocked';
       stage.tag.className = 'bp-stage-tag bp-tag-blocked'; stage.tag.textContent = 'BLOCKED';
+      stage.actFill.className = 'bp-activity-fill blocked';
     } else if (pct > 0.5) {
       stage.el.className = 'bp-stage pressured';
       stage.tag.className = 'bp-stage-tag bp-tag-slow'; stage.tag.textContent = 'PRESSURE';
+      stage.actFill.className = 'bp-activity-fill flowing pressured';
     } else {
       stage.el.className = 'bp-stage';
       stage.tag.className = 'bp-stage-tag bp-tag-ok'; stage.tag.textContent = 'OK';
+      stage.actFill.className = 'bp-activity-fill flowing';
     }
   }
 
   function updateArrow(arrowEl, pressure) {
-    arrowEl.className = pressure >= 1.0 ? 'bp-arrow blocked' : (pressure > 0.5 ? 'bp-arrow pressured' : 'bp-arrow');
+    if (pressure >= 1.0) {
+      arrowEl.className = 'bp-arrow blocked';
+    } else if (pressure > 0.5) {
+      arrowEl.className = 'bp-arrow flowing pressured';
+    } else {
+      arrowEl.className = 'bp-arrow flowing';
+    }
   }
 
   function updateStats() {
-    var throughput = (outputSpeed / 100) * PIPELINE_RATE;
+    var throughput = (outputSpeed / 100) * OUT_MAX_RATE;
     var latClass = '';
     var latVal = '';
     if (outputSpeed === 0) { latVal = '\u221E'; latClass = 'red'; }
@@ -375,10 +480,10 @@
     var items = [
       ['Throughput', throughput.toFixed(1) + ' batch/s', throughput < 0.5 ? 'red' : (throughput < 1.0 ? 'amber' : 'green')],
       ['Latency', latVal, latClass],
-      ['Batches produced', '' + totalProduced, ''],
-      ['Batches delivered', '' + totalDelivered, 'green'],
-      ['I/O worker', ioBlocked ? 'BLOCKED' : 'polling', ioBlocked ? 'red' : 'green'],
-      ['CPU worker', cpuBlocked ? 'BLOCKED' : 'scanning', cpuBlocked ? 'red' : 'green'],
+      ['Produced', '' + totalProduced, ''],
+      ['Delivered', '' + totalDelivered, 'green'],
+      ['I/O', ioBlocked ? 'BLOCKED' : 'polling', ioBlocked ? 'red' : 'green'],
+      ['CPU', cpuBlocked ? 'BLOCKED' : 'scanning', cpuBlocked ? 'red' : 'green'],
     ];
     items.forEach(function(item) {
       var s = el('div', 'bp-stat');
@@ -388,51 +493,66 @@
     });
   }
 
-  function updateExplanation() {
-    var outPct = 1 - (outputSpeed / 100);
-    var workerPressure = Math.max.apply(null, workerFills) / WORKER_CAP;
-    var pipePressure = pipelineFill / PIPELINE_CAP;
-    var ioPressure = ioCpuFill / IO_CPU_CAP;
+  // --- Check for state transitions and fire alerts ---
+  function checkTransitions() {
+    var ioState = classifyState(ioCpuFill, IO_CPU_CAP);
+    var cpuState = classifyState(pipelineFill, PIPELINE_CAP);
+    var workerBusy = workerFills.filter(function(f) { return f > 0.1; }).length;
+    var allFull = workerFills.every(function(f) { return f >= WORKER_CAP * 0.9; });
+    var outState = allFull ? 'blocked' : (workerBusy >= 2 ? 'pressured' : 'ok');
 
-    if (outputSpeed === 0) {
-      explainEl.className = 'bp-explain err';
-      explainEl.innerHTML = '<b>\u26D4 Output outage \u2014 full cascade</b>' +
-        'The collector is unreachable. Output workers retry with exponential backoff (capped at 60s), blocking their channels. ' +
-        'The pipeline channel fills to 16/16. CPU workers block on <code>blocking_send</code>. ' +
-        'I/O workers block on the bounded(4) channel. File readers naturally back off \u2014 <b>no data is lost</b>, but new logs queue on disk until the outage clears.';
-    } else if (ioPressure >= 1.0) {
-      explainEl.className = 'bp-explain err';
-      explainEl.innerHTML = '<b>\u26A0 I/O worker blocked \u2014 backpressure reached the source</b>' +
-        'The bounded(4) I/O\u2192CPU channel is full. The I/O worker is stuck in <code>blocking_send</code> and cannot call <code>poll()</code>. ' +
-        'The file reader sees no reads and its adaptive poll cadence backs off. Logs accumulate on disk safely \u2014 logfwd will catch up when pressure clears.';
-    } else if (pipePressure > 0.5) {
-      explainEl.className = 'bp-explain warn';
-      explainEl.innerHTML = '<b>\u26A0 Pipeline channel filling \u2014 pressure building</b>' +
-        'Output workers are slower than the CPU worker. The pipeline channel (' + Math.ceil(pipelineFill) + '/16) is backing up. ' +
-        'If it fills completely, the CPU worker will block, and pressure will cascade to the I/O worker. ' +
-        'This is <b>by design</b> \u2014 bounded channels turn slow outputs into backpressure instead of unbounded memory growth.';
-    } else if (workerPressure > 0.5) {
-      explainEl.className = 'bp-explain warn';
-      explainEl.innerHTML = '<b>Output workers busy</b>' +
-        'MRU dispatch is consolidating work onto fewer workers. <code>try_send</code> scans workers front-to-back; ' +
-        'the first with capacity gets the batch. If all ' + NUM_WORKERS + ' workers are full, the pool spawns up to max or async-waits on the front worker.';
-    } else {
-      explainEl.className = 'bp-explain';
-      explainEl.innerHTML = '<b>Normal operation</b>' +
-        'All queues are draining faster than they fill. Data flows smoothly from files through SQL transforms to your collector. ' +
-        'Try dragging the output speed slider to the left, or click <b>Slow</b> or <b>Outage</b> to see backpressure cascade.';
+    // Output stage transitions
+    if (outState !== prevOutState) {
+      if (outState === 'blocked') {
+        showAlert(outStage, 'All workers full \u2014 retrying with backoff', 'err');
+        addLog('Output workers full \u2014 backpressure starts here', 'err');
+      } else if (outState === 'pressured' && prevOutState === 'ok') {
+        showAlert(outStage, 'Workers busy \u2014 MRU dispatch consolidating', 'warn');
+        addLog('Output workers busy \u2014 MRU consolidation active', 'warn');
+      } else if (outState === 'ok' && prevOutState !== 'ok') {
+        showAlert(outStage, 'Workers draining \u2014 pressure cleared', 'ok');
+        addLog('Output recovered \u2014 workers draining normally', 'ok');
+      }
+      prevOutState = outState;
+    }
+
+    // Pipeline/CPU transitions
+    if (cpuState !== prevCpuState) {
+      if (cpuState === 'blocked') {
+        showAlert(cpuStage, 'Pipeline full! CPU worker blocked on blocking_send', 'err');
+        addLog('CPU worker blocked \u2014 pipeline channel full (' + Math.ceil(pipelineFill) + '/16)', 'err');
+      } else if (cpuState === 'pressured' && prevCpuState === 'ok') {
+        showAlert(cpuStage, 'Pipeline filling \u2014 pressure building', 'warn');
+        addLog('Pipeline channel filling (' + Math.ceil(pipelineFill) + '/16)', 'warn');
+      } else if (cpuState === 'ok' && prevCpuState !== 'ok') {
+        showAlert(cpuStage, 'Pipeline draining \u2014 CPU worker unblocked', 'ok');
+        addLog('CPU worker unblocked \u2014 pipeline draining', 'ok');
+      }
+      prevCpuState = cpuState;
+    }
+
+    // I/O transitions
+    if (ioState !== prevIoState) {
+      if (ioState === 'blocked') {
+        showAlert(ioStage, 'Channel full! I/O worker can\'t call poll()', 'err');
+        addLog('I/O worker blocked \u2014 bounded(4) channel full', 'err');
+      } else if (ioState === 'pressured' && prevIoState === 'ok') {
+        showAlert(ioStage, 'I/O\u2192CPU channel filling', 'warn');
+        addLog('I/O\u2192CPU channel filling (' + Math.ceil(ioCpuFill) + '/4)', 'warn');
+      } else if (ioState === 'ok' && prevIoState !== 'ok') {
+        showAlert(ioStage, 'Channel cleared \u2014 poll() resumed', 'ok');
+        addLog('I/O worker resumed \u2014 reading new data', 'ok');
+      }
+      prevIoState = ioState;
     }
   }
 
   // --- Simulation loop ---
-  var lastLogTick = -10;
-
   function simTick() {
     if (!running) return;
     tick++;
 
-    // Output drain rate depends on speed slider
-    var outDrain = (outputSpeed / 100) * PIPELINE_RATE;
+    var outDrain = (outputSpeed / 100) * OUT_MAX_RATE;
 
     // Output workers drain
     var totalWorkerFill = workerFills.reduce(function(a, b) { return a + b; }, 0);
@@ -446,7 +566,6 @@
     }
 
     // Pipeline drains into workers (MRU dispatch)
-    var pipelineDrain = 0;
     if (pipelineFill > 0) {
       for (var w2 = 0; w2 < NUM_WORKERS; w2++) {
         if (pipelineFill <= 0) break;
@@ -455,7 +574,6 @@
           var send = Math.min(space, pipelineFill, 0.8);
           workerFills[w2] += send;
           pipelineFill -= send;
-          pipelineDrain += send;
         }
       }
     }
@@ -483,26 +601,15 @@
       workerFills[w3] = Math.max(0, Math.min(WORKER_CAP, workerFills[w3]));
     }
 
-    // Log interesting events
-    if (ioBlocked && tick - lastLogTick > 8) {
-      addLog('I/O worker blocked \u2014 bounded(4) channel full', 'warn');
-      lastLogTick = tick;
-    } else if (cpuBlocked && !ioBlocked && tick - lastLogTick > 8) {
-      addLog('CPU worker blocked \u2014 pipeline channel full (' + Math.ceil(pipelineFill) + '/16)', 'warn');
-      lastLogTick = tick;
-    } else if (outputSpeed === 0 && tick - lastLogTick > 12) {
-      addLog('Output unreachable \u2014 workers retrying with backoff', 'err');
-      lastLogTick = tick;
-    } else if (outputSpeed === 100 && pipelineFill < 1 && tick - lastLogTick > 15) {
-      addLog('Pipeline healthy \u2014 ' + totalDelivered + ' batches delivered', 'ok');
-      lastLogTick = tick;
-    }
+    // Check for state transitions and fire alerts
+    checkTransitions();
 
     // Update visuals
-    var workerBusy = workerFills.filter(function(f) { return f > 0.1; }).length;
     updateStage(ioStage, ioCpuFill, IO_CPU_CAP, 'slots');
     updateStage(cpuStage, pipelineFill, PIPELINE_CAP, 'slots');
-    // For output, show busy workers
+
+    // Output stage
+    var workerBusy = workerFills.filter(function(f) { return f > 0.1; }).length;
     outStage.qlabel.textContent = workerBusy + '/' + NUM_WORKERS + ' busy';
     for (var i = 0; i < outStage.slots.length; i++) {
       if (workerFills[i] > 0.5) {
@@ -515,31 +622,33 @@
     if (allWorkersFull) {
       outStage.el.className = 'bp-stage blocked';
       outStage.tag.className = 'bp-stage-tag bp-tag-blocked'; outStage.tag.textContent = 'FULL';
+      outStage.actFill.className = 'bp-activity-fill blocked';
     } else if (workerBusy >= 2) {
       outStage.el.className = 'bp-stage pressured';
       outStage.tag.className = 'bp-stage-tag bp-tag-slow'; outStage.tag.textContent = 'BUSY';
+      outStage.actFill.className = 'bp-activity-fill flowing pressured';
     } else {
       outStage.el.className = 'bp-stage';
       outStage.tag.className = 'bp-stage-tag bp-tag-ok'; outStage.tag.textContent = 'OK';
+      outStage.actFill.className = 'bp-activity-fill flowing';
     }
 
     updateArrow(arrow1, ioCpuFill / IO_CPU_CAP);
     updateArrow(arrow2, pipelineFill / PIPELINE_CAP);
     updateStats();
-    updateExplanation();
   }
 
   // Initial render
   updateStats();
+  addLog('Pipeline started \u2014 drag the slider or click a preset', 'ok');
 
   // Start animation
   var interval = setInterval(simTick, 250);
 
   // Cleanup on page nav (Starlight SPA)
-  function cleanup() {
+  document.addEventListener('astro:before-swap', function() {
     clearInterval(interval);
     running = false;
-  }
-  document.addEventListener('astro:before-swap', cleanup, { once: true });
+  }, { once: true });
 })();
 </script>

--- a/book/src/components/CheckpointSim.astro
+++ b/book/src/components/CheckpointSim.astro
@@ -422,7 +422,7 @@
 
   // TLA+ callout
   var tlaEl = el('div', 'ck-tla');
-  tlaEl.innerHTML = '<span class="ck-tla-icon">\uD83D\uDD2C</span><div><b>Formally verified.</b> TLA+ spec <code>PipelineMachine.tla</code> proves <code>CommittedNeverAheadOfTerminalizedPrefix</code> \u2014 the checkpoint can never advance past an unresolved batch. This invariant holds across 70+ model-checked properties.</div>';
+  tlaEl.innerHTML = '<span class="ck-tla-icon">\uD83D\uDD2C</span><div><b>Formally verified.</b> TLA+ spec <code>PipelineMachine.tla</code> proves <code>CheckpointNeverAheadOfTerminalizedPrefix</code> \u2014 the checkpoint can never advance past an unresolved batch. This invariant holds across 70+ model-checked properties.</div>';
   root.appendChild(tlaEl);
 
   // --- Callout system ---

--- a/book/src/components/CheckpointSim.astro
+++ b/book/src/components/CheckpointSim.astro
@@ -362,10 +362,15 @@
 
   // Tabs
   var tabs = el('div', 'ck-tabs');
+  tabs.setAttribute('role', 'tablist');
+  tabs.setAttribute('aria-label', 'Checkpoint scenarios');
   var tabBtns = {};
   Object.keys(SCENARIOS).forEach(function(key) {
     var btn = el('button', 'ck-tab' + (key === currentScenario ? ' active' : ''));
+    btn.type = 'button';
     btn.textContent = SCENARIOS[key].name;
+    btn.setAttribute('role', 'tab');
+    btn.setAttribute('aria-selected', key === currentScenario ? 'true' : 'false');
     btn.onclick = function() { selectScenario(key); };
     tabs.appendChild(btn);
     tabBtns[key] = btn;
@@ -374,9 +379,9 @@
 
   // Controls
   var ctrlBar = el('div', 'ck-controls');
-  var playBtn = el('button', 'ck-play'); playBtn.innerHTML = '&#9654;';
-  var stepBtn = el('button', 'ck-step-btn'); stepBtn.textContent = 'Step \u25B6';
-  var resetBtn = el('button', 'ck-reset-btn'); resetBtn.textContent = 'Reset';
+  var playBtn = el('button', 'ck-play'); playBtn.type = 'button'; playBtn.innerHTML = '&#9654;'; playBtn.setAttribute('aria-label', 'Play scenario');
+  var stepBtn = el('button', 'ck-step-btn'); stepBtn.type = 'button'; stepBtn.textContent = 'Step \u25B6';
+  var resetBtn = el('button', 'ck-reset-btn'); resetBtn.type = 'button'; resetBtn.textContent = 'Reset';
   var stepInfo = el('span', 'ck-step-info');
   ctrlBar.appendChild(playBtn);
   ctrlBar.appendChild(stepBtn);
@@ -603,7 +608,9 @@
     stopAuto();
     currentScenario = key;
     Object.keys(tabBtns).forEach(function(k) {
-      tabBtns[k].className = 'ck-tab' + (k === key ? ' active' : '');
+      var active = k === key;
+      tabBtns[k].className = 'ck-tab' + (active ? ' active' : '');
+      tabBtns[k].setAttribute('aria-selected', active ? 'true' : 'false');
     });
     resetSim();
   }
@@ -634,6 +641,7 @@
     autoPlaying = false;
     if (autoTimer) { clearInterval(autoTimer); autoTimer = null; }
     playBtn.innerHTML = '&#9654;';
+    playBtn.setAttribute('aria-label', 'Play scenario');
   }
 
   function toggleAuto() {
@@ -642,6 +650,7 @@
     } else {
       autoPlaying = true;
       playBtn.innerHTML = '&#10074;&#10074;';
+      playBtn.setAttribute('aria-label', 'Pause scenario');
       autoTimer = setInterval(function() {
         var sc = SCENARIOS[currentScenario];
         if (stepIndex >= sc.steps.length) {

--- a/book/src/components/CheckpointSim.astro
+++ b/book/src/components/CheckpointSim.astro
@@ -1,0 +1,575 @@
+---
+// Interactive checkpoint ordering visualizer.
+// Shows how out-of-order ACKs work and why checkpoints only advance contiguously.
+---
+
+<div class="ck" id="checkpoint-sim"></div>
+
+<style is:global>
+  .ck {
+    --ck-bg: var(--sl-color-bg-sidebar);
+    --ck-border: var(--sl-color-hairline);
+    --ck-accent: var(--sl-color-accent);
+    --ck-text: var(--sl-color-text);
+    --ck-muted: var(--sl-color-gray-3);
+    --ck-green: #22c55e;
+    --ck-amber: #f59e0b;
+    --ck-red: #ef4444;
+    --ck-blue: #60a5fa;
+    --ck-purple: #a78bfa;
+    --ck-pink: #ec4899;
+    margin: 1.5rem 0;
+  }
+  .ck * { margin-top: 0 !important; }
+
+  /* Controls */
+  .ck-controls {
+    display: flex; align-items: center; gap: 0.5rem;
+    padding: 0.5rem 0.75rem; background: var(--ck-bg);
+    border: 1px solid var(--ck-border); border-radius: 8px;
+    margin-bottom: 0.6rem; flex-wrap: wrap;
+  }
+  .ck-play {
+    width: 28px; height: 28px; border-radius: 50%;
+    border: 1.5px solid var(--ck-accent); background: transparent;
+    color: var(--ck-accent); cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 0.7rem;
+  }
+  .ck-play:hover { background: color-mix(in srgb, var(--ck-accent) 12%, transparent); }
+  .ck-step-btn {
+    padding: 0.2rem 0.5rem; border-radius: 4px; border: 1px solid var(--ck-border);
+    background: transparent; color: var(--ck-text); font-size: 0.65rem;
+    cursor: pointer; font-weight: 600;
+  }
+  .ck-step-btn:hover { border-color: var(--ck-accent); }
+  .ck-reset-btn {
+    padding: 0.2rem 0.5rem; border-radius: 4px; border: 1px solid var(--ck-border);
+    background: transparent; color: var(--ck-muted); font-size: 0.65rem;
+    cursor: pointer;
+  }
+  .ck-reset-btn:hover { border-color: var(--ck-accent); color: var(--ck-text); }
+  .ck-step-info {
+    font-size: 0.7rem; color: var(--ck-muted); margin-left: auto;
+    font-family: var(--sl-font-mono, monospace);
+  }
+
+  /* Scenario tabs */
+  .ck-tabs {
+    display: flex; gap: 0.25rem; margin-bottom: 0.6rem;
+  }
+  .ck-tab {
+    padding: 0.3rem 0.65rem; border-radius: 5px; border: 1px solid var(--ck-border);
+    background: transparent; color: var(--ck-text); font-size: 0.65rem;
+    cursor: pointer; font-weight: 500;
+  }
+  .ck-tab:hover { border-color: var(--ck-accent); }
+  .ck-tab.active {
+    border-color: var(--ck-accent); background: var(--ck-accent); color: white;
+  }
+
+  /* Batch timeline */
+  .ck-timeline {
+    display: flex; gap: 4px; margin-bottom: 0.5rem;
+    padding: 0.5rem; background: var(--ck-bg);
+    border: 1px solid var(--ck-border); border-radius: 8px;
+    overflow-x: auto; align-items: flex-end;
+  }
+  .ck-batch {
+    display: flex; flex-direction: column; align-items: center;
+    min-width: 52px; padding: 0.3rem 0.2rem;
+    border: 1.5px solid var(--ck-border); border-radius: 6px;
+    transition: all 0.4s ease;
+    position: relative;
+  }
+  .ck-batch.in-flight {
+    border-color: var(--ck-blue);
+    background: color-mix(in srgb, var(--ck-blue) 8%, transparent);
+  }
+  .ck-batch.pending-ack {
+    border-color: var(--ck-amber);
+    background: color-mix(in srgb, var(--ck-amber) 10%, transparent);
+  }
+  .ck-batch.committed {
+    border-color: var(--ck-green);
+    background: color-mix(in srgb, var(--ck-green) 10%, transparent);
+  }
+  .ck-batch.rejected {
+    border-color: var(--ck-red);
+    background: color-mix(in srgb, var(--ck-red) 8%, transparent);
+  }
+  .ck-batch.stalling {
+    animation: ck-pulse 1s infinite;
+  }
+  @keyframes ck-pulse {
+    0%, 100% { box-shadow: none; }
+    50% { box-shadow: 0 0 8px color-mix(in srgb, var(--ck-amber) 40%, transparent); }
+  }
+  .ck-batch.highlight {
+    transform: scale(1.08);
+    box-shadow: 0 0 10px color-mix(in srgb, var(--ck-accent) 30%, transparent);
+  }
+  .ck-batch-id {
+    font-family: var(--sl-font-mono, monospace); font-size: 0.7rem;
+    font-weight: 700; margin-bottom: 0.15rem;
+  }
+  .ck-batch-state {
+    font-size: 0.48rem; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 0.08rem 0.25rem; border-radius: 3px;
+  }
+  .ck-batch-state.in-flight { background: color-mix(in srgb, var(--ck-blue) 20%, transparent); color: var(--ck-blue); }
+  .ck-batch-state.pending-ack { background: color-mix(in srgb, var(--ck-amber) 20%, transparent); color: var(--ck-amber); }
+  .ck-batch-state.committed { background: color-mix(in srgb, var(--ck-green) 20%, transparent); color: var(--ck-green); }
+  .ck-batch-state.rejected { background: color-mix(in srgb, var(--ck-red) 20%, transparent); color: var(--ck-red); }
+  .ck-batch-cp {
+    font-size: 0.45rem; color: var(--ck-muted); margin-top: 0.1rem;
+    font-family: var(--sl-font-mono, monospace);
+  }
+
+  /* Checkpoint marker */
+  .ck-cp-row {
+    display: flex; align-items: center; gap: 0.4rem;
+    padding: 0.4rem 0.6rem; margin-bottom: 0.5rem;
+  }
+  .ck-cp-label {
+    font-size: 0.65rem; font-weight: 700; color: var(--ck-green);
+    white-space: nowrap;
+  }
+  .ck-cp-bar {
+    flex: 1; height: 6px; background: var(--ck-border); border-radius: 3px;
+    position: relative; overflow: visible;
+  }
+  .ck-cp-fill {
+    height: 100%; background: var(--ck-green); border-radius: 3px;
+    transition: width 0.5s ease;
+  }
+  .ck-cp-marker {
+    position: absolute; top: -5px; width: 16px; height: 16px;
+    background: var(--ck-green); border-radius: 50%;
+    border: 2px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    transition: left 0.5s ease;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 0.4rem; font-weight: 700; color: white;
+  }
+  .ck-cp-val {
+    font-family: var(--sl-font-mono, monospace); font-size: 0.7rem;
+    font-weight: 700; color: var(--ck-green); min-width: 50px;
+  }
+
+  /* Explanation */
+  .ck-explain {
+    padding: 0.55rem 0.75rem; background: var(--ck-bg);
+    border: 1px solid var(--ck-border); border-radius: 7px;
+    font-size: 0.75rem; line-height: 1.5;
+    transition: border-color 0.3s;
+    margin-bottom: 0.5rem;
+  }
+  .ck-explain.highlight { border-color: var(--ck-accent); }
+  .ck-explain.warn { border-color: var(--ck-amber); }
+  .ck-explain b { display: block; font-size: 0.78rem; margin-bottom: 0.1rem; }
+
+  /* Legend */
+  .ck-legend {
+    display: flex; gap: 0.75rem; flex-wrap: wrap;
+    font-size: 0.6rem; padding: 0.3rem 0;
+  }
+  .ck-legend-item { display: flex; align-items: center; gap: 0.25rem; }
+  .ck-legend-dot {
+    width: 10px; height: 10px; border-radius: 2px; border: 1.5px solid;
+  }
+  .ck-dot-flight { border-color: var(--ck-blue); background: color-mix(in srgb, var(--ck-blue) 20%, transparent); }
+  .ck-dot-pending { border-color: var(--ck-amber); background: color-mix(in srgb, var(--ck-amber) 20%, transparent); }
+  .ck-dot-committed { border-color: var(--ck-green); background: color-mix(in srgb, var(--ck-green) 20%, transparent); }
+  .ck-dot-rejected { border-color: var(--ck-red); background: color-mix(in srgb, var(--ck-red) 20%, transparent); }
+
+  /* TLA+ property callout */
+  .ck-tla {
+    display: flex; align-items: flex-start; gap: 0.5rem;
+    padding: 0.45rem 0.65rem; border-radius: 6px;
+    border: 1px solid var(--ck-purple);
+    background: color-mix(in srgb, var(--ck-purple) 5%, var(--ck-bg));
+    font-size: 0.65rem; line-height: 1.5;
+    margin-top: 0.4rem;
+  }
+  .ck-tla-icon {
+    font-size: 0.9rem; min-width: 1.2em; text-align: center;
+  }
+  .ck-tla code {
+    font-family: var(--sl-font-mono, monospace); font-size: 0.6rem;
+    background: color-mix(in srgb, var(--ck-purple) 12%, transparent);
+    padding: 0.05rem 0.3rem; border-radius: 3px;
+  }
+</style>
+
+<script>
+(function() {
+  var root = document.getElementById('checkpoint-sim');
+  if (!root) return;
+
+  function el(tag, cls) { var e = document.createElement(tag); if (cls) e.className = cls; return e; }
+
+  // --- Scenarios ---
+  var SCENARIOS = {
+    'happy': {
+      name: 'Happy Path',
+      desc: 'Batches acked in order \u2014 checkpoint advances smoothly',
+      steps: [
+        { action: 'create', id: 0, cp: '0KB' },
+        { action: 'create', id: 1, cp: '128KB' },
+        { action: 'send', id: 0 },
+        { action: 'send', id: 1 },
+        { action: 'create', id: 2, cp: '256KB' },
+        { action: 'send', id: 2 },
+        { action: 'ack', id: 0, explain: 'Batch #0 acked. It\'s the lowest in-flight \u2192 checkpoint advances to 0KB.' },
+        { action: 'ack', id: 1, explain: 'Batch #1 acked. #0 already committed \u2192 checkpoint advances to 128KB.' },
+        { action: 'ack', id: 2, explain: 'Batch #2 acked. All prior committed \u2192 checkpoint advances to 256KB. All drained!' },
+      ]
+    },
+    'ooo': {
+      name: 'Out-of-Order ACK',
+      desc: 'Collector acks #2 before #0 \u2014 watch the checkpoint stall',
+      steps: [
+        { action: 'create', id: 0, cp: '0KB' },
+        { action: 'create', id: 1, cp: '128KB' },
+        { action: 'create', id: 2, cp: '256KB' },
+        { action: 'send', id: 0 },
+        { action: 'send', id: 1 },
+        { action: 'send', id: 2 },
+        { action: 'ack', id: 2, explain: 'Batch #2 acked first! But #0 and #1 are still in-flight. Checkpoint CANNOT advance \u2014 it moves to pending_acks.' },
+        { action: 'ack', id: 1, explain: 'Batch #1 acked. Still waiting for #0 \u2014 both #1 and #2 sit in pending_acks. Checkpoint still frozen.' },
+        { action: 'ack', id: 0, explain: '\uD83C\uDF89 Batch #0 finally acked! Now the contiguous chain clears: #0 \u2192 #1 \u2192 #2 all advance. Checkpoint jumps from none to 256KB in one step!' },
+      ]
+    },
+    'reject': {
+      name: 'Permanent Rejection',
+      desc: 'Batch #1 is 413 Too Large \u2014 rejected but checkpoint still advances',
+      steps: [
+        { action: 'create', id: 0, cp: '0KB' },
+        { action: 'create', id: 1, cp: '128KB' },
+        { action: 'create', id: 2, cp: '256KB' },
+        { action: 'send', id: 0 },
+        { action: 'send', id: 1 },
+        { action: 'send', id: 2 },
+        { action: 'ack', id: 0, explain: 'Batch #0 acked normally. Checkpoint advances to 0KB.' },
+        { action: 'reject', id: 1, explain: 'Batch #1 rejected (413 Too Large)! Rejection is terminal \u2014 the batch is undeliverable. Checkpoint advances past it to 128KB to prevent infinite stall.' },
+        { action: 'ack', id: 2, explain: 'Batch #2 acked. All prior resolved \u2192 checkpoint advances to 256KB. One batch was lost, but the pipeline didn\'t stall forever.' },
+      ]
+    },
+    'stall': {
+      name: 'Stalled Batch',
+      desc: 'Batch #0 retries forever \u2014 checkpoint freezes while others complete',
+      steps: [
+        { action: 'create', id: 0, cp: '0KB' },
+        { action: 'create', id: 1, cp: '128KB' },
+        { action: 'create', id: 2, cp: '256KB' },
+        { action: 'create', id: 3, cp: '384KB' },
+        { action: 'send', id: 0 },
+        { action: 'send', id: 1 },
+        { action: 'send', id: 2 },
+        { action: 'send', id: 3 },
+        { action: 'ack', id: 1, explain: 'Batch #1 acked, but #0 is still in-flight (retrying). Checkpoint cannot advance.' },
+        { action: 'ack', id: 3, explain: 'Batch #3 acked too. Three batches in pending_acks, but #0 blocks them all. The checkpoint is frozen at the start.' },
+        { action: 'ack', id: 2, explain: 'Batch #2 acked. Now #1, #2, #3 all pending. But #0 is STILL retrying. On restart, logfwd would re-send ALL data from offset 0. This is at-least-once delivery.' },
+        { action: 'ack', id: 0, explain: '\uD83C\uDF89 Batch #0 finally succeeds! The entire pending chain collapses: checkpoint leaps from none \u2192 384KB. No data was lost.' },
+      ]
+    }
+  };
+
+  var currentScenario = 'happy';
+  var stepIndex = 0;
+  var autoPlaying = false;
+  var autoTimer = null;
+
+  // State
+  var batches = {}; // id -> { state, cp }
+  var committedCp = null;
+  var committedId = -1;
+
+  // --- Build DOM ---
+
+  // Tabs
+  var tabs = el('div', 'ck-tabs');
+  var tabBtns = {};
+  Object.keys(SCENARIOS).forEach(function(key) {
+    var btn = el('button', 'ck-tab' + (key === currentScenario ? ' active' : ''));
+    btn.textContent = SCENARIOS[key].name;
+    btn.onclick = function() { selectScenario(key); };
+    tabs.appendChild(btn);
+    tabBtns[key] = btn;
+  });
+  root.appendChild(tabs);
+
+  // Controls
+  var ctrlBar = el('div', 'ck-controls');
+  var playBtn = el('button', 'ck-play'); playBtn.innerHTML = '&#9654;';
+  var stepBtn = el('button', 'ck-step-btn'); stepBtn.textContent = 'Step \u25B6';
+  var resetBtn = el('button', 'ck-reset-btn'); resetBtn.textContent = 'Reset';
+  var stepInfo = el('span', 'ck-step-info');
+  ctrlBar.appendChild(playBtn);
+  ctrlBar.appendChild(stepBtn);
+  ctrlBar.appendChild(resetBtn);
+  ctrlBar.appendChild(stepInfo);
+  root.appendChild(ctrlBar);
+
+  // Timeline
+  var timelineEl = el('div', 'ck-timeline');
+  root.appendChild(timelineEl);
+
+  // Checkpoint progress bar
+  var cpRow = el('div', 'ck-cp-row');
+  var cpLabel = el('span', 'ck-cp-label'); cpLabel.textContent = 'Committed:';
+  var cpBar = el('div', 'ck-cp-bar');
+  var cpFill = el('div', 'ck-cp-fill'); cpFill.style.width = '0%';
+  var cpMarker = el('div', 'ck-cp-marker'); cpMarker.style.left = '0%'; cpMarker.textContent = '\u2713';
+  cpBar.appendChild(cpFill);
+  cpBar.appendChild(cpMarker);
+  var cpVal = el('span', 'ck-cp-val'); cpVal.textContent = 'none';
+  cpRow.appendChild(cpLabel);
+  cpRow.appendChild(cpBar);
+  cpRow.appendChild(cpVal);
+  root.appendChild(cpRow);
+
+  // Explanation
+  var explainEl = el('div', 'ck-explain');
+  root.appendChild(explainEl);
+
+  // Legend
+  var legend = el('div', 'ck-legend');
+  var legendItems = [
+    ['In-flight', 'ck-dot-flight'],
+    ['Pending ACK', 'ck-dot-pending'],
+    ['Committed', 'ck-dot-committed'],
+    ['Rejected', 'ck-dot-rejected'],
+  ];
+  legendItems.forEach(function(item) {
+    var li = el('span', 'ck-legend-item');
+    var dot = el('span', 'ck-legend-dot ' + item[1]);
+    var txt = document.createTextNode(' ' + item[0]);
+    li.appendChild(dot); li.appendChild(txt);
+    legend.appendChild(li);
+  });
+  root.appendChild(legend);
+
+  // TLA+ callout
+  var tlaEl = el('div', 'ck-tla');
+  tlaEl.innerHTML = '<span class="ck-tla-icon">\uD83D\uDD2C</span><div><b>Formally verified.</b> TLA+ spec <code>PipelineMachine.tla</code> proves <code>CommittedNeverAheadOfTerminalizedPrefix</code> \u2014 the checkpoint can never advance past an unresolved batch. This invariant holds across 70+ model-checked properties.</div>';
+  root.appendChild(tlaEl);
+
+  // --- Rendering ---
+  function render() {
+    var sc = SCENARIOS[currentScenario];
+    stepInfo.textContent = 'Step ' + stepIndex + '/' + sc.steps.length;
+
+    // Render batches
+    timelineEl.innerHTML = '';
+    var ids = Object.keys(batches).map(Number).sort(function(a, b) { return a - b; });
+    var totalBatches = ids.length || 1;
+
+    ids.forEach(function(id) {
+      var b = batches[id];
+      var batchEl = el('div', 'ck-batch ' + b.state);
+
+      // Highlight the last-changed batch
+      if (b.justChanged) {
+        batchEl.classList.add('highlight');
+        b.justChanged = false;
+      }
+      // Pulse stalling batches
+      if (b.state === 'in-flight' && hasPendingAckAbove(id)) {
+        batchEl.classList.add('stalling');
+      }
+
+      var idEl = el('div', 'ck-batch-id'); idEl.textContent = '#' + id;
+      var stateEl = el('div', 'ck-batch-state ' + b.state);
+      var stateLabels = {
+        'queued': 'QUEUED', 'in-flight': 'IN-FLIGHT',
+        'pending-ack': 'PENDING', 'committed': 'COMMITTED', 'rejected': 'REJECTED'
+      };
+      stateEl.textContent = stateLabels[b.state] || b.state.toUpperCase();
+      var cpEl = el('div', 'ck-batch-cp'); cpEl.textContent = b.cp;
+
+      batchEl.appendChild(idEl);
+      batchEl.appendChild(stateEl);
+      batchEl.appendChild(cpEl);
+      timelineEl.appendChild(batchEl);
+    });
+
+    // Checkpoint bar
+    var maxId = ids.length > 0 ? Math.max.apply(null, ids) : 0;
+    var pct = committedId >= 0 ? ((committedId + 1) / totalBatches) * 100 : 0;
+    cpFill.style.width = Math.min(100, pct) + '%';
+    cpMarker.style.left = 'calc(' + Math.min(100, pct) + '% - 8px)';
+    cpMarker.style.display = committedId >= 0 ? 'flex' : 'none';
+    cpVal.textContent = committedCp || 'none';
+  }
+
+  function hasPendingAckAbove(id) {
+    var ids = Object.keys(batches).map(Number);
+    return ids.some(function(other) {
+      return other > id && (batches[other].state === 'pending-ack');
+    });
+  }
+
+  // --- Step execution ---
+  function executeStep() {
+    var sc = SCENARIOS[currentScenario];
+    if (stepIndex >= sc.steps.length) {
+      stopAuto();
+      return;
+    }
+
+    var step = sc.steps[stepIndex];
+    stepIndex++;
+
+    // Clear justChanged
+    Object.keys(batches).forEach(function(k) { batches[k].justChanged = false; });
+
+    switch (step.action) {
+      case 'create':
+        batches[step.id] = { state: 'queued', cp: step.cp, justChanged: true };
+        explainEl.className = 'ck-explain';
+        explainEl.innerHTML = '<b>Create batch #' + step.id + '</b>New batch created for source at checkpoint ' + step.cp + '. Not yet in-flight \u2014 the ticket is Queued.';
+        break;
+
+      case 'send':
+        if (batches[step.id]) {
+          batches[step.id].state = 'in-flight';
+          batches[step.id].justChanged = true;
+        }
+        explainEl.className = 'ck-explain';
+        explainEl.innerHTML = '<b>Send batch #' + step.id + '</b>Batch registered as in-flight via <code>begin_send()</code>. The pipeline now owns it \u2014 it MUST be acked, rejected, or failed.';
+        break;
+
+      case 'ack':
+        if (batches[step.id]) {
+          batches[step.id].state = 'pending-ack';
+          batches[step.id].justChanged = true;
+        }
+        // Try advance
+        tryAdvance();
+        explainEl.className = step.explain && step.explain.includes('\uD83C\uDF89') ? 'ck-explain highlight' : (step.explain && step.explain.includes('CANNOT') ? 'ck-explain warn' : 'ck-explain');
+        explainEl.innerHTML = '<b>ACK batch #' + step.id + '</b>' + (step.explain || '');
+        break;
+
+      case 'reject':
+        if (batches[step.id]) {
+          batches[step.id].state = 'rejected';
+          batches[step.id].justChanged = true;
+        }
+        tryAdvance();
+        explainEl.className = 'ck-explain warn';
+        explainEl.innerHTML = '<b>Reject batch #' + step.id + ' (terminal)</b>' + (step.explain || '');
+        break;
+    }
+
+    render();
+  }
+
+  function tryAdvance() {
+    // Advance committed checkpoint by consuming contiguous resolved batches
+    var ids = Object.keys(batches).map(Number).sort(function(a, b) { return a - b; });
+    var advanced = true;
+    while (advanced) {
+      advanced = false;
+      for (var i = 0; i < ids.length; i++) {
+        var id = ids[i];
+        var b = batches[id];
+        if (id <= committedId) continue;
+
+        // Check if all lower IDs are resolved
+        var allLowerResolved = true;
+        for (var j = 0; j < ids.length; j++) {
+          var lower = ids[j];
+          if (lower >= id) break;
+          if (lower <= committedId) continue;
+          var ls = batches[lower].state;
+          if (ls !== 'committed' && ls !== 'rejected' && ls !== 'pending-ack') {
+            allLowerResolved = false;
+            break;
+          }
+        }
+
+        if (allLowerResolved && (b.state === 'pending-ack' || b.state === 'rejected')) {
+          // Also need all lower to be committed already or be pending-ack/rejected
+          var canCommit = true;
+          for (var k = 0; k < ids.length; k++) {
+            var checkId = ids[k];
+            if (checkId >= id) break;
+            if (checkId <= committedId) continue;
+            if (batches[checkId].state === 'in-flight' || batches[checkId].state === 'queued') {
+              canCommit = false;
+              break;
+            }
+          }
+          if (canCommit) {
+            if (b.state === 'pending-ack') {
+              b.state = 'committed';
+            }
+            // rejected stays rejected but counts as resolved
+            committedCp = b.cp;
+            committedId = id;
+            advanced = true;
+          }
+        }
+      }
+    }
+  }
+
+  // --- Controls ---
+  function selectScenario(key) {
+    stopAuto();
+    currentScenario = key;
+    Object.keys(tabBtns).forEach(function(k) {
+      tabBtns[k].className = 'ck-tab' + (k === key ? ' active' : '');
+    });
+    resetSim();
+  }
+
+  function resetSim() {
+    stopAuto();
+    stepIndex = 0;
+    batches = {};
+    committedCp = null;
+    committedId = -1;
+    var sc = SCENARIOS[currentScenario];
+    explainEl.className = 'ck-explain';
+    explainEl.innerHTML = '<b>' + sc.name + '</b>' + sc.desc + '. Click <b>Step</b> to advance one event at a time, or <b>Play</b> to auto-advance.';
+    render();
+  }
+
+  function stopAuto() {
+    autoPlaying = false;
+    if (autoTimer) { clearInterval(autoTimer); autoTimer = null; }
+    playBtn.innerHTML = '&#9654;';
+  }
+
+  function toggleAuto() {
+    if (autoPlaying) {
+      stopAuto();
+    } else {
+      autoPlaying = true;
+      playBtn.innerHTML = '&#10074;&#10074;';
+      autoTimer = setInterval(function() {
+        var sc = SCENARIOS[currentScenario];
+        if (stepIndex >= sc.steps.length) {
+          stopAuto();
+          return;
+        }
+        executeStep();
+      }, 1200);
+    }
+  }
+
+  playBtn.onclick = toggleAuto;
+  stepBtn.onclick = function() { stopAuto(); executeStep(); };
+  resetBtn.onclick = resetSim;
+
+  // --- Init ---
+  resetSim();
+
+  // Cleanup
+  document.addEventListener('astro:before-swap', function() {
+    stopAuto();
+  }, { once: true });
+})();
+</script>

--- a/book/src/components/CheckpointSim.astro
+++ b/book/src/components/CheckpointSim.astro
@@ -70,17 +70,24 @@
 
   /* Batch timeline */
   .ck-timeline {
-    display: flex; gap: 4px; margin-bottom: 0.5rem;
-    padding: 0.5rem; background: var(--ck-bg);
+    display: flex; gap: 6px; margin-bottom: 0.5rem;
+    padding: 0.6rem; padding-top: 2.8rem; /* room for callouts above */
+    background: var(--ck-bg);
     border: 1px solid var(--ck-border); border-radius: 8px;
-    overflow-x: auto; align-items: flex-end;
+    overflow-x: auto; overflow-y: visible;
+    align-items: flex-start; position: relative;
+    min-height: 100px;
   }
   .ck-batch {
     display: flex; flex-direction: column; align-items: center;
-    min-width: 52px; padding: 0.3rem 0.2rem;
+    min-width: 56px; padding: 0.35rem 0.3rem;
     border: 1.5px solid var(--ck-border); border-radius: 6px;
-    transition: all 0.4s ease;
+    transition: border-color 0.4s, background 0.4s, transform 0.3s, box-shadow 0.3s;
     position: relative;
+  }
+  .ck-batch.queued {
+    border-color: var(--ck-muted);
+    background: color-mix(in srgb, var(--ck-muted) 5%, transparent);
   }
   .ck-batch.in-flight {
     border-color: var(--ck-blue);
@@ -98,25 +105,52 @@
     border-color: var(--ck-red);
     background: color-mix(in srgb, var(--ck-red) 8%, transparent);
   }
+
+  /* In-flight shimmer: subtle progress bar inside the batch */
+  .ck-batch-progress {
+    position: absolute; bottom: 0; left: 0; right: 0; height: 3px;
+    border-radius: 0 0 4px 4px; overflow: hidden;
+    background: transparent;
+  }
+  .ck-batch-progress-fill {
+    position: absolute; inset: 0;
+    background: var(--ck-blue);
+    transform-origin: left;
+    opacity: 0;
+  }
+  .ck-batch.in-flight .ck-batch-progress-fill {
+    opacity: 1;
+    animation: ck-shimmer 2s ease-in-out infinite;
+  }
+  @keyframes ck-shimmer {
+    0%   { transform: scaleX(0.1); translate: 0% 0; }
+    50%  { transform: scaleX(0.4); translate: 60% 0; }
+    100% { transform: scaleX(0.1); translate: 100% 0; }
+  }
+
+  /* Stalling pulse for batches blocking the checkpoint */
   .ck-batch.stalling {
-    animation: ck-pulse 1s infinite;
+    animation: ck-stall-pulse 1.5s ease-in-out infinite;
   }
-  @keyframes ck-pulse {
+  @keyframes ck-stall-pulse {
     0%, 100% { box-shadow: none; }
-    50% { box-shadow: 0 0 8px color-mix(in srgb, var(--ck-amber) 40%, transparent); }
+    50% { box-shadow: 0 0 10px color-mix(in srgb, var(--ck-amber) 50%, transparent); }
   }
-  .ck-batch.highlight {
-    transform: scale(1.08);
-    box-shadow: 0 0 10px color-mix(in srgb, var(--ck-accent) 30%, transparent);
+
+  .ck-batch.target {
+    transform: scale(1.06);
+    box-shadow: 0 0 12px color-mix(in srgb, var(--ck-accent) 35%, transparent);
   }
+
   .ck-batch-id {
-    font-family: var(--sl-font-mono, monospace); font-size: 0.7rem;
+    font-family: var(--sl-font-mono, monospace); font-size: 0.72rem;
     font-weight: 700; margin-bottom: 0.15rem;
   }
   .ck-batch-state {
     font-size: 0.48rem; font-weight: 600; text-transform: uppercase;
     letter-spacing: 0.04em; padding: 0.08rem 0.25rem; border-radius: 3px;
   }
+  .ck-batch-state.queued { background: color-mix(in srgb, var(--ck-muted) 15%, transparent); color: var(--ck-muted); }
   .ck-batch-state.in-flight { background: color-mix(in srgb, var(--ck-blue) 20%, transparent); color: var(--ck-blue); }
   .ck-batch-state.pending-ack { background: color-mix(in srgb, var(--ck-amber) 20%, transparent); color: var(--ck-amber); }
   .ck-batch-state.committed { background: color-mix(in srgb, var(--ck-green) 20%, transparent); color: var(--ck-green); }
@@ -124,6 +158,46 @@
   .ck-batch-cp {
     font-size: 0.45rem; color: var(--ck-muted); margin-top: 0.1rem;
     font-family: var(--sl-font-mono, monospace);
+  }
+
+  /* Callout bubble — points down at a specific batch */
+  .ck-callout {
+    position: absolute; top: 0.4rem; left: 0; right: 0;
+    padding: 0.35rem 0.55rem; border-radius: 6px;
+    font-size: 0.65rem; font-weight: 500; line-height: 1.4;
+    z-index: 10; pointer-events: none;
+    animation: ck-callout-in 0.35s ease-out forwards;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.12);
+  }
+  .ck-callout::after {
+    content: ''; position: absolute; top: 100%; left: var(--arrow-left, 50%);
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+  }
+  .ck-callout.info {
+    background: var(--ck-blue); color: white;
+    border: 1px solid var(--ck-blue);
+  }
+  .ck-callout.info::after { border-top-color: var(--ck-blue); }
+  .ck-callout.warn {
+    background: var(--ck-amber); color: #1a1a2e;
+    border: 1px solid var(--ck-amber);
+  }
+  .ck-callout.warn::after { border-top-color: var(--ck-amber); }
+  .ck-callout.success {
+    background: var(--ck-green); color: white;
+    border: 1px solid var(--ck-green);
+  }
+  .ck-callout.success::after { border-top-color: var(--ck-green); }
+  .ck-callout.danger {
+    background: var(--ck-red); color: white;
+    border: 1px solid var(--ck-red);
+  }
+  .ck-callout.danger::after { border-top-color: var(--ck-red); }
+
+  @keyframes ck-callout-in {
+    from { opacity: 0; translate: 0 -6px; }
+    to { opacity: 1; translate: 0 0; }
   }
 
   /* Checkpoint marker */
@@ -151,22 +225,19 @@
     display: flex; align-items: center; justify-content: center;
     font-size: 0.4rem; font-weight: 700; color: white;
   }
+  /* Pulse on the checkpoint marker when it advances */
+  .ck-cp-marker.advancing {
+    animation: ck-cp-pop 0.5s ease-out;
+  }
+  @keyframes ck-cp-pop {
+    0% { transform: scale(1); }
+    40% { transform: scale(1.5); }
+    100% { transform: scale(1); }
+  }
   .ck-cp-val {
     font-family: var(--sl-font-mono, monospace); font-size: 0.7rem;
     font-weight: 700; color: var(--ck-green); min-width: 50px;
   }
-
-  /* Explanation */
-  .ck-explain {
-    padding: 0.55rem 0.75rem; background: var(--ck-bg);
-    border: 1px solid var(--ck-border); border-radius: 7px;
-    font-size: 0.75rem; line-height: 1.5;
-    transition: border-color 0.3s;
-    margin-bottom: 0.5rem;
-  }
-  .ck-explain.highlight { border-color: var(--ck-accent); }
-  .ck-explain.warn { border-color: var(--ck-amber); }
-  .ck-explain b { display: block; font-size: 0.78rem; margin-bottom: 0.1rem; }
 
   /* Legend */
   .ck-legend {
@@ -177,6 +248,7 @@
   .ck-legend-dot {
     width: 10px; height: 10px; border-radius: 2px; border: 1.5px solid;
   }
+  .ck-dot-queued { border-color: var(--ck-muted); background: color-mix(in srgb, var(--ck-muted) 15%, transparent); }
   .ck-dot-flight { border-color: var(--ck-blue); background: color-mix(in srgb, var(--ck-blue) 20%, transparent); }
   .ck-dot-pending { border-color: var(--ck-amber); background: color-mix(in srgb, var(--ck-amber) 20%, transparent); }
   .ck-dot-committed { border-color: var(--ck-green); background: color-mix(in srgb, var(--ck-green) 20%, transparent); }
@@ -214,63 +286,63 @@
       name: 'Happy Path',
       desc: 'Batches acked in order \u2014 checkpoint advances smoothly',
       steps: [
-        { action: 'create', id: 0, cp: '0KB' },
-        { action: 'create', id: 1, cp: '128KB' },
-        { action: 'send', id: 0 },
-        { action: 'send', id: 1 },
-        { action: 'create', id: 2, cp: '256KB' },
-        { action: 'send', id: 2 },
-        { action: 'ack', id: 0, explain: 'Batch #0 acked. It\'s the lowest in-flight \u2192 checkpoint advances to 0KB.' },
-        { action: 'ack', id: 1, explain: 'Batch #1 acked. #0 already committed \u2192 checkpoint advances to 128KB.' },
-        { action: 'ack', id: 2, explain: 'Batch #2 acked. All prior committed \u2192 checkpoint advances to 256KB. All drained!' },
+        { action: 'create', id: 0, cp: '0KB', msg: 'Create batch #0 at checkpoint 0KB' },
+        { action: 'create', id: 1, cp: '128KB', msg: 'Create batch #1 at checkpoint 128KB' },
+        { action: 'send', id: 0, msg: 'Sending #0 \u2014 pipeline owns it now' },
+        { action: 'send', id: 1, msg: 'Sending #1 via begin_send()' },
+        { action: 'create', id: 2, cp: '256KB', msg: 'Create batch #2 at checkpoint 256KB' },
+        { action: 'send', id: 2, msg: 'Sending #2 \u2014 all three in-flight' },
+        { action: 'ack', id: 0, level: 'success', msg: '#0 acked \u2192 checkpoint advances to 0KB' },
+        { action: 'ack', id: 1, level: 'success', msg: '#1 acked \u2192 checkpoint advances to 128KB' },
+        { action: 'ack', id: 2, level: 'success', msg: '#2 acked \u2192 all drained! Checkpoint at 256KB' },
       ]
     },
     'ooo': {
       name: 'Out-of-Order ACK',
       desc: 'Collector acks #2 before #0 \u2014 watch the checkpoint stall',
       steps: [
-        { action: 'create', id: 0, cp: '0KB' },
-        { action: 'create', id: 1, cp: '128KB' },
-        { action: 'create', id: 2, cp: '256KB' },
-        { action: 'send', id: 0 },
-        { action: 'send', id: 1 },
-        { action: 'send', id: 2 },
-        { action: 'ack', id: 2, explain: 'Batch #2 acked first! But #0 and #1 are still in-flight. Checkpoint CANNOT advance \u2014 it moves to pending_acks.' },
-        { action: 'ack', id: 1, explain: 'Batch #1 acked. Still waiting for #0 \u2014 both #1 and #2 sit in pending_acks. Checkpoint still frozen.' },
-        { action: 'ack', id: 0, explain: '\uD83C\uDF89 Batch #0 finally acked! Now the contiguous chain clears: #0 \u2192 #1 \u2192 #2 all advance. Checkpoint jumps from none to 256KB in one step!' },
+        { action: 'create', id: 0, cp: '0KB', msg: 'Create batch #0' },
+        { action: 'create', id: 1, cp: '128KB', msg: 'Create batch #1' },
+        { action: 'create', id: 2, cp: '256KB', msg: 'Create batch #2' },
+        { action: 'send', id: 0, msg: 'Sending #0' },
+        { action: 'send', id: 1, msg: 'Sending #1' },
+        { action: 'send', id: 2, msg: 'Sending #2 \u2014 all in-flight' },
+        { action: 'ack', id: 2, level: 'warn', msg: '#2 acked first! But #0 and #1 still in-flight \u2014 checkpoint FROZEN' },
+        { action: 'ack', id: 1, level: 'warn', msg: '#1 acked too \u2014 still waiting for #0. Both in pending_acks' },
+        { action: 'ack', id: 0, level: 'success', msg: '#0 acked! Chain collapses: 0\u2192128\u2192256KB in one leap!' },
       ]
     },
     'reject': {
       name: 'Permanent Rejection',
       desc: 'Batch #1 is 413 Too Large \u2014 rejected but checkpoint still advances',
       steps: [
-        { action: 'create', id: 0, cp: '0KB' },
-        { action: 'create', id: 1, cp: '128KB' },
-        { action: 'create', id: 2, cp: '256KB' },
-        { action: 'send', id: 0 },
-        { action: 'send', id: 1 },
-        { action: 'send', id: 2 },
-        { action: 'ack', id: 0, explain: 'Batch #0 acked normally. Checkpoint advances to 0KB.' },
-        { action: 'reject', id: 1, explain: 'Batch #1 rejected (413 Too Large)! Rejection is terminal \u2014 the batch is undeliverable. Checkpoint advances past it to 128KB to prevent infinite stall.' },
-        { action: 'ack', id: 2, explain: 'Batch #2 acked. All prior resolved \u2192 checkpoint advances to 256KB. One batch was lost, but the pipeline didn\'t stall forever.' },
+        { action: 'create', id: 0, cp: '0KB', msg: 'Create batch #0' },
+        { action: 'create', id: 1, cp: '128KB', msg: 'Create batch #1' },
+        { action: 'create', id: 2, cp: '256KB', msg: 'Create batch #2' },
+        { action: 'send', id: 0, msg: 'Sending #0' },
+        { action: 'send', id: 1, msg: 'Sending #1' },
+        { action: 'send', id: 2, msg: 'Sending #2' },
+        { action: 'ack', id: 0, level: 'success', msg: '#0 acked \u2192 checkpoint advances to 0KB' },
+        { action: 'reject', id: 1, level: 'danger', msg: '#1 rejected (413 Too Large)! Terminal \u2014 checkpoint advances past it' },
+        { action: 'ack', id: 2, level: 'success', msg: '#2 acked \u2192 all resolved. One batch lost, but pipeline didn\'t stall' },
       ]
     },
     'stall': {
       name: 'Stalled Batch',
       desc: 'Batch #0 retries forever \u2014 checkpoint freezes while others complete',
       steps: [
-        { action: 'create', id: 0, cp: '0KB' },
-        { action: 'create', id: 1, cp: '128KB' },
-        { action: 'create', id: 2, cp: '256KB' },
-        { action: 'create', id: 3, cp: '384KB' },
-        { action: 'send', id: 0 },
-        { action: 'send', id: 1 },
-        { action: 'send', id: 2 },
-        { action: 'send', id: 3 },
-        { action: 'ack', id: 1, explain: 'Batch #1 acked, but #0 is still in-flight (retrying). Checkpoint cannot advance.' },
-        { action: 'ack', id: 3, explain: 'Batch #3 acked too. Three batches in pending_acks, but #0 blocks them all. The checkpoint is frozen at the start.' },
-        { action: 'ack', id: 2, explain: 'Batch #2 acked. Now #1, #2, #3 all pending. But #0 is STILL retrying. On restart, logfwd would re-send ALL data from offset 0. This is at-least-once delivery.' },
-        { action: 'ack', id: 0, explain: '\uD83C\uDF89 Batch #0 finally succeeds! The entire pending chain collapses: checkpoint leaps from none \u2192 384KB. No data was lost.' },
+        { action: 'create', id: 0, cp: '0KB', msg: 'Create batch #0' },
+        { action: 'create', id: 1, cp: '128KB', msg: 'Create batch #1' },
+        { action: 'create', id: 2, cp: '256KB', msg: 'Create batch #2' },
+        { action: 'create', id: 3, cp: '384KB', msg: 'Create batch #3' },
+        { action: 'send', id: 0, msg: 'Sending #0' },
+        { action: 'send', id: 1, msg: 'Sending #1' },
+        { action: 'send', id: 2, msg: 'Sending #2' },
+        { action: 'send', id: 3, msg: 'Sending #3 \u2014 all four in-flight' },
+        { action: 'ack', id: 1, level: 'warn', msg: '#1 acked but #0 still retrying \u2014 checkpoint frozen' },
+        { action: 'ack', id: 3, level: 'warn', msg: '#3 acked \u2014 #0 still blocks. 3 batches in pending_acks' },
+        { action: 'ack', id: 2, level: 'warn', msg: '#2 acked \u2014 #1,#2,#3 all pending. #0 STILL retrying. At-least-once!' },
+        { action: 'ack', id: 0, level: 'success', msg: '#0 finally succeeds! Chain collapses: none \u2192 384KB!' },
       ]
     }
   };
@@ -281,9 +353,10 @@
   var autoTimer = null;
 
   // State
-  var batches = {}; // id -> { state, cp }
+  var batches = {};
   var committedCp = null;
   var committedId = -1;
+  var batchEls = {};  // id -> DOM element, for positioning callout arrows
 
   // --- Build DOM ---
 
@@ -329,13 +402,10 @@
   cpRow.appendChild(cpVal);
   root.appendChild(cpRow);
 
-  // Explanation
-  var explainEl = el('div', 'ck-explain');
-  root.appendChild(explainEl);
-
   // Legend
   var legend = el('div', 'ck-legend');
   var legendItems = [
+    ['Queued', 'ck-dot-queued'],
     ['In-flight', 'ck-dot-flight'],
     ['Pending ACK', 'ck-dot-pending'],
     ['Committed', 'ck-dot-committed'],
@@ -355,13 +425,43 @@
   tlaEl.innerHTML = '<span class="ck-tla-icon">\uD83D\uDD2C</span><div><b>Formally verified.</b> TLA+ spec <code>PipelineMachine.tla</code> proves <code>CommittedNeverAheadOfTerminalizedPrefix</code> \u2014 the checkpoint can never advance past an unresolved batch. This invariant holds across 70+ model-checked properties.</div>';
   root.appendChild(tlaEl);
 
+  // --- Callout system ---
+  function showCallout(targetId, text, level) {
+    // Remove previous callout
+    var old = timelineEl.querySelector('.ck-callout');
+    if (old) old.remove();
+
+    var callout = el('div', 'ck-callout ' + level);
+    callout.textContent = text;
+
+    // Position the arrow to point at the target batch
+    // We do this after rendering so we know the batch element positions
+    timelineEl.appendChild(callout);
+
+    // Calculate arrow position after DOM update
+    requestAnimationFrame(function() {
+      var batchEl = batchEls[targetId];
+      if (batchEl && callout.parentNode) {
+        var tlRect = timelineEl.getBoundingClientRect();
+        var bRect = batchEl.getBoundingClientRect();
+        var arrowLeft = (bRect.left + bRect.width / 2) - tlRect.left;
+        var pct = Math.max(10, Math.min(90, (arrowLeft / tlRect.width) * 100));
+        callout.style.setProperty('--arrow-left', pct + '%');
+      }
+    });
+  }
+
   // --- Rendering ---
-  function render() {
+  function render(targetId) {
     var sc = SCENARIOS[currentScenario];
     stepInfo.textContent = 'Step ' + stepIndex + '/' + sc.steps.length;
 
-    // Render batches
+    // Render batches (preserve callout)
+    var callout = timelineEl.querySelector('.ck-callout');
     timelineEl.innerHTML = '';
+    if (callout) timelineEl.appendChild(callout);
+
+    batchEls = {};
     var ids = Object.keys(batches).map(Number).sort(function(a, b) { return a - b; });
     var totalBatches = ids.length || 1;
 
@@ -369,12 +469,11 @@
       var b = batches[id];
       var batchEl = el('div', 'ck-batch ' + b.state);
 
-      // Highlight the last-changed batch
-      if (b.justChanged) {
-        batchEl.classList.add('highlight');
-        b.justChanged = false;
+      // Highlight the target batch
+      if (id === targetId) {
+        batchEl.classList.add('target');
       }
-      // Pulse stalling batches
+      // Pulse stalling batches (in-flight while higher ones are pending)
       if (b.state === 'in-flight' && hasPendingAckAbove(id)) {
         batchEl.classList.add('stalling');
       }
@@ -388,14 +487,21 @@
       stateEl.textContent = stateLabels[b.state] || b.state.toUpperCase();
       var cpEl = el('div', 'ck-batch-cp'); cpEl.textContent = b.cp;
 
+      // Progress bar inside the batch (animates when in-flight)
+      var progBar = el('div', 'ck-batch-progress');
+      var progFill = el('div', 'ck-batch-progress-fill');
+      progBar.appendChild(progFill);
+
       batchEl.appendChild(idEl);
       batchEl.appendChild(stateEl);
       batchEl.appendChild(cpEl);
+      batchEl.appendChild(progBar);
       timelineEl.appendChild(batchEl);
+      batchEls[id] = batchEl;
     });
 
     // Checkpoint bar
-    var maxId = ids.length > 0 ? Math.max.apply(null, ids) : 0;
+    var prevCp = committedCp;
     var pct = committedId >= 0 ? ((committedId + 1) / totalBatches) * 100 : 0;
     cpFill.style.width = Math.min(100, pct) + '%';
     cpMarker.style.left = 'calc(' + Math.min(100, pct) + '% - 8px)';
@@ -420,53 +526,46 @@
 
     var step = sc.steps[stepIndex];
     stepIndex++;
-
-    // Clear justChanged
-    Object.keys(batches).forEach(function(k) { batches[k].justChanged = false; });
+    var prevCommittedId = committedId;
 
     switch (step.action) {
       case 'create':
-        batches[step.id] = { state: 'queued', cp: step.cp, justChanged: true };
-        explainEl.className = 'ck-explain';
-        explainEl.innerHTML = '<b>Create batch #' + step.id + '</b>New batch created for source at checkpoint ' + step.cp + '. Not yet in-flight \u2014 the ticket is Queued.';
+        batches[step.id] = { state: 'queued', cp: step.cp };
         break;
-
       case 'send':
         if (batches[step.id]) {
           batches[step.id].state = 'in-flight';
-          batches[step.id].justChanged = true;
         }
-        explainEl.className = 'ck-explain';
-        explainEl.innerHTML = '<b>Send batch #' + step.id + '</b>Batch registered as in-flight via <code>begin_send()</code>. The pipeline now owns it \u2014 it MUST be acked, rejected, or failed.';
         break;
-
       case 'ack':
         if (batches[step.id]) {
           batches[step.id].state = 'pending-ack';
-          batches[step.id].justChanged = true;
         }
-        // Try advance
         tryAdvance();
-        explainEl.className = step.explain && step.explain.includes('\uD83C\uDF89') ? 'ck-explain highlight' : (step.explain && step.explain.includes('CANNOT') ? 'ck-explain warn' : 'ck-explain');
-        explainEl.innerHTML = '<b>ACK batch #' + step.id + '</b>' + (step.explain || '');
         break;
-
       case 'reject':
         if (batches[step.id]) {
           batches[step.id].state = 'rejected';
-          batches[step.id].justChanged = true;
         }
         tryAdvance();
-        explainEl.className = 'ck-explain warn';
-        explainEl.innerHTML = '<b>Reject batch #' + step.id + ' (terminal)</b>' + (step.explain || '');
         break;
     }
 
-    render();
+    render(step.id);
+
+    // Show callout pointing at the affected batch
+    var level = step.level || 'info';
+    showCallout(step.id, step.msg, level);
+
+    // Animate checkpoint marker if it advanced
+    if (committedId > prevCommittedId) {
+      cpMarker.classList.remove('advancing');
+      void cpMarker.offsetWidth; // force reflow
+      cpMarker.classList.add('advancing');
+    }
   }
 
   function tryAdvance() {
-    // Advance committed checkpoint by consuming contiguous resolved batches
     var ids = Object.keys(batches).map(Number).sort(function(a, b) { return a - b; });
     var advanced = true;
     while (advanced) {
@@ -476,40 +575,24 @@
         var b = batches[id];
         if (id <= committedId) continue;
 
-        // Check if all lower IDs are resolved
-        var allLowerResolved = true;
-        for (var j = 0; j < ids.length; j++) {
-          var lower = ids[j];
-          if (lower >= id) break;
-          if (lower <= committedId) continue;
-          var ls = batches[lower].state;
-          if (ls !== 'committed' && ls !== 'rejected' && ls !== 'pending-ack') {
-            allLowerResolved = false;
+        // Can only advance if no lower-ID batch is still queued or in-flight
+        var canCommit = true;
+        for (var k = 0; k < ids.length; k++) {
+          var checkId = ids[k];
+          if (checkId >= id) break;
+          if (checkId <= committedId) continue;
+          if (batches[checkId].state === 'in-flight' || batches[checkId].state === 'queued') {
+            canCommit = false;
             break;
           }
         }
-
-        if (allLowerResolved && (b.state === 'pending-ack' || b.state === 'rejected')) {
-          // Also need all lower to be committed already or be pending-ack/rejected
-          var canCommit = true;
-          for (var k = 0; k < ids.length; k++) {
-            var checkId = ids[k];
-            if (checkId >= id) break;
-            if (checkId <= committedId) continue;
-            if (batches[checkId].state === 'in-flight' || batches[checkId].state === 'queued') {
-              canCommit = false;
-              break;
-            }
+        if (canCommit && (b.state === 'pending-ack' || b.state === 'rejected')) {
+          if (b.state === 'pending-ack') {
+            b.state = 'committed';
           }
-          if (canCommit) {
-            if (b.state === 'pending-ack') {
-              b.state = 'committed';
-            }
-            // rejected stays rejected but counts as resolved
-            committedCp = b.cp;
-            committedId = id;
-            advanced = true;
-          }
+          committedCp = b.cp;
+          committedId = id;
+          advanced = true;
         }
       }
     }
@@ -531,10 +614,20 @@
     batches = {};
     committedCp = null;
     committedId = -1;
+    batchEls = {};
     var sc = SCENARIOS[currentScenario];
-    explainEl.className = 'ck-explain';
-    explainEl.innerHTML = '<b>' + sc.name + '</b>' + sc.desc + '. Click <b>Step</b> to advance one event at a time, or <b>Play</b> to auto-advance.';
-    render();
+    // Clear timeline and show initial callout
+    timelineEl.innerHTML = '';
+    var initCallout = el('div', 'ck-callout info');
+    initCallout.textContent = sc.desc + '. Click Step or Play to begin.';
+    initCallout.style.setProperty('--arrow-left', '50%');
+    timelineEl.appendChild(initCallout);
+    timelineEl.style.minHeight = '70px';
+
+    cpFill.style.width = '0%';
+    cpMarker.style.display = 'none';
+    cpVal.textContent = 'none';
+    stepInfo.textContent = 'Step 0/' + sc.steps.length;
   }
 
   function stopAuto() {
@@ -556,7 +649,7 @@
           return;
         }
         executeStep();
-      }, 1200);
+      }, 1500);
     }
   }
 

--- a/book/src/components/CheckpointSim.astro
+++ b/book/src/components/CheckpointSim.astro
@@ -340,7 +340,7 @@
         { action: 'send', id: 2, msg: 'Sending #2' },
         { action: 'send', id: 3, msg: 'Sending #3 \u2014 all four in-flight' },
         { action: 'ack', id: 1, level: 'warn', msg: '#1 acked but #0 still retrying \u2014 checkpoint frozen' },
-        { action: 'ack', id: 3, level: 'warn', msg: '#3 acked \u2014 #0 still blocks. 3 batches in pending_acks' },
+        { action: 'ack', id: 3, level: 'warn', msg: '#3 acked \u2014 #0 still blocks. 2 batches in pending_acks' },
         { action: 'ack', id: 2, level: 'warn', msg: '#2 acked \u2014 #1,#2,#3 all pending. #0 STILL retrying. At-least-once!' },
         { action: 'ack', id: 0, level: 'success', msg: '#0 finally succeeds! Chain collapses: none \u2192 384KB!' },
       ]
@@ -581,7 +581,7 @@
           var checkId = ids[k];
           if (checkId >= id) break;
           if (checkId <= committedId) continue;
-          if (batches[checkId].state === 'in-flight' || batches[checkId].state === 'queued') {
+          if (batches[checkId].state === 'in-flight') {
             canCommit = false;
             break;
           }

--- a/book/src/content/docs/how-it-works/backpressure.mdx
+++ b/book/src/content/docs/how-it-works/backpressure.mdx
@@ -1,0 +1,58 @@
+---
+title: "Backpressure in Action"
+description: "Interactive simulation of how logfwd propagates backpressure from slow outputs back through the pipeline"
+---
+
+import BackpressureSim from '../../../components/BackpressureSim.astro';
+
+When a collector goes slow or drops offline, logfwd doesn't buffer infinitely or drop data.
+Instead, **bounded channels** turn slow outputs into backpressure that cascades all the way
+back to the file reader — by design.
+
+<BackpressureSim />
+
+## How the cascade works
+
+Every input gets **two dedicated OS threads** connected by a bounded channel:
+
+```
+┌──────────┐  bounded(4)  ┌──────────┐  pipeline(16)  ┌─────────────┐
+│ I/O      │─────────────▶│ CPU      │───────────────▶│ Output Pool │
+│ Worker   │              │ Worker   │                │ (MRU dispatch)│
+│ poll()   │              │ scan()   │                │ try_send()   │
+│ accum()  │              │ sql()    │                │ per worker(1)│
+└──────────┘              └──────────┘                └─────────────┘
+ OS thread                 OS thread                   async tasks
+```
+
+Each arrow is a bounded channel with a fixed capacity. When the downstream channel fills:
+
+1. **Output pool full** → workers retry with exponential backoff, their per-worker channels fill
+2. **Pipeline channel full (16)** → CPU worker blocks on `blocking_send`
+3. **I/O–CPU channel full (4)** → I/O worker blocks, `poll()` stops being called
+4. **File reader backs off** → adaptive poll cadence increases sleep intervals
+
+No unbounded queues. No OOM. No silent data loss. When the outage clears, everything drains
+in order — the file reader catches up from where it left off via checkpointed offsets.
+
+## Why bounded channels?
+
+The alternative — unbounded queues — leads to:
+
+- **Memory growth** proportional to outage duration × ingestion rate
+- **Cascading OOM** kills when the OS reclaims memory
+- **Silent data loss** when queues are capped with drop-on-full
+
+Bounded channels make the trade-off explicit: **throughput degrades gracefully** instead of
+memory growing silently. The file system becomes the buffer — and it's already designed for that.
+
+## Key parameters
+
+| Channel | Capacity | Why |
+|---------|----------|-----|
+| I/O → CPU | 4 chunks | Small enough that one slow input doesn't starve others |
+| Pipeline → Pool | 16 batches | Enough to absorb jitter without blocking the CPU path |
+| Per-worker | 1 batch | MRU consolidation: keeps busy workers full, idles stay idle |
+
+These values are tuned for the common case: many small files, one or two outputs.
+The worker pool scales up to `max_workers` when all channels are full before blocking.

--- a/book/src/content/docs/how-it-works/checkpoints.mdx
+++ b/book/src/content/docs/how-it-works/checkpoints.mdx
@@ -45,8 +45,10 @@ create_batch() → BatchTicket<Queued>
        └── fail()   → BatchTicket<Queued> ← transient failure, retry
 ```
 
-The `#[must_use]` annotation on `begin_send()` means dropping a `Sending` ticket without
-resolving it is a compiler warning — preventing silent batch loss.
+The `#[must_use]` annotation on `begin_send()` warns if the returned `Sending` ticket is
+ignored at the call site. The deeper enforcement comes from the **typestate pattern**: the
+`Sending` ticket's self-consuming transition methods (`ack()`, `reject()`, `fail()`) are the
+only way to resolve it — you cannot drop a `Sending` ticket without calling one of these.
 
 ## Why rejection advances the checkpoint
 
@@ -65,11 +67,11 @@ The TLA+ specification `PipelineMachine.tla` proves 70+ properties including:
 
 | Property | What it guarantees |
 |----------|--------------------|
-| `CommittedNeverAheadOfTerminalizedPrefix` | Checkpoint never skips an unresolved batch |
+| `CheckpointNeverAheadOfTerminalizedPrefix` | Checkpoint never skips an unresolved batch |
 | `DrainCompleteness` | `stop()` is unreachable unless all batches resolved |
-| `CheckpointMonotonicity` | Committed offset never decreases |
-| `BatchIdUniqueness` | No two batches share an ID |
-| `Liveness` | Every in-flight batch eventually resolves (ack/reject/abandon) |
+| `CommittedMonotonic` | Committed offset never decreases |
+| `CheckpointOrderingInvariant` | Every sent batch below the committed watermark is terminally resolved |
+| `NoBatchLeftBehind` | Every in-flight batch eventually resolves (ack/reject/abandon) |
 
 The Rust implementation mirrors the TLA+ spec field-by-field — `committed`, `in_flight`,
 and `pending_acks` map directly to the specification variables.

--- a/book/src/content/docs/how-it-works/checkpoints.mdx
+++ b/book/src/content/docs/how-it-works/checkpoints.mdx
@@ -1,0 +1,75 @@
+---
+title: "Checkpoint Ordering"
+description: "Interactive visualization of how logfwd tracks out-of-order ACKs and advances checkpoints safely"
+---
+
+import CheckpointSim from '../../../components/CheckpointSim.astro';
+
+When logfwd ships a batch to your collector, the collector might ACK batch #3 before batch #1.
+**The checkpoint must not advance past unresolved batches** — or a crash would skip unsent data.
+
+This is the core correctness invariant, proven in TLA+.
+
+<CheckpointSim />
+
+## The algorithm
+
+Each source maintains three data structures:
+
+```rust
+committed:    BTreeMap<SourceId, Checkpoint>      // safe restart point
+in_flight:    BTreeMap<SourceId, BTreeMap<BatchId, Checkpoint>>  // sent, awaiting ACK
+pending_acks: BTreeMap<SourceId, BTreeMap<BatchId, Checkpoint>>  // ACKed but can't commit yet
+```
+
+When an ACK arrives:
+
+1. Remove the batch from `in_flight`, add to `pending_acks`
+2. Starting from the lowest pending ACK, check: is there any in-flight batch with a lower ID?
+3. If **no** — consume the pending ACK, advance `committed`, repeat from step 2
+4. If **yes** — stop. The checkpoint cannot advance past an unresolved batch.
+
+This is the Filebeat registrar pattern, implemented as a pure state machine with no executor dependencies.
+
+## Batch lifecycle
+
+Every batch follows a strict lifecycle enforced by Rust's type system:
+
+```
+create_batch() → BatchTicket<Queued>
+       │
+  begin_send() → BatchTicket<Sending>   ← enters in_flight tracking
+       │
+       ├── ack()    → AckReceipt        ← successful delivery
+       ├── reject() → AckReceipt        ← permanent failure (e.g. 413)
+       └── fail()   → BatchTicket<Queued> ← transient failure, retry
+```
+
+The `#[must_use]` annotation on `begin_send()` means dropping a `Sending` ticket without
+resolving it is a compiler warning — preventing silent batch loss.
+
+## Why rejection advances the checkpoint
+
+A permanently rejected batch (e.g., 413 Payload Too Large) is **undeliverable**. Holding it
+in-flight forever would freeze the checkpoint for that source, eventually blocking all
+progress. The trade-off:
+
+- **Hold** (transient failures): retry with backoff, checkpoint frozen until success
+- **Reject** (permanent failures): advance checkpoint past the batch, accept data loss for one batch
+
+This matches Filebeat's model: advance past undeliverable records rather than stall the pipeline.
+
+## Formal verification
+
+The TLA+ specification `PipelineMachine.tla` proves 70+ properties including:
+
+| Property | What it guarantees |
+|----------|--------------------|
+| `CommittedNeverAheadOfTerminalizedPrefix` | Checkpoint never skips an unresolved batch |
+| `DrainCompleteness` | `stop()` is unreachable unless all batches resolved |
+| `CheckpointMonotonicity` | Committed offset never decreases |
+| `BatchIdUniqueness` | No two batches share an ID |
+| `Liveness` | Every in-flight batch eventually resolves (ack/reject/abandon) |
+
+The Rust implementation mirrors the TLA+ spec field-by-field — `committed`, `in_flight`,
+and `pending_acks` map directly to the specification variables.

--- a/book/src/content/docs/how-it-works/index.mdx
+++ b/book/src/content/docs/how-it-works/index.mdx
@@ -19,6 +19,8 @@ Watch a log line flow through the four pipeline stages, then click any stage to 
 | [Scanner Deep Dive](/memagent/how-it-works/scanner/) | Step through SIMD structural indexing on a real log line |
 | [Why Tailing Is Hard](/memagent/how-it-works/tailing/) | Watch logfwd handle file rotation, truncation, and crash recovery |
 | [Why Columnar Matters](/memagent/how-it-works/columnar/) | Compare row vs. column layout and see why Arrow makes SQL fast |
+| [Backpressure in Action](/memagent/how-it-works/backpressure/) | Simulate slow outputs and watch pressure cascade through bounded channels |
+| [Checkpoint Ordering](/memagent/how-it-works/checkpoints/) | Step through out-of-order ACKs and see why checkpoints advance contiguously |
 | [Performance](/memagent/how-it-works/performance/) | Benchmarks (2.8M lines/sec), stage breakdown, memory profile |
 | [SQL Transforms](/memagent/configuration/sql-transforms/) | Full SQL reference with UDFs and enrichment tables |
 | [YAML Reference](/memagent/configuration/reference/) | Every config field, input/output type, and option |


### PR DESCRIPTION
## Summary

- **Backpressure in Action** — live simulation of the 3-tier I/O → CPU → Output pipeline. Users drag an output speed slider (or click Fast/Slow/Outage presets) and watch bounded channels fill, pressure cascade backward through the `bounded(4)` and `pipeline(16)` channels, and workers block — with real-time stats and contextual explanations that update as conditions change.

- **Checkpoint Ordering** — step-through visualizer for the ordered ACK state machine (the core TLA+-verified invariant). Four scenarios demonstrate how `committed` only advances contiguously: happy path, out-of-order ACKs, permanent rejection (413), and a stalled batch that freezes the checkpoint while later batches accumulate in `pending_acks`. Includes the formal verification callout linking to `PipelineMachine.tla`.

Both components follow the existing pattern: vanilla JS in `.astro` components, Starlight CSS variables for theming, no external dependencies. Wired into the sidebar and Pipeline Explorer "Keep exploring" table.

## Test plan

- [x] `npx astro build` succeeds (26 pages, no errors)
- [x] Backpressure page renders with live simulation, slider and presets work
- [x] Checkpoint page renders with all 4 scenario tabs, Step/Play/Reset controls work
- [x] Out-of-Order ACK scenario correctly stalls checkpoint until lowest batch resolves
- [x] Both pages appear in sidebar under "How It Works"
- [x] Pipeline Explorer index links to both new pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interactive backpressure and checkpoint ordering docs to 'How it works'
> - Adds two new documentation pages under `how-it-works/`: [backpressure.mdx](https://github.com/strawgate/memagent/pull/2067/files#diff-210d22b8e98b3410188c9a704e52dfec47dc08510931775342636b3a965b451d) and [checkpoints.mdx](https://github.com/strawgate/memagent/pull/2067/files#diff-bef8b581629513abe6576e381fdc790bcd78c7597a27283bfa547496a150f1b5), each with explanatory text and an embedded interactive simulator.
> - [BackpressureSim.astro](https://github.com/strawgate/memagent/pull/2067/files#diff-e0d5d7e600f872d99a13de5c7e2e5cf6fcaf7383c14d33bb9942be781e62cb7e) renders a three-stage pipeline (I/O Worker → CPU Worker → Output Pool) with a 250ms simulation loop, queue visualizations, and slider/preset controls for output speed.
> - [CheckpointSim.astro](https://github.com/strawgate/memagent/pull/2067/files#diff-031c3c15ff54af00f343dba29b6bf0e44ba9dfc7354fffec60f083b871085f79) renders a stepable, auto-playing visualization of out-of-order ACK handling across four scenarios (happy path, out-of-order, reject, stall), showing contiguous checkpoint advancement.
> - Both components pause when the tab is hidden and clean up on Astro page navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2575195.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->