### PR TITLE
feat: ColumnarBatchBuilder prototype — typed columnar Arrow construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,7 +400,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           key: kani
 
-      - name: Run Kani verification
+      - name: Run Kani verification (all packages except logfwd-arrow)
         uses: model-checking/kani-github-action@v1
         with:
           args: >-
@@ -408,13 +408,19 @@ jobs:
             -Z mem-predicates
             -Z stubbing
             -p logfwd-core
-            -p logfwd-arrow
             -p logfwd-types
             -p logfwd-io
             -p logfwd-output
             -p logfwd-runtime
             -p logfwd-diagnostics
             -p logfwd
+        env:
+          RUSTC_WRAPPER: ""
+
+      - name: Run Kani verification (logfwd-arrow --lib)
+        # logfwd-arrow has a binary with required-features that cargo-kani
+        # cannot skip, so verify only the library target.
+        run: cargo kani -p logfwd-arrow --lib -Z function-contracts -Z mem-predicates -Z stubbing
         env:
           RUSTC_WRAPPER: ""
 

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ error.log
 # Research intermediate artifacts (cloud task diffs, extracts)
 **/cloud-artifacts/
 .codex/
+scripts/__pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2594,6 +2594,7 @@ dependencies = [
  "bytes",
  "logfwd-core",
  "logfwd-types",
+ "proptest",
  "serial_test",
  "stats_alloc",
 ]

--- a/crates/logfwd-arrow/Cargo.toml
+++ b/crates/logfwd-arrow/Cargo.toml
@@ -23,5 +23,9 @@ bytes = "1"
 serial_test = "3"
 stats_alloc = "0.1"
 
+[[bin]]
+name = "builder_profile"
+required-features = ["_test-internals"]
+
 [lints]
 workspace = true

--- a/crates/logfwd-arrow/Cargo.toml
+++ b/crates/logfwd-arrow/Cargo.toml
@@ -20,6 +20,7 @@ arrow = { workspace = true }
 bytes = "1"
 
 [dev-dependencies]
+proptest = { workspace = true }
 serial_test = "3"
 stats_alloc = "0.1"
 

--- a/crates/logfwd-arrow/Cargo.toml
+++ b/crates/logfwd-arrow/Cargo.toml
@@ -8,6 +8,11 @@ publish = false
 [lib]
 doctest = false
 
+[features]
+# Expose columnar builder internals for allocation profiling integration tests.
+# Not for production use.
+_test-internals = []
+
 [dependencies]
 logfwd-core = { version = "0.1.0", path = "../logfwd-core" }
 logfwd-types = { version = "0.1.0", path = "../logfwd-types" }

--- a/crates/logfwd-arrow/src/bin/builder_profile.rs
+++ b/crates/logfwd-arrow/src/bin/builder_profile.rs
@@ -1,73 +1,98 @@
 //! Profiling harness for ColumnarBatchBuilder vs StreamingBuilder.
 //!
+//! Three workloads model different real producer patterns:
+//!   - `zero-copy`: strings reference an input buffer (OTLP/scanner path)
+//!   - `generated`: strings are written/copied into a generated buffer (JSON decode)
+//!   - `mixed`: half zero-copy refs, half generated (realistic blend)
+//!
 //! Usage:
 //!   cargo build -p logfwd-arrow --release --features _test-internals --bin builder_profile
-//!   valgrind --tool=callgrind ./target/release/builder_profile columnar 50
-//!   valgrind --tool=callgrind ./target/release/builder_profile streaming 50
-//!   valgrind --tool=dhat      ./target/release/builder_profile columnar 10
-//!   valgrind --tool=massif    ./target/release/builder_profile columnar 10
+//!   valgrind --tool=callgrind ./target/release/builder_profile columnar-zero-copy 50
+//!   valgrind --tool=callgrind ./target/release/builder_profile streaming-zero-copy 50
 
 use std::env;
 use std::hint::black_box;
 
+use logfwd_arrow::columnar::accumulator::StringRef;
 use logfwd_arrow::columnar::builder::ColumnarBatchBuilder;
 use logfwd_arrow::columnar::plan::{BatchPlan, FieldHandle, FieldKind};
 use logfwd_arrow::streaming_builder::StreamingBuilder;
 
 const ROWS_PER_BATCH: u32 = 1000;
 
-fn run_columnar_detached(num_batches: u64) {
+// Pre-built input buffer: 10 string fields × "example-value-0123456789" (24 bytes each).
+// In a real pipeline this would be the protobuf wire bytes or JSON input line.
+const STR_VALUE: &str = "example-value-0123456789";
+const STR_COUNT: usize = 10;
+
+fn build_input_buffer() -> Vec<u8> {
+    let mut buf = Vec::with_capacity(STR_VALUE.len() * STR_COUNT);
+    for _ in 0..STR_COUNT {
+        buf.extend_from_slice(STR_VALUE.as_bytes());
+    }
+    buf
+}
+
+fn str_refs_for_row() -> [StringRef; STR_COUNT] {
+    let len = STR_VALUE.len() as u32;
+    core::array::from_fn(|i| StringRef {
+        offset: (i as u32) * len,
+        len,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Columnar: zero-copy (write_str_ref into input buffer)
+// ---------------------------------------------------------------------------
+fn run_columnar_zero_copy(num_batches: u64) {
+    let input_buf = build_input_buffer();
+    let refs = str_refs_for_row();
+
     let mut plan = BatchPlan::new();
-    let int_handles: [FieldHandle; 4] = [
-        plan.declare_planned("timestamp_ns", FieldKind::Int64)
-            .unwrap(),
-        plan.declare_planned("severity_number", FieldKind::Int64)
-            .unwrap(),
-        plan.declare_planned("flags", FieldKind::Int64).unwrap(),
-        plan.declare_planned("attributes.http.status_code", FieldKind::Int64)
-            .unwrap(),
-    ];
-    let str_handles: [FieldHandle; 10] = [
-        plan.declare_planned("severity_text", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("body", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("trace_id", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("span_id", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("resource.service.name", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("resource.host.name", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("scope.name", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("scope.version", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("attributes.http.method", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("attributes.http.path", FieldKind::Utf8View)
-            .unwrap(),
-    ];
-    let float_handles: [FieldHandle; 1] = [plan
-        .declare_planned("attributes.duration_ms", FieldKind::Float64)
-        .unwrap()];
+    let int_handles: [FieldHandle; 4] = core::array::from_fn(|i| {
+        plan.declare_planned(
+            ["timestamp_ns", "severity_number", "flags", "http.status_code"][i],
+            FieldKind::Int64,
+        )
+        .unwrap()
+    });
+    let str_handles: [FieldHandle; STR_COUNT] = core::array::from_fn(|i| {
+        plan.declare_planned(
+            [
+                "severity_text",
+                "body",
+                "trace_id",
+                "span_id",
+                "resource.service.name",
+                "resource.host.name",
+                "scope.name",
+                "scope.version",
+                "attributes.http.method",
+                "attributes.http.path",
+            ][i],
+            FieldKind::Utf8View,
+        )
+        .unwrap()
+    });
+    let float_h = plan
+        .declare_planned("duration_ms", FieldKind::Float64)
+        .unwrap();
 
     let mut b = ColumnarBatchBuilder::new(plan);
 
     for batch_idx in 0..num_batches {
         b.begin_batch();
+        b.set_original_buffer(&input_buf);
         for row in 0..ROWS_PER_BATCH {
             b.begin_row();
             let base = (batch_idx as i64) * (ROWS_PER_BATCH as i64) + row as i64;
             for (i, &h) in int_handles.iter().enumerate() {
                 b.write_i64(h, base + i as i64 * 1000);
             }
-            for &h in &str_handles {
-                b.write_str(h, "example-value-0123456789").unwrap();
+            for (i, &h) in str_handles.iter().enumerate() {
+                b.write_str_ref(h, refs[i]);
             }
-            for &h in &float_handles {
-                b.write_f64(h, base as f64 * 0.001);
-            }
+            b.write_f64(float_h, base as f64 * 0.001);
             b.end_row();
         }
         let batch = b.finish_batch().unwrap();
@@ -75,41 +100,39 @@ fn run_columnar_detached(num_batches: u64) {
     }
 }
 
-fn run_columnar_view(num_batches: u64) {
+// ---------------------------------------------------------------------------
+// Columnar: generated strings (write_str copies into string_buf)
+// ---------------------------------------------------------------------------
+fn run_columnar_generated(num_batches: u64) {
     let mut plan = BatchPlan::new();
-    let int_handles: [FieldHandle; 4] = [
-        plan.declare_planned("timestamp_ns", FieldKind::Int64)
-            .unwrap(),
-        plan.declare_planned("severity_number", FieldKind::Int64)
-            .unwrap(),
-        plan.declare_planned("flags", FieldKind::Int64).unwrap(),
-        plan.declare_planned("attributes.http.status_code", FieldKind::Int64)
-            .unwrap(),
-    ];
-    let str_handles: [FieldHandle; 10] = [
-        plan.declare_planned("severity_text", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("body", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("trace_id", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("span_id", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("resource.service.name", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("resource.host.name", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("scope.name", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("scope.version", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("attributes.http.method", FieldKind::Utf8View)
-            .unwrap(),
-        plan.declare_planned("attributes.http.path", FieldKind::Utf8View)
-            .unwrap(),
-    ];
-    let float_handles: [FieldHandle; 1] = [plan
-        .declare_planned("attributes.duration_ms", FieldKind::Float64)
-        .unwrap()];
+    let int_handles: [FieldHandle; 4] = core::array::from_fn(|i| {
+        plan.declare_planned(
+            ["timestamp_ns", "severity_number", "flags", "http.status_code"][i],
+            FieldKind::Int64,
+        )
+        .unwrap()
+    });
+    let str_handles: [FieldHandle; STR_COUNT] = core::array::from_fn(|i| {
+        plan.declare_planned(
+            [
+                "severity_text",
+                "body",
+                "trace_id",
+                "span_id",
+                "resource.service.name",
+                "resource.host.name",
+                "scope.name",
+                "scope.version",
+                "attributes.http.method",
+                "attributes.http.path",
+            ][i],
+            FieldKind::Utf8View,
+        )
+        .unwrap()
+    });
+    let float_h = plan
+        .declare_planned("duration_ms", FieldKind::Float64)
+        .unwrap();
 
     let mut b = ColumnarBatchBuilder::new(plan);
 
@@ -122,19 +145,83 @@ fn run_columnar_view(num_batches: u64) {
                 b.write_i64(h, base + i as i64 * 1000);
             }
             for &h in &str_handles {
-                b.write_str(h, "example-value-0123456789").unwrap();
+                b.write_str(h, STR_VALUE).unwrap();
             }
-            for &h in &float_handles {
-                b.write_f64(h, base as f64 * 0.001);
-            }
+            b.write_f64(float_h, base as f64 * 0.001);
             b.end_row();
         }
-        let batch = b
-            .finish_batch_view(arrow::buffer::Buffer::from(b"" as &[u8]), 0)
-            .unwrap();
+        let batch = b.finish_batch().unwrap();
         black_box(&batch);
     }
 }
+
+// ---------------------------------------------------------------------------
+// Columnar: mixed (5 zero-copy refs + 5 generated)
+// ---------------------------------------------------------------------------
+fn run_columnar_mixed(num_batches: u64) {
+    let input_buf = build_input_buffer();
+    let refs = str_refs_for_row();
+
+    let mut plan = BatchPlan::new();
+    let int_handles: [FieldHandle; 4] = core::array::from_fn(|i| {
+        plan.declare_planned(
+            ["timestamp_ns", "severity_number", "flags", "http.status_code"][i],
+            FieldKind::Int64,
+        )
+        .unwrap()
+    });
+    let str_handles: [FieldHandle; STR_COUNT] = core::array::from_fn(|i| {
+        plan.declare_planned(
+            [
+                "severity_text",
+                "body",
+                "trace_id",
+                "span_id",
+                "resource.service.name",
+                "resource.host.name",
+                "scope.name",
+                "scope.version",
+                "attributes.http.method",
+                "attributes.http.path",
+            ][i],
+            FieldKind::Utf8View,
+        )
+        .unwrap()
+    });
+    let float_h = plan
+        .declare_planned("duration_ms", FieldKind::Float64)
+        .unwrap();
+
+    let mut b = ColumnarBatchBuilder::new(plan);
+
+    for batch_idx in 0..num_batches {
+        b.begin_batch();
+        b.set_original_buffer(&input_buf);
+        for row in 0..ROWS_PER_BATCH {
+            b.begin_row();
+            let base = (batch_idx as i64) * (ROWS_PER_BATCH as i64) + row as i64;
+            for (i, &h) in int_handles.iter().enumerate() {
+                b.write_i64(h, base + i as i64 * 1000);
+            }
+            // First 5 fields: zero-copy from input buffer
+            for (h, r) in str_handles[..5].iter().zip(&refs[..5]) {
+                b.write_str_ref(*h, *r);
+            }
+            // Last 5 fields: generated/decoded strings
+            for &h in &str_handles[5..] {
+                b.write_str(h, STR_VALUE).unwrap();
+            }
+            b.write_f64(float_h, base as f64 * 0.001);
+            b.end_row();
+        }
+        let batch = b.finish_batch().unwrap();
+        black_box(&batch);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming baselines
+// ---------------------------------------------------------------------------
 
 const FIELD_NAMES: [&str; 15] = [
     "timestamp_ns",
@@ -154,12 +241,13 @@ const FIELD_NAMES: [&str; 15] = [
     "attributes.http.path",
 ];
 
-fn run_streaming_detached(num_batches: u64) {
+fn run_streaming_zero_copy(num_batches: u64) {
+    let input_buf = build_input_buffer();
     let mut sb = StreamingBuilder::new(None);
 
     for _batch in 0..num_batches {
-        let dummy = bytes::Bytes::from_static(b"");
-        sb.begin_batch(dummy);
+        let buf = bytes::Bytes::copy_from_slice(&input_buf);
+        sb.begin_batch(buf.clone());
         let indices: Vec<usize> = FIELD_NAMES
             .iter()
             .map(|name| sb.resolve_field(name.as_bytes()))
@@ -170,19 +258,15 @@ fn run_streaming_detached(num_batches: u64) {
             for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
                 sb.append_i64_value_by_idx(idx, row as i64);
             }
-            for &idx in &[
-                indices[2],
-                indices[3],
-                indices[5],
-                indices[6],
-                indices[7],
-                indices[8],
-                indices[9],
-                indices[10],
-                indices[11],
-                indices[14],
-            ] {
-                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+            // Subslice directly from the Bytes so offset_of recognizes pointer identity.
+            let str_indices = [
+                indices[2], indices[3], indices[5], indices[6], indices[7],
+                indices[8], indices[9], indices[10], indices[11], indices[14],
+            ];
+            for (i, &idx) in str_indices.iter().enumerate() {
+                let start = i * STR_VALUE.len();
+                let end = start + STR_VALUE.len();
+                sb.append_str_by_idx(idx, &buf[start..end]);
             }
             sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
             sb.end_row();
@@ -192,7 +276,7 @@ fn run_streaming_detached(num_batches: u64) {
     }
 }
 
-fn run_streaming_view(num_batches: u64) {
+fn run_streaming_generated(num_batches: u64) {
     let mut sb = StreamingBuilder::new(None);
 
     for _batch in 0..num_batches {
@@ -209,30 +293,22 @@ fn run_streaming_view(num_batches: u64) {
                 sb.append_i64_value_by_idx(idx, row as i64);
             }
             for &idx in &[
-                indices[2],
-                indices[3],
-                indices[5],
-                indices[6],
-                indices[7],
-                indices[8],
-                indices[9],
-                indices[10],
-                indices[11],
-                indices[14],
+                indices[2], indices[3], indices[5], indices[6], indices[7],
+                indices[8], indices[9], indices[10], indices[11], indices[14],
             ] {
-                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+                sb.append_decoded_str_by_idx(idx, STR_VALUE.as_bytes());
             }
             sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
             sb.end_row();
         }
-        let batch = sb.finish_batch().unwrap();
+        let batch = sb.finish_batch_detached().unwrap();
         black_box(&batch);
     }
 }
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let mode = args.get(1).map_or("columnar", String::as_str);
+    let mode = args.get(1).map_or("columnar-zero-copy", String::as_str);
     let num_batches: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(20);
 
     let total_rows = ROWS_PER_BATCH as u64 * num_batches;
@@ -241,15 +317,15 @@ fn main() {
     let start = std::time::Instant::now();
 
     match mode {
-        "columnar" => run_columnar_detached(num_batches),
-        "columnar-view" => run_columnar_view(num_batches),
-        "streaming" => run_streaming_detached(num_batches),
-        "streaming-view" => run_streaming_view(num_batches),
+        "columnar-zero-copy" => run_columnar_zero_copy(num_batches),
+        "columnar-generated" => run_columnar_generated(num_batches),
+        "columnar-mixed" => run_columnar_mixed(num_batches),
+        "streaming-zero-copy" => run_streaming_zero_copy(num_batches),
+        "streaming-generated" => run_streaming_generated(num_batches),
         other => {
             eprintln!("Unknown mode: {other}");
-            eprintln!(
-                "Usage: builder_profile <columnar|columnar-view|streaming|streaming-view> [batches]"
-            );
+            eprintln!("Modes: columnar-zero-copy, columnar-generated, columnar-mixed,");
+            eprintln!("       streaming-zero-copy, streaming-generated");
             std::process::exit(1);
         }
     }

--- a/crates/logfwd-arrow/src/bin/builder_profile.rs
+++ b/crates/logfwd-arrow/src/bin/builder_profile.rs
@@ -338,7 +338,7 @@ fn run_streaming_generated(num_batches: u64) {
             sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
             sb.end_row();
         }
-        let batch = sb.finish_batch_detached().unwrap();
+        let batch = sb.finish_batch().unwrap();
         black_box(&batch);
     }
 }

--- a/crates/logfwd-arrow/src/bin/builder_profile.rs
+++ b/crates/logfwd-arrow/src/bin/builder_profile.rs
@@ -86,7 +86,6 @@ fn run_columnar_zero_copy(num_batches: u64) {
         .unwrap();
 
     let mut b = ColumnarBatchBuilder::new(plan);
-    b.set_dedup_enabled(false);
 
     for batch_idx in 0..num_batches {
         b.begin_batch();
@@ -148,7 +147,6 @@ fn run_columnar_generated(num_batches: u64) {
         .unwrap();
 
     let mut b = ColumnarBatchBuilder::new(plan);
-    b.set_dedup_enabled(false);
 
     for batch_idx in 0..num_batches {
         b.begin_batch();
@@ -213,7 +211,6 @@ fn run_columnar_mixed(num_batches: u64) {
         .unwrap();
 
     let mut b = ColumnarBatchBuilder::new(plan);
-    b.set_dedup_enabled(false);
 
     for batch_idx in 0..num_batches {
         b.begin_batch();
@@ -266,13 +263,16 @@ fn run_streaming_zero_copy(num_batches: u64) {
     let input_buf = build_input_buffer();
     let mut sb = StreamingBuilder::new(None);
 
+    // StreamingBuilder clears its field_index each batch, so resolve_field must
+    // be called per batch. Use a fixed-size array to avoid per-batch Vec alloc.
+    let mut indices = [0usize; 15];
+
     for _batch in 0..num_batches {
         let buf = bytes::Bytes::copy_from_slice(&input_buf);
         sb.begin_batch(buf.clone());
-        let indices: Vec<usize> = FIELD_NAMES
-            .iter()
-            .map(|name| sb.resolve_field(name.as_bytes()))
-            .collect();
+        for (i, name) in FIELD_NAMES.iter().enumerate() {
+            indices[i] = sb.resolve_field(name.as_bytes());
+        }
 
         for row in 0..ROWS_PER_BATCH {
             sb.begin_row();
@@ -307,14 +307,14 @@ fn run_streaming_zero_copy(num_batches: u64) {
 
 fn run_streaming_generated(num_batches: u64) {
     let mut sb = StreamingBuilder::new(None);
+    let mut indices = [0usize; 15];
 
     for _batch in 0..num_batches {
         let dummy = bytes::Bytes::from_static(b"");
         sb.begin_batch(dummy);
-        let indices: Vec<usize> = FIELD_NAMES
-            .iter()
-            .map(|name| sb.resolve_field(name.as_bytes()))
-            .collect();
+        for (i, name) in FIELD_NAMES.iter().enumerate() {
+            indices[i] = sb.resolve_field(name.as_bytes());
+        }
 
         for row in 0..ROWS_PER_BATCH {
             sb.begin_row();

--- a/crates/logfwd-arrow/src/bin/builder_profile.rs
+++ b/crates/logfwd-arrow/src/bin/builder_profile.rs
@@ -13,6 +13,7 @@
 use std::env;
 use std::hint::black_box;
 
+use arrow::buffer::Buffer;
 use logfwd_arrow::columnar::accumulator::StringRef;
 use logfwd_arrow::columnar::builder::ColumnarBatchBuilder;
 use logfwd_arrow::columnar::plan::{BatchPlan, FieldHandle, FieldKind};
@@ -46,6 +47,7 @@ fn str_refs_for_row() -> [StringRef; STR_COUNT] {
 // ---------------------------------------------------------------------------
 fn run_columnar_zero_copy(num_batches: u64) {
     let input_buf = build_input_buffer();
+    let input_arrow = Buffer::from_vec(input_buf);
     let refs = str_refs_for_row();
 
     let mut plan = BatchPlan::new();
@@ -88,7 +90,7 @@ fn run_columnar_zero_copy(num_batches: u64) {
 
     for batch_idx in 0..num_batches {
         b.begin_batch();
-        b.set_original_buffer(&input_buf);
+        b.set_original_buffer(input_arrow.clone());
         for row in 0..ROWS_PER_BATCH {
             b.begin_row();
             let base = (batch_idx as i64) * (ROWS_PER_BATCH as i64) + row as i64;
@@ -172,6 +174,7 @@ fn run_columnar_generated(num_batches: u64) {
 // ---------------------------------------------------------------------------
 fn run_columnar_mixed(num_batches: u64) {
     let input_buf = build_input_buffer();
+    let input_arrow = Buffer::from_vec(input_buf);
     let refs = str_refs_for_row();
 
     let mut plan = BatchPlan::new();
@@ -214,7 +217,7 @@ fn run_columnar_mixed(num_batches: u64) {
 
     for batch_idx in 0..num_batches {
         b.begin_batch();
-        b.set_original_buffer(&input_buf);
+        b.set_original_buffer(input_arrow.clone());
         for row in 0..ROWS_PER_BATCH {
             b.begin_row();
             let base = (batch_idx as i64) * (ROWS_PER_BATCH as i64) + row as i64;

--- a/crates/logfwd-arrow/src/bin/builder_profile.rs
+++ b/crates/logfwd-arrow/src/bin/builder_profile.rs
@@ -51,7 +51,12 @@ fn run_columnar_zero_copy(num_batches: u64) {
     let mut plan = BatchPlan::new();
     let int_handles: [FieldHandle; 4] = core::array::from_fn(|i| {
         plan.declare_planned(
-            ["timestamp_ns", "severity_number", "flags", "http.status_code"][i],
+            [
+                "timestamp_ns",
+                "severity_number",
+                "flags",
+                "http.status_code",
+            ][i],
             FieldKind::Int64,
         )
         .unwrap()
@@ -107,7 +112,12 @@ fn run_columnar_generated(num_batches: u64) {
     let mut plan = BatchPlan::new();
     let int_handles: [FieldHandle; 4] = core::array::from_fn(|i| {
         plan.declare_planned(
-            ["timestamp_ns", "severity_number", "flags", "http.status_code"][i],
+            [
+                "timestamp_ns",
+                "severity_number",
+                "flags",
+                "http.status_code",
+            ][i],
             FieldKind::Int64,
         )
         .unwrap()
@@ -165,7 +175,12 @@ fn run_columnar_mixed(num_batches: u64) {
     let mut plan = BatchPlan::new();
     let int_handles: [FieldHandle; 4] = core::array::from_fn(|i| {
         plan.declare_planned(
-            ["timestamp_ns", "severity_number", "flags", "http.status_code"][i],
+            [
+                "timestamp_ns",
+                "severity_number",
+                "flags",
+                "http.status_code",
+            ][i],
             FieldKind::Int64,
         )
         .unwrap()
@@ -260,8 +275,16 @@ fn run_streaming_zero_copy(num_batches: u64) {
             }
             // Subslice directly from the Bytes so offset_of recognizes pointer identity.
             let str_indices = [
-                indices[2], indices[3], indices[5], indices[6], indices[7],
-                indices[8], indices[9], indices[10], indices[11], indices[14],
+                indices[2],
+                indices[3],
+                indices[5],
+                indices[6],
+                indices[7],
+                indices[8],
+                indices[9],
+                indices[10],
+                indices[11],
+                indices[14],
             ];
             for (i, &idx) in str_indices.iter().enumerate() {
                 let start = i * STR_VALUE.len();
@@ -293,8 +316,16 @@ fn run_streaming_generated(num_batches: u64) {
                 sb.append_i64_value_by_idx(idx, row as i64);
             }
             for &idx in &[
-                indices[2], indices[3], indices[5], indices[6], indices[7],
-                indices[8], indices[9], indices[10], indices[11], indices[14],
+                indices[2],
+                indices[3],
+                indices[5],
+                indices[6],
+                indices[7],
+                indices[8],
+                indices[9],
+                indices[10],
+                indices[11],
+                indices[14],
             ] {
                 sb.append_decoded_str_by_idx(idx, STR_VALUE.as_bytes());
             }

--- a/crates/logfwd-arrow/src/bin/builder_profile.rs
+++ b/crates/logfwd-arrow/src/bin/builder_profile.rs
@@ -300,7 +300,7 @@ fn run_streaming_zero_copy(num_batches: u64) {
             sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
             sb.end_row();
         }
-        let batch = sb.finish_batch_detached().unwrap();
+        let batch = sb.finish_batch().unwrap();
         black_box(&batch);
     }
 }

--- a/crates/logfwd-arrow/src/bin/builder_profile.rs
+++ b/crates/logfwd-arrow/src/bin/builder_profile.rs
@@ -84,6 +84,7 @@ fn run_columnar_zero_copy(num_batches: u64) {
         .unwrap();
 
     let mut b = ColumnarBatchBuilder::new(plan);
+    b.set_dedup_enabled(false);
 
     for batch_idx in 0..num_batches {
         b.begin_batch();
@@ -145,6 +146,7 @@ fn run_columnar_generated(num_batches: u64) {
         .unwrap();
 
     let mut b = ColumnarBatchBuilder::new(plan);
+    b.set_dedup_enabled(false);
 
     for batch_idx in 0..num_batches {
         b.begin_batch();
@@ -208,6 +210,7 @@ fn run_columnar_mixed(num_batches: u64) {
         .unwrap();
 
     let mut b = ColumnarBatchBuilder::new(plan);
+    b.set_dedup_enabled(false);
 
     for batch_idx in 0..num_batches {
         b.begin_batch();

--- a/crates/logfwd-arrow/src/bin/builder_profile.rs
+++ b/crates/logfwd-arrow/src/bin/builder_profile.rs
@@ -1,0 +1,264 @@
+//! Profiling harness for ColumnarBatchBuilder vs StreamingBuilder.
+//!
+//! Usage:
+//!   cargo build -p logfwd-arrow --release --features _test-internals --bin builder_profile
+//!   valgrind --tool=callgrind ./target/release/builder_profile columnar 50
+//!   valgrind --tool=callgrind ./target/release/builder_profile streaming 50
+//!   valgrind --tool=dhat      ./target/release/builder_profile columnar 10
+//!   valgrind --tool=massif    ./target/release/builder_profile columnar 10
+
+use std::env;
+use std::hint::black_box;
+
+use logfwd_arrow::columnar::builder::ColumnarBatchBuilder;
+use logfwd_arrow::columnar::plan::{BatchPlan, FieldHandle, FieldKind};
+use logfwd_arrow::streaming_builder::StreamingBuilder;
+
+const ROWS_PER_BATCH: u32 = 1000;
+
+fn run_columnar_detached(num_batches: u64) {
+    let mut plan = BatchPlan::new();
+    let int_handles: [FieldHandle; 4] = [
+        plan.declare_planned("timestamp_ns", FieldKind::Int64)
+            .unwrap(),
+        plan.declare_planned("severity_number", FieldKind::Int64)
+            .unwrap(),
+        plan.declare_planned("flags", FieldKind::Int64).unwrap(),
+        plan.declare_planned("attributes.http.status_code", FieldKind::Int64)
+            .unwrap(),
+    ];
+    let str_handles: [FieldHandle; 10] = [
+        plan.declare_planned("severity_text", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("body", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("trace_id", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("span_id", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("resource.service.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("resource.host.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("scope.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("scope.version", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("attributes.http.method", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("attributes.http.path", FieldKind::Utf8View)
+            .unwrap(),
+    ];
+    let float_handles: [FieldHandle; 1] = [plan
+        .declare_planned("attributes.duration_ms", FieldKind::Float64)
+        .unwrap()];
+
+    let mut b = ColumnarBatchBuilder::new(plan);
+
+    for batch_idx in 0..num_batches {
+        b.begin_batch();
+        for row in 0..ROWS_PER_BATCH {
+            b.begin_row();
+            let base = (batch_idx as i64) * (ROWS_PER_BATCH as i64) + row as i64;
+            for (i, &h) in int_handles.iter().enumerate() {
+                b.write_i64(h, base + i as i64 * 1000);
+            }
+            for &h in &str_handles {
+                b.write_str(h, "example-value-0123456789").unwrap();
+            }
+            for &h in &float_handles {
+                b.write_f64(h, base as f64 * 0.001);
+            }
+            b.end_row();
+        }
+        let batch = b.finish_batch().unwrap();
+        black_box(&batch);
+    }
+}
+
+fn run_columnar_view(num_batches: u64) {
+    let mut plan = BatchPlan::new();
+    let int_handles: [FieldHandle; 4] = [
+        plan.declare_planned("timestamp_ns", FieldKind::Int64)
+            .unwrap(),
+        plan.declare_planned("severity_number", FieldKind::Int64)
+            .unwrap(),
+        plan.declare_planned("flags", FieldKind::Int64).unwrap(),
+        plan.declare_planned("attributes.http.status_code", FieldKind::Int64)
+            .unwrap(),
+    ];
+    let str_handles: [FieldHandle; 10] = [
+        plan.declare_planned("severity_text", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("body", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("trace_id", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("span_id", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("resource.service.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("resource.host.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("scope.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("scope.version", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("attributes.http.method", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("attributes.http.path", FieldKind::Utf8View)
+            .unwrap(),
+    ];
+    let float_handles: [FieldHandle; 1] = [plan
+        .declare_planned("attributes.duration_ms", FieldKind::Float64)
+        .unwrap()];
+
+    let mut b = ColumnarBatchBuilder::new(plan);
+
+    for batch_idx in 0..num_batches {
+        b.begin_batch();
+        for row in 0..ROWS_PER_BATCH {
+            b.begin_row();
+            let base = (batch_idx as i64) * (ROWS_PER_BATCH as i64) + row as i64;
+            for (i, &h) in int_handles.iter().enumerate() {
+                b.write_i64(h, base + i as i64 * 1000);
+            }
+            for &h in &str_handles {
+                b.write_str(h, "example-value-0123456789").unwrap();
+            }
+            for &h in &float_handles {
+                b.write_f64(h, base as f64 * 0.001);
+            }
+            b.end_row();
+        }
+        let batch = b
+            .finish_batch_view(arrow::buffer::Buffer::from(b"" as &[u8]), 0)
+            .unwrap();
+        black_box(&batch);
+    }
+}
+
+const FIELD_NAMES: [&str; 15] = [
+    "timestamp_ns",
+    "severity_number",
+    "severity_text",
+    "body",
+    "flags",
+    "trace_id",
+    "span_id",
+    "resource.service.name",
+    "resource.host.name",
+    "scope.name",
+    "scope.version",
+    "attributes.http.method",
+    "attributes.http.status_code",
+    "attributes.duration_ms",
+    "attributes.http.path",
+];
+
+fn run_streaming_detached(num_batches: u64) {
+    let mut sb = StreamingBuilder::new(None);
+
+    for _batch in 0..num_batches {
+        let dummy = bytes::Bytes::from_static(b"");
+        sb.begin_batch(dummy);
+        let indices: Vec<usize> = FIELD_NAMES
+            .iter()
+            .map(|name| sb.resolve_field(name.as_bytes()))
+            .collect();
+
+        for row in 0..ROWS_PER_BATCH {
+            sb.begin_row();
+            for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
+                sb.append_i64_value_by_idx(idx, row as i64);
+            }
+            for &idx in &[
+                indices[2],
+                indices[3],
+                indices[5],
+                indices[6],
+                indices[7],
+                indices[8],
+                indices[9],
+                indices[10],
+                indices[11],
+                indices[14],
+            ] {
+                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+            }
+            sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
+            sb.end_row();
+        }
+        let batch = sb.finish_batch_detached().unwrap();
+        black_box(&batch);
+    }
+}
+
+fn run_streaming_view(num_batches: u64) {
+    let mut sb = StreamingBuilder::new(None);
+
+    for _batch in 0..num_batches {
+        let dummy = bytes::Bytes::from_static(b"");
+        sb.begin_batch(dummy);
+        let indices: Vec<usize> = FIELD_NAMES
+            .iter()
+            .map(|name| sb.resolve_field(name.as_bytes()))
+            .collect();
+
+        for row in 0..ROWS_PER_BATCH {
+            sb.begin_row();
+            for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
+                sb.append_i64_value_by_idx(idx, row as i64);
+            }
+            for &idx in &[
+                indices[2],
+                indices[3],
+                indices[5],
+                indices[6],
+                indices[7],
+                indices[8],
+                indices[9],
+                indices[10],
+                indices[11],
+                indices[14],
+            ] {
+                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+            }
+            sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
+            sb.end_row();
+        }
+        let batch = sb.finish_batch().unwrap();
+        black_box(&batch);
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let mode = args.get(1).map_or("columnar", String::as_str);
+    let num_batches: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(20);
+
+    let total_rows = ROWS_PER_BATCH as u64 * num_batches;
+    eprintln!("Running {mode} for {num_batches} batches ({total_rows} rows)...");
+
+    let start = std::time::Instant::now();
+
+    match mode {
+        "columnar" => run_columnar_detached(num_batches),
+        "columnar-view" => run_columnar_view(num_batches),
+        "streaming" => run_streaming_detached(num_batches),
+        "streaming-view" => run_streaming_view(num_batches),
+        other => {
+            eprintln!("Unknown mode: {other}");
+            eprintln!(
+                "Usage: builder_profile <columnar|columnar-view|streaming|streaming-view> [batches]"
+            );
+            std::process::exit(1);
+        }
+    }
+
+    let elapsed = start.elapsed();
+    eprintln!(
+        "Done in {:.1?} ({:.0} ns/row, {:.0} rows/sec)",
+        elapsed,
+        elapsed.as_nanos() as f64 / total_rows as f64,
+        total_rows as f64 / elapsed.as_secs_f64(),
+    );
+}

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -433,52 +433,85 @@ pub enum FinalizationMode<'a> {
 // ---------------------------------------------------------------------------
 
 fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
+    let dense = facts.len() == num_rows;
     let mut values = vec![0i64; num_rows];
-    let mut valid = vec![false; num_rows];
+    let mut valid = if dense {
+        Vec::new()
+    } else {
+        vec![false; num_rows]
+    };
     for &(row, v) in facts {
         let r = row as usize;
         if r < num_rows {
             values[r] = v;
-            valid[r] = true;
+            if !dense {
+                valid[r] = true;
+            }
         }
     }
-    let nulls = NullBuffer::from(valid);
+    let nulls = if dense {
+        None
+    } else {
+        Some(NullBuffer::from(valid))
+    };
     (
-        Arc::new(Int64Array::new(values.into(), Some(nulls))),
+        Arc::new(Int64Array::new(values.into(), nulls)),
         DataType::Int64,
     )
 }
 
 fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) {
+    let dense = facts.len() == num_rows;
     let mut values = vec![0.0f64; num_rows];
-    let mut valid = vec![false; num_rows];
+    let mut valid = if dense {
+        Vec::new()
+    } else {
+        vec![false; num_rows]
+    };
     for &(row, v) in facts {
         let r = row as usize;
         if r < num_rows {
             values[r] = v;
-            valid[r] = true;
+            if !dense {
+                valid[r] = true;
+            }
         }
     }
-    let nulls = NullBuffer::from(valid);
+    let nulls = if dense {
+        None
+    } else {
+        Some(NullBuffer::from(valid))
+    };
     (
-        Arc::new(Float64Array::new(values.into(), Some(nulls))),
+        Arc::new(Float64Array::new(values.into(), nulls)),
         DataType::Float64,
     )
 }
 
 fn build_bool(facts: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
+    let dense = facts.len() == num_rows;
     let mut values = vec![false; num_rows];
-    let mut valid = vec![false; num_rows];
+    let mut valid = if dense {
+        Vec::new()
+    } else {
+        vec![false; num_rows]
+    };
     for &(row, v) in facts {
         let r = row as usize;
         if r < num_rows {
             values[r] = v;
-            valid[r] = true;
+            if !dense {
+                valid[r] = true;
+            }
         }
     }
-    let nulls = NullBuffer::from(valid);
+    let nulls = if dense {
+        None
+    } else {
+        Some(NullBuffer::from(valid))
+    };
     (
-        Arc::new(BooleanArray::new(values.into(), Some(nulls))),
+        Arc::new(BooleanArray::new(values.into(), nulls)),
         DataType::Boolean,
     )
 }
@@ -494,6 +527,7 @@ fn build_string(
             generated_buf,
         } => {
             let original_len = original_buf.len();
+            let dense = facts.len() == num_rows;
             // Build offsets + values directly, skipping per-value UTF-8 validation.
             // Safety argument: all strings entered via write_str(&str) are already
             // valid UTF-8 by Rust's type system. StringRef data written via
@@ -502,7 +536,11 @@ fn build_string(
             let mut offsets: Vec<i32> = Vec::with_capacity(num_rows + 1);
             let mut values: Vec<u8> =
                 Vec::with_capacity(facts.iter().map(|(_, sref)| sref.len as usize).sum());
-            let mut validity: Vec<bool> = Vec::with_capacity(num_rows);
+            let mut validity: Vec<bool> = if dense {
+                Vec::new()
+            } else {
+                Vec::with_capacity(num_rows)
+            };
             let mut vi = 0;
 
             for row in 0..num_rows as u32 {
@@ -511,16 +549,21 @@ fn build_string(
                     let sref = facts[vi].1;
                     let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
                     values.extend_from_slice(bytes);
-                    validity.push(true);
+                    if !dense {
+                        validity.push(true);
+                    }
                     vi += 1;
-                } else {
+                } else if !dense {
                     validity.push(false);
                 }
             }
             offsets.push(values.len() as i32);
 
-            // Single UTF-8 validation of the entire values buffer.
-            if std::str::from_utf8(&values).is_err() {
+            // UTF-8 validation: skip when original_buf is empty, because all
+            // string data came through write_str(&str), which guarantees UTF-8
+            // by Rust's type system. Only validate when original_buf is present
+            // (write_str_ref data from external sources).
+            if !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {
                 // Find the offending string for a precise error.
                 let mut fvi = 0;
                 for row in 0..num_rows as u32 {
@@ -539,7 +582,7 @@ fn build_string(
                 }
             }
 
-            let nulls = if validity.iter().all(|&v| v) {
+            let nulls = if facts.len() == num_rows {
                 None
             } else {
                 Some(NullBuffer::from(validity))

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -416,6 +416,10 @@ pub enum FinalizationMode<'a> {
         original_buf: &'a [u8],
         /// Generated/decoded buffer, for reading decoded strings.
         generated_buf: &'a [u8],
+        /// When true, all string data is known to be valid UTF-8 (validated
+        /// at the ingestion boundary — scanner, OTLP decoder, etc.). Skips
+        /// redundant validation in Arrow array construction.
+        utf8_trusted: bool,
     },
     /// Zero-copy `StringViewArray` backed by Arrow buffers.
     View {
@@ -525,14 +529,11 @@ fn build_string(
         FinalizationMode::Detached {
             original_buf,
             generated_buf,
+            utf8_trusted,
         } => {
             let original_len = original_buf.len();
             let dense = facts.len() == num_rows;
             // Build offsets + values directly, skipping per-value UTF-8 validation.
-            // Safety argument: all strings entered via write_str(&str) are already
-            // valid UTF-8 by Rust's type system. StringRef data written via
-            // write_str_ref may originate from arbitrary bytes, so we validate
-            // the entire concatenated values buffer once at the end.
             let mut offsets: Vec<i32> = Vec::with_capacity(num_rows + 1);
             let mut values: Vec<u8> =
                 Vec::with_capacity(facts.iter().map(|(_, sref)| sref.len as usize).sum());
@@ -559,12 +560,13 @@ fn build_string(
             }
             offsets.push(values.len() as i32);
 
-            // UTF-8 validation: skip when original_buf is empty, because all
-            // string data came through write_str(&str), which guarantees UTF-8
-            // by Rust's type system. Only validate when original_buf is present
-            // (write_str_ref data from external sources).
-            if !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {
-                // Find the offending string for a precise error.
+            // UTF-8 validation strategy:
+            // - utf8_trusted: ingestion boundary (scanner/decoder) already validated.
+            //   Skip entirely — Arrow's StringArray::new does redundant validation.
+            // - original_buf empty: all data from write_str(&str) — Rust type system
+            //   guarantees UTF-8. Skip.
+            // - otherwise: external bytes via write_str_ref need validation.
+            if !utf8_trusted && !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {
                 let mut fvi = 0;
                 for row in 0..num_rows as u32 {
                     if fvi < facts.len() && facts[fvi].0 == row {
@@ -582,13 +584,31 @@ fn build_string(
                 }
             }
 
-            let nulls = if facts.len() == num_rows {
+            let nulls = if dense {
                 None
             } else {
                 Some(NullBuffer::from(validity))
             };
             let offset_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
-            let array = StringArray::new(offset_buf, Buffer::from_vec(values), nulls);
+            let values_buf = Buffer::from_vec(values);
+
+            let array = if *utf8_trusted || original_buf.is_empty() {
+                debug_assert!(
+                    std::str::from_utf8(values_buf.as_slice()).is_ok(),
+                    "utf8_trusted was set but string buffer contains invalid UTF-8 — \
+                     the ingestion boundary (scanner/decoder) has a validation bug"
+                );
+                // SAFETY: offsets are built sequentially from 0..values.len(),
+                // each pair spans a contiguous slice from the source buffers.
+                // UTF-8 validity is guaranteed by either:
+                // - utf8_trusted: scanner/decoder validated at ingestion
+                //   (see ScanConfig::validate_utf8, scanner.rs debug_assert)
+                // - original_buf empty: all data from write_str(&str), which
+                //   is valid UTF-8 by Rust's type system
+                unsafe { StringArray::new_unchecked(offset_buf, values_buf, nulls) }
+            } else {
+                StringArray::new(offset_buf, values_buf, nulls)
+            };
             Ok((Arc::new(array), DataType::Utf8))
         }
         FinalizationMode::View {
@@ -783,6 +803,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: &[],
             generated_buf: &[],
+            utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("ts", 3, mode).unwrap().unwrap();
         assert_eq!(field.name(), "ts");
@@ -802,6 +823,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: input,
             generated_buf: &[],
+            utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
         let a = arr.as_string::<i32>();
@@ -849,6 +871,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: input,
             generated_buf: generated,
+            utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
         let a = arr.as_string::<i32>();
@@ -865,6 +888,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: &[],
             generated_buf: &[],
+            utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("x", 2, mode).unwrap().unwrap();
         assert_eq!(field.data_type(), &DataType::Int64);
@@ -884,6 +908,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: input,
             generated_buf: &[],
+            utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("status", 2, mode).unwrap().unwrap();
         assert!(matches!(field.data_type(), DataType::Struct(_)));
@@ -900,6 +925,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: &[],
             generated_buf: &[],
+            utf8_trusted: true,
         };
         assert!(acc.materialize("x", 3, mode).unwrap().is_none());
     }
@@ -914,6 +940,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: &[],
             generated_buf: &[],
+            utf8_trusted: true,
         };
         assert!(acc.materialize("x", 1, mode).unwrap().is_none()); // no int facts → None
     }
@@ -928,6 +955,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: &[],
             generated_buf: &[],
+            utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("x", 1, mode).unwrap().unwrap();
         assert_eq!(arr.as_primitive::<Int64Type>().value(0), 200);
@@ -975,6 +1003,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: b"short",
             generated_buf: &[],
+            utf8_trusted: true,
         };
         let result = acc.materialize("x", 1, mode);
         assert!(result.is_err());
@@ -994,6 +1023,7 @@ mod tests {
         let mode = FinalizationMode::Detached {
             original_buf: bad_bytes,
             generated_buf: &[],
+            utf8_trusted: false,
         };
         let result = acc.materialize("x", 1, mode);
         assert!(result.is_err());

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -887,6 +887,8 @@ fn build_conflict_struct(
 
 #[cfg(test)]
 mod tests {
+    use std::mem::size_of_val;
+
     use super::*;
     use arrow::array::{Array, AsArray};
     use arrow::datatypes::Int64Type;
@@ -1068,8 +1070,8 @@ mod tests {
         let planned = ColumnAccumulator::for_planned(FieldKind::Int64);
         let dynamic = ColumnAccumulator::dynamic();
 
-        let planned_size = std::mem::size_of_val(&planned);
-        let dynamic_size = std::mem::size_of_val(&dynamic);
+        let planned_size = size_of_val(&planned);
+        let dynamic_size = size_of_val(&dynamic);
 
         // The enum discriminant means planned isn't dramatically smaller in stack
         // size due to enum sizing rules, but the heap allocation count differs.
@@ -1150,5 +1152,361 @@ mod tests {
         };
         let result = acc.materialize("x", 1, mode);
         assert!(result.is_err());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kani proofs — exhaustive verification of pure u128 packing logic
+// ---------------------------------------------------------------------------
+//
+// Verification strategy (aligned with project conventions in VERIFICATION.md):
+//   - Kani: pure logic only — no heap allocations, no Arrow construction
+//   - proptest: allocation-heavy paths (build_int64/float64/bool, read_str_bytes)
+//   - Unit tests: Arrow integration (RecordBatch, finish_batch)
+//
+// build_int64/float64/bool and read_str_bytes are verified via proptest below
+// because they allocate Vecs and/or use slice operations that cause CBMC solver
+// timeouts (>10 min for read_str_bytes on [u8; 16]).
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    // ── make_string_view ────────────────────────────────────────────────────
+
+    /// Inline path (len ≤ 12): length encodes correctly, data bytes round-trip.
+    #[kani::proof]
+    #[kani::unwind(17)]
+    fn verify_make_string_view_inline_roundtrip() {
+        let len: u32 = kani::any();
+        kani::assume(len > 0 && len <= 12);
+
+        let mut buf = [0u8; 12];
+        for i in 0..12 {
+            buf[i] = kani::any();
+        }
+
+        let sref = StringRef { offset: 0, len };
+        let view =
+            make_string_view(sref, &buf[..len as usize], &[], len as usize, 0, None).unwrap();
+
+        // Extract length from view — bytes 0..4 little-endian.
+        let extracted_len = (view & 0xFFFF_FFFF) as u32;
+        assert_eq!(extracted_len, len, "encoded length must match");
+
+        // Extract inline data — bytes 4..4+len.
+        let view_bytes = view.to_le_bytes();
+        for i in 0..len as usize {
+            assert_eq!(
+                view_bytes[4 + i],
+                buf[i],
+                "inline data byte must match source"
+            );
+        }
+
+        kani::cover!(len == 1, "minimal inline");
+        kani::cover!(len == 12, "max inline");
+    }
+
+    /// Zero-length string encodes as zero u128.
+    #[kani::proof]
+    fn verify_make_string_view_zero_length() {
+        let sref = StringRef { offset: 0, len: 0 };
+        let view = make_string_view(sref, &[], &[], 0, 0, None).unwrap();
+        assert_eq!(view, 0u128, "zero-length string must be all-zero view");
+    }
+
+    /// Buffer-ref path (len > 12): u128 field packing is non-overlapping and
+    /// each 32-bit lane round-trips correctly.
+    #[kani::proof]
+    fn verify_make_string_view_buffer_ref_packing() {
+        let len: u32 = kani::any();
+        kani::assume(len > 12 && len <= 64);
+        let block_idx: u32 = kani::any();
+        let local_offset: u32 = kani::any();
+        kani::assume((local_offset as usize) + (len as usize) <= 256);
+
+        let buf_len = local_offset as usize + len as usize;
+        let buf = vec![0xABu8; buf_len];
+
+        let sref = StringRef {
+            offset: local_offset,
+            len,
+        };
+        let view = make_string_view(sref, &buf, &[], buf_len, block_idx, None).unwrap();
+
+        // Lane 0: length
+        assert_eq!((view & 0xFFFF_FFFF) as u32, len);
+        // Lane 1: prefix (first 4 bytes of string data = 0xAB repeated)
+        let expected_prefix = u32::from_le_bytes([0xAB, 0xAB, 0xAB, 0xAB]);
+        assert_eq!(((view >> 32) & 0xFFFF_FFFF) as u32, expected_prefix);
+        // Lane 2: block index
+        assert_eq!(((view >> 64) & 0xFFFF_FFFF) as u32, block_idx);
+        // Lane 3: local offset
+        assert_eq!(((view >> 96) & 0xFFFF_FFFF) as u32, local_offset);
+    }
+
+    /// Out-of-bounds StringRef returns error, never panics.
+    #[kani::proof]
+    fn verify_make_string_view_out_of_bounds() {
+        let offset: u32 = kani::any();
+        let len: u32 = kani::any();
+        kani::assume(len > 0);
+        let buf_len: usize = kani::any();
+        kani::assume(buf_len < 256);
+        let total = (offset as usize).saturating_add(len as usize);
+        kani::assume(total > buf_len);
+
+        let buf = vec![0u8; buf_len];
+        let sref = StringRef { offset, len };
+        let result = make_string_view(sref, &buf, &[], buf_len, 0, None);
+        assert!(result.is_err(), "OOB reference must return error");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Proptest — statistical verification for allocation-heavy materialization
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use arrow::array::Array;
+    use proptest::prelude::*;
+
+    // ── build_int64 ─────────────────────────────────────────────────────────
+
+    proptest! {
+        /// Dense int64: all rows present, no nulls.
+        #[test]
+        fn build_int64_dense(values in prop::collection::vec(any::<i64>(), 1..=64)) {
+            let num_rows = values.len();
+            let facts: Vec<(u32, i64)> = values.iter().enumerate()
+                .map(|(i, &v)| (i as u32, v)).collect();
+            let (arr, dt) = build_int64(&facts, num_rows);
+            prop_assert_eq!(dt, DataType::Int64);
+            prop_assert_eq!(arr.len(), num_rows);
+            prop_assert_eq!(arr.null_count(), 0, "dense path must have no nulls");
+            let typed = arr.as_any().downcast_ref::<Int64Array>().unwrap();
+            for (i, &v) in values.iter().enumerate() {
+                prop_assert_eq!(typed.value(i), v);
+            }
+        }
+
+        /// Sparse int64: random subset of rows, gaps are null.
+        #[test]
+        fn build_int64_sparse(
+            num_rows in 1usize..=32,
+            seed in any::<u64>(),
+        ) {
+            // Deterministic sparse pattern from seed.
+            let mut facts: Vec<(u32, i64)> = Vec::new();
+            for row in 0..num_rows as u32 {
+                if (seed.wrapping_mul(row as u64 + 1)) % 3 != 0 {
+                    facts.push((row, row as i64 * 100));
+                }
+            }
+            if facts.is_empty() {
+                // Ensure at least one fact for a meaningful test.
+                facts.push((0, 42));
+            }
+            let (arr, _) = build_int64(&facts, num_rows);
+            prop_assert_eq!(arr.len(), num_rows);
+
+            let typed = arr.as_any().downcast_ref::<Int64Array>().unwrap();
+            let mut fi = 0;
+            for row in 0..num_rows {
+                if fi < facts.len() && facts[fi].0 as usize == row {
+                    prop_assert!(!typed.is_null(row), "fact row must not be null");
+                    prop_assert_eq!(typed.value(row), facts[fi].1);
+                    fi += 1;
+                } else {
+                    prop_assert!(typed.is_null(row), "gap row must be null");
+                }
+            }
+        }
+    }
+
+    // ── build_float64 ───────────────────────────────────────────────────────
+
+    proptest! {
+        /// Dense float64: all rows present, no nulls.
+        #[test]
+        fn build_float64_dense(
+            values in prop::collection::vec(
+                any::<f64>().prop_filter("finite", |v| v.is_finite()),
+                1..=64,
+            )
+        ) {
+            let num_rows = values.len();
+            let facts: Vec<(u32, f64)> = values.iter().enumerate()
+                .map(|(i, &v)| (i as u32, v)).collect();
+            let (arr, dt) = build_float64(&facts, num_rows);
+            prop_assert_eq!(dt, DataType::Float64);
+            prop_assert_eq!(arr.len(), num_rows);
+            prop_assert_eq!(arr.null_count(), 0);
+            let typed = arr.as_any().downcast_ref::<Float64Array>().unwrap();
+            for (i, &v) in values.iter().enumerate() {
+                prop_assert_eq!(typed.value(i).to_bits(), v.to_bits());
+            }
+        }
+
+        /// Sparse float64: gaps are null.
+        #[test]
+        fn build_float64_sparse(num_rows in 1usize..=32, seed in any::<u64>()) {
+            let mut facts: Vec<(u32, f64)> = Vec::new();
+            for row in 0..num_rows as u32 {
+                if (seed.wrapping_mul(row as u64 + 1)) % 3 != 0 {
+                    facts.push((row, row as f64 * 1.5));
+                }
+            }
+            if facts.is_empty() {
+                facts.push((0, 42.0));
+            }
+            let (arr, _) = build_float64(&facts, num_rows);
+            prop_assert_eq!(arr.len(), num_rows);
+
+            let typed = arr.as_any().downcast_ref::<Float64Array>().unwrap();
+            let mut fi = 0;
+            for row in 0..num_rows {
+                if fi < facts.len() && facts[fi].0 as usize == row {
+                    prop_assert!(!typed.is_null(row));
+                    prop_assert_eq!(
+                        typed.value(row).to_bits(),
+                        facts[fi].1.to_bits(),
+                        "value mismatch at row {}", row
+                    );
+                    fi += 1;
+                } else {
+                    prop_assert!(typed.is_null(row));
+                }
+            }
+        }
+    }
+
+    // ── build_bool ──────────────────────────────────────────────────────────
+
+    proptest! {
+        /// Dense bool: all rows present, no nulls.
+        #[test]
+        fn build_bool_dense(values in prop::collection::vec(any::<bool>(), 1..=64)) {
+            let num_rows = values.len();
+            let facts: Vec<(u32, bool)> = values.iter().enumerate()
+                .map(|(i, &v)| (i as u32, v)).collect();
+            let (arr, dt) = build_bool(&facts, num_rows);
+            prop_assert_eq!(dt, DataType::Boolean);
+            prop_assert_eq!(arr.len(), num_rows);
+            prop_assert_eq!(arr.null_count(), 0);
+            let typed = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
+            for (i, &v) in values.iter().enumerate() {
+                prop_assert_eq!(typed.value(i), v);
+            }
+        }
+
+        /// Sparse bool: gaps are null.
+        #[test]
+        fn build_bool_sparse(num_rows in 1usize..=32, seed in any::<u64>()) {
+            let mut facts: Vec<(u32, bool)> = Vec::new();
+            for row in 0..num_rows as u32 {
+                if (seed.wrapping_mul(row as u64 + 1)) % 3 != 0 {
+                    facts.push((row, row % 2 == 0));
+                }
+            }
+            if facts.is_empty() {
+                facts.push((0, true));
+            }
+            let (arr, _) = build_bool(&facts, num_rows);
+            prop_assert_eq!(arr.len(), num_rows);
+
+            let typed = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
+            let mut fi = 0;
+            for row in 0..num_rows {
+                if fi < facts.len() && facts[fi].0 as usize == row {
+                    prop_assert!(!typed.is_null(row));
+                    prop_assert_eq!(typed.value(row), facts[fi].1);
+                    fi += 1;
+                } else {
+                    prop_assert!(typed.is_null(row));
+                }
+            }
+        }
+    }
+
+    // ── read_str_bytes ──────────────────────────────────────────────────────
+
+    proptest! {
+        /// Strings in the original buffer resolve correctly.
+        #[test]
+        fn read_str_bytes_original_buffer(
+            orig_len in 1usize..=128,
+            offset in 0u32..128,
+            len in 1u32..=64,
+        ) {
+            prop_assume!((offset as usize) + (len as usize) <= orig_len);
+            let original = vec![0xCCu8; orig_len];
+            let generated: Vec<u8> = vec![0xDDu8; 16];
+
+            let sref = StringRef { offset, len };
+            let result = read_str_bytes(&original, &generated, orig_len, sref);
+            prop_assert!(result.is_ok());
+            let bytes = result.unwrap();
+            prop_assert_eq!(bytes.len(), len as usize);
+            for &b in bytes {
+                prop_assert_eq!(b, 0xCC);
+            }
+        }
+
+        /// Strings in the generated buffer resolve correctly.
+        #[test]
+        fn read_str_bytes_generated_buffer(
+            orig_len in 1usize..=64,
+            gen_len in 1usize..=128,
+            gen_offset in 0u32..128,
+            len in 1u32..=64,
+        ) {
+            prop_assume!((gen_offset as usize) + (len as usize) <= gen_len);
+            let original = vec![0xCCu8; orig_len];
+            let generated = vec![0xDDu8; gen_len];
+
+            let sref = StringRef {
+                offset: orig_len as u32 + gen_offset,
+                len,
+            };
+            let result = read_str_bytes(&original, &generated, orig_len, sref);
+            prop_assert!(result.is_ok());
+            let bytes = result.unwrap();
+            prop_assert_eq!(bytes.len(), len as usize);
+            for &b in bytes {
+                prop_assert_eq!(b, 0xDD);
+            }
+        }
+
+        /// A string starting in original but extending past it is rejected.
+        #[test]
+        fn read_str_bytes_spanning_rejected(
+            offset in 0u32..8,
+            len in 2u32..=12,
+        ) {
+            let orig_len = 8usize;
+            prop_assume!((offset as usize) < orig_len);
+            prop_assume!((offset as usize + len as usize) > orig_len);
+
+            let original = [0xCCu8; 8];
+            let generated = [0xDDu8; 8];
+            let sref = StringRef { offset, len };
+            let result = read_str_bytes(&original, &generated, orig_len, sref);
+            prop_assert!(result.is_err(), "spanning strings must be rejected");
+        }
+
+        /// Completely out-of-bounds references always fail.
+        #[test]
+        fn read_str_bytes_out_of_bounds(
+            offset in 128u32..256,
+            len in 1u32..=32,
+        ) {
+            let original = [0xCCu8; 8];
+            let generated = [0xDDu8; 8];
+            let sref = StringRef { offset, len };
+            let result = read_str_bytes(&original, &generated, 8, sref);
+            prop_assert!(result.is_err());
+        }
     }
 }

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -618,11 +618,11 @@ fn build_string_view_trusted(
             // Validate UTF-8 for all referenced string bytes in debug builds.
             let mut ok = true;
             for &(_, sref) in facts {
-                if let Ok(bytes) = read_str_bytes(original_buf, generated_buf, original_len, sref) {
-                    if std::str::from_utf8(bytes).is_err() {
-                        ok = false;
-                        break;
-                    }
+                if let Ok(bytes) = read_str_bytes(original_buf, generated_buf, original_len, sref)
+                    && std::str::from_utf8(bytes).is_err()
+                {
+                    ok = false;
+                    break;
                 }
             }
             ok

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -633,21 +633,20 @@ fn build_string_view_trusted(
             )?;
         }
     } else {
-        // Sparse: walk facts in row order, null rows stay as 0 (zero-length view).
+        // Sparse: iterate all facts, assign by row index (last-write-wins for duplicates).
         let mut valid = vec![false; num_rows];
-        let mut vi = 0;
-        for (row, view_slot) in views.iter_mut().enumerate() {
-            if vi < facts.len() && facts[vi].0 as usize == row {
-                *view_slot = make_string_view(
-                    facts[vi].1,
+        for &(row, sref) in facts {
+            let r = row as usize;
+            if r < num_rows {
+                views[r] = make_string_view(
+                    sref,
                     original_buf,
                     generated_buf,
                     original_len,
                     orig_block,
                     gen_block,
                 )?;
-                valid[row] = true;
-                vi += 1;
+                valid[r] = true;
             }
         }
         nulls = Some(NullBuffer::from(valid));
@@ -716,7 +715,14 @@ fn make_string_view(
     };
 
     let local_start = local_offset as usize;
-    let local_end = local_start + len as usize;
+    let local_end =
+        local_start
+            .checked_add(len as usize)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: buf.len(),
+            })?;
     if local_end > buf.len() {
         return Err(MaterializeError::StringRefOutOfBounds {
             offset: sref.offset,
@@ -779,16 +785,24 @@ fn build_string_array_validated(
             values.extend_from_slice(bytes);
         }
     } else {
-        let mut vi = 0;
-        for row in 0..num_rows as u32 {
+        // Sparse: two-pass to handle duplicate row indices correctly.
+        // First pass: find last fact index per row (last-write-wins).
+        let mut last_fact_for_row: Vec<Option<usize>> = vec![None; num_rows];
+        for (fi, &(row, _)) in facts.iter().enumerate() {
+            let r = row as usize;
+            if r < num_rows {
+                last_fact_for_row[r] = Some(fi);
+            }
+        }
+        // Second pass: build offsets and values in row order.
+        for entry in &last_fact_for_row {
             let off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
             offsets.push(off);
-            if vi < facts.len() && facts[vi].0 == row {
-                let sref = facts[vi].1;
+            if let Some(fi) = entry {
+                let sref = facts[*fi].1;
                 let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
                 values.extend_from_slice(bytes);
                 validity.push(true);
-                vi += 1;
             } else {
                 validity.push(false);
             }
@@ -799,19 +813,15 @@ fn build_string_array_validated(
 
     // Validate UTF-8 for external bytes.
     if !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {
-        let mut fvi = 0;
-        for row in 0..num_rows as u32 {
-            if fvi < facts.len() && facts[fvi].0 == row {
-                let sref = facts[fvi].1;
-                let start = offsets[row as usize] as usize;
-                let end = offsets[row as usize + 1] as usize;
-                if std::str::from_utf8(&values[start..end]).is_err() {
-                    return Err(MaterializeError::InvalidUtf8 {
-                        offset: sref.offset,
-                        len: sref.len,
-                    });
-                }
-                fvi += 1;
+        // Identify which row contains the invalid UTF-8.
+        for row in 0..num_rows {
+            let start = offsets[row] as usize;
+            let end = offsets[row + 1] as usize;
+            if start < end && std::str::from_utf8(&values[start..end]).is_err() {
+                return Err(MaterializeError::InvalidUtf8 {
+                    offset: offsets[row] as u32,
+                    len: (end - start) as u32,
+                });
             }
         }
     }

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -16,7 +16,8 @@
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, StringViewBuilder, StructArray,
+    ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, StringViewArray,
+    StringViewBuilder, StructArray,
 };
 use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{DataType, Field, Fields};
@@ -277,7 +278,7 @@ impl ColumnAccumulator {
         &self,
         name: &str,
         num_rows: usize,
-        mode: FinalizationMode<'_>,
+        mode: FinalizationMode,
     ) -> Result<Option<(Field, ArrayRef)>, MaterializeError> {
         match self {
             ColumnAccumulator::Int64 { facts, .. } => {
@@ -409,16 +410,20 @@ impl std::error::Error for MaterializeError {
 
 /// Controls how string columns are built at finalization.
 #[derive(Clone)]
-pub enum FinalizationMode<'a> {
-    /// Copy strings into contiguous `StringArray` (self-contained, input-freeable).
+pub enum FinalizationMode {
+    /// Build string columns from owned Arrow buffers.
+    ///
+    /// When `utf8_trusted` is true, produces `StringViewArray` with zero per-string
+    /// byte copying — views reference the source buffers directly. When false,
+    /// copies bytes into a contiguous `StringArray` with full UTF-8 validation.
     Detached {
-        /// Original input buffer, for reading string data.
-        original_buf: &'a [u8],
-        /// Generated/decoded buffer, for reading decoded strings.
-        generated_buf: &'a [u8],
+        /// Original input buffer (e.g., protobuf wire bytes, scanner input).
+        original_buf: Buffer,
+        /// Generated/decoded buffer (e.g., JSON-unescaped strings).
+        generated_buf: Buffer,
         /// When true, all string data is known to be valid UTF-8 (validated
-        /// at the ingestion boundary — scanner, OTLP decoder, etc.). Skips
-        /// redundant validation in Arrow array construction.
+        /// at the ingestion boundary — scanner, OTLP decoder, etc.). Enables
+        /// zero-copy StringViewArray construction.
         utf8_trusted: bool,
     },
     /// Zero-copy `StringViewArray` backed by Arrow buffers.
@@ -523,7 +528,7 @@ fn build_bool(facts: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
 fn build_string(
     facts: &[(u32, StringRef)],
     num_rows: usize,
-    mode: &FinalizationMode<'_>,
+    mode: &FinalizationMode,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
     match mode {
         FinalizationMode::Detached {
@@ -531,85 +536,11 @@ fn build_string(
             generated_buf,
             utf8_trusted,
         } => {
-            let original_len = original_buf.len();
-            let dense = facts.len() == num_rows;
-            // Build offsets + values directly, skipping per-value UTF-8 validation.
-            let mut offsets: Vec<i32> = Vec::with_capacity(num_rows + 1);
-            let mut values: Vec<u8> =
-                Vec::with_capacity(facts.iter().map(|(_, sref)| sref.len as usize).sum());
-            let mut validity: Vec<bool> = if dense {
-                Vec::new()
+            if *utf8_trusted {
+                build_string_view_trusted(facts, num_rows, original_buf, generated_buf)
             } else {
-                Vec::with_capacity(num_rows)
-            };
-            let mut vi = 0;
-
-            for row in 0..num_rows as u32 {
-                offsets.push(values.len() as i32);
-                if vi < facts.len() && facts[vi].0 == row {
-                    let sref = facts[vi].1;
-                    let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
-                    values.extend_from_slice(bytes);
-                    if !dense {
-                        validity.push(true);
-                    }
-                    vi += 1;
-                } else if !dense {
-                    validity.push(false);
-                }
+                build_string_array_validated(facts, num_rows, original_buf, generated_buf)
             }
-            offsets.push(values.len() as i32);
-
-            // UTF-8 validation strategy:
-            // - utf8_trusted: ingestion boundary (scanner/decoder) already validated.
-            //   Skip entirely — Arrow's StringArray::new does redundant validation.
-            // - original_buf empty: all data from write_str(&str) — Rust type system
-            //   guarantees UTF-8. Skip.
-            // - otherwise: external bytes via write_str_ref need validation.
-            if !utf8_trusted && !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {
-                let mut fvi = 0;
-                for row in 0..num_rows as u32 {
-                    if fvi < facts.len() && facts[fvi].0 == row {
-                        let sref = facts[fvi].1;
-                        let start = offsets[row as usize] as usize;
-                        let end = offsets[row as usize + 1] as usize;
-                        if std::str::from_utf8(&values[start..end]).is_err() {
-                            return Err(MaterializeError::InvalidUtf8 {
-                                offset: sref.offset,
-                                len: sref.len,
-                            });
-                        }
-                        fvi += 1;
-                    }
-                }
-            }
-
-            let nulls = if dense {
-                None
-            } else {
-                Some(NullBuffer::from(validity))
-            };
-            let offset_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
-            let values_buf = Buffer::from_vec(values);
-
-            let array = if *utf8_trusted || original_buf.is_empty() {
-                debug_assert!(
-                    std::str::from_utf8(values_buf.as_slice()).is_ok(),
-                    "utf8_trusted was set but string buffer contains invalid UTF-8 — \
-                     the ingestion boundary (scanner/decoder) has a validation bug"
-                );
-                // SAFETY: offsets are built sequentially from 0..values.len(),
-                // each pair spans a contiguous slice from the source buffers.
-                // UTF-8 validity is guaranteed by either:
-                // - utf8_trusted: scanner/decoder validated at ingestion
-                //   (see ScanConfig::validate_utf8, scanner.rs debug_assert)
-                // - original_buf empty: all data from write_str(&str), which
-                //   is valid UTF-8 by Rust's type system
-                unsafe { StringArray::new_unchecked(offset_buf, values_buf, nulls) }
-            } else {
-                StringArray::new(offset_buf, values_buf, nulls)
-            };
-            Ok((Arc::new(array), DataType::Utf8))
         }
         FinalizationMode::View {
             original,
@@ -648,6 +579,267 @@ fn build_string(
             }
             Ok((Arc::new(builder.finish()), DataType::Utf8View))
         }
+    }
+}
+
+/// Build a `StringViewArray` from trusted UTF-8 buffers — zero per-string copy.
+///
+/// Views reference the source buffers directly. For strings ≤ 12 bytes, Arrow
+/// inlines the data in the view itself. For longer strings, the view points
+/// into the original or generated buffer block.
+///
+/// # Safety contract
+///
+/// Caller guarantees all bytes referenced by `facts` are valid UTF-8 (validated
+/// at the ingestion boundary — scanner, OTLP decoder, or Rust's type system
+/// via `write_str(&str)`).
+fn build_string_view_trusted(
+    facts: &[(u32, StringRef)],
+    num_rows: usize,
+    original_buf: &Buffer,
+    generated_buf: &Buffer,
+) -> Result<(ArrayRef, DataType), MaterializeError> {
+    let original_len = original_buf.len();
+    let dense = facts.len() == num_rows;
+
+    // Register source buffers as StringViewArray blocks.
+    // block 0 = original, block 1 = generated (if non-empty).
+    let mut buffers: Vec<Buffer> = Vec::with_capacity(2);
+    let orig_block: u32 = 0;
+    buffers.push(original_buf.clone()); // O(1) Arc bump
+    let gen_block = if generated_buf.is_empty() {
+        None
+    } else {
+        buffers.push(generated_buf.clone()); // O(1) Arc bump
+        Some(1u32)
+    };
+
+    let mut views: Vec<u128> = vec![0u128; num_rows];
+
+    if dense {
+        // Fast path: every row has a value, facts[i] corresponds to row i.
+        for (i, &(_, sref)) in facts.iter().enumerate() {
+            views[i] = make_string_view(
+                sref,
+                original_buf,
+                generated_buf,
+                original_len,
+                orig_block,
+                gen_block,
+            )?;
+        }
+    } else {
+        // Sparse: walk facts in row order, null rows stay as 0 (zero-length view).
+        let mut vi = 0;
+        for (row, view_slot) in views.iter_mut().enumerate() {
+            if vi < facts.len() && facts[vi].0 as usize == row {
+                *view_slot = make_string_view(
+                    facts[vi].1,
+                    original_buf,
+                    generated_buf,
+                    original_len,
+                    orig_block,
+                    gen_block,
+                )?;
+                vi += 1;
+            }
+            // else: views[row] remains 0 (null)
+        }
+    }
+
+    let nulls = if dense {
+        None
+    } else {
+        let valid: Vec<bool> = (0..num_rows)
+            .map(|row| {
+                facts
+                    .binary_search_by_key(&(row as u32), |&(r, _)| r)
+                    .is_ok()
+            })
+            .collect();
+        Some(NullBuffer::from(valid))
+    };
+
+    debug_assert!(
+        {
+            // Validate UTF-8 for all referenced string bytes in debug builds.
+            let mut ok = true;
+            for &(_, sref) in facts {
+                if let Ok(bytes) = read_str_bytes(original_buf, generated_buf, original_len, sref) {
+                    if std::str::from_utf8(bytes).is_err() {
+                        ok = false;
+                        break;
+                    }
+                }
+            }
+            ok
+        },
+        "utf8_trusted was set but string buffer contains invalid UTF-8 — \
+         the ingestion boundary (scanner/decoder) has a validation bug"
+    );
+
+    // SAFETY: views are constructed from validated offsets into the registered
+    // buffer blocks. UTF-8 validity guaranteed by the ingestion boundary
+    // (scanner/decoder) or Rust's type system (write_str takes &str).
+    let array =
+        unsafe { StringViewArray::new_unchecked(ScalarBuffer::from(views), buffers, nulls) };
+    Ok((Arc::new(array), DataType::Utf8View))
+}
+
+/// Construct a u128 StringView for a given StringRef.
+///
+/// Strings ≤ 12 bytes are inlined. Longer strings reference a buffer block.
+#[inline]
+fn make_string_view(
+    sref: StringRef,
+    original_buf: &[u8],
+    generated_buf: &[u8],
+    original_len: usize,
+    orig_block: u32,
+    gen_block: Option<u32>,
+) -> Result<u128, MaterializeError> {
+    let len = sref.len;
+    let start = sref.offset as usize;
+    let end = start
+        .checked_add(len as usize)
+        .ok_or(MaterializeError::StringRefOutOfBounds {
+            offset: sref.offset,
+            len: sref.len,
+            buffer_len: original_buf.len() + generated_buf.len(),
+        })?;
+
+    // Resolve which buffer and the bytes.
+    let (bytes, block_idx, block_offset) = if start < original_len {
+        let b = original_buf
+            .get(start..end)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: original_buf.len(),
+            })?;
+        (b, orig_block, sref.offset)
+    } else {
+        let dec_start = start - original_len;
+        let dec_end = end - original_len;
+        let b = generated_buf.get(dec_start..dec_end).ok_or(
+            MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: generated_buf.len(),
+            },
+        )?;
+        (
+            b,
+            gen_block.ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: 0,
+            })?,
+            dec_start as u32,
+        )
+    };
+
+    if len == 0 {
+        return Ok(0u128);
+    }
+
+    Ok(if len <= 12 {
+        // Inline: pack length + data directly into the view.
+        let mut view_bytes = [0u8; 16];
+        view_bytes[0..4].copy_from_slice(&len.to_le_bytes());
+        view_bytes[4..4 + len as usize].copy_from_slice(bytes);
+        u128::from_le_bytes(view_bytes)
+    } else {
+        // Buffer reference: length + 4-byte prefix + block index + offset.
+        let mut view_bytes = [0u8; 16];
+        view_bytes[0..4].copy_from_slice(&len.to_le_bytes());
+        view_bytes[4..8].copy_from_slice(&bytes[..4]);
+        view_bytes[8..12].copy_from_slice(&block_idx.to_le_bytes());
+        view_bytes[12..16].copy_from_slice(&block_offset.to_le_bytes());
+        u128::from_le_bytes(view_bytes)
+    })
+}
+
+/// Build a `StringArray` with full UTF-8 validation (untrusted path).
+///
+/// Copies string bytes into a contiguous values buffer. Used when the ingestion
+/// boundary has not validated UTF-8 (e.g., raw external input).
+fn build_string_array_validated(
+    facts: &[(u32, StringRef)],
+    num_rows: usize,
+    original_buf: &Buffer,
+    generated_buf: &Buffer,
+) -> Result<(ArrayRef, DataType), MaterializeError> {
+    let original_len = original_buf.len();
+    let dense = facts.len() == num_rows;
+    let mut offsets: Vec<i32> = Vec::with_capacity(num_rows + 1);
+    let mut values: Vec<u8> =
+        Vec::with_capacity(facts.iter().map(|(_, sref)| sref.len as usize).sum());
+    let mut validity: Vec<bool> = if dense {
+        Vec::new()
+    } else {
+        Vec::with_capacity(num_rows)
+    };
+
+    if dense {
+        // Dense fast path: skip per-row branch check.
+        for &(_, sref) in facts {
+            offsets.push(values.len() as i32);
+            let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
+            values.extend_from_slice(bytes);
+        }
+    } else {
+        let mut vi = 0;
+        for row in 0..num_rows as u32 {
+            offsets.push(values.len() as i32);
+            if vi < facts.len() && facts[vi].0 == row {
+                let sref = facts[vi].1;
+                let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
+                values.extend_from_slice(bytes);
+                validity.push(true);
+                vi += 1;
+            } else {
+                validity.push(false);
+            }
+        }
+    }
+    offsets.push(values.len() as i32);
+
+    // Validate UTF-8 for external bytes.
+    if !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {
+        let mut fvi = 0;
+        for row in 0..num_rows as u32 {
+            if fvi < facts.len() && facts[fvi].0 == row {
+                let sref = facts[fvi].1;
+                let start = offsets[row as usize] as usize;
+                let end = offsets[row as usize + 1] as usize;
+                if std::str::from_utf8(&values[start..end]).is_err() {
+                    return Err(MaterializeError::InvalidUtf8 {
+                        offset: sref.offset,
+                        len: sref.len,
+                    });
+                }
+                fvi += 1;
+            }
+        }
+    }
+
+    let nulls = if dense {
+        None
+    } else {
+        Some(NullBuffer::from(validity))
+    };
+    let offset_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
+    let values_buf = Buffer::from_vec(values);
+
+    if original_buf.is_empty() {
+        // All data from write_str(&str) — valid UTF-8 by Rust's type system.
+        // SAFETY: offsets built sequentially, source is &str.
+        let array = unsafe { StringArray::new_unchecked(offset_buf, values_buf, nulls) };
+        Ok((Arc::new(array), DataType::Utf8))
+    } else {
+        let array = StringArray::new(offset_buf, values_buf, nulls);
+        Ok((Arc::new(array), DataType::Utf8))
     }
 }
 
@@ -737,7 +929,7 @@ fn read_str_bytes<'a>(
 fn build_conflict_struct(
     name: &str,
     num_rows: usize,
-    mode: &FinalizationMode<'_>,
+    mode: &FinalizationMode,
     int_facts: &[(u32, i64)],
     float_facts: &[(u32, f64)],
     bool_facts: &[(u32, bool)],
@@ -801,8 +993,8 @@ mod tests {
         acc.push_i64(2, 300);
 
         let mode = FinalizationMode::Detached {
-            original_buf: &[],
-            generated_buf: &[],
+            original_buf: Buffer::from(&[] as &[u8]),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("ts", 3, mode).unwrap().unwrap();
@@ -821,12 +1013,12 @@ mod tests {
         acc.push_str(1, StringRef { offset: 6, len: 5 }); // "world"
 
         let mode = FinalizationMode::Detached {
-            original_buf: input,
-            generated_buf: &[],
+            original_buf: Buffer::from(&input[..]),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
-        let a = arr.as_string::<i32>();
+        let a = arr.as_string_view();
         assert_eq!(a.value(0), "hello");
         assert_eq!(a.value(1), "world");
     }
@@ -869,12 +1061,12 @@ mod tests {
         );
 
         let mode = FinalizationMode::Detached {
-            original_buf: input,
-            generated_buf: generated,
+            original_buf: Buffer::from(&input[..]),
+            generated_buf: Buffer::from(&generated[..]),
             utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
-        let a = arr.as_string::<i32>();
+        let a = arr.as_string_view();
         assert_eq!(a.value(0), "original");
         assert_eq!(a.value(1), "decoded");
     }
@@ -886,8 +1078,8 @@ mod tests {
         acc.push_i64(1, 99);
 
         let mode = FinalizationMode::Detached {
-            original_buf: &[],
-            generated_buf: &[],
+            original_buf: Buffer::from(&[] as &[u8]),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("x", 2, mode).unwrap().unwrap();
@@ -906,8 +1098,8 @@ mod tests {
         acc.push_str(1, StringRef { offset: 0, len: 2 });
 
         let mode = FinalizationMode::Detached {
-            original_buf: input,
-            generated_buf: &[],
+            original_buf: Buffer::from(&input[..]),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("status", 2, mode).unwrap().unwrap();
@@ -923,8 +1115,8 @@ mod tests {
     fn empty_accumulator_returns_none() {
         let acc = ColumnAccumulator::for_planned(FieldKind::Int64);
         let mode = FinalizationMode::Detached {
-            original_buf: &[],
-            generated_buf: &[],
+            original_buf: Buffer::from(&[] as &[u8]),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
         assert!(acc.materialize("x", 3, mode).unwrap().is_none());
@@ -938,8 +1130,8 @@ mod tests {
         acc.push_bool(0, true); // no-op for Int64
 
         let mode = FinalizationMode::Detached {
-            original_buf: &[],
-            generated_buf: &[],
+            original_buf: Buffer::from(&[] as &[u8]),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
         assert!(acc.materialize("x", 1, mode).unwrap().is_none()); // no int facts → None
@@ -953,8 +1145,8 @@ mod tests {
         acc.push_i64(0, 200);
 
         let mode = FinalizationMode::Detached {
-            original_buf: &[],
-            generated_buf: &[],
+            original_buf: Buffer::from(&[] as &[u8]),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("x", 1, mode).unwrap().unwrap();
@@ -1001,8 +1193,8 @@ mod tests {
         );
 
         let mode = FinalizationMode::Detached {
-            original_buf: b"short",
-            generated_buf: &[],
+            original_buf: Buffer::from(b"short" as &[u8]),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
         let result = acc.materialize("x", 1, mode);
@@ -1021,8 +1213,8 @@ mod tests {
         acc.push_str(0, StringRef { offset: 0, len: 4 });
 
         let mode = FinalizationMode::Detached {
-            original_buf: bad_bytes,
-            generated_buf: &[],
+            original_buf: Buffer::from(bad_bytes),
+            generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: false,
         };
         let result = acc.materialize("x", 1, mode);

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -281,34 +281,35 @@ impl ColumnAccumulator {
         name: &str,
         num_rows: usize,
         mode: FinalizationMode,
+        dedup: bool,
     ) -> Result<Option<(Field, ArrayRef)>, MaterializeError> {
         match self {
             ColumnAccumulator::Int64 { facts, .. } => {
                 if facts.is_empty() {
                     return Ok(None);
                 }
-                let (arr, dt) = build_int64(facts, num_rows);
+                let (arr, dt) = build_int64(facts, num_rows, dedup);
                 Ok(Some((Field::new(name, dt, true), arr)))
             }
             ColumnAccumulator::Float64 { facts, .. } => {
                 if facts.is_empty() {
                     return Ok(None);
                 }
-                let (arr, dt) = build_float64(facts, num_rows);
+                let (arr, dt) = build_float64(facts, num_rows, dedup);
                 Ok(Some((Field::new(name, dt, true), arr)))
             }
             ColumnAccumulator::Bool { facts, .. } => {
                 if facts.is_empty() {
                     return Ok(None);
                 }
-                let (arr, dt) = build_bool(facts, num_rows);
+                let (arr, dt) = build_bool(facts, num_rows, dedup);
                 Ok(Some((Field::new(name, dt, true), arr)))
             }
             ColumnAccumulator::String { facts, .. } => {
                 if facts.is_empty() {
                     return Ok(None);
                 }
-                let (arr, dt) = build_string(facts, num_rows, &mode)?;
+                let (arr, dt) = build_string(facts, num_rows, &mode, dedup)?;
                 Ok(Some((Field::new(name, dt, true), arr)))
             }
             ColumnAccumulator::Dynamic {
@@ -337,20 +338,21 @@ impl ColumnAccumulator {
                         float_facts,
                         bool_facts,
                         str_facts,
+                        dedup,
                     )?))
                 } else {
                     // Single type → flat column
                     if *has_int {
-                        let (arr, dt) = build_int64(int_facts, num_rows);
+                        let (arr, dt) = build_int64(int_facts, num_rows, dedup);
                         Ok(Some((Field::new(name, dt, true), arr)))
                     } else if *has_float {
-                        let (arr, dt) = build_float64(float_facts, num_rows);
+                        let (arr, dt) = build_float64(float_facts, num_rows, dedup);
                         Ok(Some((Field::new(name, dt, true), arr)))
                     } else if *has_str {
-                        let (arr, dt) = build_string(str_facts, num_rows, &mode)?;
+                        let (arr, dt) = build_string(str_facts, num_rows, &mode, dedup)?;
                         Ok(Some((Field::new(name, dt, true), arr)))
                     } else {
-                        let (arr, dt) = build_bool(bool_facts, num_rows);
+                        let (arr, dt) = build_bool(bool_facts, num_rows, dedup);
                         Ok(Some((Field::new(name, dt, true), arr)))
                     }
                 }
@@ -428,15 +430,19 @@ pub struct FinalizationMode {
 
 /// Check whether facts cover rows 0..num_rows exactly (no gaps, no duplicates).
 ///
-/// Facts are appended in row order. If `facts.len() == num_rows` and the last
-/// fact targets row `num_rows - 1`, the pigeonhole principle guarantees every
-/// row is present exactly once (rows are monotonically non-decreasing).
-fn is_dense<T>(facts: &[(u32, T)], num_rows: usize) -> bool {
-    facts.len() == num_rows && (num_rows == 0 || facts[num_rows - 1].0 as usize == num_rows - 1)
+/// The pigeonhole argument requires that row indices are *distinct*. With dedup
+/// enabled the builder's bitset/last-row guard guarantees at most one write per
+/// (row, field), so `facts.len() == num_rows ∧ last == num_rows - 1` is
+/// sufficient.  When dedup is disabled duplicate writes are possible, breaking
+/// the pigeonhole premise, so we conservatively return false.
+fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
+    dedup
+        && facts.len() == num_rows
+        && (num_rows == 0 || facts[num_rows - 1].0 as usize == num_rows - 1)
 }
 
-fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
-    let dense = is_dense(facts, num_rows);
+fn build_int64(facts: &[(u32, i64)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
+    let dense = is_dense(facts, num_rows, dedup);
     let mut values = vec![0i64; num_rows];
     if dense {
         debug_assert!(
@@ -472,8 +478,8 @@ fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
     )
 }
 
-fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) {
-    let dense = is_dense(facts, num_rows);
+fn build_float64(facts: &[(u32, f64)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
+    let dense = is_dense(facts, num_rows, dedup);
     let mut values = vec![0.0f64; num_rows];
     if dense {
         debug_assert!(
@@ -509,8 +515,8 @@ fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) 
     )
 }
 
-fn build_bool(facts: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
-    let dense = is_dense(facts, num_rows);
+fn build_bool(facts: &[(u32, bool)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
+    let dense = is_dense(facts, num_rows, dedup);
     let mut values = vec![false; num_rows];
     if dense {
         debug_assert!(
@@ -550,11 +556,24 @@ fn build_string(
     facts: &[(u32, StringRef)],
     num_rows: usize,
     mode: &FinalizationMode,
+    dedup: bool,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
     if mode.utf8_trusted {
-        build_string_view_trusted(facts, num_rows, &mode.original_buf, &mode.generated_buf)
+        build_string_view_trusted(
+            facts,
+            num_rows,
+            &mode.original_buf,
+            &mode.generated_buf,
+            dedup,
+        )
     } else {
-        build_string_array_validated(facts, num_rows, &mode.original_buf, &mode.generated_buf)
+        build_string_array_validated(
+            facts,
+            num_rows,
+            &mode.original_buf,
+            &mode.generated_buf,
+            dedup,
+        )
     }
 }
 
@@ -574,9 +593,10 @@ fn build_string_view_trusted(
     num_rows: usize,
     original_buf: &Buffer,
     generated_buf: &Buffer,
+    dedup: bool,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
     let original_len = original_buf.len();
-    let dense = is_dense(facts, num_rows);
+    let dense = is_dense(facts, num_rows, dedup);
 
     // Register source buffers as StringViewArray blocks.
     // block 0 = original, block 1 = generated (if non-empty).
@@ -737,9 +757,10 @@ fn build_string_array_validated(
     num_rows: usize,
     original_buf: &Buffer,
     generated_buf: &Buffer,
+    dedup: bool,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
     let original_len = original_buf.len();
-    let dense = is_dense(facts, num_rows);
+    let dense = is_dense(facts, num_rows, dedup);
     let mut offsets: Vec<i32> = Vec::with_capacity(num_rows + 1);
     let mut values: Vec<u8> =
         Vec::with_capacity(facts.iter().map(|(_, sref)| sref.len as usize).sum());
@@ -854,6 +875,7 @@ fn read_str_bytes<'a>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_conflict_struct(
     name: &str,
     num_rows: usize,
@@ -862,27 +884,28 @@ fn build_conflict_struct(
     float_facts: &[(u32, f64)],
     bool_facts: &[(u32, bool)],
     str_facts: &[(u32, StringRef)],
+    dedup: bool,
 ) -> Result<(Field, ArrayRef), MaterializeError> {
     let mut child_fields: Vec<Arc<Field>> = Vec::new();
     let mut child_arrays: Vec<ArrayRef> = Vec::new();
 
     if !int_facts.is_empty() {
-        let (arr, _) = build_int64(int_facts, num_rows);
+        let (arr, _) = build_int64(int_facts, num_rows, dedup);
         child_fields.push(Arc::new(Field::new("int", DataType::Int64, true)));
         child_arrays.push(arr);
     }
     if !float_facts.is_empty() {
-        let (arr, _) = build_float64(float_facts, num_rows);
+        let (arr, _) = build_float64(float_facts, num_rows, dedup);
         child_fields.push(Arc::new(Field::new("float", DataType::Float64, true)));
         child_arrays.push(arr);
     }
     if !str_facts.is_empty() {
-        let (arr, dt) = build_string(str_facts, num_rows, mode)?;
+        let (arr, dt) = build_string(str_facts, num_rows, mode, dedup)?;
         child_fields.push(Arc::new(Field::new("str", dt, true)));
         child_arrays.push(arr);
     }
     if !bool_facts.is_empty() {
-        let (arr, _) = build_bool(bool_facts, num_rows);
+        let (arr, _) = build_bool(bool_facts, num_rows, dedup);
         child_fields.push(Arc::new(Field::new("bool", DataType::Boolean, true)));
         child_arrays.push(arr);
     }
@@ -927,7 +950,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        let (field, arr) = acc.materialize("ts", 3, mode).unwrap().unwrap();
+        let (field, arr) = acc.materialize("ts", 3, mode, true).unwrap().unwrap();
         assert_eq!(field.name(), "ts");
         let a = arr.as_primitive::<Int64Type>();
         assert_eq!(a.value(0), 100);
@@ -947,7 +970,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        let (_, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
+        let (_, arr) = acc.materialize("msg", 2, mode, true).unwrap().unwrap();
         let a = arr.as_string_view();
         assert_eq!(a.value(0), "hello");
         assert_eq!(a.value(1), "world");
@@ -965,7 +988,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        let (field, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
+        let (field, arr) = acc.materialize("msg", 2, mode, true).unwrap().unwrap();
         assert_eq!(field.data_type(), &DataType::Utf8View);
         let a = arr.as_string_view();
         assert_eq!(a.value(0), "hello");
@@ -994,7 +1017,7 @@ mod tests {
             generated_buf: Buffer::from(&generated[..]),
             utf8_trusted: true,
         };
-        let (_, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
+        let (_, arr) = acc.materialize("msg", 2, mode, true).unwrap().unwrap();
         let a = arr.as_string_view();
         assert_eq!(a.value(0), "original");
         assert_eq!(a.value(1), "decoded");
@@ -1011,7 +1034,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        let (field, arr) = acc.materialize("x", 2, mode).unwrap().unwrap();
+        let (field, arr) = acc.materialize("x", 2, mode, true).unwrap().unwrap();
         assert_eq!(field.data_type(), &DataType::Int64);
         let a = arr.as_primitive::<Int64Type>();
         assert_eq!(a.value(0), 42);
@@ -1031,7 +1054,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        let (field, arr) = acc.materialize("status", 2, mode).unwrap().unwrap();
+        let (field, arr) = acc.materialize("status", 2, mode, true).unwrap().unwrap();
         assert!(matches!(field.data_type(), DataType::Struct(_)));
         let s = arr.as_struct();
         assert_eq!(s.num_columns(), 2);
@@ -1048,7 +1071,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        assert!(acc.materialize("x", 3, mode).unwrap().is_none());
+        assert!(acc.materialize("x", 3, mode, true).unwrap().is_none());
     }
 
     #[test]
@@ -1063,7 +1086,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        assert!(acc.materialize("x", 1, mode).unwrap().is_none()); // no int facts → None
+        assert!(acc.materialize("x", 1, mode, true).unwrap().is_none()); // no int facts → None
     }
 
     #[test]
@@ -1078,7 +1101,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        let (_, arr) = acc.materialize("x", 1, mode).unwrap().unwrap();
+        let (_, arr) = acc.materialize("x", 1, mode, true).unwrap().unwrap();
         assert_eq!(arr.as_primitive::<Int64Type>().value(0), 200);
     }
 
@@ -1126,7 +1149,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        let result = acc.materialize("x", 1, mode);
+        let result = acc.materialize("x", 1, mode, true);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -1146,7 +1169,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: false,
         };
-        let result = acc.materialize("x", 1, mode);
+        let result = acc.materialize("x", 1, mode, true);
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
@@ -1173,7 +1196,7 @@ mod tests {
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
         };
-        let result = acc.materialize("x", 1, mode);
+        let result = acc.materialize("x", 1, mode, true);
         assert!(result.is_err());
     }
 }
@@ -1386,7 +1409,7 @@ mod proptests {
             let num_rows = values.len();
             let facts: Vec<(u32, i64)> = values.iter().enumerate()
                 .map(|(i, &v)| (i as u32, v)).collect();
-            let (arr, dt) = build_int64(&facts, num_rows);
+            let (arr, dt) = build_int64(&facts, num_rows, true);
             prop_assert_eq!(dt, DataType::Int64);
             prop_assert_eq!(arr.len(), num_rows);
             prop_assert_eq!(arr.null_count(), 0, "dense path must have no nulls");
@@ -1413,7 +1436,7 @@ mod proptests {
                 // Ensure at least one fact for a meaningful test.
                 facts.push((0, 42));
             }
-            let (arr, _) = build_int64(&facts, num_rows);
+            let (arr, _) = build_int64(&facts, num_rows, true);
             prop_assert_eq!(arr.len(), num_rows);
 
             let typed = arr.as_any().downcast_ref::<Int64Array>().unwrap();
@@ -1444,7 +1467,7 @@ mod proptests {
             let num_rows = values.len();
             let facts: Vec<(u32, f64)> = values.iter().enumerate()
                 .map(|(i, &v)| (i as u32, v)).collect();
-            let (arr, dt) = build_float64(&facts, num_rows);
+            let (arr, dt) = build_float64(&facts, num_rows, true);
             prop_assert_eq!(dt, DataType::Float64);
             prop_assert_eq!(arr.len(), num_rows);
             prop_assert_eq!(arr.null_count(), 0);
@@ -1466,7 +1489,7 @@ mod proptests {
             if facts.is_empty() {
                 facts.push((0, 42.0));
             }
-            let (arr, _) = build_float64(&facts, num_rows);
+            let (arr, _) = build_float64(&facts, num_rows, true);
             prop_assert_eq!(arr.len(), num_rows);
 
             let typed = arr.as_any().downcast_ref::<Float64Array>().unwrap();
@@ -1496,7 +1519,7 @@ mod proptests {
             let num_rows = values.len();
             let facts: Vec<(u32, bool)> = values.iter().enumerate()
                 .map(|(i, &v)| (i as u32, v)).collect();
-            let (arr, dt) = build_bool(&facts, num_rows);
+            let (arr, dt) = build_bool(&facts, num_rows, true);
             prop_assert_eq!(dt, DataType::Boolean);
             prop_assert_eq!(arr.len(), num_rows);
             prop_assert_eq!(arr.null_count(), 0);
@@ -1518,7 +1541,7 @@ mod proptests {
             if facts.is_empty() {
                 facts.push((0, true));
             }
-            let (arr, _) = build_bool(&facts, num_rows);
+            let (arr, _) = build_bool(&facts, num_rows, true);
             prop_assert_eq!(arr.len(), num_rows);
 
             let typed = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
@@ -1530,6 +1553,41 @@ mod proptests {
                     fi += 1;
                 } else {
                     prop_assert!(typed.is_null(row));
+                }
+            }
+        }
+    }
+
+    // ── dedup=false duplicate rows ──────────────────────────────────────────
+
+    proptest! {
+        /// With dedup disabled and duplicate row indices, the sparse path must be
+        /// used and last-write-wins for each row.
+        #[test]
+        fn build_int64_no_dedup_duplicates(num_rows in 2usize..=16, seed in any::<u64>()) {
+            // Build facts with some duplicate row indices.
+            let mut facts: Vec<(u32, i64)> = Vec::new();
+            for i in 0..num_rows as u32 {
+                let row = (seed.wrapping_mul(i as u64 + 1) % num_rows as u64) as u32;
+                facts.push((row, i as i64 * 7));
+            }
+            // Sort by row to satisfy monotonicity requirement.
+            facts.sort_by_key(|f| f.0);
+            let (arr, _) = build_int64(&facts, num_rows, false);
+            prop_assert_eq!(arr.len(), num_rows);
+            let typed = arr.as_any().downcast_ref::<Int64Array>().unwrap();
+
+            // Verify last-write-wins for each row.
+            let mut expected: std::collections::HashMap<u32, i64> = std::collections::HashMap::new();
+            for &(row, val) in &facts {
+                expected.insert(row, val);
+            }
+            for row in 0..num_rows {
+                if let Some(&val) = expected.get(&(row as u32)) {
+                    prop_assert!(!typed.is_null(row), "written row must not be null");
+                    prop_assert_eq!(typed.value(row), val);
+                } else {
+                    prop_assert!(typed.is_null(row), "unwritten row must be null");
                 }
             }
         }

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -1,0 +1,759 @@
+// accumulator.rs — ColumnAccumulator: typed per-field storage.
+//
+// Each variant carries only the storage it needs:
+//   - Planned Int64 → one Vec<(u32, i64)>
+//   - Planned String → one Vec<(u32, u32, u32)> (row, offset, len)
+//   - Dynamic → all 4 vecs + conflict flags (same as FieldColumns today)
+//
+// Materialization is distributed: each variant builds its own Arrow array.
+// No monolithic finalization function.
+
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int64Array, StringBuilder, StringViewBuilder, StructArray,
+};
+use arrow::buffer::{Buffer, NullBuffer};
+use arrow::datatypes::{DataType, Field, Fields};
+
+use super::plan::FieldKind;
+
+// ---------------------------------------------------------------------------
+// StringRef — uniform reference into a 2-buffer system
+// ---------------------------------------------------------------------------
+
+/// Reference to a string value in the builder's buffer system.
+///
+/// The 2-buffer model: offsets `< original_len` point into the input buffer;
+/// offsets `>= original_len` point into the generated buffer at
+/// `offset - original_len`.  This encoding costs zero extra bits per fact.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StringRef {
+    pub(crate) offset: u32,
+    pub(crate) len: u32,
+}
+
+// ---------------------------------------------------------------------------
+// ColumnAccumulator — typed per-field storage + materialization
+// ---------------------------------------------------------------------------
+
+/// Typed per-field storage.  Each variant carries only what it needs.
+///
+/// Planned fields use single-type variants (one Vec per field).
+/// Dynamic fields use `Dynamic` (all 4 Vecs + conflict flags).
+pub(crate) enum ColumnAccumulator {
+    /// Planned Int64 field — single fact vector.
+    Int64 {
+        facts: Vec<(u32, i64)>,
+        last_row: u32,
+    },
+    /// Planned Float64 field — single fact vector.
+    Float64 {
+        facts: Vec<(u32, f64)>,
+        last_row: u32,
+    },
+    /// Planned Bool field — single fact vector.
+    Bool {
+        facts: Vec<(u32, bool)>,
+        last_row: u32,
+    },
+    /// Planned string field — references into the 2-buffer system.
+    String {
+        facts: Vec<(u32, StringRef)>,
+        last_row: u32,
+    },
+    /// Dynamic field — accumulates all types, detects conflicts at finalization.
+    Dynamic {
+        int_facts: Vec<(u32, i64)>,
+        float_facts: Vec<(u32, f64)>,
+        bool_facts: Vec<(u32, bool)>,
+        str_facts: Vec<(u32, StringRef)>,
+        has_int: bool,
+        has_float: bool,
+        has_bool: bool,
+        has_str: bool,
+        last_row: u32,
+    },
+}
+
+impl ColumnAccumulator {
+    /// Create the right variant for a planned field kind.
+    pub(crate) fn for_planned(kind: FieldKind) -> Self {
+        match kind {
+            FieldKind::Int64 => ColumnAccumulator::Int64 {
+                facts: Vec::with_capacity(256),
+                last_row: u32::MAX,
+            },
+            FieldKind::Float64 => ColumnAccumulator::Float64 {
+                facts: Vec::with_capacity(256),
+                last_row: u32::MAX,
+            },
+            FieldKind::Bool => ColumnAccumulator::Bool {
+                facts: Vec::with_capacity(256),
+                last_row: u32::MAX,
+            },
+            FieldKind::Utf8View | FieldKind::BinaryView | FieldKind::FixedBinary(_) => {
+                ColumnAccumulator::String {
+                    facts: Vec::with_capacity(256),
+                    last_row: u32::MAX,
+                }
+            }
+        }
+    }
+
+    /// Create a Dynamic variant (for JSON-style discovered fields).
+    pub(crate) fn dynamic() -> Self {
+        ColumnAccumulator::Dynamic {
+            int_facts: Vec::new(),
+            float_facts: Vec::new(),
+            bool_facts: Vec::new(),
+            str_facts: Vec::new(),
+            has_int: false,
+            has_float: false,
+            has_bool: false,
+            has_str: false,
+            last_row: u32::MAX,
+        }
+    }
+
+    /// Clear accumulated data for batch reuse.
+    pub(crate) fn clear(&mut self) {
+        match self {
+            ColumnAccumulator::Int64 { facts, last_row } => {
+                facts.clear();
+                *last_row = u32::MAX;
+            }
+            ColumnAccumulator::Float64 { facts, last_row } => {
+                facts.clear();
+                *last_row = u32::MAX;
+            }
+            ColumnAccumulator::Bool { facts, last_row } => {
+                facts.clear();
+                *last_row = u32::MAX;
+            }
+            ColumnAccumulator::String { facts, last_row } => {
+                facts.clear();
+                *last_row = u32::MAX;
+            }
+            ColumnAccumulator::Dynamic {
+                int_facts,
+                float_facts,
+                bool_facts,
+                str_facts,
+                has_int,
+                has_float,
+                has_bool,
+                has_str,
+                last_row,
+            } => {
+                int_facts.clear();
+                float_facts.clear();
+                bool_facts.clear();
+                str_facts.clear();
+                *has_int = false;
+                *has_float = false;
+                *has_bool = false;
+                *has_str = false;
+                *last_row = u32::MAX;
+            }
+        }
+    }
+
+    /// Mutable last_row for dedup when field index >= 64.
+    pub(crate) fn last_row_mut(&mut self) -> &mut u32 {
+        match self {
+            ColumnAccumulator::Int64 { last_row, .. }
+            | ColumnAccumulator::Float64 { last_row, .. }
+            | ColumnAccumulator::Bool { last_row, .. }
+            | ColumnAccumulator::String { last_row, .. }
+            | ColumnAccumulator::Dynamic { last_row, .. } => last_row,
+        }
+    }
+
+    /// Last row written.
+    pub(crate) fn last_row(&self) -> u32 {
+        match self {
+            ColumnAccumulator::Int64 { last_row, .. }
+            | ColumnAccumulator::Float64 { last_row, .. }
+            | ColumnAccumulator::Bool { last_row, .. }
+            | ColumnAccumulator::String { last_row, .. }
+            | ColumnAccumulator::Dynamic { last_row, .. } => *last_row,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Typed write methods
+    // -----------------------------------------------------------------------
+
+    /// Append an i64 fact.  For planned Int64, goes to the single vec.
+    /// For Dynamic, goes to int_facts.
+    #[inline(always)]
+    pub(crate) fn push_i64(&mut self, row: u32, value: i64) {
+        match self {
+            ColumnAccumulator::Int64 { facts, .. } => facts.push((row, value)),
+            ColumnAccumulator::Dynamic {
+                int_facts, has_int, ..
+            } => {
+                *has_int = true;
+                int_facts.push((row, value));
+            }
+            // Wrong-type write to a planned non-Int64 field: no-op.
+            _ => {}
+        }
+    }
+
+    /// Append an f64 fact.
+    #[inline(always)]
+    pub(crate) fn push_f64(&mut self, row: u32, value: f64) {
+        match self {
+            ColumnAccumulator::Float64 { facts, .. } => facts.push((row, value)),
+            ColumnAccumulator::Dynamic {
+                float_facts,
+                has_float,
+                ..
+            } => {
+                *has_float = true;
+                float_facts.push((row, value));
+            }
+            _ => {}
+        }
+    }
+
+    /// Append a bool fact.
+    #[inline(always)]
+    pub(crate) fn push_bool(&mut self, row: u32, value: bool) {
+        match self {
+            ColumnAccumulator::Bool { facts, .. } => facts.push((row, value)),
+            ColumnAccumulator::Dynamic {
+                bool_facts,
+                has_bool,
+                ..
+            } => {
+                *has_bool = true;
+                bool_facts.push((row, value));
+            }
+            _ => {}
+        }
+    }
+
+    /// Append a string ref.
+    #[inline(always)]
+    pub(crate) fn push_str(&mut self, row: u32, sref: StringRef) {
+        match self {
+            ColumnAccumulator::String { facts, .. } => facts.push((row, sref)),
+            ColumnAccumulator::Dynamic {
+                str_facts, has_str, ..
+            } => {
+                *has_str = true;
+                str_facts.push((row, sref));
+            }
+            _ => {}
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Materialization — each variant builds its own Arrow array
+    // -----------------------------------------------------------------------
+
+    /// Materialize into an Arrow field + array.
+    ///
+    /// Returns `None` if the accumulator has no data (sparse all-null field
+    /// with no writes — omitted from schema like StreamingBuilder does).
+    ///
+    /// `mode` controls string materialization:
+    ///   - `Detached`: uses `StringBuilder` (copies strings, self-contained)
+    ///   - `View`: uses `StringViewArray` backed by input + generated buffers
+    pub(crate) fn materialize(
+        &self,
+        name: &str,
+        num_rows: usize,
+        mode: FinalizationMode<'_>,
+    ) -> Option<(Field, ArrayRef)> {
+        match self {
+            ColumnAccumulator::Int64 { facts, .. } => {
+                if facts.is_empty() {
+                    return None;
+                }
+                let (arr, dt) = build_int64(facts, num_rows);
+                Some((Field::new(name, dt, true), arr))
+            }
+            ColumnAccumulator::Float64 { facts, .. } => {
+                if facts.is_empty() {
+                    return None;
+                }
+                let (arr, dt) = build_float64(facts, num_rows);
+                Some((Field::new(name, dt, true), arr))
+            }
+            ColumnAccumulator::Bool { facts, .. } => {
+                if facts.is_empty() {
+                    return None;
+                }
+                let (arr, dt) = build_bool(facts, num_rows);
+                Some((Field::new(name, dt, true), arr))
+            }
+            ColumnAccumulator::String { facts, .. } => {
+                if facts.is_empty() {
+                    return None;
+                }
+                let (arr, dt) = build_string(facts, num_rows, &mode);
+                Some((Field::new(name, dt, true), arr))
+            }
+            ColumnAccumulator::Dynamic {
+                int_facts,
+                float_facts,
+                bool_facts,
+                str_facts,
+                has_int,
+                has_float,
+                has_bool,
+                has_str,
+                ..
+            } => {
+                let type_count =
+                    *has_int as u8 + *has_float as u8 + *has_str as u8 + *has_bool as u8;
+                if type_count == 0 {
+                    return None;
+                }
+                if type_count > 1 {
+                    // Conflict → StructArray
+                    Some(build_conflict_struct(
+                        name,
+                        num_rows,
+                        &mode,
+                        int_facts,
+                        float_facts,
+                        bool_facts,
+                        str_facts,
+                    ))
+                } else {
+                    // Single type → flat column
+                    if *has_int {
+                        let (arr, dt) = build_int64(int_facts, num_rows);
+                        Some((Field::new(name, dt, true), arr))
+                    } else if *has_float {
+                        let (arr, dt) = build_float64(float_facts, num_rows);
+                        Some((Field::new(name, dt, true), arr))
+                    } else if *has_str {
+                        let (arr, dt) = build_string(str_facts, num_rows, &mode);
+                        Some((Field::new(name, dt, true), arr))
+                    } else {
+                        let (arr, dt) = build_bool(bool_facts, num_rows);
+                        Some((Field::new(name, dt, true), arr))
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// FinalizationMode — controls string materialization strategy
+// ---------------------------------------------------------------------------
+
+/// Controls how string columns are built at finalization.
+#[derive(Clone)]
+pub(crate) enum FinalizationMode<'a> {
+    /// Copy strings into contiguous `StringArray` (self-contained, input-freeable).
+    Detached {
+        /// Original input buffer, for reading string data.
+        original_buf: &'a [u8],
+        /// Generated/decoded buffer, for reading decoded strings.
+        generated_buf: &'a [u8],
+    },
+    /// Zero-copy `StringViewArray` backed by Arrow buffers.
+    View {
+        /// Arrow buffer wrapping the original input.
+        original: Buffer,
+        /// Original buffer length (for the 2-buffer offset convention).
+        original_len: u32,
+        /// Arrow buffer wrapping generated/decoded strings (if any).
+        generated: Option<Buffer>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Array builders (free functions, no &self)
+// ---------------------------------------------------------------------------
+
+fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
+    let mut values = vec![0i64; num_rows];
+    let mut valid = vec![false; num_rows];
+    for &(row, v) in facts {
+        let r = row as usize;
+        if r < num_rows {
+            values[r] = v;
+            valid[r] = true;
+        }
+    }
+    let nulls = NullBuffer::from(valid);
+    (
+        Arc::new(Int64Array::new(values.into(), Some(nulls))),
+        DataType::Int64,
+    )
+}
+
+fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) {
+    let mut values = vec![0.0f64; num_rows];
+    let mut valid = vec![false; num_rows];
+    for &(row, v) in facts {
+        let r = row as usize;
+        if r < num_rows {
+            values[r] = v;
+            valid[r] = true;
+        }
+    }
+    let nulls = NullBuffer::from(valid);
+    (
+        Arc::new(Float64Array::new(values.into(), Some(nulls))),
+        DataType::Float64,
+    )
+}
+
+fn build_bool(facts: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
+    let mut values = vec![false; num_rows];
+    let mut valid = vec![false; num_rows];
+    for &(row, v) in facts {
+        let r = row as usize;
+        if r < num_rows {
+            values[r] = v;
+            valid[r] = true;
+        }
+    }
+    let nulls = NullBuffer::from(valid);
+    (
+        Arc::new(BooleanArray::new(values.into(), Some(nulls))),
+        DataType::Boolean,
+    )
+}
+
+fn build_string(
+    facts: &[(u32, StringRef)],
+    num_rows: usize,
+    mode: &FinalizationMode<'_>,
+) -> (ArrayRef, DataType) {
+    match mode {
+        FinalizationMode::Detached {
+            original_buf,
+            generated_buf,
+        } => {
+            let original_len = original_buf.len();
+            let mut builder = StringBuilder::with_capacity(facts.len(), 0);
+            let mut vi = 0;
+            for row in 0..num_rows as u32 {
+                if vi < facts.len() && facts[vi].0 == row {
+                    let sref = facts[vi].1;
+                    let s = read_str(original_buf, generated_buf, original_len, sref);
+                    match s {
+                        Some(s) => builder.append_value(s),
+                        None => builder.append_null(),
+                    }
+                    vi += 1;
+                } else {
+                    builder.append_null();
+                }
+            }
+            (Arc::new(builder.finish()), DataType::Utf8)
+        }
+        FinalizationMode::View {
+            original,
+            original_len,
+            generated,
+        } => {
+            let mut builder = StringViewBuilder::new();
+            let orig_block = builder.append_block(original.clone());
+            let gen_block = generated.as_ref().map(|g| builder.append_block(g.clone()));
+            let mut vi = 0;
+            for row in 0..num_rows as u32 {
+                if vi < facts.len() && facts[vi].0 == row {
+                    let sref = facts[vi].1;
+                    if sref.offset < *original_len
+                        || (sref.len == 0 && sref.offset == *original_len)
+                    {
+                        builder
+                            .try_append_view(orig_block, sref.offset, sref.len)
+                            .expect("pre-validated offset/len");
+                    } else if let Some(gen_block) = gen_block {
+                        let gen_offset = sref.offset - *original_len;
+                        builder
+                            .try_append_view(gen_block, gen_offset, sref.len)
+                            .expect("pre-validated offset/len");
+                    } else {
+                        builder.append_null();
+                    }
+                    vi += 1;
+                } else {
+                    builder.append_null();
+                }
+            }
+            (Arc::new(builder.finish()), DataType::Utf8View)
+        }
+    }
+}
+
+/// Read a string from the 2-buffer system.
+fn read_str<'a>(
+    original: &'a [u8],
+    generated: &'a [u8],
+    original_len: usize,
+    sref: StringRef,
+) -> Option<&'a str> {
+    let start = sref.offset as usize;
+    let end = start.checked_add(sref.len as usize)?;
+    let bytes = if start < original_len {
+        original.get(start..end)?
+    } else {
+        let dec_start = start.checked_sub(original_len)?;
+        let dec_end = end.checked_sub(original_len)?;
+        generated.get(dec_start..dec_end)?
+    };
+    std::str::from_utf8(bytes).ok()
+}
+
+fn build_conflict_struct(
+    name: &str,
+    num_rows: usize,
+    mode: &FinalizationMode<'_>,
+    int_facts: &[(u32, i64)],
+    float_facts: &[(u32, f64)],
+    bool_facts: &[(u32, bool)],
+    str_facts: &[(u32, StringRef)],
+) -> (Field, ArrayRef) {
+    let mut child_fields: Vec<Arc<Field>> = Vec::new();
+    let mut child_arrays: Vec<ArrayRef> = Vec::new();
+
+    if !int_facts.is_empty() {
+        let (arr, _) = build_int64(int_facts, num_rows);
+        child_fields.push(Arc::new(Field::new("int", DataType::Int64, true)));
+        child_arrays.push(arr);
+    }
+    if !float_facts.is_empty() {
+        let (arr, _) = build_float64(float_facts, num_rows);
+        child_fields.push(Arc::new(Field::new("float", DataType::Float64, true)));
+        child_arrays.push(arr);
+    }
+    if !str_facts.is_empty() {
+        let (arr, dt) = build_string(str_facts, num_rows, mode);
+        child_fields.push(Arc::new(Field::new("str", dt, true)));
+        child_arrays.push(arr);
+    }
+    if !bool_facts.is_empty() {
+        let (arr, _) = build_bool(bool_facts, num_rows);
+        child_fields.push(Arc::new(Field::new("bool", DataType::Boolean, true)));
+        child_arrays.push(arr);
+    }
+
+    let struct_validity: Vec<bool> = (0..num_rows)
+        .map(|i| child_arrays.iter().any(|arr| !arr.is_null(i)))
+        .collect();
+
+    let fields = Fields::from(child_fields);
+    let struct_arr = StructArray::new(
+        fields.clone(),
+        child_arrays,
+        Some(NullBuffer::from(struct_validity)),
+    );
+
+    (
+        Field::new(name, DataType::Struct(fields), true),
+        Arc::new(struct_arr),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, AsArray};
+    use arrow::datatypes::Int64Type;
+
+    #[test]
+    fn planned_int64_materialize() {
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Int64);
+        acc.push_i64(0, 100);
+        acc.push_i64(2, 300);
+
+        let mode = FinalizationMode::Detached {
+            original_buf: &[],
+            generated_buf: &[],
+        };
+        let (field, arr) = acc.materialize("ts", 3, mode).unwrap();
+        assert_eq!(field.name(), "ts");
+        let a = arr.as_primitive::<Int64Type>();
+        assert_eq!(a.value(0), 100);
+        assert!(a.is_null(1));
+        assert_eq!(a.value(2), 300);
+    }
+
+    #[test]
+    fn planned_string_detached_materialize() {
+        let input = b"hello world";
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
+        acc.push_str(0, StringRef { offset: 0, len: 5 }); // "hello"
+        acc.push_str(1, StringRef { offset: 6, len: 5 }); // "world"
+
+        let mode = FinalizationMode::Detached {
+            original_buf: input,
+            generated_buf: &[],
+        };
+        let (_, arr) = acc.materialize("msg", 2, mode).unwrap();
+        let a = arr.as_string::<i32>();
+        assert_eq!(a.value(0), "hello");
+        assert_eq!(a.value(1), "world");
+    }
+
+    #[test]
+    fn planned_string_view_materialize() {
+        let input = b"hello world";
+        let arrow_buf = Buffer::from(&input[..]);
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
+        acc.push_str(0, StringRef { offset: 0, len: 5 });
+        acc.push_str(1, StringRef { offset: 6, len: 5 });
+
+        let mode = FinalizationMode::View {
+            original: arrow_buf,
+            original_len: input.len() as u32,
+            generated: None,
+        };
+        let (field, arr) = acc.materialize("msg", 2, mode).unwrap();
+        assert_eq!(field.data_type(), &DataType::Utf8View);
+        let a = arr.as_string_view();
+        assert_eq!(a.value(0), "hello");
+        assert_eq!(a.value(1), "world");
+    }
+
+    #[test]
+    fn planned_string_with_generated_buffer() {
+        let input = b"original";
+        let generated = b"decoded";
+        let original_len = input.len() as u32;
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
+        // Row 0: from original
+        acc.push_str(0, StringRef { offset: 0, len: 8 });
+        // Row 1: from generated (offset >= original_len)
+        acc.push_str(
+            1,
+            StringRef {
+                offset: original_len,
+                len: 7,
+            },
+        );
+
+        let mode = FinalizationMode::Detached {
+            original_buf: input,
+            generated_buf: generated,
+        };
+        let (_, arr) = acc.materialize("msg", 2, mode).unwrap();
+        let a = arr.as_string::<i32>();
+        assert_eq!(a.value(0), "original");
+        assert_eq!(a.value(1), "decoded");
+    }
+
+    #[test]
+    fn dynamic_single_type_flat() {
+        let mut acc = ColumnAccumulator::dynamic();
+        acc.push_i64(0, 42);
+        acc.push_i64(1, 99);
+
+        let mode = FinalizationMode::Detached {
+            original_buf: &[],
+            generated_buf: &[],
+        };
+        let (field, arr) = acc.materialize("x", 2, mode).unwrap();
+        assert_eq!(field.data_type(), &DataType::Int64);
+        let a = arr.as_primitive::<Int64Type>();
+        assert_eq!(a.value(0), 42);
+        assert_eq!(a.value(1), 99);
+    }
+
+    #[test]
+    fn dynamic_conflict_struct() {
+        let mut acc = ColumnAccumulator::dynamic();
+        acc.push_i64(0, 200);
+
+        let input = b"OK";
+        acc.push_str(
+            1,
+            StringRef {
+                offset: 0,
+                len: 2,
+            },
+        );
+
+        let mode = FinalizationMode::Detached {
+            original_buf: input,
+            generated_buf: &[],
+        };
+        let (field, arr) = acc.materialize("status", 2, mode).unwrap();
+        assert!(matches!(field.data_type(), DataType::Struct(_)));
+        let s = arr.as_struct();
+        assert_eq!(s.num_columns(), 2);
+        let int_col = s.column_by_name("int").unwrap();
+        assert!(!int_col.is_null(0));
+        assert!(int_col.is_null(1));
+    }
+
+    #[test]
+    fn empty_accumulator_returns_none() {
+        let acc = ColumnAccumulator::for_planned(FieldKind::Int64);
+        let mode = FinalizationMode::Detached {
+            original_buf: &[],
+            generated_buf: &[],
+        };
+        assert!(acc.materialize("x", 3, mode).is_none());
+    }
+
+    #[test]
+    fn wrong_type_write_to_planned_is_noop() {
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Int64);
+        acc.push_str(0, StringRef { offset: 0, len: 3 }); // no-op for Int64
+        acc.push_f64(0, 1.5); // no-op for Int64
+        acc.push_bool(0, true); // no-op for Int64
+
+        let mode = FinalizationMode::Detached {
+            original_buf: &[],
+            generated_buf: &[],
+        };
+        assert!(acc.materialize("x", 1, mode).is_none()); // no int facts → None
+    }
+
+    #[test]
+    fn clear_and_reuse() {
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Int64);
+        acc.push_i64(0, 100);
+        acc.clear();
+        acc.push_i64(0, 200);
+
+        let mode = FinalizationMode::Detached {
+            original_buf: &[],
+            generated_buf: &[],
+        };
+        let (_, arr) = acc.materialize("x", 1, mode).unwrap();
+        assert_eq!(arr.as_primitive::<Int64Type>().value(0), 200);
+    }
+
+    // -----------------------------------------------------------------------
+    // Memory savings test: planned field allocates 1 vec, not 4
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn planned_field_memory_is_smaller_than_dynamic() {
+        // A planned Int64 accumulator should have significantly less overhead
+        // than a Dynamic one because it only allocates one Vec, not four.
+        let planned = ColumnAccumulator::for_planned(FieldKind::Int64);
+        let dynamic = ColumnAccumulator::dynamic();
+
+        let planned_size = std::mem::size_of_val(&planned);
+        let dynamic_size = std::mem::size_of_val(&dynamic);
+
+        // The enum discriminant means planned isn't dramatically smaller in stack
+        // size due to enum sizing rules, but the heap allocation count differs.
+        // This test is really about documenting the difference.
+        assert!(
+            planned_size <= dynamic_size,
+            "planned {planned_size} should be <= dynamic {dynamic_size}"
+        );
+    }
+}

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -16,8 +16,7 @@
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, StringViewArray,
-    StringViewBuilder, StructArray,
+    ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, StringViewArray, StructArray,
 };
 use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{DataType, Field, Fields};
@@ -266,9 +265,9 @@ impl ColumnAccumulator {
     /// Returns `Ok(None)` if the accumulator has no data (sparse all-null field
     /// with no writes — omitted from schema like StreamingBuilder does).
     ///
-    /// `mode` controls string materialization:
-    ///   - `Detached`: uses `StringBuilder` (copies strings, self-contained)
-    ///   - `View`: uses `StringViewArray` backed by input + generated buffers
+    /// `mode` controls string materialization: when `utf8_trusted` is true,
+    /// produces zero-copy `StringViewArray`; otherwise copies into `StringArray`
+    /// with full UTF-8 validation.
     ///
     /// # Errors
     ///
@@ -372,8 +371,6 @@ pub enum MaterializeError {
     },
     /// Buffer data was not valid UTF-8 at the referenced range.
     InvalidUtf8 { offset: u32, len: u32 },
-    /// Arrow's `StringViewBuilder::try_append_view` failed.
-    ViewAppend(arrow::error::ArrowError),
 }
 
 impl std::fmt::Display for MaterializeError {
@@ -390,19 +387,11 @@ impl std::fmt::Display for MaterializeError {
             MaterializeError::InvalidUtf8 { offset, len } => {
                 write!(f, "invalid UTF-8 at StringRef(offset={offset}, len={len})")
             }
-            MaterializeError::ViewAppend(e) => write!(f, "StringViewBuilder append failed: {e}"),
         }
     }
 }
 
-impl std::error::Error for MaterializeError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            MaterializeError::ViewAppend(e) => Some(e),
-            _ => None,
-        }
-    }
-}
+impl std::error::Error for MaterializeError {}
 
 // ---------------------------------------------------------------------------
 // FinalizationMode — controls string materialization strategy
@@ -410,31 +399,16 @@ impl std::error::Error for MaterializeError {
 
 /// Controls how string columns are built at finalization.
 #[derive(Clone)]
-pub enum FinalizationMode {
-    /// Build string columns from owned Arrow buffers.
-    ///
-    /// When `utf8_trusted` is true, produces `StringViewArray` with zero per-string
-    /// byte copying — views reference the source buffers directly. When false,
-    /// copies bytes into a contiguous `StringArray` with full UTF-8 validation.
-    Detached {
-        /// Original input buffer (e.g., protobuf wire bytes, scanner input).
-        original_buf: Buffer,
-        /// Generated/decoded buffer (e.g., JSON-unescaped strings).
-        generated_buf: Buffer,
-        /// When true, all string data is known to be valid UTF-8 (validated
-        /// at the ingestion boundary — scanner, OTLP decoder, etc.). Enables
-        /// zero-copy StringViewArray construction.
-        utf8_trusted: bool,
-    },
-    /// Zero-copy `StringViewArray` backed by Arrow buffers.
-    View {
-        /// Arrow buffer wrapping the original input.
-        original: Buffer,
-        /// Original buffer length (for the 2-buffer offset convention).
-        original_len: u32,
-        /// Arrow buffer wrapping generated/decoded strings (if any).
-        generated: Option<Buffer>,
-    },
+pub struct FinalizationMode {
+    /// Original input buffer (e.g., protobuf wire bytes, scanner input).
+    pub original_buf: Buffer,
+    /// Generated/decoded buffer (e.g., JSON-unescaped strings).
+    pub generated_buf: Buffer,
+    /// When true, all string data is known to be valid UTF-8 (validated
+    /// at the ingestion boundary — scanner, OTLP decoder, etc.). Enables
+    /// zero-copy StringViewArray construction.  When false, copies bytes
+    /// into a contiguous `StringArray` with full UTF-8 validation.
+    pub utf8_trusted: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -445,6 +419,10 @@ fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
     let dense = facts.len() == num_rows;
     let mut values = vec![0i64; num_rows];
     if dense {
+        debug_assert!(
+            facts.is_empty() || facts[0].0 == 0,
+            "dense path requires consecutive rows starting at 0"
+        );
         for (i, &(_, v)) in facts.iter().enumerate() {
             values[i] = v;
         }
@@ -478,6 +456,10 @@ fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) 
     let dense = facts.len() == num_rows;
     let mut values = vec![0.0f64; num_rows];
     if dense {
+        debug_assert!(
+            facts.is_empty() || facts[0].0 == 0,
+            "dense path requires consecutive rows starting at 0"
+        );
         for (i, &(_, v)) in facts.iter().enumerate() {
             values[i] = v;
         }
@@ -511,6 +493,10 @@ fn build_bool(facts: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
     let dense = facts.len() == num_rows;
     let mut values = vec![false; num_rows];
     if dense {
+        debug_assert!(
+            facts.is_empty() || facts[0].0 == 0,
+            "dense path requires consecutive rows starting at 0"
+        );
         for (i, &(_, v)) in facts.iter().enumerate() {
             values[i] = v;
         }
@@ -545,55 +531,10 @@ fn build_string(
     num_rows: usize,
     mode: &FinalizationMode,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
-    match mode {
-        FinalizationMode::Detached {
-            original_buf,
-            generated_buf,
-            utf8_trusted,
-        } => {
-            if *utf8_trusted {
-                build_string_view_trusted(facts, num_rows, original_buf, generated_buf)
-            } else {
-                build_string_array_validated(facts, num_rows, original_buf, generated_buf)
-            }
-        }
-        FinalizationMode::View {
-            original,
-            original_len,
-            generated,
-        } => {
-            let mut builder = StringViewBuilder::new();
-            let orig_block = builder.append_block(original.clone());
-            let gen_block = generated.as_ref().map(|g| builder.append_block(g.clone()));
-            let mut vi = 0;
-            for row in 0..num_rows as u32 {
-                if vi < facts.len() && facts[vi].0 == row {
-                    let sref = facts[vi].1;
-                    if sref.offset < *original_len
-                        || (sref.len == 0 && sref.offset == *original_len)
-                    {
-                        builder
-                            .try_append_view(orig_block, sref.offset, sref.len)
-                            .map_err(MaterializeError::ViewAppend)?;
-                    } else if let Some(gen_block) = gen_block {
-                        let gen_offset = sref.offset - *original_len;
-                        builder
-                            .try_append_view(gen_block, gen_offset, sref.len)
-                            .map_err(MaterializeError::ViewAppend)?;
-                    } else {
-                        return Err(MaterializeError::StringRefOutOfBounds {
-                            offset: sref.offset,
-                            len: sref.len,
-                            buffer_len: original.len(),
-                        });
-                    }
-                    vi += 1;
-                } else {
-                    builder.append_null();
-                }
-            }
-            Ok((Arc::new(builder.finish()), DataType::Utf8View))
-        }
+    if mode.utf8_trusted {
+        build_string_view_trusted(facts, num_rows, &mode.original_buf, &mode.generated_buf)
+    } else {
+        build_string_array_validated(facts, num_rows, &mode.original_buf, &mode.generated_buf)
     }
 }
 
@@ -633,9 +574,14 @@ fn build_string_view_trusted(
     // zeroes 16KB in ~200 instructions while the Result iterator adapter
     // (GenericShunt) adds ~25M instructions of overhead.
     let mut views: Vec<u128> = vec![0u128; num_rows];
+    let mut nulls: Option<NullBuffer> = None;
 
     if dense {
         // Dense fast path: every row has a value, facts[i] corresponds to row i.
+        debug_assert!(
+            facts.is_empty() || facts[0].0 == 0,
+            "dense path requires consecutive rows starting at 0"
+        );
         for (i, &(_, sref)) in facts.iter().enumerate() {
             views[i] = make_string_view(
                 sref,
@@ -648,6 +594,7 @@ fn build_string_view_trusted(
         }
     } else {
         // Sparse: walk facts in row order, null rows stay as 0 (zero-length view).
+        let mut valid = vec![false; num_rows];
         let mut vi = 0;
         for (row, view_slot) in views.iter_mut().enumerate() {
             if vi < facts.len() && facts[vi].0 as usize == row {
@@ -659,23 +606,12 @@ fn build_string_view_trusted(
                     orig_block,
                     gen_block,
                 )?;
+                valid[row] = true;
                 vi += 1;
             }
         }
+        nulls = Some(NullBuffer::from(valid));
     }
-
-    let nulls = if dense {
-        None
-    } else {
-        let valid: Vec<bool> = (0..num_rows)
-            .map(|row| {
-                facts
-                    .binary_search_by_key(&(row as u32), |&(r, _)| r)
-                    .is_ok()
-            })
-            .collect();
-        Some(NullBuffer::from(valid))
-    };
 
     debug_assert!(
         {
@@ -855,49 +791,6 @@ fn build_string_array_validated(
     }
 }
 
-/// Read a string from the 2-buffer system.
-///
-/// Returns an error if the reference is out of bounds or the bytes are not valid UTF-8.
-fn read_str<'a>(
-    original: &'a [u8],
-    generated: &'a [u8],
-    original_len: usize,
-    sref: StringRef,
-) -> Result<&'a str, MaterializeError> {
-    let start = sref.offset as usize;
-    let end =
-        start
-            .checked_add(sref.len as usize)
-            .ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: original.len() + generated.len(),
-            })?;
-    let bytes = if start < original_len {
-        original
-            .get(start..end)
-            .ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: original.len(),
-            })?
-    } else {
-        let dec_start = start - original_len;
-        let dec_end = end - original_len;
-        generated
-            .get(dec_start..dec_end)
-            .ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: generated.len(),
-            })?
-    };
-    std::str::from_utf8(bytes).map_err(|_| MaterializeError::InvalidUtf8 {
-        offset: sref.offset,
-        len: sref.len,
-    })
-}
-
 /// Read string bytes from the 2-buffer system without UTF-8 validation.
 ///
 /// Returns the raw bytes referenced by `sref`. Callers must validate UTF-8
@@ -1004,7 +897,7 @@ mod tests {
         acc.push_i64(0, 100);
         acc.push_i64(2, 300);
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(&[] as &[u8]),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
@@ -1024,7 +917,7 @@ mod tests {
         acc.push_str(0, StringRef { offset: 0, len: 5 }); // "hello"
         acc.push_str(1, StringRef { offset: 6, len: 5 }); // "world"
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(&input[..]),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
@@ -1036,17 +929,16 @@ mod tests {
     }
 
     #[test]
-    fn planned_string_view_materialize() {
+    fn planned_string_trusted_materialize() {
         let input = b"hello world";
-        let arrow_buf = Buffer::from(&input[..]);
         let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
         acc.push_str(0, StringRef { offset: 0, len: 5 });
         acc.push_str(1, StringRef { offset: 6, len: 5 });
 
-        let mode = FinalizationMode::View {
-            original: arrow_buf,
-            original_len: input.len() as u32,
-            generated: None,
+        let mode = FinalizationMode {
+            original_buf: Buffer::from(&input[..]),
+            generated_buf: Buffer::from(&[] as &[u8]),
+            utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
         assert_eq!(field.data_type(), &DataType::Utf8View);
@@ -1072,7 +964,7 @@ mod tests {
             },
         );
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(&input[..]),
             generated_buf: Buffer::from(&generated[..]),
             utf8_trusted: true,
@@ -1089,7 +981,7 @@ mod tests {
         acc.push_i64(0, 42);
         acc.push_i64(1, 99);
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(&[] as &[u8]),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
@@ -1109,7 +1001,7 @@ mod tests {
         let input = b"OK";
         acc.push_str(1, StringRef { offset: 0, len: 2 });
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(&input[..]),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
@@ -1126,7 +1018,7 @@ mod tests {
     #[test]
     fn empty_accumulator_returns_none() {
         let acc = ColumnAccumulator::for_planned(FieldKind::Int64);
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(&[] as &[u8]),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
@@ -1141,7 +1033,7 @@ mod tests {
         acc.push_f64(0, 1.5); // no-op for Int64
         acc.push_bool(0, true); // no-op for Int64
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(&[] as &[u8]),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
@@ -1156,7 +1048,7 @@ mod tests {
         acc.clear();
         acc.push_i64(0, 200);
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(&[] as &[u8]),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
@@ -1204,7 +1096,7 @@ mod tests {
             },
         );
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(b"short" as &[u8]),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: true,
@@ -1224,7 +1116,7 @@ mod tests {
         let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
         acc.push_str(0, StringRef { offset: 0, len: 4 });
 
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: Buffer::from(bad_bytes),
             generated_buf: Buffer::from(&[] as &[u8]),
             utf8_trusted: false,
@@ -1239,11 +1131,10 @@ mod tests {
     }
 
     #[test]
-    fn view_mode_out_of_bounds_returns_error() {
+    fn out_of_bounds_generated_returns_error() {
         let input = b"short";
-        let arrow_buf = Buffer::from(&input[..]);
         let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
-        // Reference past generated buffer (which doesn't exist)
+        // Reference past generated buffer (which is empty)
         acc.push_str(
             0,
             StringRef {
@@ -1252,10 +1143,10 @@ mod tests {
             },
         );
 
-        let mode = FinalizationMode::View {
-            original: arrow_buf,
-            original_len: input.len() as u32,
-            generated: None,
+        let mode = FinalizationMode {
+            original_buf: Buffer::from(&input[..]),
+            generated_buf: Buffer::from(&[] as &[u8]),
+            utf8_trusted: true,
         };
         let result = acc.materialize("x", 1, mode);
         assert!(result.is_err());

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -34,9 +34,9 @@ use super::plan::FieldKind;
 /// offsets `>= original_len` point into the generated buffer at
 /// `offset - original_len`.  This encoding costs zero extra bits per fact.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct StringRef {
-    pub(crate) offset: u32,
-    pub(crate) len: u32,
+pub struct StringRef {
+    pub offset: u32,
+    pub len: u32,
 }
 
 // ---------------------------------------------------------------------------
@@ -47,7 +47,7 @@ pub(crate) struct StringRef {
 ///
 /// Planned fields use single-type variants (one Vec per field).
 /// Dynamic fields use `Dynamic` (all 4 Vecs + conflict flags).
-pub(crate) enum ColumnAccumulator {
+pub enum ColumnAccumulator {
     /// Planned Int64 field — single fact vector.
     Int64 {
         facts: Vec<(u32, i64)>,
@@ -84,7 +84,7 @@ pub(crate) enum ColumnAccumulator {
 
 impl ColumnAccumulator {
     /// Create the right variant for a planned field kind.
-    pub(crate) fn for_planned(kind: FieldKind) -> Self {
+    pub fn for_planned(kind: FieldKind) -> Self {
         match kind {
             FieldKind::Int64 => ColumnAccumulator::Int64 {
                 facts: Vec::with_capacity(256),
@@ -108,7 +108,7 @@ impl ColumnAccumulator {
     }
 
     /// Create a Dynamic variant (for JSON-style discovered fields).
-    pub(crate) fn dynamic() -> Self {
+    pub fn dynamic() -> Self {
         ColumnAccumulator::Dynamic {
             int_facts: Vec::new(),
             float_facts: Vec::new(),
@@ -123,7 +123,7 @@ impl ColumnAccumulator {
     }
 
     /// Clear accumulated data for batch reuse.
-    pub(crate) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         match self {
             ColumnAccumulator::Int64 { facts, last_row } => {
                 facts.clear();
@@ -166,7 +166,7 @@ impl ColumnAccumulator {
     }
 
     /// Mutable last_row for dedup when field index >= 64.
-    pub(crate) fn last_row_mut(&mut self) -> &mut u32 {
+    pub fn last_row_mut(&mut self) -> &mut u32 {
         match self {
             ColumnAccumulator::Int64 { last_row, .. }
             | ColumnAccumulator::Float64 { last_row, .. }
@@ -177,7 +177,7 @@ impl ColumnAccumulator {
     }
 
     /// Last row written.
-    pub(crate) fn last_row(&self) -> u32 {
+    pub fn last_row(&self) -> u32 {
         match self {
             ColumnAccumulator::Int64 { last_row, .. }
             | ColumnAccumulator::Float64 { last_row, .. }
@@ -194,7 +194,7 @@ impl ColumnAccumulator {
     /// Append an i64 fact.  For planned Int64, goes to the single vec.
     /// For Dynamic, goes to int_facts.
     #[inline(always)]
-    pub(crate) fn push_i64(&mut self, row: u32, value: i64) {
+    pub fn push_i64(&mut self, row: u32, value: i64) {
         match self {
             ColumnAccumulator::Int64 { facts, .. } => facts.push((row, value)),
             ColumnAccumulator::Dynamic {
@@ -210,7 +210,7 @@ impl ColumnAccumulator {
 
     /// Append an f64 fact.
     #[inline(always)]
-    pub(crate) fn push_f64(&mut self, row: u32, value: f64) {
+    pub fn push_f64(&mut self, row: u32, value: f64) {
         match self {
             ColumnAccumulator::Float64 { facts, .. } => facts.push((row, value)),
             ColumnAccumulator::Dynamic {
@@ -227,7 +227,7 @@ impl ColumnAccumulator {
 
     /// Append a bool fact.
     #[inline(always)]
-    pub(crate) fn push_bool(&mut self, row: u32, value: bool) {
+    pub fn push_bool(&mut self, row: u32, value: bool) {
         match self {
             ColumnAccumulator::Bool { facts, .. } => facts.push((row, value)),
             ColumnAccumulator::Dynamic {
@@ -244,7 +244,7 @@ impl ColumnAccumulator {
 
     /// Append a string ref.
     #[inline(always)]
-    pub(crate) fn push_str(&mut self, row: u32, sref: StringRef) {
+    pub fn push_str(&mut self, row: u32, sref: StringRef) {
         match self {
             ColumnAccumulator::String { facts, .. } => facts.push((row, sref)),
             ColumnAccumulator::Dynamic {
@@ -274,7 +274,7 @@ impl ColumnAccumulator {
     ///
     /// Returns `Err` if a string reference points outside the provided buffers
     /// or if buffer data is not valid UTF-8.
-    pub(crate) fn materialize(
+    pub fn materialize(
         &self,
         name: &str,
         num_rows: usize,
@@ -363,7 +363,7 @@ impl ColumnAccumulator {
 
 /// Error during column materialization.
 #[derive(Debug)]
-pub(crate) enum MaterializeError {
+pub enum MaterializeError {
     /// A `StringRef` pointed outside the provided buffers.
     StringRefOutOfBounds {
         offset: u32,
@@ -410,7 +410,7 @@ impl std::error::Error for MaterializeError {
 
 /// Controls how string columns are built at finalization.
 #[derive(Clone)]
-pub(crate) enum FinalizationMode<'a> {
+pub enum FinalizationMode<'a> {
     /// Copy strings into contiguous `StringArray` (self-contained, input-freeable).
     Detached {
         /// Original input buffer, for reading string data.
@@ -495,7 +495,12 @@ fn build_string(
             generated_buf,
         } => {
             let original_len = original_buf.len();
-            let mut builder = StringBuilder::with_capacity(facts.len(), 0);
+            // Pre-compute total string bytes to avoid reallocation.
+            let total_str_bytes: usize = facts
+                .iter()
+                .map(|(_, sref)| sref.len as usize)
+                .sum();
+            let mut builder = StringBuilder::with_capacity(facts.len(), total_str_bytes);
             let mut vi = 0;
             for row in 0..num_rows as u32 {
                 if vi < facts.len() && facts[vi].0 == row {

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -2,16 +2,22 @@
 //
 // Each variant carries only the storage it needs:
 //   - Planned Int64 → one Vec<(u32, i64)>
-//   - Planned String → one Vec<(u32, u32, u32)> (row, offset, len)
+//   - Planned String → one Vec<(u32, StringRef)> (row + buffer reference)
 //   - Dynamic → all 4 vecs + conflict flags (same as FieldColumns today)
 //
 // Materialization is distributed: each variant builds its own Arrow array.
 // No monolithic finalization function.
+//
+// INVARIANT: facts within each vec must be pushed in non-decreasing row order.
+// The builder enforces this by calling push_* only with the current row_count,
+// which monotonically increases. build_string relies on this for its
+// sequential merge with the row range.
 
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, StringBuilder, StringViewBuilder, StructArray,
+    ArrayRef, BooleanArray, Float64Array, Int64Array, StringBuilder, StringViewBuilder,
+    StructArray,
 };
 use arrow::buffer::{Buffer, NullBuffer};
 use arrow::datatypes::{DataType, Field, Fields};
@@ -257,46 +263,51 @@ impl ColumnAccumulator {
 
     /// Materialize into an Arrow field + array.
     ///
-    /// Returns `None` if the accumulator has no data (sparse all-null field
+    /// Returns `Ok(None)` if the accumulator has no data (sparse all-null field
     /// with no writes — omitted from schema like StreamingBuilder does).
     ///
     /// `mode` controls string materialization:
     ///   - `Detached`: uses `StringBuilder` (copies strings, self-contained)
     ///   - `View`: uses `StringViewArray` backed by input + generated buffers
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if a string reference points outside the provided buffers
+    /// or if buffer data is not valid UTF-8.
     pub(crate) fn materialize(
         &self,
         name: &str,
         num_rows: usize,
         mode: FinalizationMode<'_>,
-    ) -> Option<(Field, ArrayRef)> {
+    ) -> Result<Option<(Field, ArrayRef)>, MaterializeError> {
         match self {
             ColumnAccumulator::Int64 { facts, .. } => {
                 if facts.is_empty() {
-                    return None;
+                    return Ok(None);
                 }
                 let (arr, dt) = build_int64(facts, num_rows);
-                Some((Field::new(name, dt, true), arr))
+                Ok(Some((Field::new(name, dt, true), arr)))
             }
             ColumnAccumulator::Float64 { facts, .. } => {
                 if facts.is_empty() {
-                    return None;
+                    return Ok(None);
                 }
                 let (arr, dt) = build_float64(facts, num_rows);
-                Some((Field::new(name, dt, true), arr))
+                Ok(Some((Field::new(name, dt, true), arr)))
             }
             ColumnAccumulator::Bool { facts, .. } => {
                 if facts.is_empty() {
-                    return None;
+                    return Ok(None);
                 }
                 let (arr, dt) = build_bool(facts, num_rows);
-                Some((Field::new(name, dt, true), arr))
+                Ok(Some((Field::new(name, dt, true), arr)))
             }
             ColumnAccumulator::String { facts, .. } => {
                 if facts.is_empty() {
-                    return None;
+                    return Ok(None);
                 }
-                let (arr, dt) = build_string(facts, num_rows, &mode);
-                Some((Field::new(name, dt, true), arr))
+                let (arr, dt) = build_string(facts, num_rows, &mode)?;
+                Ok(Some((Field::new(name, dt, true), arr)))
             }
             ColumnAccumulator::Dynamic {
                 int_facts,
@@ -312,11 +323,11 @@ impl ColumnAccumulator {
                 let type_count =
                     *has_int as u8 + *has_float as u8 + *has_str as u8 + *has_bool as u8;
                 if type_count == 0 {
-                    return None;
+                    return Ok(None);
                 }
                 if type_count > 1 {
                     // Conflict → StructArray
-                    Some(build_conflict_struct(
+                    Ok(Some(build_conflict_struct(
                         name,
                         num_rows,
                         &mode,
@@ -324,24 +335,71 @@ impl ColumnAccumulator {
                         float_facts,
                         bool_facts,
                         str_facts,
-                    ))
+                    )?))
                 } else {
                     // Single type → flat column
                     if *has_int {
                         let (arr, dt) = build_int64(int_facts, num_rows);
-                        Some((Field::new(name, dt, true), arr))
+                        Ok(Some((Field::new(name, dt, true), arr)))
                     } else if *has_float {
                         let (arr, dt) = build_float64(float_facts, num_rows);
-                        Some((Field::new(name, dt, true), arr))
+                        Ok(Some((Field::new(name, dt, true), arr)))
                     } else if *has_str {
-                        let (arr, dt) = build_string(str_facts, num_rows, &mode);
-                        Some((Field::new(name, dt, true), arr))
+                        let (arr, dt) = build_string(str_facts, num_rows, &mode)?;
+                        Ok(Some((Field::new(name, dt, true), arr)))
                     } else {
                         let (arr, dt) = build_bool(bool_facts, num_rows);
-                        Some((Field::new(name, dt, true), arr))
+                        Ok(Some((Field::new(name, dt, true), arr)))
                     }
                 }
             }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MaterializeError
+// ---------------------------------------------------------------------------
+
+/// Error during column materialization.
+#[derive(Debug)]
+pub(crate) enum MaterializeError {
+    /// A `StringRef` pointed outside the provided buffers.
+    StringRefOutOfBounds {
+        offset: u32,
+        len: u32,
+        buffer_len: usize,
+    },
+    /// Buffer data was not valid UTF-8 at the referenced range.
+    InvalidUtf8 { offset: u32, len: u32 },
+    /// Arrow's `StringViewBuilder::try_append_view` failed.
+    ViewAppend(arrow::error::ArrowError),
+}
+
+impl std::fmt::Display for MaterializeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MaterializeError::StringRefOutOfBounds {
+                offset,
+                len,
+                buffer_len,
+            } => write!(
+                f,
+                "StringRef(offset={offset}, len={len}) out of bounds for buffer(len={buffer_len})"
+            ),
+            MaterializeError::InvalidUtf8 { offset, len } => {
+                write!(f, "invalid UTF-8 at StringRef(offset={offset}, len={len})")
+            }
+            MaterializeError::ViewAppend(e) => write!(f, "StringViewBuilder append failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for MaterializeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            MaterializeError::ViewAppend(e) => Some(e),
+            _ => None,
         }
     }
 }
@@ -430,7 +488,7 @@ fn build_string(
     facts: &[(u32, StringRef)],
     num_rows: usize,
     mode: &FinalizationMode<'_>,
-) -> (ArrayRef, DataType) {
+) -> Result<(ArrayRef, DataType), MaterializeError> {
     match mode {
         FinalizationMode::Detached {
             original_buf,
@@ -442,17 +500,14 @@ fn build_string(
             for row in 0..num_rows as u32 {
                 if vi < facts.len() && facts[vi].0 == row {
                     let sref = facts[vi].1;
-                    let s = read_str(original_buf, generated_buf, original_len, sref);
-                    match s {
-                        Some(s) => builder.append_value(s),
-                        None => builder.append_null(),
-                    }
+                    let s = read_str(original_buf, generated_buf, original_len, sref)?;
+                    builder.append_value(s);
                     vi += 1;
                 } else {
                     builder.append_null();
                 }
             }
-            (Arc::new(builder.finish()), DataType::Utf8)
+            Ok((Arc::new(builder.finish()), DataType::Utf8))
         }
         FinalizationMode::View {
             original,
@@ -471,42 +526,69 @@ fn build_string(
                     {
                         builder
                             .try_append_view(orig_block, sref.offset, sref.len)
-                            .expect("pre-validated offset/len");
+                            .map_err(MaterializeError::ViewAppend)?;
                     } else if let Some(gen_block) = gen_block {
                         let gen_offset = sref.offset - *original_len;
                         builder
                             .try_append_view(gen_block, gen_offset, sref.len)
-                            .expect("pre-validated offset/len");
+                            .map_err(MaterializeError::ViewAppend)?;
                     } else {
-                        builder.append_null();
+                        return Err(MaterializeError::StringRefOutOfBounds {
+                            offset: sref.offset,
+                            len: sref.len,
+                            buffer_len: original.len(),
+                        });
                     }
                     vi += 1;
                 } else {
                     builder.append_null();
                 }
             }
-            (Arc::new(builder.finish()), DataType::Utf8View)
+            Ok((Arc::new(builder.finish()), DataType::Utf8View))
         }
     }
 }
 
 /// Read a string from the 2-buffer system.
+///
+/// Returns an error if the reference is out of bounds or the bytes are not valid UTF-8.
 fn read_str<'a>(
     original: &'a [u8],
     generated: &'a [u8],
     original_len: usize,
     sref: StringRef,
-) -> Option<&'a str> {
+) -> Result<&'a str, MaterializeError> {
     let start = sref.offset as usize;
-    let end = start.checked_add(sref.len as usize)?;
+    let end = start.checked_add(sref.len as usize).ok_or(
+        MaterializeError::StringRefOutOfBounds {
+            offset: sref.offset,
+            len: sref.len,
+            buffer_len: original.len() + generated.len(),
+        },
+    )?;
     let bytes = if start < original_len {
-        original.get(start..end)?
+        original.get(start..end).ok_or(
+            MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: original.len(),
+            },
+        )?
     } else {
-        let dec_start = start.checked_sub(original_len)?;
-        let dec_end = end.checked_sub(original_len)?;
-        generated.get(dec_start..dec_end)?
+        let dec_start = start - original_len;
+        let dec_end = end - original_len;
+        generated.get(dec_start..dec_end).ok_or(
+            MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: generated.len(),
+            },
+        )?
     };
-    std::str::from_utf8(bytes).ok()
+    std::str::from_utf8(bytes).map_err(|_| MaterializeError::InvalidUtf8 {
+        offset: sref.offset,
+        len: sref.len,
+    })
 }
 
 fn build_conflict_struct(
@@ -517,7 +599,7 @@ fn build_conflict_struct(
     float_facts: &[(u32, f64)],
     bool_facts: &[(u32, bool)],
     str_facts: &[(u32, StringRef)],
-) -> (Field, ArrayRef) {
+) -> Result<(Field, ArrayRef), MaterializeError> {
     let mut child_fields: Vec<Arc<Field>> = Vec::new();
     let mut child_arrays: Vec<ArrayRef> = Vec::new();
 
@@ -532,7 +614,7 @@ fn build_conflict_struct(
         child_arrays.push(arr);
     }
     if !str_facts.is_empty() {
-        let (arr, dt) = build_string(str_facts, num_rows, mode);
+        let (arr, dt) = build_string(str_facts, num_rows, mode)?;
         child_fields.push(Arc::new(Field::new("str", dt, true)));
         child_arrays.push(arr);
     }
@@ -553,10 +635,10 @@ fn build_conflict_struct(
         Some(NullBuffer::from(struct_validity)),
     );
 
-    (
+    Ok((
         Field::new(name, DataType::Struct(fields), true),
         Arc::new(struct_arr),
-    )
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -579,7 +661,7 @@ mod tests {
             original_buf: &[],
             generated_buf: &[],
         };
-        let (field, arr) = acc.materialize("ts", 3, mode).unwrap();
+        let (field, arr) = acc.materialize("ts", 3, mode).unwrap().unwrap();
         assert_eq!(field.name(), "ts");
         let a = arr.as_primitive::<Int64Type>();
         assert_eq!(a.value(0), 100);
@@ -598,7 +680,7 @@ mod tests {
             original_buf: input,
             generated_buf: &[],
         };
-        let (_, arr) = acc.materialize("msg", 2, mode).unwrap();
+        let (_, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
         let a = arr.as_string::<i32>();
         assert_eq!(a.value(0), "hello");
         assert_eq!(a.value(1), "world");
@@ -617,7 +699,7 @@ mod tests {
             original_len: input.len() as u32,
             generated: None,
         };
-        let (field, arr) = acc.materialize("msg", 2, mode).unwrap();
+        let (field, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
         assert_eq!(field.data_type(), &DataType::Utf8View);
         let a = arr.as_string_view();
         assert_eq!(a.value(0), "hello");
@@ -645,7 +727,7 @@ mod tests {
             original_buf: input,
             generated_buf: generated,
         };
-        let (_, arr) = acc.materialize("msg", 2, mode).unwrap();
+        let (_, arr) = acc.materialize("msg", 2, mode).unwrap().unwrap();
         let a = arr.as_string::<i32>();
         assert_eq!(a.value(0), "original");
         assert_eq!(a.value(1), "decoded");
@@ -661,7 +743,7 @@ mod tests {
             original_buf: &[],
             generated_buf: &[],
         };
-        let (field, arr) = acc.materialize("x", 2, mode).unwrap();
+        let (field, arr) = acc.materialize("x", 2, mode).unwrap().unwrap();
         assert_eq!(field.data_type(), &DataType::Int64);
         let a = arr.as_primitive::<Int64Type>();
         assert_eq!(a.value(0), 42);
@@ -686,7 +768,7 @@ mod tests {
             original_buf: input,
             generated_buf: &[],
         };
-        let (field, arr) = acc.materialize("status", 2, mode).unwrap();
+        let (field, arr) = acc.materialize("status", 2, mode).unwrap().unwrap();
         assert!(matches!(field.data_type(), DataType::Struct(_)));
         let s = arr.as_struct();
         assert_eq!(s.num_columns(), 2);
@@ -702,7 +784,7 @@ mod tests {
             original_buf: &[],
             generated_buf: &[],
         };
-        assert!(acc.materialize("x", 3, mode).is_none());
+        assert!(acc.materialize("x", 3, mode).unwrap().is_none());
     }
 
     #[test]
@@ -716,7 +798,7 @@ mod tests {
             original_buf: &[],
             generated_buf: &[],
         };
-        assert!(acc.materialize("x", 1, mode).is_none()); // no int facts → None
+        assert!(acc.materialize("x", 1, mode).unwrap().is_none()); // no int facts → None
     }
 
     #[test]
@@ -730,7 +812,7 @@ mod tests {
             original_buf: &[],
             generated_buf: &[],
         };
-        let (_, arr) = acc.materialize("x", 1, mode).unwrap();
+        let (_, arr) = acc.materialize("x", 1, mode).unwrap().unwrap();
         assert_eq!(arr.as_primitive::<Int64Type>().value(0), 200);
     }
 
@@ -755,5 +837,70 @@ mod tests {
             planned_size <= dynamic_size,
             "planned {planned_size} should be <= dynamic {dynamic_size}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Error handling tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn string_ref_out_of_bounds_returns_error() {
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
+        // Reference past end of buffer
+        acc.push_str(0, StringRef { offset: 100, len: 5 });
+
+        let mode = FinalizationMode::Detached {
+            original_buf: b"short",
+            generated_buf: &[],
+        };
+        let result = acc.materialize("x", 1, mode);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, MaterializeError::StringRefOutOfBounds { .. }),
+            "expected StringRefOutOfBounds, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_returns_error() {
+        let bad_bytes: &[u8] = &[0xFF, 0xFE, 0x80, 0x81];
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
+        acc.push_str(0, StringRef { offset: 0, len: 4 });
+
+        let mode = FinalizationMode::Detached {
+            original_buf: bad_bytes,
+            generated_buf: &[],
+        };
+        let result = acc.materialize("x", 1, mode);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, MaterializeError::InvalidUtf8 { .. }),
+            "expected InvalidUtf8, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn view_mode_out_of_bounds_returns_error() {
+        let input = b"short";
+        let arrow_buf = Buffer::from(&input[..]);
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
+        // Reference past generated buffer (which doesn't exist)
+        acc.push_str(
+            0,
+            StringRef {
+                offset: input.len() as u32,
+                len: 10,
+            },
+        );
+
+        let mode = FinalizationMode::View {
+            original: arrow_buf,
+            original_len: input.len() as u32,
+            generated: None,
+        };
+        let result = acc.materialize("x", 1, mode);
+        assert!(result.is_err());
     }
 }

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -1174,12 +1174,15 @@ mod verification {
     // ── make_string_view ────────────────────────────────────────────────────
 
     /// Inline path (len ≤ 12): length encodes correctly, data bytes round-trip.
+    /// Uses fully symbolic byte content (not constant fill) so the solver
+    /// explores all byte-value-dependent paths.
     #[kani::proof]
-    #[kani::unwind(17)]
+    #[kani::unwind(17)] // 12-byte loop + margin
     fn verify_make_string_view_inline_roundtrip() {
         let len: u32 = kani::any();
         kani::assume(len > 0 && len <= 12);
 
+        // Symbolic bytes — solver explores all values (unlike constant fill).
         let mut buf = [0u8; 12];
         for i in 0..12 {
             buf[i] = kani::any();
@@ -1189,12 +1192,12 @@ mod verification {
         let view =
             make_string_view(sref, &buf[..len as usize], &[], len as usize, 0, None).unwrap();
 
-        // Extract length from view — bytes 0..4 little-endian.
-        let extracted_len = (view & 0xFFFF_FFFF) as u32;
+        // Oracle: independently decode the u128 and verify every field.
+        let view_bytes = view.to_le_bytes();
+        let extracted_len =
+            u32::from_le_bytes([view_bytes[0], view_bytes[1], view_bytes[2], view_bytes[3]]);
         assert_eq!(extracted_len, len, "encoded length must match");
 
-        // Extract inline data — bytes 4..4+len.
-        let view_bytes = view.to_le_bytes();
         for i in 0..len as usize {
             assert_eq!(
                 view_bytes[4 + i],
@@ -1202,9 +1205,15 @@ mod verification {
                 "inline data byte must match source"
             );
         }
+        // Padding bytes beyond data must be zero.
+        for i in (4 + len as usize)..16 {
+            assert_eq!(view_bytes[i], 0, "padding byte must be zero");
+        }
 
         kani::cover!(len == 1, "minimal inline");
         kani::cover!(len == 12, "max inline");
+        kani::cover!(buf[0] == 0x00, "zero first byte");
+        kani::cover!(buf[0] == 0xFF, "high first byte");
     }
 
     /// Zero-length string encodes as zero u128.
@@ -1217,49 +1226,122 @@ mod verification {
 
     /// Buffer-ref path (len > 12): u128 field packing is non-overlapping and
     /// each 32-bit lane round-trips correctly.
+    ///
+    /// Uses symbolic prefix bytes (not constant fill) so solver explores
+    /// endianness-dependent bugs. Fixed 32-byte buffer to keep CBMC tractable.
     #[kani::proof]
+    #[kani::solver(kissat)]
     fn verify_make_string_view_buffer_ref_packing() {
         let len: u32 = kani::any();
-        kani::assume(len > 12 && len <= 64);
+        kani::assume(len > 12 && len <= 20); // bounded for solver tractability
+
         let block_idx: u32 = kani::any();
         let local_offset: u32 = kani::any();
-        kani::assume((local_offset as usize) + (len as usize) <= 256);
+        kani::assume(local_offset <= 8); // keep buffer small
+        kani::assume((local_offset as usize) + (len as usize) <= 32);
 
+        // Symbolic first 4 bytes (prefix) + remaining bytes are fixed.
         let buf_len = local_offset as usize + len as usize;
-        let buf = vec![0xABu8; buf_len];
+        let mut buf = [0u8; 32];
+        let start = local_offset as usize;
+        buf[start] = kani::any();
+        buf[start + 1] = kani::any();
+        buf[start + 2] = kani::any();
+        buf[start + 3] = kani::any();
 
         let sref = StringRef {
             offset: local_offset,
             len,
         };
-        let view = make_string_view(sref, &buf, &[], buf_len, block_idx, None).unwrap();
+        let view = make_string_view(sref, &buf[..buf_len], &[], buf_len, block_idx, None).unwrap();
 
-        // Lane 0: length
-        assert_eq!((view & 0xFFFF_FFFF) as u32, len);
-        // Lane 1: prefix (first 4 bytes of string data = 0xAB repeated)
-        let expected_prefix = u32::from_le_bytes([0xAB, 0xAB, 0xAB, 0xAB]);
-        assert_eq!(((view >> 32) & 0xFFFF_FFFF) as u32, expected_prefix);
-        // Lane 2: block index
-        assert_eq!(((view >> 64) & 0xFFFF_FFFF) as u32, block_idx);
-        // Lane 3: local offset
-        assert_eq!(((view >> 96) & 0xFFFF_FFFF) as u32, local_offset);
+        // Oracle: independently recompute expected u128 from the spec.
+        let expected_prefix =
+            u32::from_le_bytes([buf[start], buf[start + 1], buf[start + 2], buf[start + 3]]);
+        let expected_view = (len as u128)
+            | ((expected_prefix as u128) << 32)
+            | ((block_idx as u128) << 64)
+            | ((local_offset as u128) << 96);
+        assert_eq!(view, expected_view, "view must match oracle computation");
+
+        kani::cover!(block_idx > 0, "non-zero block index");
+        kani::cover!(local_offset > 0, "non-zero local offset");
+        kani::cover!(buf[start] == 0x00, "zero prefix byte");
+        kani::cover!(buf[start] == 0xFF, "high prefix byte");
     }
 
     /// Out-of-bounds StringRef returns error, never panics.
+    /// Uses fixed-size array (not vec with symbolic length) to avoid CBMC timeout.
     #[kani::proof]
+    #[kani::solver(kissat)]
     fn verify_make_string_view_out_of_bounds() {
         let offset: u32 = kani::any();
         let len: u32 = kani::any();
-        kani::assume(len > 0);
+        kani::assume(len > 0 && len <= 128);
+        kani::assume(offset <= 128);
+
         let buf_len: usize = kani::any();
-        kani::assume(buf_len < 256);
+        kani::assume(buf_len <= 64);
         let total = (offset as usize).saturating_add(len as usize);
         kani::assume(total > buf_len);
 
-        let buf = vec![0u8; buf_len];
+        // Fixed-size array avoids CBMC symbolic-allocation explosion.
+        let buf = [0u8; 64];
         let sref = StringRef { offset, len };
-        let result = make_string_view(sref, &buf, &[], buf_len, 0, None);
+        let result = make_string_view(sref, &buf[..buf_len], &[], buf_len, 0, None);
         assert!(result.is_err(), "OOB reference must return error");
+
+        kani::cover!(offset == 0, "zero offset with large len");
+        kani::cover!(offset > 0 && len > 0, "non-zero offset and len");
+        kani::cover!(buf_len == 0, "empty buffer");
+    }
+
+    /// Buffer selection: offset < original_len uses original buffer,
+    /// offset >= original_len uses generated buffer.
+    #[kani::proof]
+    fn verify_make_string_view_buffer_selection() {
+        let len: u32 = kani::any();
+        kani::assume(len > 0 && len <= 4);
+
+        let original_len: usize = 8;
+        let original = [0xAAu8; 8];
+        let generated = [0xBBu8; 8];
+
+        // Original buffer path: offset < original_len.
+        let orig_offset: u32 = kani::any();
+        kani::assume(orig_offset <= (original_len as u32) - len);
+        let sref_orig = StringRef {
+            offset: orig_offset,
+            len,
+        };
+        let result_orig =
+            make_string_view(sref_orig, &original, &generated, original_len, 0, Some(1));
+        assert!(result_orig.is_ok(), "valid original ref must succeed");
+
+        // Generated buffer path: offset >= original_len.
+        let gen_offset: u32 = kani::any();
+        kani::assume(gen_offset <= (generated.len() as u32) - len);
+        let sref_gen = StringRef {
+            offset: original_len as u32 + gen_offset,
+            len,
+        };
+        let result_gen =
+            make_string_view(sref_gen, &original, &generated, original_len, 0, Some(1));
+        assert!(result_gen.is_ok(), "valid generated ref must succeed");
+
+        // No generated buffer + offset in generated range → error.
+        let sref_no_gen = StringRef {
+            offset: original_len as u32,
+            len: 1,
+        };
+        let result_no_gen = make_string_view(sref_no_gen, &original, &[], original_len, 0, None);
+        assert!(
+            result_no_gen.is_err(),
+            "generated offset with no generated buffer must error"
+        );
+
+        kani::cover!(orig_offset == 0, "start of original");
+        kani::cover!(gen_offset == 0, "start of generated");
     }
 }
 

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -190,13 +190,53 @@ impl ColumnAccumulator {
     }
 
     // -----------------------------------------------------------------------
+    // Type-acceptance checks
+    // -----------------------------------------------------------------------
+
+    /// Whether this accumulator accepts i64 writes.
+    #[inline(always)]
+    pub fn accepts_i64(&self) -> bool {
+        matches!(
+            self,
+            ColumnAccumulator::Int64 { .. } | ColumnAccumulator::Dynamic { .. }
+        )
+    }
+
+    /// Whether this accumulator accepts f64 writes.
+    #[inline(always)]
+    pub fn accepts_f64(&self) -> bool {
+        matches!(
+            self,
+            ColumnAccumulator::Float64 { .. } | ColumnAccumulator::Dynamic { .. }
+        )
+    }
+
+    /// Whether this accumulator accepts bool writes.
+    #[inline(always)]
+    pub fn accepts_bool(&self) -> bool {
+        matches!(
+            self,
+            ColumnAccumulator::Bool { .. } | ColumnAccumulator::Dynamic { .. }
+        )
+    }
+
+    /// Whether this accumulator accepts string writes.
+    #[inline(always)]
+    pub fn accepts_str(&self) -> bool {
+        matches!(
+            self,
+            ColumnAccumulator::String { .. } | ColumnAccumulator::Dynamic { .. }
+        )
+    }
+
+    // -----------------------------------------------------------------------
     // Typed write methods
     // -----------------------------------------------------------------------
 
-    /// Append an i64 fact.  For planned Int64, goes to the single vec.
-    /// For Dynamic, goes to int_facts.
-    /// For other planned types, the write is silently ignored — the planned
-    /// kind determines the output type, not the write method called.
+    /// Append an i64 fact.
+    ///
+    /// Accepted by `Int64` and `Dynamic` accumulators. For other planned
+    /// types the caller should check `accepts_i64()` first.
     #[inline(always)]
     pub fn push_i64(&mut self, row: u32, value: i64) {
         match self {
@@ -212,7 +252,6 @@ impl ColumnAccumulator {
     }
 
     /// Append an f64 fact.
-    /// For other planned types, the write is silently ignored.
     #[inline(always)]
     pub fn push_f64(&mut self, row: u32, value: f64) {
         match self {
@@ -230,7 +269,6 @@ impl ColumnAccumulator {
     }
 
     /// Append a bool fact.
-    /// For other planned types, the write is silently ignored.
     #[inline(always)]
     pub fn push_bool(&mut self, row: u32, value: bool) {
         match self {
@@ -248,7 +286,6 @@ impl ColumnAccumulator {
     }
 
     /// Append a string ref.
-    /// For other planned types, the write is silently ignored.
     #[inline(always)]
     pub fn push_str(&mut self, row: u32, sref: StringRef) {
         match self {

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -444,23 +444,28 @@ pub enum FinalizationMode {
 fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
     let dense = facts.len() == num_rows;
     let mut values = vec![0i64; num_rows];
-    let mut valid = if dense {
-        Vec::new()
+    if dense {
+        for (i, &(_, v)) in facts.iter().enumerate() {
+            values[i] = v;
+        }
     } else {
-        vec![false; num_rows]
-    };
-    for &(row, v) in facts {
-        let r = row as usize;
-        if r < num_rows {
-            values[r] = v;
-            if !dense {
-                valid[r] = true;
+        for &(row, v) in facts {
+            let r = row as usize;
+            if r < num_rows {
+                values[r] = v;
             }
         }
     }
     let nulls = if dense {
         None
     } else {
+        let mut valid = vec![false; num_rows];
+        for &(row, _) in facts {
+            let r = row as usize;
+            if r < num_rows {
+                valid[r] = true;
+            }
+        }
         Some(NullBuffer::from(valid))
     };
     (
@@ -472,23 +477,28 @@ fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
 fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) {
     let dense = facts.len() == num_rows;
     let mut values = vec![0.0f64; num_rows];
-    let mut valid = if dense {
-        Vec::new()
+    if dense {
+        for (i, &(_, v)) in facts.iter().enumerate() {
+            values[i] = v;
+        }
     } else {
-        vec![false; num_rows]
-    };
-    for &(row, v) in facts {
-        let r = row as usize;
-        if r < num_rows {
-            values[r] = v;
-            if !dense {
-                valid[r] = true;
+        for &(row, v) in facts {
+            let r = row as usize;
+            if r < num_rows {
+                values[r] = v;
             }
         }
     }
     let nulls = if dense {
         None
     } else {
+        let mut valid = vec![false; num_rows];
+        for &(row, _) in facts {
+            let r = row as usize;
+            if r < num_rows {
+                valid[r] = true;
+            }
+        }
         Some(NullBuffer::from(valid))
     };
     (
@@ -500,23 +510,28 @@ fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) 
 fn build_bool(facts: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
     let dense = facts.len() == num_rows;
     let mut values = vec![false; num_rows];
-    let mut valid = if dense {
-        Vec::new()
+    if dense {
+        for (i, &(_, v)) in facts.iter().enumerate() {
+            values[i] = v;
+        }
     } else {
-        vec![false; num_rows]
-    };
-    for &(row, v) in facts {
-        let r = row as usize;
-        if r < num_rows {
-            values[r] = v;
-            if !dense {
-                valid[r] = true;
+        for &(row, v) in facts {
+            let r = row as usize;
+            if r < num_rows {
+                values[r] = v;
             }
         }
     }
     let nulls = if dense {
         None
     } else {
+        let mut valid = vec![false; num_rows];
+        for &(row, _) in facts {
+            let r = row as usize;
+            if r < num_rows {
+                valid[r] = true;
+            }
+        }
         Some(NullBuffer::from(valid))
     };
     (
@@ -614,10 +629,13 @@ fn build_string_view_trusted(
         Some(1u32)
     };
 
+    // Pre-zero + indexed write is faster than collect() because memset_avx2
+    // zeroes 16KB in ~200 instructions while the Result iterator adapter
+    // (GenericShunt) adds ~25M instructions of overhead.
     let mut views: Vec<u128> = vec![0u128; num_rows];
 
     if dense {
-        // Fast path: every row has a value, facts[i] corresponds to row i.
+        // Dense fast path: every row has a value, facts[i] corresponds to row i.
         for (i, &(_, sref)) in facts.iter().enumerate() {
             views[i] = make_string_view(
                 sref,
@@ -643,7 +661,6 @@ fn build_string_view_trusted(
                 )?;
                 vi += 1;
             }
-            // else: views[row] remains 0 (null)
         }
     }
 
@@ -689,7 +706,7 @@ fn build_string_view_trusted(
 /// Construct a u128 StringView for a given StringRef.
 ///
 /// Strings ≤ 12 bytes are inlined. Longer strings reference a buffer block.
-#[inline]
+#[inline(always)]
 fn make_string_view(
     sref: StringRef,
     original_buf: &[u8],
@@ -699,64 +716,59 @@ fn make_string_view(
     gen_block: Option<u32>,
 ) -> Result<u128, MaterializeError> {
     let len = sref.len;
-    let start = sref.offset as usize;
-    let end = start
-        .checked_add(len as usize)
-        .ok_or(MaterializeError::StringRefOutOfBounds {
-            offset: sref.offset,
-            len: sref.len,
-            buffer_len: original_buf.len() + generated_buf.len(),
-        })?;
-
-    // Resolve which buffer and the bytes.
-    let (bytes, block_idx, block_offset) = if start < original_len {
-        let b = original_buf
-            .get(start..end)
-            .ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: original_buf.len(),
-            })?;
-        (b, orig_block, sref.offset)
-    } else {
-        let dec_start = start - original_len;
-        let dec_end = end - original_len;
-        let b = generated_buf.get(dec_start..dec_end).ok_or(
-            MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: generated_buf.len(),
-            },
-        )?;
-        (
-            b,
-            gen_block.ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: 0,
-            })?,
-            dec_start as u32,
-        )
-    };
-
     if len == 0 {
         return Ok(0u128);
     }
 
+    let start = sref.offset as usize;
+
+    // Resolve buffer, block index, and local offset.
+    let (buf, block_idx, local_offset) = if start < original_len {
+        (original_buf, orig_block, sref.offset)
+    } else {
+        let dec_start = (start - original_len) as u32;
+        match gen_block {
+            Some(gb) => (generated_buf, gb, dec_start),
+            None => {
+                return Err(MaterializeError::StringRefOutOfBounds {
+                    offset: sref.offset,
+                    len: sref.len,
+                    buffer_len: 0,
+                });
+            }
+        }
+    };
+
+    let local_start = local_offset as usize;
+    let local_end = local_start + len as usize;
+    if local_end > buf.len() {
+        return Err(MaterializeError::StringRefOutOfBounds {
+            offset: sref.offset,
+            len: sref.len,
+            buffer_len: buf.len(),
+        });
+    }
+
+    // Build the u128 view using arithmetic — avoids byte array + copy_from_slice.
     Ok(if len <= 12 {
-        // Inline: pack length + data directly into the view.
+        // Inline: [len:4][data:12] packed little-endian.
         let mut view_bytes = [0u8; 16];
         view_bytes[0..4].copy_from_slice(&len.to_le_bytes());
-        view_bytes[4..4 + len as usize].copy_from_slice(bytes);
+        view_bytes[4..4 + len as usize].copy_from_slice(&buf[local_start..local_end]);
         u128::from_le_bytes(view_bytes)
     } else {
-        // Buffer reference: length + 4-byte prefix + block index + offset.
-        let mut view_bytes = [0u8; 16];
-        view_bytes[0..4].copy_from_slice(&len.to_le_bytes());
-        view_bytes[4..8].copy_from_slice(&bytes[..4]);
-        view_bytes[8..12].copy_from_slice(&block_idx.to_le_bytes());
-        view_bytes[12..16].copy_from_slice(&block_offset.to_le_bytes());
-        u128::from_le_bytes(view_bytes)
+        // Buffer ref: [len:4][prefix:4][block_idx:4][offset:4] packed little-endian.
+        // Use arithmetic to avoid array copies.
+        let prefix = u32::from_le_bytes([
+            buf[local_start],
+            buf[local_start + 1],
+            buf[local_start + 2],
+            buf[local_start + 3],
+        ]);
+        (len as u128)
+            | ((prefix as u128) << 32)
+            | ((block_idx as u128) << 64)
+            | ((local_offset as u128) << 96)
     })
 }
 

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -195,6 +195,8 @@ impl ColumnAccumulator {
 
     /// Append an i64 fact.  For planned Int64, goes to the single vec.
     /// For Dynamic, goes to int_facts.
+    /// For other planned types, the write is silently ignored — the planned
+    /// kind determines the output type, not the write method called.
     #[inline(always)]
     pub fn push_i64(&mut self, row: u32, value: i64) {
         match self {
@@ -205,12 +207,12 @@ impl ColumnAccumulator {
                 *has_int = true;
                 int_facts.push((row, value));
             }
-            // Wrong-type write to a planned non-Int64 field: no-op.
             _ => {}
         }
     }
 
     /// Append an f64 fact.
+    /// For other planned types, the write is silently ignored.
     #[inline(always)]
     pub fn push_f64(&mut self, row: u32, value: f64) {
         match self {
@@ -228,6 +230,7 @@ impl ColumnAccumulator {
     }
 
     /// Append a bool fact.
+    /// For other planned types, the write is silently ignored.
     #[inline(always)]
     pub fn push_bool(&mut self, row: u32, value: bool) {
         match self {
@@ -245,6 +248,7 @@ impl ColumnAccumulator {
     }
 
     /// Append a string ref.
+    /// For other planned types, the write is silently ignored.
     #[inline(always)]
     pub fn push_str(&mut self, row: u32, sref: StringRef) {
         match self {

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -16,10 +16,9 @@
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, StringBuilder, StringViewBuilder,
-    StructArray,
+    ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, StringViewBuilder, StructArray,
 };
-use arrow::buffer::{Buffer, NullBuffer};
+use arrow::buffer::{Buffer, NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{DataType, Field, Fields};
 
 use super::plan::FieldKind;
@@ -495,24 +494,59 @@ fn build_string(
             generated_buf,
         } => {
             let original_len = original_buf.len();
-            // Pre-compute total string bytes to avoid reallocation.
-            let total_str_bytes: usize = facts
-                .iter()
-                .map(|(_, sref)| sref.len as usize)
-                .sum();
-            let mut builder = StringBuilder::with_capacity(facts.len(), total_str_bytes);
+            // Build offsets + values directly, skipping per-value UTF-8 validation.
+            // Safety argument: all strings entered via write_str(&str) are already
+            // valid UTF-8 by Rust's type system. StringRef data written via
+            // write_str_ref may originate from arbitrary bytes, so we validate
+            // the entire concatenated values buffer once at the end.
+            let mut offsets: Vec<i32> = Vec::with_capacity(num_rows + 1);
+            let mut values: Vec<u8> =
+                Vec::with_capacity(facts.iter().map(|(_, sref)| sref.len as usize).sum());
+            let mut validity: Vec<bool> = Vec::with_capacity(num_rows);
             let mut vi = 0;
+
             for row in 0..num_rows as u32 {
+                offsets.push(values.len() as i32);
                 if vi < facts.len() && facts[vi].0 == row {
                     let sref = facts[vi].1;
-                    let s = read_str(original_buf, generated_buf, original_len, sref)?;
-                    builder.append_value(s);
+                    let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
+                    values.extend_from_slice(bytes);
+                    validity.push(true);
                     vi += 1;
                 } else {
-                    builder.append_null();
+                    validity.push(false);
                 }
             }
-            Ok((Arc::new(builder.finish()), DataType::Utf8))
+            offsets.push(values.len() as i32);
+
+            // Single UTF-8 validation of the entire values buffer.
+            if std::str::from_utf8(&values).is_err() {
+                // Find the offending string for a precise error.
+                let mut fvi = 0;
+                for row in 0..num_rows as u32 {
+                    if fvi < facts.len() && facts[fvi].0 == row {
+                        let sref = facts[fvi].1;
+                        let start = offsets[row as usize] as usize;
+                        let end = offsets[row as usize + 1] as usize;
+                        if std::str::from_utf8(&values[start..end]).is_err() {
+                            return Err(MaterializeError::InvalidUtf8 {
+                                offset: sref.offset,
+                                len: sref.len,
+                            });
+                        }
+                        fvi += 1;
+                    }
+                }
+            }
+
+            let nulls = if validity.iter().all(|&v| v) {
+                None
+            } else {
+                Some(NullBuffer::from(validity))
+            };
+            let offset_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
+            let array = StringArray::new(offset_buf, Buffer::from_vec(values), nulls);
+            Ok((Arc::new(array), DataType::Utf8))
         }
         FinalizationMode::View {
             original,
@@ -564,36 +598,77 @@ fn read_str<'a>(
     sref: StringRef,
 ) -> Result<&'a str, MaterializeError> {
     let start = sref.offset as usize;
-    let end = start.checked_add(sref.len as usize).ok_or(
-        MaterializeError::StringRefOutOfBounds {
-            offset: sref.offset,
-            len: sref.len,
-            buffer_len: original.len() + generated.len(),
-        },
-    )?;
+    let end =
+        start
+            .checked_add(sref.len as usize)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: original.len() + generated.len(),
+            })?;
     let bytes = if start < original_len {
-        original.get(start..end).ok_or(
-            MaterializeError::StringRefOutOfBounds {
+        original
+            .get(start..end)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
                 offset: sref.offset,
                 len: sref.len,
                 buffer_len: original.len(),
-            },
-        )?
+            })?
     } else {
         let dec_start = start - original_len;
         let dec_end = end - original_len;
-        generated.get(dec_start..dec_end).ok_or(
-            MaterializeError::StringRefOutOfBounds {
+        generated
+            .get(dec_start..dec_end)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
                 offset: sref.offset,
                 len: sref.len,
                 buffer_len: generated.len(),
-            },
-        )?
+            })?
     };
     std::str::from_utf8(bytes).map_err(|_| MaterializeError::InvalidUtf8 {
         offset: sref.offset,
         len: sref.len,
     })
+}
+
+/// Read string bytes from the 2-buffer system without UTF-8 validation.
+///
+/// Returns the raw bytes referenced by `sref`. Callers must validate UTF-8
+/// externally (e.g., once over the concatenated output).
+fn read_str_bytes<'a>(
+    original: &'a [u8],
+    generated: &'a [u8],
+    original_len: usize,
+    sref: StringRef,
+) -> Result<&'a [u8], MaterializeError> {
+    let start = sref.offset as usize;
+    let end =
+        start
+            .checked_add(sref.len as usize)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: original.len() + generated.len(),
+            })?;
+    if start < original_len {
+        original
+            .get(start..end)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: original.len(),
+            })
+    } else {
+        let dec_start = start - original_len;
+        let dec_end = end - original_len;
+        generated
+            .get(dec_start..dec_end)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: generated.len(),
+            })
+    }
 }
 
 fn build_conflict_struct(
@@ -761,13 +836,7 @@ mod tests {
         acc.push_i64(0, 200);
 
         let input = b"OK";
-        acc.push_str(
-            1,
-            StringRef {
-                offset: 0,
-                len: 2,
-            },
-        );
+        acc.push_str(1, StringRef { offset: 0, len: 2 });
 
         let mode = FinalizationMode::Detached {
             original_buf: input,
@@ -852,7 +921,13 @@ mod tests {
     fn string_ref_out_of_bounds_returns_error() {
         let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
         // Reference past end of buffer
-        acc.push_str(0, StringRef { offset: 100, len: 5 });
+        acc.push_str(
+            0,
+            StringRef {
+                offset: 100,
+                len: 5,
+            },
+        );
 
         let mode = FinalizationMode::Detached {
             original_buf: b"short",

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -97,12 +97,15 @@ impl ColumnAccumulator {
                 facts: Vec::with_capacity(256),
                 last_row: u32::MAX,
             },
-            FieldKind::Utf8View | FieldKind::BinaryView | FieldKind::FixedBinary(_) => {
-                ColumnAccumulator::String {
-                    facts: Vec::with_capacity(256),
-                    last_row: u32::MAX,
-                }
-            }
+            FieldKind::Utf8View => ColumnAccumulator::String {
+                facts: Vec::with_capacity(256),
+                last_row: u32::MAX,
+            },
+            // TODO(#1844): implement dedicated binary accumulator variants
+            FieldKind::BinaryView | FieldKind::FixedBinary(_) => ColumnAccumulator::String {
+                facts: Vec::with_capacity(256),
+                last_row: u32::MAX,
+            },
         }
     }
 
@@ -371,6 +374,8 @@ pub enum MaterializeError {
     },
     /// Buffer data was not valid UTF-8 at the referenced range.
     InvalidUtf8 { offset: u32, len: u32 },
+    /// Concatenated string bytes exceed `i32::MAX`, making Utf8 offsets invalid.
+    OffsetOverflow,
 }
 
 impl std::fmt::Display for MaterializeError {
@@ -386,6 +391,12 @@ impl std::fmt::Display for MaterializeError {
             ),
             MaterializeError::InvalidUtf8 { offset, len } => {
                 write!(f, "invalid UTF-8 at StringRef(offset={offset}, len={len})")
+            }
+            MaterializeError::OffsetOverflow => {
+                write!(
+                    f,
+                    "string data exceeds i32::MAX bytes for Utf8 offset array"
+                )
             }
         }
     }
@@ -415,8 +426,17 @@ pub struct FinalizationMode {
 // Array builders (free functions, no &self)
 // ---------------------------------------------------------------------------
 
+/// Check whether facts cover rows 0..num_rows exactly (no gaps, no duplicates).
+///
+/// Facts are appended in row order. If `facts.len() == num_rows` and the last
+/// fact targets row `num_rows - 1`, the pigeonhole principle guarantees every
+/// row is present exactly once (rows are monotonically non-decreasing).
+fn is_dense<T>(facts: &[(u32, T)], num_rows: usize) -> bool {
+    facts.len() == num_rows && (num_rows == 0 || facts[num_rows - 1].0 as usize == num_rows - 1)
+}
+
 fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
-    let dense = facts.len() == num_rows;
+    let dense = is_dense(facts, num_rows);
     let mut values = vec![0i64; num_rows];
     if dense {
         debug_assert!(
@@ -453,7 +473,7 @@ fn build_int64(facts: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
 }
 
 fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) {
-    let dense = facts.len() == num_rows;
+    let dense = is_dense(facts, num_rows);
     let mut values = vec![0.0f64; num_rows];
     if dense {
         debug_assert!(
@@ -490,7 +510,7 @@ fn build_float64(facts: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) 
 }
 
 fn build_bool(facts: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
-    let dense = facts.len() == num_rows;
+    let dense = is_dense(facts, num_rows);
     let mut values = vec![false; num_rows];
     if dense {
         debug_assert!(
@@ -556,7 +576,7 @@ fn build_string_view_trusted(
     generated_buf: &Buffer,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
     let original_len = original_buf.len();
-    let dense = facts.len() == num_rows;
+    let dense = is_dense(facts, num_rows);
 
     // Register source buffers as StringViewArray blocks.
     // block 0 = original, block 1 = generated (if non-empty).
@@ -719,7 +739,7 @@ fn build_string_array_validated(
     generated_buf: &Buffer,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
     let original_len = original_buf.len();
-    let dense = facts.len() == num_rows;
+    let dense = is_dense(facts, num_rows);
     let mut offsets: Vec<i32> = Vec::with_capacity(num_rows + 1);
     let mut values: Vec<u8> =
         Vec::with_capacity(facts.iter().map(|(_, sref)| sref.len as usize).sum());
@@ -732,14 +752,16 @@ fn build_string_array_validated(
     if dense {
         // Dense fast path: skip per-row branch check.
         for &(_, sref) in facts {
-            offsets.push(values.len() as i32);
+            let off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
+            offsets.push(off);
             let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
             values.extend_from_slice(bytes);
         }
     } else {
         let mut vi = 0;
         for row in 0..num_rows as u32 {
-            offsets.push(values.len() as i32);
+            let off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
+            offsets.push(off);
             if vi < facts.len() && facts[vi].0 == row {
                 let sref = facts[vi].1;
                 let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
@@ -751,7 +773,8 @@ fn build_string_array_validated(
             }
         }
     }
-    offsets.push(values.len() as i32);
+    let final_off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
+    offsets.push(final_off);
 
     // Validate UTF-8 for external bytes.
     if !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -472,9 +472,10 @@ fn null_column(name: &str, kind: FieldKind, num_rows: usize) -> (Field, ArrayRef
             (Field::new(name, DataType::BinaryView, true), Arc::new(arr))
         }
         FieldKind::FixedBinary(n) => {
-            let arr = arrow::array::FixedSizeBinaryArray::new_null(n as i32, num_rows);
+            let width = i32::try_from(n).expect("FixedBinary width exceeds i32::MAX");
+            let arr = arrow::array::FixedSizeBinaryArray::new_null(width, num_rows);
             (
-                Field::new(name, DataType::FixedSizeBinary(n as i32), true),
+                Field::new(name, DataType::FixedSizeBinary(width), true),
                 Arc::new(arr),
             )
         }

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -15,7 +15,9 @@
 
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringViewArray};
+use arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, StringViewArray,
+};
 use arrow::buffer::{Buffer, NullBuffer};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
@@ -441,7 +443,7 @@ impl ColumnarBatchBuilder {
                     // no values were written). Dynamic fields with no data are
                     // omitted — this matches StreamingBuilder behavior.
                     if let FieldSchemaMode::Planned(kind) = field_mode {
-                        let (field, array) = null_column(name, *kind, num_rows);
+                        let (field, array) = null_column(name, *kind, num_rows, mode.utf8_trusted);
                         schema_fields.push(field);
                         arrays.push(array);
                     }
@@ -470,7 +472,12 @@ impl ColumnarBatchBuilder {
 // ---------------------------------------------------------------------------
 
 /// Create an all-null column of the appropriate Arrow type for a planned field.
-fn null_column(name: &str, kind: FieldKind, num_rows: usize) -> (Field, ArrayRef) {
+fn null_column(
+    name: &str,
+    kind: FieldKind,
+    num_rows: usize,
+    utf8_trusted: bool,
+) -> (Field, ArrayRef) {
     match kind {
         FieldKind::Int64 => {
             let nulls = NullBuffer::new_null(num_rows);
@@ -488,8 +495,13 @@ fn null_column(name: &str, kind: FieldKind, num_rows: usize) -> (Field, ArrayRef
             (Field::new(name, DataType::Boolean, true), Arc::new(arr))
         }
         FieldKind::Utf8View => {
-            let arr = StringViewArray::new_null(num_rows);
-            (Field::new(name, DataType::Utf8View, true), Arc::new(arr))
+            if utf8_trusted {
+                let arr = StringViewArray::new_null(num_rows);
+                (Field::new(name, DataType::Utf8View, true), Arc::new(arr))
+            } else {
+                let arr = StringArray::new_null(num_rows);
+                (Field::new(name, DataType::Utf8, true), Arc::new(arr))
+            }
         }
         FieldKind::BinaryView => {
             let arr = arrow::array::BinaryViewArray::new_null(num_rows);
@@ -964,7 +976,11 @@ mod tests {
         let batch = b.finish_batch().unwrap();
         let col = batch.column_by_name("x").unwrap();
         let arr = col.as_primitive::<Int64Type>();
-        assert_eq!(arr.value(0), 42, "correct-type write after wrong-type must succeed");
+        assert_eq!(
+            arr.value(0),
+            42,
+            "correct-type write after wrong-type must succeed"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -107,8 +107,12 @@ pub struct ColumnarBatchBuilder {
     plan: BatchPlan,
     lifecycle: RowLifecycle,
     columns: Vec<ColumnAccumulator>,
-    /// Shared buffer for string values written via `write_str`.
-    /// StringRef offsets point into this buffer.
+    /// Optional original input buffer for zero-copy string references.
+    /// `write_str_ref` offsets below `original_buf.len()` point here.
+    original_buf: Vec<u8>,
+    /// Generated buffer for string values written via `write_str`.
+    /// StringRef offsets at or above `original_buf.len()` point here
+    /// (shifted by original_buf.len()).
     string_buf: Vec<u8>,
 }
 
@@ -128,6 +132,7 @@ impl ColumnarBatchBuilder {
             plan,
             lifecycle: RowLifecycle::new(),
             columns,
+            original_buf: Vec::new(),
             string_buf: Vec::new(),
         }
     }
@@ -138,7 +143,22 @@ impl ColumnarBatchBuilder {
         for col in &mut self.columns {
             col.clear();
         }
+        self.original_buf.clear();
         self.string_buf.clear();
+    }
+
+    /// Set the original input buffer for zero-copy string references.
+    ///
+    /// Call after `begin_batch` and before any writes. `write_str_ref` with
+    /// offsets below `original_buf.len()` will reference this buffer at
+    /// materialization time.
+    pub fn set_original_buffer(&mut self, buf: &[u8]) {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
+        debug_assert!(
+            self.original_buf.is_empty(),
+            "set_original_buffer called twice in the same batch"
+        );
+        self.original_buf.extend_from_slice(buf);
     }
 
     /// Start a new row.
@@ -248,7 +268,11 @@ impl ColumnarBatchBuilder {
         if self.is_duplicate(handle) {
             return Ok(());
         }
-        let offset = u32::try_from(self.string_buf.len()).map_err(|_| {
+        // Generated string offsets are shifted by original_buf.len() so that
+        // the 2-buffer model can distinguish original vs generated at
+        // materialization time.
+        let raw_offset = self.original_buf.len() + self.string_buf.len();
+        let offset = u32::try_from(raw_offset).map_err(|_| {
             BuilderError::StringBufferOverflow {
                 buffer_len: self.string_buf.len(),
                 value_len: value.len(),
@@ -299,11 +323,10 @@ impl ColumnarBatchBuilder {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
         let num_rows = self.lifecycle.row_count() as usize;
 
-        // Detached mode: string_buf is the "generated" buffer, no original.
         // utf8_trusted: true because write_str takes &str (Rust guarantees UTF-8)
         // and write_str_ref is only used with scanner-validated buffers.
         let mode = FinalizationMode::Detached {
-            original_buf: &[],
+            original_buf: &self.original_buf,
             generated_buf: &self.string_buf,
             utf8_trusted: true,
         };
@@ -867,6 +890,68 @@ mod tests {
             result.is_err(),
             "finish_batch should fail for out-of-bounds StringRef"
         );
+    }
+
+    #[test]
+    fn zero_copy_original_buffer_round_trip() {
+        let input = b"helloworld";
+        let mut plan = BatchPlan::new();
+        let a = plan.declare_planned("a", FieldKind::Utf8View).unwrap();
+        let b_h = plan.declare_planned("b", FieldKind::Utf8View).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.set_original_buffer(input);
+        b.begin_row();
+        b.write_str_ref(a, StringRef { offset: 0, len: 5 });
+        b.write_str_ref(b_h, StringRef { offset: 5, len: 5 });
+        b.end_row();
+        b.begin_row();
+        b.write_str_ref(a, StringRef { offset: 5, len: 5 });
+        b.write_str_ref(b_h, StringRef { offset: 0, len: 5 });
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        let col_a = batch.column_by_name("a").unwrap().as_string::<i32>();
+        let col_b = batch.column_by_name("b").unwrap().as_string::<i32>();
+        assert_eq!(col_a.value(0), "hello");
+        assert_eq!(col_a.value(1), "world");
+        assert_eq!(col_b.value(0), "world");
+        assert_eq!(col_b.value(1), "hello");
+    }
+
+    #[test]
+    fn mixed_zero_copy_and_generated_strings() {
+        let input = b"from-input";
+        let mut plan = BatchPlan::new();
+        let ref_field = plan
+            .declare_planned("ref_field", FieldKind::Utf8View)
+            .unwrap();
+        let gen_field = plan
+            .declare_planned("gen_field", FieldKind::Utf8View)
+            .unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.set_original_buffer(input);
+        b.begin_row();
+        b.write_str_ref(ref_field, StringRef { offset: 0, len: 10 });
+        b.write_str(gen_field, "generated-value").unwrap();
+        b.end_row();
+        b.begin_row();
+        b.write_str(gen_field, "another-gen").unwrap();
+        b.write_str_ref(ref_field, StringRef { offset: 5, len: 5 });
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        let r = batch.column_by_name("ref_field").unwrap().as_string::<i32>();
+        let g = batch.column_by_name("gen_field").unwrap().as_string::<i32>();
+        assert_eq!(r.value(0), "from-input");
+        assert_eq!(r.value(1), "input");
+        assert_eq!(g.value(0), "generated-value");
+        assert_eq!(g.value(1), "another-gen");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -293,16 +293,19 @@ impl ColumnarBatchBuilder {
 
     /// Materialize all deferred facts into an Arrow `RecordBatch` (detached).
     ///
-    /// Copies string data into `StringBuilder` arrays. The builder's internal
-    /// buffers can be reused after this call.
+    /// Copies string data into contiguous `StringArray` arrays. The builder's
+    /// internal buffers can be reused after this call.
     pub fn finish_batch(&mut self) -> Result<RecordBatch, BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
         let num_rows = self.lifecycle.row_count() as usize;
 
         // Detached mode: string_buf is the "generated" buffer, no original.
+        // utf8_trusted: true because write_str takes &str (Rust guarantees UTF-8)
+        // and write_str_ref is only used with scanner-validated buffers.
         let mode = FinalizationMode::Detached {
             original_buf: &[],
             generated_buf: &self.string_buf,
+            utf8_trusted: true,
         };
 
         let result = self.materialize_all(num_rows, mode)?;

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -866,4 +866,341 @@ mod tests {
             "finish_batch should fail for out-of-bounds StringRef"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Performance validation: planned fields at scale
+    // -----------------------------------------------------------------------
+
+    /// OTLP-like workload: 15 planned fields, 1000 rows per batch, 10 batches.
+    /// Validates correctness at scale and prints timing for manual inspection.
+    #[test]
+    fn planned_fields_at_scale() {
+        let mut plan = BatchPlan::new();
+        let ts = plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap();
+        let sev_num = plan.declare_planned("severity_number", FieldKind::Int64).unwrap();
+        let sev_text = plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap();
+        let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
+        let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
+        let trace_id = plan.declare_planned("trace_id", FieldKind::Utf8View).unwrap();
+        let span_id = plan.declare_planned("span_id", FieldKind::Utf8View).unwrap();
+        let res_svc = plan.declare_planned("resource.service.name", FieldKind::Utf8View).unwrap();
+        let res_host = plan.declare_planned("resource.host.name", FieldKind::Utf8View).unwrap();
+        let scope_name = plan.declare_planned("scope.name", FieldKind::Utf8View).unwrap();
+        let scope_ver = plan.declare_planned("scope.version", FieldKind::Utf8View).unwrap();
+        let attr_method = plan.declare_planned("attributes.http.method", FieldKind::Utf8View).unwrap();
+        let attr_status = plan.declare_planned("attributes.http.status_code", FieldKind::Int64).unwrap();
+        let attr_dur = plan.declare_planned("attributes.duration_ms", FieldKind::Float64).unwrap();
+        let attr_path = plan.declare_planned("attributes.http.path", FieldKind::Utf8View).unwrap();
+
+        let handles_int = [ts, sev_num, flags, attr_status];
+        let handles_str = [sev_text, body, trace_id, span_id, res_svc, res_host,
+            scope_name, scope_ver, attr_method, attr_path];
+        let handles_float = [attr_dur];
+
+        let mut b = ColumnarBatchBuilder::new(plan);
+        let rows_per_batch: u32 = 1000;
+        let num_batches: u64 = 10;
+
+        let start = std::time::Instant::now();
+
+        for batch_idx in 0..num_batches {
+            b.begin_batch();
+            for row in 0..rows_per_batch {
+                b.begin_row();
+                let base = (batch_idx as i64) * (rows_per_batch as i64) + row as i64;
+                for (i, &h) in handles_int.iter().enumerate() {
+                    b.write_i64(h, base + i as i64 * 1000);
+                }
+                for &h in &handles_str {
+                    b.write_str(h, "example-value-0123456789").unwrap();
+                }
+                for &h in &handles_float {
+                    b.write_f64(h, base as f64 * 0.001);
+                }
+                b.end_row();
+            }
+            let batch = b.finish_batch().unwrap();
+            assert_eq!(batch.num_rows(), rows_per_batch as usize);
+            assert_eq!(batch.num_columns(), 15);
+        }
+
+        let elapsed = start.elapsed();
+        let total_rows = u64::from(rows_per_batch) * num_batches;
+        let rows_per_sec = total_rows as f64 / elapsed.as_secs_f64();
+
+        eprintln!(
+            "\n  planned_fields_at_scale: {} rows in {:.1?} ({:.0} rows/sec, {:.0} ns/row)\n",
+            total_rows,
+            elapsed,
+            rows_per_sec,
+            elapsed.as_nanos() as f64 / total_rows as f64,
+        );
+    }
+
+    /// Mixed planned + dynamic workload: OTLP canonical + arbitrary JSON attrs.
+    #[test]
+    fn mixed_planned_dynamic_at_scale() {
+        let mut plan = BatchPlan::new();
+        let ts = plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap();
+        let sev = plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap();
+        let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
+
+        let mut b = ColumnarBatchBuilder::new(plan);
+        let rows_per_batch: u32 = 1000;
+        let num_batches: u64 = 10;
+
+        let start = std::time::Instant::now();
+
+        for batch_idx in 0..num_batches {
+            b.begin_batch();
+            for row in 0..rows_per_batch {
+                b.begin_row();
+                let base = (batch_idx as i64) * (rows_per_batch as i64) + row as i64;
+                b.write_i64(ts, base);
+                b.write_str(sev, "INFO").unwrap();
+                b.write_str(body, "example log message for testing").unwrap();
+
+                // Dynamic attributes (vary by row)
+                let attr_key = match row % 5 {
+                    0 => "http.method",
+                    1 => "http.path",
+                    2 => "user.id",
+                    3 => "region",
+                    _ => "custom.tag",
+                };
+                let h = b.resolve_dynamic(attr_key, FieldKind::Utf8View).unwrap();
+                b.write_str(h, "dynamic-value-here").unwrap();
+
+                if row % 3 == 0 {
+                    let h2 = b.resolve_dynamic("http.status_code", FieldKind::Int64).unwrap();
+                    b.write_i64(h2, 200);
+                }
+
+                b.end_row();
+            }
+            let batch = b.finish_batch().unwrap();
+            assert_eq!(batch.num_rows(), rows_per_batch as usize);
+            // 3 planned + up to 6 dynamic fields
+            assert!(batch.num_columns() >= 3);
+        }
+
+        let elapsed = start.elapsed();
+        let total_rows = u64::from(rows_per_batch) * num_batches;
+        let rows_per_sec = total_rows as f64 / elapsed.as_secs_f64();
+
+        eprintln!(
+            "\n  mixed_planned_dynamic_at_scale: {} rows in {:.1?} ({:.0} rows/sec, {:.0} ns/row)\n",
+            total_rows,
+            elapsed,
+            rows_per_sec,
+            elapsed.as_nanos() as f64 / total_rows as f64,
+        );
+    }
+
+    /// Baseline: StreamingBuilder doing the same 15-field OTLP-like workload.
+    /// Uses detached path for apples-to-apples comparison.
+    #[test]
+    fn streaming_builder_baseline_at_scale() {
+        use crate::streaming_builder::StreamingBuilder;
+
+        let field_names: Vec<&str> = vec![
+            "timestamp_ns", "severity_number", "severity_text", "body",
+            "flags", "trace_id", "span_id", "resource.service.name",
+            "resource.host.name", "scope.name", "scope.version",
+            "attributes.http.method", "attributes.http.status_code",
+            "attributes.duration_ms", "attributes.http.path",
+        ];
+
+        let rows_per_batch: u32 = 1000;
+        let num_batches: u64 = 10;
+
+        let mut sb = StreamingBuilder::new(None);
+        let start = std::time::Instant::now();
+
+        for _batch_idx in 0..num_batches {
+            // StreamingBuilder needs a Bytes buffer for begin_batch
+            let dummy_buf = bytes::Bytes::from_static(b"");
+            sb.begin_batch(dummy_buf);
+
+            // Pre-resolve field indices
+            let indices: Vec<usize> = field_names
+                .iter()
+                .map(|name| sb.resolve_field(name.as_bytes()))
+                .collect();
+
+            for row in 0..rows_per_batch {
+                sb.begin_row();
+                // int fields: timestamp_ns, severity_number, flags, status_code
+                for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
+                    sb.append_i64_value_by_idx(idx, row as i64);
+                }
+                // str fields (10 of them) — use decoded path since strings
+                // aren't subslices of the input buffer (fair comparison)
+                for &idx in &[
+                    indices[2], indices[3], indices[5], indices[6], indices[7],
+                    indices[8], indices[9], indices[10], indices[11], indices[14],
+                ] {
+                    sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+                }
+                // float field: duration_ms
+                sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
+                sb.end_row();
+            }
+            let batch = sb.finish_batch_detached().unwrap();
+            assert_eq!(batch.num_rows(), rows_per_batch as usize);
+        }
+
+        let elapsed = start.elapsed();
+        let total_rows = u64::from(rows_per_batch) * num_batches;
+        let rows_per_sec = total_rows as f64 / elapsed.as_secs_f64();
+
+        eprintln!(
+            "\n  streaming_builder_baseline: {} rows in {:.1?} ({:.0} rows/sec, {:.0} ns/row)\n",
+            total_rows,
+            elapsed,
+            rows_per_sec,
+            elapsed.as_nanos() as f64 / total_rows as f64,
+        );
+    }
+
+    /// ColumnarBatchBuilder view finalization: same 15-field workload.
+    #[test]
+    fn planned_fields_view_at_scale() {
+        let mut plan = BatchPlan::new();
+        let ts = plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap();
+        let sev_num = plan.declare_planned("severity_number", FieldKind::Int64).unwrap();
+        let sev_text = plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap();
+        let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
+        let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
+        let trace_id = plan.declare_planned("trace_id", FieldKind::Utf8View).unwrap();
+        let span_id = plan.declare_planned("span_id", FieldKind::Utf8View).unwrap();
+        let res_svc = plan.declare_planned("resource.service.name", FieldKind::Utf8View).unwrap();
+        let res_host = plan.declare_planned("resource.host.name", FieldKind::Utf8View).unwrap();
+        let scope_name = plan.declare_planned("scope.name", FieldKind::Utf8View).unwrap();
+        let scope_ver = plan.declare_planned("scope.version", FieldKind::Utf8View).unwrap();
+        let attr_method = plan.declare_planned("attributes.http.method", FieldKind::Utf8View).unwrap();
+        let attr_status = plan.declare_planned("attributes.http.status_code", FieldKind::Int64).unwrap();
+        let attr_dur = plan.declare_planned("attributes.duration_ms", FieldKind::Float64).unwrap();
+        let attr_path = plan.declare_planned("attributes.http.path", FieldKind::Utf8View).unwrap();
+
+        let handles_int = [ts, sev_num, flags, attr_status];
+        let handles_str = [sev_text, body, trace_id, span_id, res_svc, res_host,
+            scope_name, scope_ver, attr_method, attr_path];
+        let handles_float = [attr_dur];
+
+        let mut b = ColumnarBatchBuilder::new(plan);
+        let rows_per_batch: u32 = 1000;
+        let num_batches: u64 = 10;
+
+        let start = std::time::Instant::now();
+
+        for batch_idx in 0..num_batches {
+            b.begin_batch();
+            for row in 0..rows_per_batch {
+                b.begin_row();
+                let base = (batch_idx as i64) * (rows_per_batch as i64) + row as i64;
+                for (i, &h) in handles_int.iter().enumerate() {
+                    b.write_i64(h, base + i as i64 * 1000);
+                }
+                for &h in &handles_str {
+                    b.write_str(h, "example-value-0123456789").unwrap();
+                }
+                for &h in &handles_float {
+                    b.write_f64(h, base as f64 * 0.001);
+                }
+                b.end_row();
+            }
+            let batch = b.finish_batch_view(
+                arrow::buffer::Buffer::from(b"" as &[u8]),
+                0,
+            ).unwrap();
+            assert_eq!(batch.num_rows(), rows_per_batch as usize);
+            assert_eq!(batch.num_columns(), 15);
+        }
+
+        let elapsed = start.elapsed();
+        let total_rows = u64::from(rows_per_batch) * num_batches;
+        let rows_per_sec = total_rows as f64 / elapsed.as_secs_f64();
+
+        eprintln!(
+            "\n  planned_fields_view: {} rows in {:.1?} ({:.0} rows/sec, {:.0} ns/row)\n",
+            total_rows,
+            elapsed,
+            rows_per_sec,
+            elapsed.as_nanos() as f64 / total_rows as f64,
+        );
+    }
+
+    /// StreamingBuilder view baseline: same 15-field workload.
+    #[test]
+    fn streaming_builder_view_baseline_at_scale() {
+        use crate::streaming_builder::StreamingBuilder;
+
+        let field_names: Vec<&str> = vec![
+            "timestamp_ns", "severity_number", "severity_text", "body",
+            "flags", "trace_id", "span_id", "resource.service.name",
+            "resource.host.name", "scope.name", "scope.version",
+            "attributes.http.method", "attributes.http.status_code",
+            "attributes.duration_ms", "attributes.http.path",
+        ];
+
+        let rows_per_batch: u32 = 1000;
+        let num_batches: u64 = 10;
+
+        let mut sb = StreamingBuilder::new(None);
+        let start = std::time::Instant::now();
+
+        for _batch_idx in 0..num_batches {
+            let dummy_buf = bytes::Bytes::from_static(b"");
+            sb.begin_batch(dummy_buf);
+
+            let indices: Vec<usize> = field_names
+                .iter()
+                .map(|name| sb.resolve_field(name.as_bytes()))
+                .collect();
+
+            for row in 0..rows_per_batch {
+                sb.begin_row();
+                for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
+                    sb.append_i64_value_by_idx(idx, row as i64);
+                }
+                for &idx in &[
+                    indices[2], indices[3], indices[5], indices[6], indices[7],
+                    indices[8], indices[9], indices[10], indices[11], indices[14],
+                ] {
+                    sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+                }
+                sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
+                sb.end_row();
+            }
+            let batch = sb.finish_batch().unwrap();
+            assert_eq!(batch.num_rows(), rows_per_batch as usize);
+        }
+
+        let elapsed = start.elapsed();
+        let total_rows = u64::from(rows_per_batch) * num_batches;
+        let rows_per_sec = total_rows as f64 / elapsed.as_secs_f64();
+
+        eprintln!(
+            "\n  streaming_builder_view_baseline: {} rows in {:.1?} ({:.0} rows/sec, {:.0} ns/row)\n",
+            total_rows,
+            elapsed,
+            rows_per_sec,
+            elapsed.as_nanos() as f64 / total_rows as f64,
+        );
+    }
+
+    /// Report type sizes for performance-critical structures.
+    #[test]
+    fn type_sizes() {
+        use super::super::accumulator::ColumnAccumulator;
+
+        eprintln!("\n  Type sizes:");
+        eprintln!("    ColumnAccumulator: {} bytes", size_of::<ColumnAccumulator>());
+        eprintln!("    ColumnarBatchBuilder: {} bytes", size_of::<ColumnarBatchBuilder>());
+        eprintln!("    FieldHandle: {} bytes", size_of::<FieldHandle>());
+        eprintln!("    FieldKind: {} bytes", size_of::<FieldKind>());
+        eprintln!("    StringRef: {} bytes", size_of::<StringRef>());
+        eprintln!("    BatchPlan: {} bytes\n", size_of::<BatchPlan>());
+    }
 }

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -15,9 +15,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, NullArray, StringBuilder,
-};
+use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, NullArray, StringBuilder};
 use arrow::buffer::{Buffer, NullBuffer};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
@@ -244,11 +242,7 @@ impl ColumnarBatchBuilder {
     ///
     /// Returns `Err` if the string buffer would exceed u32 addressable range.
     #[inline]
-    pub fn write_str(
-        &mut self,
-        handle: FieldHandle,
-        value: &str,
-    ) -> Result<(), BuilderError> {
+    pub fn write_str(&mut self, handle: FieldHandle, value: &str) -> Result<(), BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
         if self.is_duplicate(handle) {
@@ -260,11 +254,9 @@ impl ColumnarBatchBuilder {
                 value_len: value.len(),
             }
         })?;
-        let len = u32::try_from(value.len()).map_err(|_| {
-            BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: value.len(),
-            }
+        let len = u32::try_from(value.len()).map_err(|_| BuilderError::StringBufferOverflow {
+            buffer_len: self.string_buf.len(),
+            value_len: value.len(),
         })?;
         self.string_buf.extend_from_slice(value.as_bytes());
         let sref = StringRef { offset, len };
@@ -421,7 +413,10 @@ fn null_column(name: &str, kind: FieldKind, num_rows: usize) -> (Field, ArrayRef
             for _ in 0..num_rows {
                 builder.append_null();
             }
-            (Field::new(name, DataType::Utf8, true), Arc::new(builder.finish()))
+            (
+                Field::new(name, DataType::Utf8, true),
+                Arc::new(builder.finish()),
+            )
         }
         FieldKind::BinaryView | FieldKind::FixedBinary(_) => {
             let arr = NullArray::new(num_rows);
@@ -820,16 +815,20 @@ mod tests {
         b.begin_row();
         b.write_i64(ts, 1000);
         // Use str_ref pointing into the original buffer
-        b.write_str_ref(msg, super::super::accumulator::StringRef { offset: 0, len: 5 });
+        b.write_str_ref(
+            msg,
+            super::super::accumulator::StringRef { offset: 0, len: 5 },
+        );
         b.end_row();
         b.begin_row();
         b.write_i64(ts, 2000);
-        b.write_str_ref(msg, super::super::accumulator::StringRef { offset: 6, len: 5 });
+        b.write_str_ref(
+            msg,
+            super::super::accumulator::StringRef { offset: 6, len: 5 },
+        );
         b.end_row();
 
-        let batch = b
-            .finish_batch_view(arrow_buf, input.len() as u32)
-            .unwrap();
+        let batch = b.finish_batch_view(arrow_buf, input.len() as u32).unwrap();
         assert_eq!(batch.num_rows(), 2);
 
         let msg_col = batch.column_by_name("msg").unwrap();
@@ -876,25 +875,61 @@ mod tests {
     #[test]
     fn planned_fields_at_scale() {
         let mut plan = BatchPlan::new();
-        let ts = plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap();
-        let sev_num = plan.declare_planned("severity_number", FieldKind::Int64).unwrap();
-        let sev_text = plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap();
+        let ts = plan
+            .declare_planned("timestamp_ns", FieldKind::Int64)
+            .unwrap();
+        let sev_num = plan
+            .declare_planned("severity_number", FieldKind::Int64)
+            .unwrap();
+        let sev_text = plan
+            .declare_planned("severity_text", FieldKind::Utf8View)
+            .unwrap();
         let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
         let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
-        let trace_id = plan.declare_planned("trace_id", FieldKind::Utf8View).unwrap();
-        let span_id = plan.declare_planned("span_id", FieldKind::Utf8View).unwrap();
-        let res_svc = plan.declare_planned("resource.service.name", FieldKind::Utf8View).unwrap();
-        let res_host = plan.declare_planned("resource.host.name", FieldKind::Utf8View).unwrap();
-        let scope_name = plan.declare_planned("scope.name", FieldKind::Utf8View).unwrap();
-        let scope_ver = plan.declare_planned("scope.version", FieldKind::Utf8View).unwrap();
-        let attr_method = plan.declare_planned("attributes.http.method", FieldKind::Utf8View).unwrap();
-        let attr_status = plan.declare_planned("attributes.http.status_code", FieldKind::Int64).unwrap();
-        let attr_dur = plan.declare_planned("attributes.duration_ms", FieldKind::Float64).unwrap();
-        let attr_path = plan.declare_planned("attributes.http.path", FieldKind::Utf8View).unwrap();
+        let trace_id = plan
+            .declare_planned("trace_id", FieldKind::Utf8View)
+            .unwrap();
+        let span_id = plan
+            .declare_planned("span_id", FieldKind::Utf8View)
+            .unwrap();
+        let res_svc = plan
+            .declare_planned("resource.service.name", FieldKind::Utf8View)
+            .unwrap();
+        let res_host = plan
+            .declare_planned("resource.host.name", FieldKind::Utf8View)
+            .unwrap();
+        let scope_name = plan
+            .declare_planned("scope.name", FieldKind::Utf8View)
+            .unwrap();
+        let scope_ver = plan
+            .declare_planned("scope.version", FieldKind::Utf8View)
+            .unwrap();
+        let attr_method = plan
+            .declare_planned("attributes.http.method", FieldKind::Utf8View)
+            .unwrap();
+        let attr_status = plan
+            .declare_planned("attributes.http.status_code", FieldKind::Int64)
+            .unwrap();
+        let attr_dur = plan
+            .declare_planned("attributes.duration_ms", FieldKind::Float64)
+            .unwrap();
+        let attr_path = plan
+            .declare_planned("attributes.http.path", FieldKind::Utf8View)
+            .unwrap();
 
         let handles_int = [ts, sev_num, flags, attr_status];
-        let handles_str = [sev_text, body, trace_id, span_id, res_svc, res_host,
-            scope_name, scope_ver, attr_method, attr_path];
+        let handles_str = [
+            sev_text,
+            body,
+            trace_id,
+            span_id,
+            res_svc,
+            res_host,
+            scope_name,
+            scope_ver,
+            attr_method,
+            attr_path,
+        ];
         let handles_float = [attr_dur];
 
         let mut b = ColumnarBatchBuilder::new(plan);
@@ -941,8 +976,12 @@ mod tests {
     #[test]
     fn mixed_planned_dynamic_at_scale() {
         let mut plan = BatchPlan::new();
-        let ts = plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap();
-        let sev = plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap();
+        let ts = plan
+            .declare_planned("timestamp_ns", FieldKind::Int64)
+            .unwrap();
+        let sev = plan
+            .declare_planned("severity_text", FieldKind::Utf8View)
+            .unwrap();
         let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
 
         let mut b = ColumnarBatchBuilder::new(plan);
@@ -958,7 +997,8 @@ mod tests {
                 let base = (batch_idx as i64) * (rows_per_batch as i64) + row as i64;
                 b.write_i64(ts, base);
                 b.write_str(sev, "INFO").unwrap();
-                b.write_str(body, "example log message for testing").unwrap();
+                b.write_str(body, "example log message for testing")
+                    .unwrap();
 
                 // Dynamic attributes (vary by row)
                 let attr_key = match row % 5 {
@@ -972,7 +1012,9 @@ mod tests {
                 b.write_str(h, "dynamic-value-here").unwrap();
 
                 if row % 3 == 0 {
-                    let h2 = b.resolve_dynamic("http.status_code", FieldKind::Int64).unwrap();
+                    let h2 = b
+                        .resolve_dynamic("http.status_code", FieldKind::Int64)
+                        .unwrap();
                     b.write_i64(h2, 200);
                 }
 
@@ -1004,11 +1046,21 @@ mod tests {
         use crate::streaming_builder::StreamingBuilder;
 
         let field_names: Vec<&str> = vec![
-            "timestamp_ns", "severity_number", "severity_text", "body",
-            "flags", "trace_id", "span_id", "resource.service.name",
-            "resource.host.name", "scope.name", "scope.version",
-            "attributes.http.method", "attributes.http.status_code",
-            "attributes.duration_ms", "attributes.http.path",
+            "timestamp_ns",
+            "severity_number",
+            "severity_text",
+            "body",
+            "flags",
+            "trace_id",
+            "span_id",
+            "resource.service.name",
+            "resource.host.name",
+            "scope.name",
+            "scope.version",
+            "attributes.http.method",
+            "attributes.http.status_code",
+            "attributes.duration_ms",
+            "attributes.http.path",
         ];
 
         let rows_per_batch: u32 = 1000;
@@ -1037,8 +1089,16 @@ mod tests {
                 // str fields (10 of them) — use decoded path since strings
                 // aren't subslices of the input buffer (fair comparison)
                 for &idx in &[
-                    indices[2], indices[3], indices[5], indices[6], indices[7],
-                    indices[8], indices[9], indices[10], indices[11], indices[14],
+                    indices[2],
+                    indices[3],
+                    indices[5],
+                    indices[6],
+                    indices[7],
+                    indices[8],
+                    indices[9],
+                    indices[10],
+                    indices[11],
+                    indices[14],
                 ] {
                     sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
                 }
@@ -1067,25 +1127,61 @@ mod tests {
     #[test]
     fn planned_fields_view_at_scale() {
         let mut plan = BatchPlan::new();
-        let ts = plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap();
-        let sev_num = plan.declare_planned("severity_number", FieldKind::Int64).unwrap();
-        let sev_text = plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap();
+        let ts = plan
+            .declare_planned("timestamp_ns", FieldKind::Int64)
+            .unwrap();
+        let sev_num = plan
+            .declare_planned("severity_number", FieldKind::Int64)
+            .unwrap();
+        let sev_text = plan
+            .declare_planned("severity_text", FieldKind::Utf8View)
+            .unwrap();
         let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
         let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
-        let trace_id = plan.declare_planned("trace_id", FieldKind::Utf8View).unwrap();
-        let span_id = plan.declare_planned("span_id", FieldKind::Utf8View).unwrap();
-        let res_svc = plan.declare_planned("resource.service.name", FieldKind::Utf8View).unwrap();
-        let res_host = plan.declare_planned("resource.host.name", FieldKind::Utf8View).unwrap();
-        let scope_name = plan.declare_planned("scope.name", FieldKind::Utf8View).unwrap();
-        let scope_ver = plan.declare_planned("scope.version", FieldKind::Utf8View).unwrap();
-        let attr_method = plan.declare_planned("attributes.http.method", FieldKind::Utf8View).unwrap();
-        let attr_status = plan.declare_planned("attributes.http.status_code", FieldKind::Int64).unwrap();
-        let attr_dur = plan.declare_planned("attributes.duration_ms", FieldKind::Float64).unwrap();
-        let attr_path = plan.declare_planned("attributes.http.path", FieldKind::Utf8View).unwrap();
+        let trace_id = plan
+            .declare_planned("trace_id", FieldKind::Utf8View)
+            .unwrap();
+        let span_id = plan
+            .declare_planned("span_id", FieldKind::Utf8View)
+            .unwrap();
+        let res_svc = plan
+            .declare_planned("resource.service.name", FieldKind::Utf8View)
+            .unwrap();
+        let res_host = plan
+            .declare_planned("resource.host.name", FieldKind::Utf8View)
+            .unwrap();
+        let scope_name = plan
+            .declare_planned("scope.name", FieldKind::Utf8View)
+            .unwrap();
+        let scope_ver = plan
+            .declare_planned("scope.version", FieldKind::Utf8View)
+            .unwrap();
+        let attr_method = plan
+            .declare_planned("attributes.http.method", FieldKind::Utf8View)
+            .unwrap();
+        let attr_status = plan
+            .declare_planned("attributes.http.status_code", FieldKind::Int64)
+            .unwrap();
+        let attr_dur = plan
+            .declare_planned("attributes.duration_ms", FieldKind::Float64)
+            .unwrap();
+        let attr_path = plan
+            .declare_planned("attributes.http.path", FieldKind::Utf8View)
+            .unwrap();
 
         let handles_int = [ts, sev_num, flags, attr_status];
-        let handles_str = [sev_text, body, trace_id, span_id, res_svc, res_host,
-            scope_name, scope_ver, attr_method, attr_path];
+        let handles_str = [
+            sev_text,
+            body,
+            trace_id,
+            span_id,
+            res_svc,
+            res_host,
+            scope_name,
+            scope_ver,
+            attr_method,
+            attr_path,
+        ];
         let handles_float = [attr_dur];
 
         let mut b = ColumnarBatchBuilder::new(plan);
@@ -1110,10 +1206,9 @@ mod tests {
                 }
                 b.end_row();
             }
-            let batch = b.finish_batch_view(
-                arrow::buffer::Buffer::from(b"" as &[u8]),
-                0,
-            ).unwrap();
+            let batch = b
+                .finish_batch_view(arrow::buffer::Buffer::from(b"" as &[u8]), 0)
+                .unwrap();
             assert_eq!(batch.num_rows(), rows_per_batch as usize);
             assert_eq!(batch.num_columns(), 15);
         }
@@ -1137,11 +1232,21 @@ mod tests {
         use crate::streaming_builder::StreamingBuilder;
 
         let field_names: Vec<&str> = vec![
-            "timestamp_ns", "severity_number", "severity_text", "body",
-            "flags", "trace_id", "span_id", "resource.service.name",
-            "resource.host.name", "scope.name", "scope.version",
-            "attributes.http.method", "attributes.http.status_code",
-            "attributes.duration_ms", "attributes.http.path",
+            "timestamp_ns",
+            "severity_number",
+            "severity_text",
+            "body",
+            "flags",
+            "trace_id",
+            "span_id",
+            "resource.service.name",
+            "resource.host.name",
+            "scope.name",
+            "scope.version",
+            "attributes.http.method",
+            "attributes.http.status_code",
+            "attributes.duration_ms",
+            "attributes.http.path",
         ];
 
         let rows_per_batch: u32 = 1000;
@@ -1165,8 +1270,16 @@ mod tests {
                     sb.append_i64_value_by_idx(idx, row as i64);
                 }
                 for &idx in &[
-                    indices[2], indices[3], indices[5], indices[6], indices[7],
-                    indices[8], indices[9], indices[10], indices[11], indices[14],
+                    indices[2],
+                    indices[3],
+                    indices[5],
+                    indices[6],
+                    indices[7],
+                    indices[8],
+                    indices[9],
+                    indices[10],
+                    indices[11],
+                    indices[14],
                 ] {
                     sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
                 }
@@ -1196,8 +1309,14 @@ mod tests {
         use super::super::accumulator::ColumnAccumulator;
 
         eprintln!("\n  Type sizes:");
-        eprintln!("    ColumnAccumulator: {} bytes", size_of::<ColumnAccumulator>());
-        eprintln!("    ColumnarBatchBuilder: {} bytes", size_of::<ColumnarBatchBuilder>());
+        eprintln!(
+            "    ColumnAccumulator: {} bytes",
+            size_of::<ColumnAccumulator>()
+        );
+        eprintln!(
+            "    ColumnarBatchBuilder: {} bytes",
+            size_of::<ColumnarBatchBuilder>()
+        );
         eprintln!("    FieldHandle: {} bytes", size_of::<FieldHandle>());
         eprintln!("    FieldKind: {} bytes", size_of::<FieldKind>());
         eprintln!("    StringRef: {} bytes", size_of::<StringRef>());
@@ -1208,25 +1327,61 @@ mod tests {
     #[test]
     fn cpu_breakdown_write_vs_materialize() {
         let mut plan = BatchPlan::new();
-        let ts = plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap();
-        let sev_num = plan.declare_planned("severity_number", FieldKind::Int64).unwrap();
-        let sev_text = plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap();
+        let ts = plan
+            .declare_planned("timestamp_ns", FieldKind::Int64)
+            .unwrap();
+        let sev_num = plan
+            .declare_planned("severity_number", FieldKind::Int64)
+            .unwrap();
+        let sev_text = plan
+            .declare_planned("severity_text", FieldKind::Utf8View)
+            .unwrap();
         let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
         let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
-        let trace_id = plan.declare_planned("trace_id", FieldKind::Utf8View).unwrap();
-        let span_id = plan.declare_planned("span_id", FieldKind::Utf8View).unwrap();
-        let res_svc = plan.declare_planned("resource.service.name", FieldKind::Utf8View).unwrap();
-        let res_host = plan.declare_planned("resource.host.name", FieldKind::Utf8View).unwrap();
-        let scope_name = plan.declare_planned("scope.name", FieldKind::Utf8View).unwrap();
-        let scope_ver = plan.declare_planned("scope.version", FieldKind::Utf8View).unwrap();
-        let attr_method = plan.declare_planned("attributes.http.method", FieldKind::Utf8View).unwrap();
-        let attr_status = plan.declare_planned("attributes.http.status_code", FieldKind::Int64).unwrap();
-        let attr_dur = plan.declare_planned("attributes.duration_ms", FieldKind::Float64).unwrap();
-        let attr_path = plan.declare_planned("attributes.http.path", FieldKind::Utf8View).unwrap();
+        let trace_id = plan
+            .declare_planned("trace_id", FieldKind::Utf8View)
+            .unwrap();
+        let span_id = plan
+            .declare_planned("span_id", FieldKind::Utf8View)
+            .unwrap();
+        let res_svc = plan
+            .declare_planned("resource.service.name", FieldKind::Utf8View)
+            .unwrap();
+        let res_host = plan
+            .declare_planned("resource.host.name", FieldKind::Utf8View)
+            .unwrap();
+        let scope_name = plan
+            .declare_planned("scope.name", FieldKind::Utf8View)
+            .unwrap();
+        let scope_ver = plan
+            .declare_planned("scope.version", FieldKind::Utf8View)
+            .unwrap();
+        let attr_method = plan
+            .declare_planned("attributes.http.method", FieldKind::Utf8View)
+            .unwrap();
+        let attr_status = plan
+            .declare_planned("attributes.http.status_code", FieldKind::Int64)
+            .unwrap();
+        let attr_dur = plan
+            .declare_planned("attributes.duration_ms", FieldKind::Float64)
+            .unwrap();
+        let attr_path = plan
+            .declare_planned("attributes.http.path", FieldKind::Utf8View)
+            .unwrap();
 
         let handles_int = [ts, sev_num, flags, attr_status];
-        let handles_str = [sev_text, body, trace_id, span_id, res_svc, res_host,
-            scope_name, scope_ver, attr_method, attr_path];
+        let handles_str = [
+            sev_text,
+            body,
+            trace_id,
+            span_id,
+            res_svc,
+            res_host,
+            scope_name,
+            scope_ver,
+            attr_method,
+            attr_path,
+        ];
         let handles_float = [attr_dur];
 
         let mut b = ColumnarBatchBuilder::new(plan);

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -119,6 +119,10 @@ pub struct ColumnarBatchBuilder {
     /// When false, skip per-field dedup checks (producers that guarantee
     /// at most one write per field per row can disable for throughput).
     dedup_enabled: bool,
+    /// When true (default), string materialization produces zero-copy
+    /// `StringViewArray` using `new_unchecked`. When false, produces
+    /// validated `StringArray` with full UTF-8 checking.
+    utf8_trusted: bool,
 }
 
 impl ColumnarBatchBuilder {
@@ -140,6 +144,7 @@ impl ColumnarBatchBuilder {
             original_buf: Buffer::from(Vec::<u8>::new()),
             string_buf: Vec::new(),
             dedup_enabled: true,
+            utf8_trusted: true,
         }
     }
 
@@ -151,6 +156,22 @@ impl ColumnarBatchBuilder {
     /// values are recorded and the second silently wins at materialization.
     pub fn set_dedup_enabled(&mut self, enabled: bool) {
         self.dedup_enabled = enabled;
+    }
+
+    /// Control UTF-8 trust level for string materialization.
+    ///
+    /// When `true` (the default), string columns are materialized as zero-copy
+    /// `StringViewArray` using `new_unchecked`. This is safe when all string
+    /// data comes from trusted boundaries:
+    /// - `write_str(&str)` — Rust's type system guarantees UTF-8.
+    /// - `write_str_ref` — caller guarantees the referenced buffer is valid
+    ///   UTF-8 (e.g., scanner-validated input, OTLP decoder output).
+    ///
+    /// When `false`, strings are copied into a validated `StringArray` with
+    /// full UTF-8 checking. Use this for untrusted producers where the
+    /// referenced buffer may contain arbitrary bytes.
+    pub fn set_utf8_trusted(&mut self, trusted: bool) {
+        self.utf8_trusted = trusted;
     }
 
     /// Start a new batch.
@@ -194,6 +215,12 @@ impl ColumnarBatchBuilder {
     ///
     /// This is the runtime field-discovery path for JSON/CRI-style producers.
     /// Returns a stable handle that can be used for writes in the current row.
+    ///
+    /// Dynamically resolved fields grow the plan and column storage
+    /// monotonically — `begin_batch` clears all column data but does not
+    /// remove columns. This means the schema can grow across batches but
+    /// never shrinks. A future schema-reset API can be added if producers
+    /// need to discard stale dynamic fields between batches.
     pub fn resolve_dynamic(
         &mut self,
         name: &str,
@@ -214,7 +241,9 @@ impl ColumnarBatchBuilder {
     /// Check if a write to `handle` in the current row is a duplicate.
     ///
     /// Returns `true` if the write should be suppressed (duplicate).
-    /// For fields 0–63, uses the bitmask. For fields ≥64, uses last_row.
+    /// For fields 0–63, uses the O(1) bitmask in `RowLifecycle`.
+    /// For fields ≥64, falls back to per-column `last_row` tracking.
+    /// Both paths are correct; the bitmask path is faster for common cases.
     #[inline]
     fn is_duplicate(&mut self, handle: FieldHandle) -> bool {
         let idx = handle.index();
@@ -322,10 +351,13 @@ impl ColumnarBatchBuilder {
         self.columns[handle.index()].push_str(self.lifecycle.row_count(), sref);
     }
 
-    /// Write a null for the given field in the current row.
+    /// Record that a field is explicitly null for the current row.
     ///
-    /// Sparse fields are null by default; this just marks the field as
-    /// written for dedup purposes.
+    /// Sparse fields default to null for rows with no writes, so this is only
+    /// needed to consume the dedup slot (preventing a later non-null write from
+    /// being recorded). When dedup is disabled, this is a no-op — the field
+    /// remains whatever it was before (null if unwritten, or the prior value
+    /// if already written in this row).
     #[inline]
     pub fn write_null(&mut self, handle: FieldHandle) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
@@ -353,12 +385,10 @@ impl ColumnarBatchBuilder {
         let original = std::mem::replace(&mut self.original_buf, Buffer::from(Vec::<u8>::new()));
         let generated = Buffer::from_vec(std::mem::take(&mut self.string_buf));
 
-        // utf8_trusted: true because write_str takes &str (Rust guarantees UTF-8)
-        // and write_str_ref is only used with scanner-validated buffers.
         let mode = FinalizationMode {
             original_buf: original,
             generated_buf: generated,
-            utf8_trusted: true,
+            utf8_trusted: self.utf8_trusted,
         };
 
         let result = self.materialize_all(num_rows, mode)?;

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -377,7 +377,7 @@ impl ColumnarBatchBuilder {
 
         for (handle, name, field_mode) in self.plan.fields() {
             let col = &self.columns[handle.index()];
-            match col.materialize(name, num_rows, mode.clone())? {
+            match col.materialize(name, num_rows, mode.clone(), self.dedup_enabled)? {
                 Some((field, array)) => {
                     schema_fields.push(field);
                     arrays.push(array);

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -347,7 +347,7 @@ impl ColumnarBatchBuilder {
 
         // utf8_trusted: true because write_str takes &str (Rust guarantees UTF-8)
         // and write_str_ref is only used with scanner-validated buffers.
-        let mode = FinalizationMode::Detached {
+        let mode = FinalizationMode {
             original_buf: original,
             generated_buf: generated,
             utf8_trusted: true,
@@ -358,37 +358,7 @@ impl ColumnarBatchBuilder {
         Ok(result)
     }
 
-    /// Materialize with zero-copy StringViewArray.
-    ///
-    /// `original` is the input buffer (e.g., protobuf wire bytes).
-    /// `original_len` is the length of the original buffer.
-    /// Strings with `offset < original_len` reference the original buffer;
-    /// strings with `offset >= original_len` reference the generated buffer.
-    pub fn finish_batch_view(
-        &mut self,
-        original: Buffer,
-        original_len: u32,
-    ) -> Result<RecordBatch, BuilderError> {
-        debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
-        let num_rows = self.lifecycle.row_count() as usize;
-
-        let generated = if self.string_buf.is_empty() {
-            None
-        } else {
-            Some(Buffer::from(self.string_buf.as_slice()))
-        };
-        let mode = FinalizationMode::View {
-            original,
-            original_len,
-            generated,
-        };
-
-        let result = self.materialize_all(num_rows, mode)?;
-        self.lifecycle.finish_batch();
-        Ok(result)
-    }
-
-    /// Core materialization shared by both detached and view paths.
+    /// Core materialization — shared by all finalization paths.
     fn materialize_all(
         &self,
         num_rows: usize,
@@ -486,6 +456,73 @@ mod tests {
         let val = plan.declare_planned("value", FieldKind::Float64).unwrap();
         let builder = ColumnarBatchBuilder::new(plan);
         (builder, ts, sev, val)
+    }
+
+    /// OTLP-like 15-field plan for scale tests (4 int, 10 str, 1 float).
+    struct OtlpHandles {
+        int_handles: [FieldHandle; 4],
+        str_handles: [FieldHandle; 10],
+        float_handles: [FieldHandle; 1],
+    }
+
+    fn make_otlp_plan() -> (ColumnarBatchBuilder, OtlpHandles) {
+        let mut plan = BatchPlan::new();
+        let int_handles: [FieldHandle; 4] = [
+            plan.declare_planned("timestamp_ns", FieldKind::Int64)
+                .unwrap(),
+            plan.declare_planned("severity_number", FieldKind::Int64)
+                .unwrap(),
+            plan.declare_planned("flags", FieldKind::Int64).unwrap(),
+            plan.declare_planned("attributes.http.status_code", FieldKind::Int64)
+                .unwrap(),
+        ];
+        let str_handles: [FieldHandle; 10] = [
+            plan.declare_planned("severity_text", FieldKind::Utf8View)
+                .unwrap(),
+            plan.declare_planned("body", FieldKind::Utf8View).unwrap(),
+            plan.declare_planned("trace_id", FieldKind::Utf8View)
+                .unwrap(),
+            plan.declare_planned("span_id", FieldKind::Utf8View)
+                .unwrap(),
+            plan.declare_planned("resource.service.name", FieldKind::Utf8View)
+                .unwrap(),
+            plan.declare_planned("resource.host.name", FieldKind::Utf8View)
+                .unwrap(),
+            plan.declare_planned("scope.name", FieldKind::Utf8View)
+                .unwrap(),
+            plan.declare_planned("scope.version", FieldKind::Utf8View)
+                .unwrap(),
+            plan.declare_planned("attributes.http.method", FieldKind::Utf8View)
+                .unwrap(),
+            plan.declare_planned("attributes.http.path", FieldKind::Utf8View)
+                .unwrap(),
+        ];
+        let float_handles: [FieldHandle; 1] = [plan
+            .declare_planned("attributes.duration_ms", FieldKind::Float64)
+            .unwrap()];
+
+        (
+            ColumnarBatchBuilder::new(plan),
+            OtlpHandles {
+                int_handles,
+                str_handles,
+                float_handles,
+            },
+        )
+    }
+
+    fn write_otlp_row(b: &mut ColumnarBatchBuilder, h: &OtlpHandles, base: i64) {
+        b.begin_row();
+        for (i, &handle) in h.int_handles.iter().enumerate() {
+            b.write_i64(handle, base + i as i64 * 1000);
+        }
+        for &handle in &h.str_handles {
+            b.write_str(handle, "example-value-0123456789").unwrap();
+        }
+        for &handle in &h.float_handles {
+            b.write_f64(handle, base as f64 * 0.001);
+        }
+        b.end_row();
     }
 
     // -----------------------------------------------------------------------
@@ -839,37 +876,30 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // View mode finalization
+    // Zero-copy finalization via set_original_buffer
     // -----------------------------------------------------------------------
 
     #[test]
-    fn finish_batch_view_produces_string_view_array() {
+    fn original_buffer_produces_string_view_array() {
         let mut plan = BatchPlan::new();
         let ts = plan.declare_planned("ts", FieldKind::Int64).unwrap();
         let msg = plan.declare_planned("msg", FieldKind::Utf8View).unwrap();
         let mut b = ColumnarBatchBuilder::new(plan);
 
         let input = b"hello world";
-        let arrow_buf = Buffer::from(&input[..]);
 
         b.begin_batch();
+        b.set_original_buffer(input);
         b.begin_row();
         b.write_i64(ts, 1000);
-        // Use str_ref pointing into the original buffer
-        b.write_str_ref(
-            msg,
-            super::super::accumulator::StringRef { offset: 0, len: 5 },
-        );
+        b.write_str_ref(msg, StringRef { offset: 0, len: 5 });
         b.end_row();
         b.begin_row();
         b.write_i64(ts, 2000);
-        b.write_str_ref(
-            msg,
-            super::super::accumulator::StringRef { offset: 6, len: 5 },
-        );
+        b.write_str_ref(msg, StringRef { offset: 6, len: 5 });
         b.end_row();
 
-        let batch = b.finish_batch_view(arrow_buf, input.len() as u32).unwrap();
+        let batch = b.finish_batch().unwrap();
         assert_eq!(batch.num_rows(), 2);
 
         let msg_col = batch.column_by_name("msg").unwrap();
@@ -893,7 +923,7 @@ mod tests {
         // Write a str_ref pointing beyond any valid buffer
         b.write_str_ref(
             msg,
-            super::super::accumulator::StringRef {
+            StringRef {
                 offset: 9999,
                 len: 10,
             },
@@ -977,65 +1007,7 @@ mod tests {
     /// Validates correctness at scale and prints timing for manual inspection.
     #[test]
     fn planned_fields_at_scale() {
-        let mut plan = BatchPlan::new();
-        let ts = plan
-            .declare_planned("timestamp_ns", FieldKind::Int64)
-            .unwrap();
-        let sev_num = plan
-            .declare_planned("severity_number", FieldKind::Int64)
-            .unwrap();
-        let sev_text = plan
-            .declare_planned("severity_text", FieldKind::Utf8View)
-            .unwrap();
-        let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
-        let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
-        let trace_id = plan
-            .declare_planned("trace_id", FieldKind::Utf8View)
-            .unwrap();
-        let span_id = plan
-            .declare_planned("span_id", FieldKind::Utf8View)
-            .unwrap();
-        let res_svc = plan
-            .declare_planned("resource.service.name", FieldKind::Utf8View)
-            .unwrap();
-        let res_host = plan
-            .declare_planned("resource.host.name", FieldKind::Utf8View)
-            .unwrap();
-        let scope_name = plan
-            .declare_planned("scope.name", FieldKind::Utf8View)
-            .unwrap();
-        let scope_ver = plan
-            .declare_planned("scope.version", FieldKind::Utf8View)
-            .unwrap();
-        let attr_method = plan
-            .declare_planned("attributes.http.method", FieldKind::Utf8View)
-            .unwrap();
-        let attr_status = plan
-            .declare_planned("attributes.http.status_code", FieldKind::Int64)
-            .unwrap();
-        let attr_dur = plan
-            .declare_planned("attributes.duration_ms", FieldKind::Float64)
-            .unwrap();
-        let attr_path = plan
-            .declare_planned("attributes.http.path", FieldKind::Utf8View)
-            .unwrap();
-
-        let handles_int = [ts, sev_num, flags, attr_status];
-        let handles_str = [
-            sev_text,
-            body,
-            trace_id,
-            span_id,
-            res_svc,
-            res_host,
-            scope_name,
-            scope_ver,
-            attr_method,
-            attr_path,
-        ];
-        let handles_float = [attr_dur];
-
-        let mut b = ColumnarBatchBuilder::new(plan);
+        let (mut b, h) = make_otlp_plan();
         let rows_per_batch: u32 = 1000;
         let num_batches: u64 = 10;
 
@@ -1044,18 +1016,8 @@ mod tests {
         for batch_idx in 0..num_batches {
             b.begin_batch();
             for row in 0..rows_per_batch {
-                b.begin_row();
                 let base = (batch_idx as i64) * (rows_per_batch as i64) + row as i64;
-                for (i, &h) in handles_int.iter().enumerate() {
-                    b.write_i64(h, base + i as i64 * 1000);
-                }
-                for &h in &handles_str {
-                    b.write_str(h, "example-value-0123456789").unwrap();
-                }
-                for &h in &handles_float {
-                    b.write_f64(h, base as f64 * 0.001);
-                }
-                b.end_row();
+                write_otlp_row(&mut b, &h, base);
             }
             let batch = b.finish_batch().unwrap();
             assert_eq!(batch.num_rows(), rows_per_batch as usize);
@@ -1226,186 +1188,6 @@ mod tests {
         );
     }
 
-    /// ColumnarBatchBuilder view finalization: same 15-field workload.
-    #[test]
-    fn planned_fields_view_at_scale() {
-        let mut plan = BatchPlan::new();
-        let ts = plan
-            .declare_planned("timestamp_ns", FieldKind::Int64)
-            .unwrap();
-        let sev_num = plan
-            .declare_planned("severity_number", FieldKind::Int64)
-            .unwrap();
-        let sev_text = plan
-            .declare_planned("severity_text", FieldKind::Utf8View)
-            .unwrap();
-        let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
-        let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
-        let trace_id = plan
-            .declare_planned("trace_id", FieldKind::Utf8View)
-            .unwrap();
-        let span_id = plan
-            .declare_planned("span_id", FieldKind::Utf8View)
-            .unwrap();
-        let res_svc = plan
-            .declare_planned("resource.service.name", FieldKind::Utf8View)
-            .unwrap();
-        let res_host = plan
-            .declare_planned("resource.host.name", FieldKind::Utf8View)
-            .unwrap();
-        let scope_name = plan
-            .declare_planned("scope.name", FieldKind::Utf8View)
-            .unwrap();
-        let scope_ver = plan
-            .declare_planned("scope.version", FieldKind::Utf8View)
-            .unwrap();
-        let attr_method = plan
-            .declare_planned("attributes.http.method", FieldKind::Utf8View)
-            .unwrap();
-        let attr_status = plan
-            .declare_planned("attributes.http.status_code", FieldKind::Int64)
-            .unwrap();
-        let attr_dur = plan
-            .declare_planned("attributes.duration_ms", FieldKind::Float64)
-            .unwrap();
-        let attr_path = plan
-            .declare_planned("attributes.http.path", FieldKind::Utf8View)
-            .unwrap();
-
-        let handles_int = [ts, sev_num, flags, attr_status];
-        let handles_str = [
-            sev_text,
-            body,
-            trace_id,
-            span_id,
-            res_svc,
-            res_host,
-            scope_name,
-            scope_ver,
-            attr_method,
-            attr_path,
-        ];
-        let handles_float = [attr_dur];
-
-        let mut b = ColumnarBatchBuilder::new(plan);
-        let rows_per_batch: u32 = 1000;
-        let num_batches: u64 = 10;
-
-        let start = std::time::Instant::now();
-
-        for batch_idx in 0..num_batches {
-            b.begin_batch();
-            for row in 0..rows_per_batch {
-                b.begin_row();
-                let base = (batch_idx as i64) * (rows_per_batch as i64) + row as i64;
-                for (i, &h) in handles_int.iter().enumerate() {
-                    b.write_i64(h, base + i as i64 * 1000);
-                }
-                for &h in &handles_str {
-                    b.write_str(h, "example-value-0123456789").unwrap();
-                }
-                for &h in &handles_float {
-                    b.write_f64(h, base as f64 * 0.001);
-                }
-                b.end_row();
-            }
-            let batch = b
-                .finish_batch_view(arrow::buffer::Buffer::from(b"" as &[u8]), 0)
-                .unwrap();
-            assert_eq!(batch.num_rows(), rows_per_batch as usize);
-            assert_eq!(batch.num_columns(), 15);
-        }
-
-        let elapsed = start.elapsed();
-        let total_rows = u64::from(rows_per_batch) * num_batches;
-        let rows_per_sec = total_rows as f64 / elapsed.as_secs_f64();
-
-        eprintln!(
-            "\n  planned_fields_view: {} rows in {:.1?} ({:.0} rows/sec, {:.0} ns/row)\n",
-            total_rows,
-            elapsed,
-            rows_per_sec,
-            elapsed.as_nanos() as f64 / total_rows as f64,
-        );
-    }
-
-    /// StreamingBuilder view baseline: same 15-field workload.
-    #[test]
-    fn streaming_builder_view_baseline_at_scale() {
-        use crate::streaming_builder::StreamingBuilder;
-
-        let field_names: Vec<&str> = vec![
-            "timestamp_ns",
-            "severity_number",
-            "severity_text",
-            "body",
-            "flags",
-            "trace_id",
-            "span_id",
-            "resource.service.name",
-            "resource.host.name",
-            "scope.name",
-            "scope.version",
-            "attributes.http.method",
-            "attributes.http.status_code",
-            "attributes.duration_ms",
-            "attributes.http.path",
-        ];
-
-        let rows_per_batch: u32 = 1000;
-        let num_batches: u64 = 10;
-
-        let mut sb = StreamingBuilder::new(None);
-        let start = std::time::Instant::now();
-
-        for _batch_idx in 0..num_batches {
-            let dummy_buf = bytes::Bytes::from_static(b"");
-            sb.begin_batch(dummy_buf);
-
-            let indices: Vec<usize> = field_names
-                .iter()
-                .map(|name| sb.resolve_field(name.as_bytes()))
-                .collect();
-
-            for row in 0..rows_per_batch {
-                sb.begin_row();
-                for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
-                    sb.append_i64_value_by_idx(idx, row as i64);
-                }
-                for &idx in &[
-                    indices[2],
-                    indices[3],
-                    indices[5],
-                    indices[6],
-                    indices[7],
-                    indices[8],
-                    indices[9],
-                    indices[10],
-                    indices[11],
-                    indices[14],
-                ] {
-                    sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
-                }
-                sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
-                sb.end_row();
-            }
-            let batch = sb.finish_batch().unwrap();
-            assert_eq!(batch.num_rows(), rows_per_batch as usize);
-        }
-
-        let elapsed = start.elapsed();
-        let total_rows = u64::from(rows_per_batch) * num_batches;
-        let rows_per_sec = total_rows as f64 / elapsed.as_secs_f64();
-
-        eprintln!(
-            "\n  streaming_builder_view_baseline: {} rows in {:.1?} ({:.0} rows/sec, {:.0} ns/row)\n",
-            total_rows,
-            elapsed,
-            rows_per_sec,
-            elapsed.as_nanos() as f64 / total_rows as f64,
-        );
-    }
-
     /// Report type sizes for performance-critical structures.
     #[test]
     fn type_sizes() {
@@ -1429,82 +1211,14 @@ mod tests {
     /// CPU breakdown: write phase vs materialization phase.
     #[test]
     fn cpu_breakdown_write_vs_materialize() {
-        let mut plan = BatchPlan::new();
-        let ts = plan
-            .declare_planned("timestamp_ns", FieldKind::Int64)
-            .unwrap();
-        let sev_num = plan
-            .declare_planned("severity_number", FieldKind::Int64)
-            .unwrap();
-        let sev_text = plan
-            .declare_planned("severity_text", FieldKind::Utf8View)
-            .unwrap();
-        let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
-        let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
-        let trace_id = plan
-            .declare_planned("trace_id", FieldKind::Utf8View)
-            .unwrap();
-        let span_id = plan
-            .declare_planned("span_id", FieldKind::Utf8View)
-            .unwrap();
-        let res_svc = plan
-            .declare_planned("resource.service.name", FieldKind::Utf8View)
-            .unwrap();
-        let res_host = plan
-            .declare_planned("resource.host.name", FieldKind::Utf8View)
-            .unwrap();
-        let scope_name = plan
-            .declare_planned("scope.name", FieldKind::Utf8View)
-            .unwrap();
-        let scope_ver = plan
-            .declare_planned("scope.version", FieldKind::Utf8View)
-            .unwrap();
-        let attr_method = plan
-            .declare_planned("attributes.http.method", FieldKind::Utf8View)
-            .unwrap();
-        let attr_status = plan
-            .declare_planned("attributes.http.status_code", FieldKind::Int64)
-            .unwrap();
-        let attr_dur = plan
-            .declare_planned("attributes.duration_ms", FieldKind::Float64)
-            .unwrap();
-        let attr_path = plan
-            .declare_planned("attributes.http.path", FieldKind::Utf8View)
-            .unwrap();
-
-        let handles_int = [ts, sev_num, flags, attr_status];
-        let handles_str = [
-            sev_text,
-            body,
-            trace_id,
-            span_id,
-            res_svc,
-            res_host,
-            scope_name,
-            scope_ver,
-            attr_method,
-            attr_path,
-        ];
-        let handles_float = [attr_dur];
-
-        let mut b = ColumnarBatchBuilder::new(plan);
+        let (mut b, h) = make_otlp_plan();
         let rows_per_batch: u32 = 1000;
         let num_batches: u64 = 20;
 
         // Warmup
         b.begin_batch();
         for row in 0..rows_per_batch {
-            b.begin_row();
-            for (i, &h) in handles_int.iter().enumerate() {
-                b.write_i64(h, row as i64 + i as i64);
-            }
-            for &h in &handles_str {
-                b.write_str(h, "warmup-string-value").unwrap();
-            }
-            for &h in &handles_float {
-                b.write_f64(h, row as f64);
-            }
-            b.end_row();
+            write_otlp_row(&mut b, &h, row as i64);
         }
         let _ = b.finish_batch().unwrap();
 
@@ -1516,18 +1230,8 @@ mod tests {
 
             let write_start = std::time::Instant::now();
             for row in 0..rows_per_batch {
-                b.begin_row();
                 let base = (batch_idx as i64) * (rows_per_batch as i64) + row as i64;
-                for (i, &h) in handles_int.iter().enumerate() {
-                    b.write_i64(h, base + i as i64 * 1000);
-                }
-                for &h in &handles_str {
-                    b.write_str(h, "example-value-0123456789").unwrap();
-                }
-                for &h in &handles_float {
-                    b.write_f64(h, base as f64 * 0.001);
-                }
-                b.end_row();
+                write_otlp_row(&mut b, &h, base);
             }
             total_write += write_start.elapsed();
 

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -1,83 +1,86 @@
-// builder.rs — ColumnarBatchBuilder prototype.
+// builder.rs — ColumnarBatchBuilder: shared column construction engine.
 //
-// Validates the BatchPlan + FieldHandle → typed writes → Arrow materialization
-// path end-to-end.  This spike informs the design of #1844-#1847 before
-// committing to a full extraction from StreamingBuilder.
+// Drives BatchPlan + FieldHandle → typed writes → Arrow materialization.
+// Uses ColumnAccumulator for per-field storage (typed enum, no dead vecs).
 //
-// Current scope:
-//   - Planned fields: fixed-kind, single-type columns, no conflict overhead
+// Scope:
+//   - Planned fields: single-type columns, zero conflict overhead
 //   - Dynamic fields: multi-type, conflict detection at finalization
-//   - Detached string materialization (copies into StringBuilder)
+//   - Detached string materialization via shared string buffer
 //   - Sparse padding with deferred (row, value) facts
+//   - StringViewArray zero-copy when given input buffer
 //
-// Out of scope (future #1844):
-//   - Zero-copy StringViewArray via block store
-//   - ScanBuilder trait adapter (StreamingBuilder keeps that role)
-//   - Resource attributes, line capture (StreamingBuilder concerns)
+// StreamingBuilder remains the scanner-facing ScanBuilder adapter.
+// ColumnarBatchBuilder is for structured producers (OTLP, CSV, etc).
 
 use std::sync::Arc;
 
 use arrow::array::{
-    ArrayRef, BooleanArray, Float64Array, Int64Array, StringBuilder, StructArray,
+    ArrayRef, BooleanArray, Float64Array, Int64Array, NullArray, StringBuilder,
 };
-use arrow::buffer::NullBuffer;
-use arrow::datatypes::{DataType, Field, Fields, Schema};
+use arrow::buffer::{Buffer, NullBuffer};
+use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
 
 use logfwd_core::scanner::BuilderState;
 
+use super::accumulator::{ColumnAccumulator, FinalizationMode, MaterializeError, StringRef};
 use super::plan::{BatchPlan, FieldHandle, FieldKind, FieldSchemaMode, PlanError};
 use super::row_protocol::RowLifecycle;
 use crate::check_dup_bits;
 
 // ---------------------------------------------------------------------------
-// Per-field column storage (deferred facts)
+// BuilderError
 // ---------------------------------------------------------------------------
 
-/// Deferred (row, value) facts for a single field.
-///
-/// Same approach as `StreamingBuilder::FieldColumns`: store facts during row
-/// writes, materialize into Arrow arrays at `finish_batch` time.  Sparse rows
-/// become null via the validity bitmap.
-struct ColumnStorage {
-    str_values: Vec<(u32, String)>,
-    int_values: Vec<(u32, i64)>,
-    float_values: Vec<(u32, f64)>,
-    bool_values: Vec<(u32, bool)>,
-    has_str: bool,
-    has_int: bool,
-    has_float: bool,
-    has_bool: bool,
-    /// Last row written, for dedup when field index >= 64.
-    last_row: u32,
+/// Errors from `ColumnarBatchBuilder` operations.
+#[derive(Debug)]
+pub(crate) enum BuilderError {
+    /// Arrow error during RecordBatch construction.
+    Arrow(ArrowError),
+    /// String buffer exceeded u32 addressable range.
+    StringBufferOverflow { buffer_len: usize, value_len: usize },
+    /// Column materialization failed (invalid StringRef, bad UTF-8, etc).
+    Materialize(MaterializeError),
 }
 
-impl ColumnStorage {
-    fn new() -> Self {
-        ColumnStorage {
-            str_values: Vec::new(),
-            int_values: Vec::new(),
-            float_values: Vec::new(),
-            bool_values: Vec::new(),
-            has_str: false,
-            has_int: false,
-            has_float: false,
-            has_bool: false,
-            last_row: u32::MAX,
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BuilderError::Arrow(e) => write!(f, "Arrow error: {e}"),
+            BuilderError::StringBufferOverflow {
+                buffer_len,
+                value_len,
+            } => write!(
+                f,
+                "string buffer overflow: buffer_len={buffer_len}, value_len={value_len}, \
+                 exceeds u32::MAX"
+            ),
+            BuilderError::Materialize(e) => write!(f, "materialize error: {e}"),
         }
     }
+}
 
-    fn clear(&mut self) {
-        self.str_values.clear();
-        self.int_values.clear();
-        self.float_values.clear();
-        self.bool_values.clear();
-        self.has_str = false;
-        self.has_int = false;
-        self.has_float = false;
-        self.has_bool = false;
-        self.last_row = u32::MAX;
+impl std::error::Error for BuilderError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            BuilderError::Arrow(e) => Some(e),
+            BuilderError::Materialize(e) => Some(e),
+            BuilderError::StringBufferOverflow { .. } => None,
+        }
+    }
+}
+
+impl From<ArrowError> for BuilderError {
+    fn from(e: ArrowError) -> Self {
+        BuilderError::Arrow(e)
+    }
+}
+
+impl From<MaterializeError> for BuilderError {
+    fn from(e: MaterializeError) -> Self {
+        BuilderError::Materialize(e)
     }
 }
 
@@ -85,42 +88,49 @@ impl ColumnStorage {
 // ColumnarBatchBuilder
 // ---------------------------------------------------------------------------
 
-/// Prototype shared columnar batch builder driven by `BatchPlan` + `FieldHandle`.
+/// Shared columnar batch builder driven by `BatchPlan` + `FieldHandle`.
 ///
 /// Producers declare fields up front (planned) or discover them dynamically,
-/// then write typed values via stable handles.  At `finish_batch`, deferred
+/// then write typed values via stable handles. At `finish_batch`, deferred
 /// facts are materialized into an Arrow `RecordBatch`.
 ///
-/// # Design findings (spike)
+/// String values are appended to an internal buffer and referenced via
+/// `StringRef`. At finalization, the buffer is passed to `FinalizationMode`
+/// which controls whether strings are copied (Detached) or zero-copy (View).
 ///
-/// - Planned fields bypass conflict detection entirely: the handle's kind
-///   determines the output column type.
-/// - Dynamic fields reuse the `has_*` flag + conflict struct pattern from
-///   `StreamingBuilder`.
-/// - The `BatchPlan` provides the schema metadata; storage is handle-indexed.
+/// # Design
+///
+/// - Each field gets a `ColumnAccumulator` matched to its schema mode:
+///   planned Int64 → `ColumnAccumulator::Int64` (one vec, no conflict overhead),
+///   dynamic → `ColumnAccumulator::Dynamic` (all vecs, conflict detection).
 /// - Dedup uses the same bitmask approach as `RowLifecycle::written_bits`.
-/// - String storage is detached (owned copies) in this prototype; the
-///   block store (#1844) adds zero-copy view-backed paths later.
+/// - `finish_batch` iterates fields and calls `accumulator.materialize()`.
 pub(crate) struct ColumnarBatchBuilder {
     plan: BatchPlan,
     lifecycle: RowLifecycle,
-    columns: Vec<ColumnStorage>,
+    columns: Vec<ColumnAccumulator>,
+    /// Shared buffer for string values written via `write_str`.
+    /// StringRef offsets point into this buffer.
+    string_buf: Vec<u8>,
 }
 
 impl ColumnarBatchBuilder {
     /// Create a builder from a plan.
     ///
-    /// Allocates per-field storage for all declared fields.
+    /// Allocates per-field storage matched to each field's schema mode.
     pub(crate) fn new(plan: BatchPlan) -> Self {
-        let num_fields = plan.len();
-        let mut columns = Vec::with_capacity(num_fields);
-        for _ in 0..num_fields {
-            columns.push(ColumnStorage::new());
-        }
+        let columns: Vec<ColumnAccumulator> = plan
+            .fields()
+            .map(|(_handle, _name, mode)| match mode {
+                FieldSchemaMode::Planned(kind) => ColumnAccumulator::for_planned(*kind),
+                FieldSchemaMode::Dynamic { .. } => ColumnAccumulator::dynamic(),
+            })
+            .collect();
         ColumnarBatchBuilder {
             plan,
             lifecycle: RowLifecycle::new(),
             columns,
+            string_buf: Vec::new(),
         }
     }
 
@@ -130,16 +140,17 @@ impl ColumnarBatchBuilder {
         for col in &mut self.columns {
             col.clear();
         }
+        self.string_buf.clear();
     }
 
     /// Start a new row.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn begin_row(&mut self) {
         self.lifecycle.begin_row();
     }
 
     /// Finish the current row.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn end_row(&mut self) {
         self.lifecycle.end_row();
     }
@@ -156,9 +167,33 @@ impl ColumnarBatchBuilder {
         let handle = self.plan.resolve_dynamic(name, kind)?;
         // Ensure storage exists for newly resolved fields.
         while self.columns.len() <= handle.index() {
-            self.columns.push(ColumnStorage::new());
+            self.columns.push(ColumnAccumulator::dynamic());
         }
         Ok(handle)
+    }
+
+    // -----------------------------------------------------------------------
+    // Dedup helper
+    // -----------------------------------------------------------------------
+
+    /// Check if a write to `handle` in the current row is a duplicate.
+    ///
+    /// Returns `true` if the write should be suppressed (duplicate).
+    /// For fields 0–63, uses the bitmask. For fields ≥64, uses last_row.
+    #[inline]
+    fn is_duplicate(&mut self, handle: FieldHandle) -> bool {
+        let idx = handle.index();
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+            return true;
+        }
+        if idx >= 64 {
+            let col = &mut self.columns[idx];
+            if col.last_row() == self.lifecycle.row_count() {
+                return true;
+            }
+            *col.last_row_mut() = self.lifecycle.row_count();
+        }
+        false
     }
 
     // -----------------------------------------------------------------------
@@ -166,146 +201,185 @@ impl ColumnarBatchBuilder {
     // -----------------------------------------------------------------------
 
     /// Write an i64 value for the given field in the current row.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn write_i64(&mut self, handle: FieldHandle, value: i64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
-        let idx = handle.index();
-        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+        debug_assert!(handle.index() < self.columns.len());
+        if self.is_duplicate(handle) {
             return;
         }
-        if idx >= 64 && self.columns[idx].last_row == self.lifecycle.row_count() {
-            return;
-        }
-        if idx >= 64 {
-            self.columns[idx].last_row = self.lifecycle.row_count();
-        }
-        let col = &mut self.columns[idx];
-        col.has_int = true;
-        col.int_values.push((self.lifecycle.row_count(), value));
+        self.columns[handle.index()].push_i64(self.lifecycle.row_count(), value);
     }
 
     /// Write an f64 value for the given field in the current row.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn write_f64(&mut self, handle: FieldHandle, value: f64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
-        let idx = handle.index();
-        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+        debug_assert!(handle.index() < self.columns.len());
+        if self.is_duplicate(handle) {
             return;
         }
-        if idx >= 64 && self.columns[idx].last_row == self.lifecycle.row_count() {
-            return;
-        }
-        if idx >= 64 {
-            self.columns[idx].last_row = self.lifecycle.row_count();
-        }
-        let col = &mut self.columns[idx];
-        col.has_float = true;
-        col.float_values.push((self.lifecycle.row_count(), value));
+        self.columns[handle.index()].push_f64(self.lifecycle.row_count(), value);
     }
 
     /// Write a bool value for the given field in the current row.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn write_bool(&mut self, handle: FieldHandle, value: bool) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
-        let idx = handle.index();
-        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+        debug_assert!(handle.index() < self.columns.len());
+        if self.is_duplicate(handle) {
             return;
         }
-        if idx >= 64 && self.columns[idx].last_row == self.lifecycle.row_count() {
-            return;
-        }
-        if idx >= 64 {
-            self.columns[idx].last_row = self.lifecycle.row_count();
-        }
-        let col = &mut self.columns[idx];
-        col.has_bool = true;
-        col.bool_values.push((self.lifecycle.row_count(), value));
+        self.columns[handle.index()].push_bool(self.lifecycle.row_count(), value);
     }
 
     /// Write a string value for the given field in the current row.
     ///
-    /// This is the detached (copying) path.  The block store (#1844) will add
-    /// a zero-copy view-backed alternative.
-    #[inline(always)]
-    pub(crate) fn write_str(&mut self, handle: FieldHandle, value: &str) {
+    /// The string is appended to the builder's internal buffer and
+    /// referenced via `StringRef`. At finalization, the buffer is
+    /// passed to `FinalizationMode` to produce the appropriate
+    /// Arrow string type.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the string buffer would exceed u32 addressable range.
+    #[inline]
+    pub(crate) fn write_str(
+        &mut self,
+        handle: FieldHandle,
+        value: &str,
+    ) -> Result<(), BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
-        let idx = handle.index();
-        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+        debug_assert!(handle.index() < self.columns.len());
+        if self.is_duplicate(handle) {
+            return Ok(());
+        }
+        let offset = u32::try_from(self.string_buf.len()).map_err(|_| {
+            BuilderError::StringBufferOverflow {
+                buffer_len: self.string_buf.len(),
+                value_len: value.len(),
+            }
+        })?;
+        let len = u32::try_from(value.len()).map_err(|_| {
+            BuilderError::StringBufferOverflow {
+                buffer_len: self.string_buf.len(),
+                value_len: value.len(),
+            }
+        })?;
+        self.string_buf.extend_from_slice(value.as_bytes());
+        let sref = StringRef { offset, len };
+        self.columns[handle.index()].push_str(self.lifecycle.row_count(), sref);
+        Ok(())
+    }
+
+    /// Write a `StringRef` directly (for zero-copy producers that already
+    /// have offsets into an input buffer).
+    #[inline]
+    pub(crate) fn write_str_ref(&mut self, handle: FieldHandle, sref: StringRef) {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
+        debug_assert!(handle.index() < self.columns.len());
+        if self.is_duplicate(handle) {
             return;
         }
-        if idx >= 64 && self.columns[idx].last_row == self.lifecycle.row_count() {
-            return;
-        }
-        if idx >= 64 {
-            self.columns[idx].last_row = self.lifecycle.row_count();
-        }
-        let col = &mut self.columns[idx];
-        col.has_str = true;
-        col.str_values
-            .push((self.lifecycle.row_count(), value.to_string()));
+        self.columns[handle.index()].push_str(self.lifecycle.row_count(), sref);
     }
 
     /// Write a null for the given field in the current row.
     ///
     /// Sparse fields are null by default; this just marks the field as
     /// written for dedup purposes.
-    #[inline(always)]
+    #[inline]
     pub(crate) fn write_null(&mut self, handle: FieldHandle) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
-        let idx = handle.index();
-        let _ = check_dup_bits(self.lifecycle.written_bits_mut(), idx);
-        if idx >= 64 {
-            self.columns[idx].last_row = self.lifecycle.row_count();
-        }
+        debug_assert!(handle.index() < self.columns.len());
+        let _ = self.is_duplicate(handle);
     }
 
     // -----------------------------------------------------------------------
     // Finalization
     // -----------------------------------------------------------------------
 
-    /// Materialize all deferred facts into an Arrow `RecordBatch`.
+    /// Materialize all deferred facts into an Arrow `RecordBatch` (detached).
     ///
-    /// Planned fields produce single-type columns (no conflict check).
-    /// Dynamic fields check for type conflicts and emit `StructArray` when
-    /// multiple types were observed.
-    pub(crate) fn finish_batch(&mut self) -> Result<RecordBatch, ArrowError> {
+    /// Copies string data into `StringBuilder` arrays. The builder's internal
+    /// buffers can be reused after this call.
+    pub(crate) fn finish_batch(&mut self) -> Result<RecordBatch, BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
         let num_rows = self.lifecycle.row_count() as usize;
 
-        let mut schema_fields: Vec<Field> = Vec::with_capacity(self.plan.len());
-        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.plan.len());
+        // Detached mode: string_buf is the "generated" buffer, no original.
+        let mode = FinalizationMode::Detached {
+            original_buf: &[],
+            generated_buf: &self.string_buf,
+        };
 
-        for (handle, name, mode) in self.plan.fields() {
+        let result = self.materialize_all(num_rows, mode)?;
+        self.lifecycle.finish_batch();
+        Ok(result)
+    }
+
+    /// Materialize with zero-copy StringViewArray.
+    ///
+    /// `original` is the input buffer (e.g., protobuf wire bytes).
+    /// `original_len` is the length of the original buffer.
+    /// Strings with `offset < original_len` reference the original buffer;
+    /// strings with `offset >= original_len` reference the generated buffer.
+    pub(crate) fn finish_batch_view(
+        &mut self,
+        original: Buffer,
+        original_len: u32,
+    ) -> Result<RecordBatch, BuilderError> {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
+        let num_rows = self.lifecycle.row_count() as usize;
+
+        let generated = if self.string_buf.is_empty() {
+            None
+        } else {
+            Some(Buffer::from(self.string_buf.as_slice()))
+        };
+        let mode = FinalizationMode::View {
+            original,
+            original_len,
+            generated,
+        };
+
+        let result = self.materialize_all(num_rows, mode)?;
+        self.lifecycle.finish_batch();
+        Ok(result)
+    }
+
+    /// Core materialization shared by both detached and view paths.
+    fn materialize_all(
+        &self,
+        num_rows: usize,
+        mode: FinalizationMode<'_>,
+    ) -> Result<RecordBatch, BuilderError> {
+        let mut schema_fields = Vec::with_capacity(self.plan.len());
+        let mut arrays = Vec::with_capacity(self.plan.len());
+
+        for (handle, name, field_mode) in self.plan.fields() {
             let col = &self.columns[handle.index()];
-
-            match mode {
-                FieldSchemaMode::Planned(kind) => {
-                    Self::materialize_planned(
-                        col,
-                        name,
-                        *kind,
-                        num_rows,
-                        &mut schema_fields,
-                        &mut arrays,
-                    );
+            match col.materialize(name, num_rows, mode.clone())? {
+                Some((field, array)) => {
+                    schema_fields.push(field);
+                    arrays.push(array);
                 }
-                FieldSchemaMode::Dynamic { .. } => {
-                    Self::materialize_dynamic(
-                        col,
-                        name,
-                        num_rows,
-                        &mut schema_fields,
-                        &mut arrays,
-                    );
+                None => {
+                    // Planned fields always appear in the schema (all-null if
+                    // no values were written). Dynamic fields with no data are
+                    // omitted — this matches StreamingBuilder behavior.
+                    if let FieldSchemaMode::Planned(kind) = field_mode {
+                        let (field, array) = null_column(name, *kind, num_rows);
+                        schema_fields.push(field);
+                        arrays.push(array);
+                    }
                 }
             }
         }
 
         let schema = Arc::new(Schema::new(schema_fields));
         let opts = RecordBatchOptions::new().with_row_count(Some(num_rows));
-        let result = RecordBatch::try_new_with_options(schema, arrays, &opts);
-        self.lifecycle.finish_batch();
-        result
+        Ok(RecordBatch::try_new_with_options(schema, arrays, &opts)?)
     }
 
     /// Number of completed rows in the current batch.
@@ -317,192 +391,42 @@ impl ColumnarBatchBuilder {
     pub(crate) fn plan(&self) -> &BatchPlan {
         &self.plan
     }
+}
 
-    // -----------------------------------------------------------------------
-    // Materialization helpers
-    // -----------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-    fn materialize_planned(
-        col: &ColumnStorage,
-        name: &str,
-        kind: FieldKind,
-        num_rows: usize,
-        schema_fields: &mut Vec<Field>,
-        arrays: &mut Vec<ArrayRef>,
-    ) {
-        match kind {
-            FieldKind::Int64 => {
-                let (array, dt) = Self::build_int64_column(&col.int_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            }
-            FieldKind::Float64 => {
-                let (array, dt) = Self::build_float64_column(&col.float_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            }
-            FieldKind::Bool => {
-                let (array, dt) = Self::build_bool_column(&col.bool_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            }
-            FieldKind::Utf8View => {
-                let (array, dt) = Self::build_string_column(&col.str_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            }
-            FieldKind::BinaryView | FieldKind::FixedBinary(_) => {
-                // Not yet implemented in prototype; emit null Utf8 column as placeholder.
-                let (array, dt) = Self::build_string_column(&col.str_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            }
+/// Create an all-null column of the appropriate Arrow type for a planned field.
+fn null_column(name: &str, kind: FieldKind, num_rows: usize) -> (Field, ArrayRef) {
+    match kind {
+        FieldKind::Int64 => {
+            let nulls = NullBuffer::new_null(num_rows);
+            let arr = Int64Array::new(vec![0i64; num_rows].into(), Some(nulls));
+            (Field::new(name, DataType::Int64, true), Arc::new(arr))
         }
-    }
-
-    fn materialize_dynamic(
-        col: &ColumnStorage,
-        name: &str,
-        num_rows: usize,
-        schema_fields: &mut Vec<Field>,
-        arrays: &mut Vec<ArrayRef>,
-    ) {
-        let type_count = col.has_int as u8
-            + col.has_float as u8
-            + col.has_str as u8
-            + col.has_bool as u8;
-
-        if type_count > 1 {
-            // Conflict: emit StructArray with typed children.
-            let mut child_fields: Vec<Arc<Field>> = Vec::new();
-            let mut child_arrays: Vec<ArrayRef> = Vec::new();
-
-            if col.has_int {
-                let (array, _) = Self::build_int64_column(&col.int_values, num_rows);
-                child_fields.push(Arc::new(Field::new("int", DataType::Int64, true)));
-                child_arrays.push(array);
-            }
-            if col.has_float {
-                let (array, _) = Self::build_float64_column(&col.float_values, num_rows);
-                child_fields.push(Arc::new(Field::new("float", DataType::Float64, true)));
-                child_arrays.push(array);
-            }
-            if col.has_str {
-                let (array, _) = Self::build_string_column(&col.str_values, num_rows);
-                child_fields.push(Arc::new(Field::new("str", DataType::Utf8, true)));
-                child_arrays.push(array);
-            }
-            if col.has_bool {
-                let (array, _) = Self::build_bool_column(&col.bool_values, num_rows);
-                child_fields.push(Arc::new(Field::new("bool", DataType::Boolean, true)));
-                child_arrays.push(array);
-            }
-
-            let struct_validity: Vec<bool> = (0..num_rows)
-                .map(|i| child_arrays.iter().any(|arr| !arr.is_null(i)))
-                .collect();
-
-            let fields = Fields::from(child_fields);
-            let struct_arr = StructArray::new(
-                fields.clone(),
-                child_arrays,
-                Some(NullBuffer::from(struct_validity)),
-            );
-
-            schema_fields.push(Field::new(name, DataType::Struct(fields), true));
-            arrays.push(Arc::new(struct_arr));
-        } else {
-            // Single-type or empty: flat column.
-            if col.has_int {
-                let (array, dt) = Self::build_int64_column(&col.int_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            } else if col.has_float {
-                let (array, dt) = Self::build_float64_column(&col.float_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            } else if col.has_str {
-                let (array, dt) = Self::build_string_column(&col.str_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            } else if col.has_bool {
-                let (array, dt) = Self::build_bool_column(&col.bool_values, num_rows);
-                schema_fields.push(Field::new(name, dt, true));
-                arrays.push(array);
-            }
-            // If no values at all, field is omitted (all-null sparse field
-            // with no writes). This matches StreamingBuilder behavior.
+        FieldKind::Float64 => {
+            let nulls = NullBuffer::new_null(num_rows);
+            let arr = Float64Array::new(vec![0.0f64; num_rows].into(), Some(nulls));
+            (Field::new(name, DataType::Float64, true), Arc::new(arr))
         }
-    }
-
-    // -----------------------------------------------------------------------
-    // Column builders — deferred (row, value) → Arrow array
-    // -----------------------------------------------------------------------
-
-    fn build_int64_column(values: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
-        let mut data = vec![0i64; num_rows];
-        let mut valid = vec![false; num_rows];
-        for &(row, v) in values {
-            let row = row as usize;
-            if row < num_rows {
-                data[row] = v;
-                valid[row] = true;
-            }
+        FieldKind::Bool => {
+            let nulls = NullBuffer::new_null(num_rows);
+            let arr = BooleanArray::new(vec![false; num_rows].into(), Some(nulls));
+            (Field::new(name, DataType::Boolean, true), Arc::new(arr))
         }
-        let nulls = NullBuffer::from(valid);
-        let array = Int64Array::new(data.into(), Some(nulls));
-        (Arc::new(array), DataType::Int64)
-    }
-
-    fn build_float64_column(values: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) {
-        let mut data = vec![0.0f64; num_rows];
-        let mut valid = vec![false; num_rows];
-        for &(row, v) in values {
-            let row = row as usize;
-            if row < num_rows {
-                data[row] = v;
-                valid[row] = true;
+        FieldKind::Utf8View => {
+            // Use StringBuilder for detached mode compatibility.
+            let mut builder = StringBuilder::with_capacity(0, 0);
+            for _ in 0..num_rows {
+                builder.append_null();
             }
+            (Field::new(name, DataType::Utf8, true), Arc::new(builder.finish()))
         }
-        let nulls = NullBuffer::from(valid);
-        let array = Float64Array::new(data.into(), Some(nulls));
-        (Arc::new(array), DataType::Float64)
-    }
-
-    fn build_bool_column(values: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
-        let mut data = vec![false; num_rows];
-        let mut valid = vec![false; num_rows];
-        for &(row, v) in values {
-            let row = row as usize;
-            if row < num_rows {
-                data[row] = v;
-                valid[row] = true;
-            }
+        FieldKind::BinaryView | FieldKind::FixedBinary(_) => {
+            let arr = NullArray::new(num_rows);
+            (Field::new(name, DataType::Null, true), Arc::new(arr))
         }
-        let nulls = NullBuffer::from(valid);
-        let array = BooleanArray::new(data.into(), Some(nulls));
-        (Arc::new(array), DataType::Boolean)
-    }
-
-    fn build_string_column(values: &[(u32, String)], num_rows: usize) -> (ArrayRef, DataType) {
-        // Use StringBuilder (detached/copy path).
-        // Block store (#1844) will add StringViewBuilder with zero-copy views.
-        let mut builder = StringBuilder::with_capacity(values.len(), 0);
-        // Build a row-indexed lookup for sparse fill.
-        let mut row_map: Vec<Option<&str>> = vec![None; num_rows];
-        for (row, v) in values {
-            let row = *row as usize;
-            if row < num_rows {
-                row_map[row] = Some(v.as_str());
-            }
-        }
-        for slot in &row_map {
-            match slot {
-                Some(s) => builder.append_value(s),
-                None => builder.append_null(),
-            }
-        }
-        (Arc::new(builder.finish()), DataType::Utf8)
     }
 }
 
@@ -560,7 +484,7 @@ mod tests {
 
         // Row 1: only severity
         b.begin_row();
-        b.write_str(sev, "INFO");
+        b.write_str(sev, "INFO").unwrap();
         b.end_row();
 
         // Row 2: only value
@@ -683,13 +607,13 @@ mod tests {
         b.begin_batch();
         b.begin_row();
         let h = b.resolve_dynamic("level", FieldKind::Utf8View).unwrap();
-        b.write_str(h, "INFO");
+        b.write_str(h, "INFO").unwrap();
         b.end_row();
 
         b.begin_row();
         let h2 = b.resolve_dynamic("level", FieldKind::Utf8View).unwrap();
         assert_eq!(h, h2);
-        b.write_str(h2, "ERROR");
+        b.write_str(h2, "ERROR").unwrap();
         b.end_row();
 
         let batch = b.finish_batch().unwrap();
@@ -716,7 +640,7 @@ mod tests {
         b.begin_row();
         let h2 = b.resolve_dynamic("status", FieldKind::Utf8View).unwrap();
         assert_eq!(h, h2);
-        b.write_str(h2, "OK");
+        b.write_str(h2, "OK").unwrap();
         b.end_row();
 
         let batch = b.finish_batch().unwrap();
@@ -751,13 +675,13 @@ mod tests {
         b.begin_row();
         b.write_i64(ts, 1000);
         let msg = b.resolve_dynamic("message", FieldKind::Utf8View).unwrap();
-        b.write_str(msg, "hello");
+        b.write_str(msg, "hello").unwrap();
         b.end_row();
 
         b.begin_row();
         b.write_i64(ts, 2000);
         let msg2 = b.resolve_dynamic("message", FieldKind::Utf8View).unwrap();
-        b.write_str(msg2, "world");
+        b.write_str(msg2, "world").unwrap();
         b.end_row();
 
         let batch = b.finish_batch().unwrap();
@@ -868,7 +792,7 @@ mod tests {
 
         b.begin_batch();
         b.begin_row();
-        b.write_str(h, "not an int");
+        b.write_str(h, "not an int").unwrap();
         b.end_row();
 
         let batch = b.finish_batch().unwrap();
@@ -876,5 +800,70 @@ mod tests {
         let arr = col.as_primitive::<Int64Type>();
         // Planned kind is Int64, but we only wrote a string → int column is all-null.
         assert!(arr.is_null(0));
+    }
+
+    // -----------------------------------------------------------------------
+    // View mode finalization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn finish_batch_view_produces_string_view_array() {
+        let mut plan = BatchPlan::new();
+        let ts = plan.declare_planned("ts", FieldKind::Int64).unwrap();
+        let msg = plan.declare_planned("msg", FieldKind::Utf8View).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        let input = b"hello world";
+        let arrow_buf = Buffer::from(&input[..]);
+
+        b.begin_batch();
+        b.begin_row();
+        b.write_i64(ts, 1000);
+        // Use str_ref pointing into the original buffer
+        b.write_str_ref(msg, super::super::accumulator::StringRef { offset: 0, len: 5 });
+        b.end_row();
+        b.begin_row();
+        b.write_i64(ts, 2000);
+        b.write_str_ref(msg, super::super::accumulator::StringRef { offset: 6, len: 5 });
+        b.end_row();
+
+        let batch = b
+            .finish_batch_view(arrow_buf, input.len() as u32)
+            .unwrap();
+        assert_eq!(batch.num_rows(), 2);
+
+        let msg_col = batch.column_by_name("msg").unwrap();
+        let arr = msg_col.as_string_view();
+        assert_eq!(arr.value(0), "hello");
+        assert_eq!(arr.value(1), "world");
+    }
+
+    // -----------------------------------------------------------------------
+    // Error handling
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn finish_batch_propagates_materialize_error() {
+        let mut plan = BatchPlan::new();
+        let msg = plan.declare_planned("msg", FieldKind::Utf8View).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.begin_row();
+        // Write a str_ref pointing beyond any valid buffer
+        b.write_str_ref(
+            msg,
+            super::super::accumulator::StringRef {
+                offset: 9999,
+                len: 10,
+            },
+        );
+        b.end_row();
+
+        let result = b.finish_batch();
+        assert!(
+            result.is_err(),
+            "finish_batch should fail for out-of-bounds StringRef"
+        );
     }
 }

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -270,10 +270,17 @@ impl ColumnarBatchBuilder {
     // -----------------------------------------------------------------------
 
     /// Write an i64 value for the given field in the current row.
+    ///
+    /// If the column's planned kind does not accept i64, the write is
+    /// silently ignored and the dedup slot is NOT consumed — a subsequent
+    /// correct-type write to the same field will still succeed.
     #[inline]
     pub fn write_i64(&mut self, handle: FieldHandle, value: i64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
+        if !self.columns[handle.index()].accepts_i64() {
+            return;
+        }
         if self.dedup_enabled && self.is_duplicate(handle) {
             return;
         }
@@ -285,6 +292,9 @@ impl ColumnarBatchBuilder {
     pub fn write_f64(&mut self, handle: FieldHandle, value: f64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
+        if !self.columns[handle.index()].accepts_f64() {
+            return;
+        }
         if self.dedup_enabled && self.is_duplicate(handle) {
             return;
         }
@@ -296,6 +306,9 @@ impl ColumnarBatchBuilder {
     pub fn write_bool(&mut self, handle: FieldHandle, value: bool) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
+        if !self.columns[handle.index()].accepts_bool() {
+            return;
+        }
         if self.dedup_enabled && self.is_duplicate(handle) {
             return;
         }
@@ -316,6 +329,9 @@ impl ColumnarBatchBuilder {
     pub fn write_str(&mut self, handle: FieldHandle, value: &str) -> Result<(), BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
+        if !self.columns[handle.index()].accepts_str() {
+            return Ok(());
+        }
         if self.dedup_enabled && self.is_duplicate(handle) {
             return Ok(());
         }
@@ -350,6 +366,9 @@ impl ColumnarBatchBuilder {
     pub fn write_str_ref(&mut self, handle: FieldHandle, sref: StringRef) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
+        if !self.columns[handle.index()].accepts_str() {
+            return;
+        }
         if self.dedup_enabled && self.is_duplicate(handle) {
             return;
         }
@@ -924,6 +943,28 @@ mod tests {
         let arr = col.as_primitive::<Int64Type>();
         // Planned kind is Int64, but we only wrote a string → int column is all-null.
         assert!(arr.is_null(0));
+    }
+
+    #[test]
+    fn wrong_type_write_does_not_consume_dedup_slot() {
+        // Writing the wrong type should NOT consume the dedup slot.
+        // A subsequent correct-type write to the same field must succeed.
+        let mut plan = BatchPlan::new();
+        let h = plan.declare_planned("x", FieldKind::Int64).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.begin_row();
+        // Wrong type: string to an Int64 field — should be silently ignored.
+        b.write_str(h, "not an int").unwrap();
+        // Correct type: this must NOT be rejected as a duplicate.
+        b.write_i64(h, 42);
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        let col = batch.column_by_name("x").unwrap();
+        let arr = col.as_primitive::<Int64Type>();
+        assert_eq!(arr.value(0), 42, "correct-type write after wrong-type must succeed");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -1,0 +1,880 @@
+// builder.rs — ColumnarBatchBuilder prototype.
+//
+// Validates the BatchPlan + FieldHandle → typed writes → Arrow materialization
+// path end-to-end.  This spike informs the design of #1844-#1847 before
+// committing to a full extraction from StreamingBuilder.
+//
+// Current scope:
+//   - Planned fields: fixed-kind, single-type columns, no conflict overhead
+//   - Dynamic fields: multi-type, conflict detection at finalization
+//   - Detached string materialization (copies into StringBuilder)
+//   - Sparse padding with deferred (row, value) facts
+//
+// Out of scope (future #1844):
+//   - Zero-copy StringViewArray via block store
+//   - ScanBuilder trait adapter (StreamingBuilder keeps that role)
+//   - Resource attributes, line capture (StreamingBuilder concerns)
+
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int64Array, StringBuilder, StructArray,
+};
+use arrow::buffer::NullBuffer;
+use arrow::datatypes::{DataType, Field, Fields, Schema};
+use arrow::error::ArrowError;
+use arrow::record_batch::{RecordBatch, RecordBatchOptions};
+
+use logfwd_core::scanner::BuilderState;
+
+use super::plan::{BatchPlan, FieldHandle, FieldKind, FieldSchemaMode, PlanError};
+use super::row_protocol::RowLifecycle;
+use crate::check_dup_bits;
+
+// ---------------------------------------------------------------------------
+// Per-field column storage (deferred facts)
+// ---------------------------------------------------------------------------
+
+/// Deferred (row, value) facts for a single field.
+///
+/// Same approach as `StreamingBuilder::FieldColumns`: store facts during row
+/// writes, materialize into Arrow arrays at `finish_batch` time.  Sparse rows
+/// become null via the validity bitmap.
+struct ColumnStorage {
+    str_values: Vec<(u32, String)>,
+    int_values: Vec<(u32, i64)>,
+    float_values: Vec<(u32, f64)>,
+    bool_values: Vec<(u32, bool)>,
+    has_str: bool,
+    has_int: bool,
+    has_float: bool,
+    has_bool: bool,
+    /// Last row written, for dedup when field index >= 64.
+    last_row: u32,
+}
+
+impl ColumnStorage {
+    fn new() -> Self {
+        ColumnStorage {
+            str_values: Vec::new(),
+            int_values: Vec::new(),
+            float_values: Vec::new(),
+            bool_values: Vec::new(),
+            has_str: false,
+            has_int: false,
+            has_float: false,
+            has_bool: false,
+            last_row: u32::MAX,
+        }
+    }
+
+    fn clear(&mut self) {
+        self.str_values.clear();
+        self.int_values.clear();
+        self.float_values.clear();
+        self.bool_values.clear();
+        self.has_str = false;
+        self.has_int = false;
+        self.has_float = false;
+        self.has_bool = false;
+        self.last_row = u32::MAX;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ColumnarBatchBuilder
+// ---------------------------------------------------------------------------
+
+/// Prototype shared columnar batch builder driven by `BatchPlan` + `FieldHandle`.
+///
+/// Producers declare fields up front (planned) or discover them dynamically,
+/// then write typed values via stable handles.  At `finish_batch`, deferred
+/// facts are materialized into an Arrow `RecordBatch`.
+///
+/// # Design findings (spike)
+///
+/// - Planned fields bypass conflict detection entirely: the handle's kind
+///   determines the output column type.
+/// - Dynamic fields reuse the `has_*` flag + conflict struct pattern from
+///   `StreamingBuilder`.
+/// - The `BatchPlan` provides the schema metadata; storage is handle-indexed.
+/// - Dedup uses the same bitmask approach as `RowLifecycle::written_bits`.
+/// - String storage is detached (owned copies) in this prototype; the
+///   block store (#1844) adds zero-copy view-backed paths later.
+pub(crate) struct ColumnarBatchBuilder {
+    plan: BatchPlan,
+    lifecycle: RowLifecycle,
+    columns: Vec<ColumnStorage>,
+}
+
+impl ColumnarBatchBuilder {
+    /// Create a builder from a plan.
+    ///
+    /// Allocates per-field storage for all declared fields.
+    pub(crate) fn new(plan: BatchPlan) -> Self {
+        let num_fields = plan.len();
+        let mut columns = Vec::with_capacity(num_fields);
+        for _ in 0..num_fields {
+            columns.push(ColumnStorage::new());
+        }
+        ColumnarBatchBuilder {
+            plan,
+            lifecycle: RowLifecycle::new(),
+            columns,
+        }
+    }
+
+    /// Start a new batch.
+    pub(crate) fn begin_batch(&mut self) {
+        self.lifecycle.begin_batch();
+        for col in &mut self.columns {
+            col.clear();
+        }
+    }
+
+    /// Start a new row.
+    #[inline(always)]
+    pub(crate) fn begin_row(&mut self) {
+        self.lifecycle.begin_row();
+    }
+
+    /// Finish the current row.
+    #[inline(always)]
+    pub(crate) fn end_row(&mut self) {
+        self.lifecycle.end_row();
+    }
+
+    /// Resolve a dynamic field by name and observed kind.
+    ///
+    /// This is the runtime field-discovery path for JSON/CRI-style producers.
+    /// Returns a stable handle that can be used for writes in the current row.
+    pub(crate) fn resolve_dynamic(
+        &mut self,
+        name: &str,
+        kind: FieldKind,
+    ) -> Result<FieldHandle, PlanError> {
+        let handle = self.plan.resolve_dynamic(name, kind)?;
+        // Ensure storage exists for newly resolved fields.
+        while self.columns.len() <= handle.index() {
+            self.columns.push(ColumnStorage::new());
+        }
+        Ok(handle)
+    }
+
+    // -----------------------------------------------------------------------
+    // Typed write methods
+    // -----------------------------------------------------------------------
+
+    /// Write an i64 value for the given field in the current row.
+    #[inline(always)]
+    pub(crate) fn write_i64(&mut self, handle: FieldHandle, value: i64) {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
+        let idx = handle.index();
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+            return;
+        }
+        if idx >= 64 && self.columns[idx].last_row == self.lifecycle.row_count() {
+            return;
+        }
+        if idx >= 64 {
+            self.columns[idx].last_row = self.lifecycle.row_count();
+        }
+        let col = &mut self.columns[idx];
+        col.has_int = true;
+        col.int_values.push((self.lifecycle.row_count(), value));
+    }
+
+    /// Write an f64 value for the given field in the current row.
+    #[inline(always)]
+    pub(crate) fn write_f64(&mut self, handle: FieldHandle, value: f64) {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
+        let idx = handle.index();
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+            return;
+        }
+        if idx >= 64 && self.columns[idx].last_row == self.lifecycle.row_count() {
+            return;
+        }
+        if idx >= 64 {
+            self.columns[idx].last_row = self.lifecycle.row_count();
+        }
+        let col = &mut self.columns[idx];
+        col.has_float = true;
+        col.float_values.push((self.lifecycle.row_count(), value));
+    }
+
+    /// Write a bool value for the given field in the current row.
+    #[inline(always)]
+    pub(crate) fn write_bool(&mut self, handle: FieldHandle, value: bool) {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
+        let idx = handle.index();
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+            return;
+        }
+        if idx >= 64 && self.columns[idx].last_row == self.lifecycle.row_count() {
+            return;
+        }
+        if idx >= 64 {
+            self.columns[idx].last_row = self.lifecycle.row_count();
+        }
+        let col = &mut self.columns[idx];
+        col.has_bool = true;
+        col.bool_values.push((self.lifecycle.row_count(), value));
+    }
+
+    /// Write a string value for the given field in the current row.
+    ///
+    /// This is the detached (copying) path.  The block store (#1844) will add
+    /// a zero-copy view-backed alternative.
+    #[inline(always)]
+    pub(crate) fn write_str(&mut self, handle: FieldHandle, value: &str) {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
+        let idx = handle.index();
+        if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
+            return;
+        }
+        if idx >= 64 && self.columns[idx].last_row == self.lifecycle.row_count() {
+            return;
+        }
+        if idx >= 64 {
+            self.columns[idx].last_row = self.lifecycle.row_count();
+        }
+        let col = &mut self.columns[idx];
+        col.has_str = true;
+        col.str_values
+            .push((self.lifecycle.row_count(), value.to_string()));
+    }
+
+    /// Write a null for the given field in the current row.
+    ///
+    /// Sparse fields are null by default; this just marks the field as
+    /// written for dedup purposes.
+    #[inline(always)]
+    pub(crate) fn write_null(&mut self, handle: FieldHandle) {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
+        let idx = handle.index();
+        let _ = check_dup_bits(self.lifecycle.written_bits_mut(), idx);
+        if idx >= 64 {
+            self.columns[idx].last_row = self.lifecycle.row_count();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Finalization
+    // -----------------------------------------------------------------------
+
+    /// Materialize all deferred facts into an Arrow `RecordBatch`.
+    ///
+    /// Planned fields produce single-type columns (no conflict check).
+    /// Dynamic fields check for type conflicts and emit `StructArray` when
+    /// multiple types were observed.
+    pub(crate) fn finish_batch(&mut self) -> Result<RecordBatch, ArrowError> {
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
+        let num_rows = self.lifecycle.row_count() as usize;
+
+        let mut schema_fields: Vec<Field> = Vec::with_capacity(self.plan.len());
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.plan.len());
+
+        for (handle, name, mode) in self.plan.fields() {
+            let col = &self.columns[handle.index()];
+
+            match mode {
+                FieldSchemaMode::Planned(kind) => {
+                    Self::materialize_planned(
+                        col,
+                        name,
+                        *kind,
+                        num_rows,
+                        &mut schema_fields,
+                        &mut arrays,
+                    );
+                }
+                FieldSchemaMode::Dynamic { .. } => {
+                    Self::materialize_dynamic(
+                        col,
+                        name,
+                        num_rows,
+                        &mut schema_fields,
+                        &mut arrays,
+                    );
+                }
+            }
+        }
+
+        let schema = Arc::new(Schema::new(schema_fields));
+        let opts = RecordBatchOptions::new().with_row_count(Some(num_rows));
+        let result = RecordBatch::try_new_with_options(schema, arrays, &opts);
+        self.lifecycle.finish_batch();
+        result
+    }
+
+    /// Number of completed rows in the current batch.
+    pub(crate) fn row_count(&self) -> u32 {
+        self.lifecycle.row_count()
+    }
+
+    /// Reference to the underlying plan.
+    pub(crate) fn plan(&self) -> &BatchPlan {
+        &self.plan
+    }
+
+    // -----------------------------------------------------------------------
+    // Materialization helpers
+    // -----------------------------------------------------------------------
+
+    fn materialize_planned(
+        col: &ColumnStorage,
+        name: &str,
+        kind: FieldKind,
+        num_rows: usize,
+        schema_fields: &mut Vec<Field>,
+        arrays: &mut Vec<ArrayRef>,
+    ) {
+        match kind {
+            FieldKind::Int64 => {
+                let (array, dt) = Self::build_int64_column(&col.int_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            }
+            FieldKind::Float64 => {
+                let (array, dt) = Self::build_float64_column(&col.float_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            }
+            FieldKind::Bool => {
+                let (array, dt) = Self::build_bool_column(&col.bool_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            }
+            FieldKind::Utf8View => {
+                let (array, dt) = Self::build_string_column(&col.str_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            }
+            FieldKind::BinaryView | FieldKind::FixedBinary(_) => {
+                // Not yet implemented in prototype; emit null Utf8 column as placeholder.
+                let (array, dt) = Self::build_string_column(&col.str_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            }
+        }
+    }
+
+    fn materialize_dynamic(
+        col: &ColumnStorage,
+        name: &str,
+        num_rows: usize,
+        schema_fields: &mut Vec<Field>,
+        arrays: &mut Vec<ArrayRef>,
+    ) {
+        let type_count = col.has_int as u8
+            + col.has_float as u8
+            + col.has_str as u8
+            + col.has_bool as u8;
+
+        if type_count > 1 {
+            // Conflict: emit StructArray with typed children.
+            let mut child_fields: Vec<Arc<Field>> = Vec::new();
+            let mut child_arrays: Vec<ArrayRef> = Vec::new();
+
+            if col.has_int {
+                let (array, _) = Self::build_int64_column(&col.int_values, num_rows);
+                child_fields.push(Arc::new(Field::new("int", DataType::Int64, true)));
+                child_arrays.push(array);
+            }
+            if col.has_float {
+                let (array, _) = Self::build_float64_column(&col.float_values, num_rows);
+                child_fields.push(Arc::new(Field::new("float", DataType::Float64, true)));
+                child_arrays.push(array);
+            }
+            if col.has_str {
+                let (array, _) = Self::build_string_column(&col.str_values, num_rows);
+                child_fields.push(Arc::new(Field::new("str", DataType::Utf8, true)));
+                child_arrays.push(array);
+            }
+            if col.has_bool {
+                let (array, _) = Self::build_bool_column(&col.bool_values, num_rows);
+                child_fields.push(Arc::new(Field::new("bool", DataType::Boolean, true)));
+                child_arrays.push(array);
+            }
+
+            let struct_validity: Vec<bool> = (0..num_rows)
+                .map(|i| child_arrays.iter().any(|arr| !arr.is_null(i)))
+                .collect();
+
+            let fields = Fields::from(child_fields);
+            let struct_arr = StructArray::new(
+                fields.clone(),
+                child_arrays,
+                Some(NullBuffer::from(struct_validity)),
+            );
+
+            schema_fields.push(Field::new(name, DataType::Struct(fields), true));
+            arrays.push(Arc::new(struct_arr));
+        } else {
+            // Single-type or empty: flat column.
+            if col.has_int {
+                let (array, dt) = Self::build_int64_column(&col.int_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            } else if col.has_float {
+                let (array, dt) = Self::build_float64_column(&col.float_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            } else if col.has_str {
+                let (array, dt) = Self::build_string_column(&col.str_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            } else if col.has_bool {
+                let (array, dt) = Self::build_bool_column(&col.bool_values, num_rows);
+                schema_fields.push(Field::new(name, dt, true));
+                arrays.push(array);
+            }
+            // If no values at all, field is omitted (all-null sparse field
+            // with no writes). This matches StreamingBuilder behavior.
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Column builders — deferred (row, value) → Arrow array
+    // -----------------------------------------------------------------------
+
+    fn build_int64_column(values: &[(u32, i64)], num_rows: usize) -> (ArrayRef, DataType) {
+        let mut data = vec![0i64; num_rows];
+        let mut valid = vec![false; num_rows];
+        for &(row, v) in values {
+            let row = row as usize;
+            if row < num_rows {
+                data[row] = v;
+                valid[row] = true;
+            }
+        }
+        let nulls = NullBuffer::from(valid);
+        let array = Int64Array::new(data.into(), Some(nulls));
+        (Arc::new(array), DataType::Int64)
+    }
+
+    fn build_float64_column(values: &[(u32, f64)], num_rows: usize) -> (ArrayRef, DataType) {
+        let mut data = vec![0.0f64; num_rows];
+        let mut valid = vec![false; num_rows];
+        for &(row, v) in values {
+            let row = row as usize;
+            if row < num_rows {
+                data[row] = v;
+                valid[row] = true;
+            }
+        }
+        let nulls = NullBuffer::from(valid);
+        let array = Float64Array::new(data.into(), Some(nulls));
+        (Arc::new(array), DataType::Float64)
+    }
+
+    fn build_bool_column(values: &[(u32, bool)], num_rows: usize) -> (ArrayRef, DataType) {
+        let mut data = vec![false; num_rows];
+        let mut valid = vec![false; num_rows];
+        for &(row, v) in values {
+            let row = row as usize;
+            if row < num_rows {
+                data[row] = v;
+                valid[row] = true;
+            }
+        }
+        let nulls = NullBuffer::from(valid);
+        let array = BooleanArray::new(data.into(), Some(nulls));
+        (Arc::new(array), DataType::Boolean)
+    }
+
+    fn build_string_column(values: &[(u32, String)], num_rows: usize) -> (ArrayRef, DataType) {
+        // Use StringBuilder (detached/copy path).
+        // Block store (#1844) will add StringViewBuilder with zero-copy views.
+        let mut builder = StringBuilder::with_capacity(values.len(), 0);
+        // Build a row-indexed lookup for sparse fill.
+        let mut row_map: Vec<Option<&str>> = vec![None; num_rows];
+        for (row, v) in values {
+            let row = *row as usize;
+            if row < num_rows {
+                row_map[row] = Some(v.as_str());
+            }
+        }
+        for slot in &row_map {
+            match slot {
+                Some(s) => builder.append_value(s),
+                None => builder.append_null(),
+            }
+        }
+        (Arc::new(builder.finish()), DataType::Utf8)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::{Array, AsArray};
+    use arrow::datatypes::Int64Type;
+
+    use super::*;
+
+    fn make_planned_builder() -> (ColumnarBatchBuilder, FieldHandle, FieldHandle, FieldHandle) {
+        let mut plan = BatchPlan::new();
+        let ts = plan.declare_planned("timestamp", FieldKind::Int64).unwrap();
+        let sev = plan
+            .declare_planned("severity", FieldKind::Utf8View)
+            .unwrap();
+        let val = plan.declare_planned("value", FieldKind::Float64).unwrap();
+        let builder = ColumnarBatchBuilder::new(plan);
+        (builder, ts, sev, val)
+    }
+
+    // -----------------------------------------------------------------------
+    // Planned field tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn planned_int64_single_row() {
+        let (mut b, ts, _sev, _val) = make_planned_builder();
+        b.begin_batch();
+        b.begin_row();
+        b.write_i64(ts, 1_000_000);
+        b.end_row();
+        let batch = b.finish_batch().unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+        let col = batch.column_by_name("timestamp").unwrap();
+        let arr = col.as_primitive::<Int64Type>();
+        assert_eq!(arr.value(0), 1_000_000);
+        assert!(!arr.is_null(0));
+    }
+
+    #[test]
+    fn planned_sparse_fields_produce_nulls() {
+        let (mut b, ts, sev, val) = make_planned_builder();
+        b.begin_batch();
+
+        // Row 0: only timestamp
+        b.begin_row();
+        b.write_i64(ts, 100);
+        b.end_row();
+
+        // Row 1: only severity
+        b.begin_row();
+        b.write_str(sev, "INFO");
+        b.end_row();
+
+        // Row 2: only value
+        b.begin_row();
+        b.write_f64(val, 3.14);
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 3);
+
+        // timestamp: [100, null, null]
+        let ts_col = batch.column_by_name("timestamp").unwrap();
+        let ts_arr = ts_col.as_primitive::<Int64Type>();
+        assert!(!ts_arr.is_null(0));
+        assert!(ts_arr.is_null(1));
+        assert!(ts_arr.is_null(2));
+        assert_eq!(ts_arr.value(0), 100);
+
+        // severity: [null, "INFO", null]
+        let sev_col = batch.column_by_name("severity").unwrap();
+        assert!(sev_col.is_null(0));
+        assert!(!sev_col.is_null(1));
+        assert!(sev_col.is_null(2));
+
+        // value: [null, null, 3.14]
+        let val_col = batch.column_by_name("value").unwrap();
+        assert!(val_col.is_null(0));
+        assert!(val_col.is_null(1));
+        assert!(!val_col.is_null(2));
+    }
+
+    #[test]
+    fn planned_bool_field() {
+        let mut plan = BatchPlan::new();
+        let flag = plan.declare_planned("active", FieldKind::Bool).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.begin_row();
+        b.write_bool(flag, true);
+        b.end_row();
+        b.begin_row();
+        b.write_bool(flag, false);
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        let col = batch.column_by_name("active").unwrap();
+        let arr = col.as_boolean();
+        assert!(arr.value(0));
+        assert!(!arr.value(1));
+    }
+
+    #[test]
+    fn empty_batch_produces_zero_rows() {
+        let (mut b, _ts, _sev, _val) = make_planned_builder();
+        b.begin_batch();
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 0);
+    }
+
+    #[test]
+    fn planned_dedup_first_write_wins() {
+        let mut plan = BatchPlan::new();
+        let h = plan.declare_planned("x", FieldKind::Int64).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.begin_row();
+        b.write_i64(h, 1);
+        b.write_i64(h, 2); // should be ignored (dedup)
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        let col = batch.column_by_name("x").unwrap();
+        let arr = col.as_primitive::<Int64Type>();
+        assert_eq!(arr.value(0), 1);
+    }
+
+    #[test]
+    fn batch_reuse_resets_state() {
+        let (mut b, ts, _sev, _val) = make_planned_builder();
+
+        // First batch
+        b.begin_batch();
+        b.begin_row();
+        b.write_i64(ts, 100);
+        b.end_row();
+        let batch1 = b.finish_batch().unwrap();
+        assert_eq!(batch1.num_rows(), 1);
+
+        // Second batch (reuse builder)
+        b.begin_batch();
+        b.begin_row();
+        b.write_i64(ts, 200);
+        b.end_row();
+        b.begin_row();
+        b.write_i64(ts, 300);
+        b.end_row();
+        let batch2 = b.finish_batch().unwrap();
+        assert_eq!(batch2.num_rows(), 2);
+
+        let arr = batch2
+            .column_by_name("timestamp")
+            .unwrap()
+            .as_primitive::<Int64Type>();
+        assert_eq!(arr.value(0), 200);
+        assert_eq!(arr.value(1), 300);
+    }
+
+    // -----------------------------------------------------------------------
+    // Dynamic field tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dynamic_single_type_flat_column() {
+        let plan = BatchPlan::new();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.begin_row();
+        let h = b.resolve_dynamic("level", FieldKind::Utf8View).unwrap();
+        b.write_str(h, "INFO");
+        b.end_row();
+
+        b.begin_row();
+        let h2 = b.resolve_dynamic("level", FieldKind::Utf8View).unwrap();
+        assert_eq!(h, h2);
+        b.write_str(h2, "ERROR");
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        let col = batch.column_by_name("level").unwrap();
+        assert!(!col.is_null(0));
+        assert!(!col.is_null(1));
+    }
+
+    #[test]
+    fn dynamic_conflict_produces_struct() {
+        let plan = BatchPlan::new();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+
+        // Row 0: "status" as int
+        b.begin_row();
+        let h = b.resolve_dynamic("status", FieldKind::Int64).unwrap();
+        b.write_i64(h, 200);
+        b.end_row();
+
+        // Row 1: "status" as string
+        b.begin_row();
+        let h2 = b.resolve_dynamic("status", FieldKind::Utf8View).unwrap();
+        assert_eq!(h, h2);
+        b.write_str(h2, "OK");
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+
+        let col = batch.column_by_name("status").unwrap();
+        // Should be a StructArray with "int" and "str" children.
+        let struct_arr = col.as_struct();
+        assert_eq!(struct_arr.num_columns(), 2);
+
+        let int_child = struct_arr.column_by_name("int").unwrap();
+        let str_child = struct_arr.column_by_name("str").unwrap();
+
+        // Row 0: int=200, str=null
+        assert!(!int_child.is_null(0));
+        assert!(str_child.is_null(0));
+        assert_eq!(int_child.as_primitive::<Int64Type>().value(0), 200);
+
+        // Row 1: int=null, str="OK"
+        assert!(int_child.is_null(1));
+        assert!(!str_child.is_null(1));
+    }
+
+    #[test]
+    fn mixed_planned_and_dynamic_fields() {
+        let mut plan = BatchPlan::new();
+        let ts = plan.declare_planned("timestamp", FieldKind::Int64).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+
+        b.begin_row();
+        b.write_i64(ts, 1000);
+        let msg = b.resolve_dynamic("message", FieldKind::Utf8View).unwrap();
+        b.write_str(msg, "hello");
+        b.end_row();
+
+        b.begin_row();
+        b.write_i64(ts, 2000);
+        let msg2 = b.resolve_dynamic("message", FieldKind::Utf8View).unwrap();
+        b.write_str(msg2, "world");
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(batch.num_columns(), 2);
+
+        let ts_arr = batch
+            .column_by_name("timestamp")
+            .unwrap()
+            .as_primitive::<Int64Type>();
+        assert_eq!(ts_arr.value(0), 1000);
+        assert_eq!(ts_arr.value(1), 2000);
+    }
+
+    #[test]
+    fn write_null_marks_dedup_only() {
+        let mut plan = BatchPlan::new();
+        let h = plan.declare_planned("x", FieldKind::Int64).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.begin_row();
+        b.write_null(h);
+        b.write_i64(h, 42); // should be ignored (dedup — null was first)
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        let col = batch.column_by_name("x").unwrap();
+        let arr = col.as_primitive::<Int64Type>();
+        // The field was written as null first, so i64 write was suppressed.
+        assert!(arr.is_null(0));
+    }
+
+    #[test]
+    fn many_rows_sparse_fields() {
+        let mut plan = BatchPlan::new();
+        let a = plan.declare_planned("a", FieldKind::Int64).unwrap();
+        let b_handle = plan.declare_planned("b", FieldKind::Int64).unwrap();
+        let mut builder = ColumnarBatchBuilder::new(plan);
+
+        builder.begin_batch();
+        for i in 0..100u32 {
+            builder.begin_row();
+            if i % 2 == 0 {
+                builder.write_i64(a, i as i64);
+            }
+            if i % 3 == 0 {
+                builder.write_i64(b_handle, (i * 10) as i64);
+            }
+            builder.end_row();
+        }
+
+        let batch = builder.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), 100);
+
+        let a_arr = batch
+            .column_by_name("a")
+            .unwrap()
+            .as_primitive::<Int64Type>();
+        assert!(!a_arr.is_null(0));
+        assert!(a_arr.is_null(1));
+        assert!(!a_arr.is_null(2));
+        assert_eq!(a_arr.value(0), 0);
+        assert_eq!(a_arr.value(2), 2);
+
+        let b_arr = batch
+            .column_by_name("b")
+            .unwrap()
+            .as_primitive::<Int64Type>();
+        assert!(!b_arr.is_null(0));
+        assert!(b_arr.is_null(1));
+        assert!(b_arr.is_null(2));
+        assert!(!b_arr.is_null(3));
+        assert_eq!(b_arr.value(0), 0);
+        assert_eq!(b_arr.value(3), 30);
+    }
+
+    #[test]
+    fn column_order_matches_declaration_order() {
+        let mut plan = BatchPlan::new();
+        plan.declare_planned("z_last", FieldKind::Int64).unwrap();
+        plan.declare_planned("a_first", FieldKind::Int64).unwrap();
+        plan.declare_planned("m_middle", FieldKind::Int64).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.begin_row();
+        b.end_row();
+        let batch = b.finish_batch().unwrap();
+
+        let schema = batch.schema();
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["z_last", "a_first", "m_middle"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Planned-field type safety: wrong-type writes are benign
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn planned_wrong_type_write_stored_but_planned_kind_selects_output() {
+        // If a producer writes a string to a planned Int64 field, the string
+        // is stored but the planned kind selects int_values at materialization.
+        // The result is an all-null column for that field.
+        let mut plan = BatchPlan::new();
+        let h = plan.declare_planned("x", FieldKind::Int64).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        b.begin_batch();
+        b.begin_row();
+        b.write_str(h, "not an int");
+        b.end_row();
+
+        let batch = b.finish_batch().unwrap();
+        let col = batch.column_by_name("x").unwrap();
+        let arr = col.as_primitive::<Int64Type>();
+        // Planned kind is Int64, but we only wrote a string → int column is all-null.
+        assert!(arr.is_null(0));
+    }
+}

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -175,8 +175,15 @@ impl ColumnarBatchBuilder {
     }
 
     /// Start a new batch.
+    ///
+    /// Clears all column data, resets dynamic fields (they must be
+    /// re-resolved from scratch each batch), and resets string buffers.
     pub fn begin_batch(&mut self) {
         self.lifecycle.begin_batch();
+        // Reset dynamic fields so the schema doesn't grow unboundedly.
+        // Planned fields are kept; dynamic ones are re-resolved per batch.
+        self.plan.reset_dynamic();
+        self.columns.truncate(self.plan.len());
         for col in &mut self.columns {
             col.clear();
         }
@@ -214,13 +221,11 @@ impl ColumnarBatchBuilder {
     /// Resolve a dynamic field by name and observed kind.
     ///
     /// This is the runtime field-discovery path for JSON/CRI-style producers.
-    /// Returns a stable handle that can be used for writes in the current row.
+    /// Returns a stable handle that can be used for writes in the current batch.
     ///
-    /// Dynamically resolved fields grow the plan and column storage
-    /// monotonically — `begin_batch` clears all column data but does not
-    /// remove columns. This means the schema can grow across batches but
-    /// never shrinks. A future schema-reset API can be added if producers
-    /// need to discard stale dynamic fields between batches.
+    /// Dynamic fields are reset on `begin_batch` — handles from a previous
+    /// batch are invalidated. This matches `StreamingBuilder`'s per-batch
+    /// field resolution and prevents unbounded schema growth.
     pub fn resolve_dynamic(
         &mut self,
         name: &str,
@@ -1311,5 +1316,43 @@ mod tests {
             total,
             total.as_nanos() as f64 / total_rows as f64,
         );
+    }
+
+    #[test]
+    fn dynamic_fields_reset_between_batches() {
+        let plan = BatchPlan::new();
+        let mut b = ColumnarBatchBuilder::new(plan);
+
+        // Batch 1: fields "x" and "y", both written.
+        b.begin_batch();
+        let x = b.resolve_dynamic("x", FieldKind::Int64).unwrap();
+        let y = b.resolve_dynamic("y", FieldKind::Utf8View).unwrap();
+        b.begin_row();
+        b.write_i64(x, 1);
+        b.write_str(y, "hello").unwrap();
+        b.end_row();
+        let batch1 = b.finish_batch().unwrap();
+        assert_eq!(batch1.num_columns(), 2);
+        let names1: Vec<String> = batch1
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect();
+        assert!(names1.contains(&"x".to_string()));
+        assert!(names1.contains(&"y".to_string()));
+
+        // Batch 2: field "z" only — "x" and "y" should be gone.
+        b.begin_batch();
+        assert!(b.plan().lookup("x").is_none(), "x should be reset");
+        assert!(b.plan().lookup("y").is_none(), "y should be reset");
+        let z = b.resolve_dynamic("z", FieldKind::Float64).unwrap();
+        b.begin_row();
+        b.write_f64(z, 3.14);
+        b.end_row();
+        let batch2 = b.finish_batch().unwrap();
+        // Only field "z" — no stale columns.
+        assert_eq!(batch2.num_columns(), 1);
+        assert_eq!(batch2.schema().field(0).name(), "z");
     }
 }

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -114,6 +114,9 @@ pub struct ColumnarBatchBuilder {
     /// StringRef offsets at or above `original_buf.len()` point here
     /// (shifted by original_buf.len()).
     string_buf: Vec<u8>,
+    /// When false, skip per-field dedup checks (producers that guarantee
+    /// at most one write per field per row can disable for throughput).
+    dedup_enabled: bool,
 }
 
 impl ColumnarBatchBuilder {
@@ -134,7 +137,18 @@ impl ColumnarBatchBuilder {
             columns,
             original_buf: Vec::new(),
             string_buf: Vec::new(),
+            dedup_enabled: true,
         }
+    }
+
+    /// Disable per-field dedup checks.
+    ///
+    /// Producers that guarantee at most one write per field per row (e.g., OTLP
+    /// decoders, CSV parsers) can disable dedup for ~8% throughput improvement.
+    /// If a field is written twice in the same row with dedup disabled, both
+    /// values are recorded and the second silently wins at materialization.
+    pub fn set_dedup_enabled(&mut self, enabled: bool) {
+        self.dedup_enabled = enabled;
     }
 
     /// Start a new batch.
@@ -223,7 +237,7 @@ impl ColumnarBatchBuilder {
     pub fn write_i64(&mut self, handle: FieldHandle, value: i64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
-        if self.is_duplicate(handle) {
+        if self.dedup_enabled && self.is_duplicate(handle) {
             return;
         }
         self.columns[handle.index()].push_i64(self.lifecycle.row_count(), value);
@@ -234,7 +248,7 @@ impl ColumnarBatchBuilder {
     pub fn write_f64(&mut self, handle: FieldHandle, value: f64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
-        if self.is_duplicate(handle) {
+        if self.dedup_enabled && self.is_duplicate(handle) {
             return;
         }
         self.columns[handle.index()].push_f64(self.lifecycle.row_count(), value);
@@ -245,7 +259,7 @@ impl ColumnarBatchBuilder {
     pub fn write_bool(&mut self, handle: FieldHandle, value: bool) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
-        if self.is_duplicate(handle) {
+        if self.dedup_enabled && self.is_duplicate(handle) {
             return;
         }
         self.columns[handle.index()].push_bool(self.lifecycle.row_count(), value);
@@ -265,7 +279,7 @@ impl ColumnarBatchBuilder {
     pub fn write_str(&mut self, handle: FieldHandle, value: &str) -> Result<(), BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
-        if self.is_duplicate(handle) {
+        if self.dedup_enabled && self.is_duplicate(handle) {
             return Ok(());
         }
         // Generated string offsets are shifted by original_buf.len() so that
@@ -292,7 +306,7 @@ impl ColumnarBatchBuilder {
     pub fn write_str_ref(&mut self, handle: FieldHandle, sref: StringRef) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
-        if self.is_duplicate(handle) {
+        if self.dedup_enabled && self.is_duplicate(handle) {
             return;
         }
         self.columns[handle.index()].push_str(self.lifecycle.row_count(), sref);
@@ -306,7 +320,9 @@ impl ColumnarBatchBuilder {
     pub fn write_null(&mut self, handle: FieldHandle) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
-        let _ = self.is_duplicate(handle);
+        if self.dedup_enabled {
+            let _ = self.is_duplicate(handle);
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, NullArray, StringViewArray};
+use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, StringViewArray};
 use arrow::buffer::{Buffer, NullBuffer};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
@@ -109,7 +109,9 @@ pub struct ColumnarBatchBuilder {
     columns: Vec<ColumnAccumulator>,
     /// Optional original input buffer for zero-copy string references.
     /// `write_str_ref` offsets below `original_buf.len()` point here.
-    original_buf: Vec<u8>,
+    /// Stored as an Arrow `Buffer` (ref-counted) — O(1) to pass through
+    /// to StringViewArray without copying.
+    original_buf: Buffer,
     /// Generated buffer for string values written via `write_str`.
     /// StringRef offsets at or above `original_buf.len()` point here
     /// (shifted by original_buf.len()).
@@ -135,7 +137,7 @@ impl ColumnarBatchBuilder {
             plan,
             lifecycle: RowLifecycle::new(),
             columns,
-            original_buf: Vec::new(),
+            original_buf: Buffer::from(Vec::<u8>::new()),
             string_buf: Vec::new(),
             dedup_enabled: true,
         }
@@ -157,7 +159,7 @@ impl ColumnarBatchBuilder {
         for col in &mut self.columns {
             col.clear();
         }
-        self.original_buf.clear();
+        self.original_buf = Buffer::from(Vec::<u8>::new());
         self.string_buf.clear();
     }
 
@@ -165,14 +167,15 @@ impl ColumnarBatchBuilder {
     ///
     /// Call after `begin_batch` and before any writes. `write_str_ref` with
     /// offsets below `original_buf.len()` will reference this buffer at
-    /// materialization time.
-    pub fn set_original_buffer(&mut self, buf: &[u8]) {
+    /// materialization time. The buffer is ref-counted (Arrow `Buffer`) —
+    /// no copy on set, and O(1) pass-through to `StringViewArray`.
+    pub fn set_original_buffer(&mut self, buf: Buffer) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
         debug_assert!(
             self.original_buf.is_empty(),
             "set_original_buffer called twice in the same batch"
         );
-        self.original_buf.extend_from_slice(buf);
+        self.original_buf = buf;
     }
 
     /// Start a new row.
@@ -285,7 +288,14 @@ impl ColumnarBatchBuilder {
         // Generated string offsets are shifted by original_buf.len() so that
         // the 2-buffer model can distinguish original vs generated at
         // materialization time.
-        let raw_offset = self.original_buf.len() + self.string_buf.len();
+        let raw_offset = self
+            .original_buf
+            .len()
+            .checked_add(self.string_buf.len())
+            .ok_or(BuilderError::StringBufferOverflow {
+                buffer_len: self.string_buf.len(),
+                value_len: value.len(),
+            })?;
         let offset = u32::try_from(raw_offset).map_err(|_| BuilderError::StringBufferOverflow {
             buffer_len: self.string_buf.len(),
             value_len: value.len(),
@@ -338,12 +348,10 @@ impl ColumnarBatchBuilder {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
         let num_rows = self.lifecycle.row_count() as usize;
 
-        // Copy to aligned Arrow Buffers, then clear (preserving Vec capacity
-        // so the next batch avoids reallocation).
-        let original = Buffer::from(self.original_buf.as_slice());
-        let generated = Buffer::from(self.string_buf.as_slice());
-        self.original_buf.clear();
-        self.string_buf.clear();
+        // Transfer buffers to Arrow — O(1) for the ref-counted original,
+        // O(1) move for the generated Vec.
+        let original = std::mem::replace(&mut self.original_buf, Buffer::from(Vec::<u8>::new()));
+        let generated = Buffer::from_vec(std::mem::take(&mut self.string_buf));
 
         // utf8_trusted: true because write_str takes &str (Rust guarantees UTF-8)
         // and write_str_ref is only used with scanner-validated buffers.
@@ -429,9 +437,16 @@ fn null_column(name: &str, kind: FieldKind, num_rows: usize) -> (Field, ArrayRef
             let arr = StringViewArray::new_null(num_rows);
             (Field::new(name, DataType::Utf8View, true), Arc::new(arr))
         }
-        FieldKind::BinaryView | FieldKind::FixedBinary(_) => {
-            let arr = NullArray::new(num_rows);
-            (Field::new(name, DataType::Null, true), Arc::new(arr))
+        FieldKind::BinaryView => {
+            let arr = arrow::array::BinaryViewArray::new_null(num_rows);
+            (Field::new(name, DataType::BinaryView, true), Arc::new(arr))
+        }
+        FieldKind::FixedBinary(n) => {
+            let arr = arrow::array::FixedSizeBinaryArray::new_null(n as i32, num_rows);
+            (
+                Field::new(name, DataType::FixedSizeBinary(n as i32), true),
+                Arc::new(arr),
+            )
         }
     }
 }
@@ -889,7 +904,7 @@ mod tests {
         let input = b"hello world";
 
         b.begin_batch();
-        b.set_original_buffer(input);
+        b.set_original_buffer(Buffer::from(input.as_slice()));
         b.begin_row();
         b.write_i64(ts, 1000);
         b.write_str_ref(msg, StringRef { offset: 0, len: 5 });
@@ -946,7 +961,7 @@ mod tests {
         let mut b = ColumnarBatchBuilder::new(plan);
 
         b.begin_batch();
-        b.set_original_buffer(input);
+        b.set_original_buffer(Buffer::from(input.as_slice()));
         b.begin_row();
         b.write_str_ref(a, StringRef { offset: 0, len: 5 });
         b.write_str_ref(b_h, StringRef { offset: 5, len: 5 });
@@ -979,7 +994,7 @@ mod tests {
         let mut b = ColumnarBatchBuilder::new(plan);
 
         b.begin_batch();
-        b.set_original_buffer(input);
+        b.set_original_buffer(Buffer::from(input.as_slice()));
         b.begin_row();
         b.write_str_ref(ref_field, StringRef { offset: 0, len: 10 });
         b.write_str(gen_field, "generated-value").unwrap();

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, NullArray, StringBuilder};
+use arrow::array::{ArrayRef, BooleanArray, Float64Array, Int64Array, NullArray, StringViewArray};
 use arrow::buffer::{Buffer, NullBuffer};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::ArrowError;
@@ -272,11 +272,9 @@ impl ColumnarBatchBuilder {
         // the 2-buffer model can distinguish original vs generated at
         // materialization time.
         let raw_offset = self.original_buf.len() + self.string_buf.len();
-        let offset = u32::try_from(raw_offset).map_err(|_| {
-            BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: value.len(),
-            }
+        let offset = u32::try_from(raw_offset).map_err(|_| BuilderError::StringBufferOverflow {
+            buffer_len: self.string_buf.len(),
+            value_len: value.len(),
         })?;
         let len = u32::try_from(value.len()).map_err(|_| BuilderError::StringBufferOverflow {
             buffer_len: self.string_buf.len(),
@@ -315,19 +313,27 @@ impl ColumnarBatchBuilder {
     // Finalization
     // -----------------------------------------------------------------------
 
-    /// Materialize all deferred facts into an Arrow `RecordBatch` (detached).
+    /// Materialize all deferred facts into an Arrow `RecordBatch`.
     ///
-    /// Copies string data into contiguous `StringArray` arrays. The builder's
-    /// internal buffers can be reused after this call.
+    /// When utf8_trusted (the default), produces `StringViewArray` columns that
+    /// reference the source buffers directly — zero per-string byte copying.
+    /// The builder's internal buffers are transferred to Arrow (O(1) for reuse).
     pub fn finish_batch(&mut self) -> Result<RecordBatch, BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
         let num_rows = self.lifecycle.row_count() as usize;
 
+        // Copy to aligned Arrow Buffers, then clear (preserving Vec capacity
+        // so the next batch avoids reallocation).
+        let original = Buffer::from(self.original_buf.as_slice());
+        let generated = Buffer::from(self.string_buf.as_slice());
+        self.original_buf.clear();
+        self.string_buf.clear();
+
         // utf8_trusted: true because write_str takes &str (Rust guarantees UTF-8)
         // and write_str_ref is only used with scanner-validated buffers.
         let mode = FinalizationMode::Detached {
-            original_buf: &self.original_buf,
-            generated_buf: &self.string_buf,
+            original_buf: original,
+            generated_buf: generated,
             utf8_trusted: true,
         };
 
@@ -370,7 +376,7 @@ impl ColumnarBatchBuilder {
     fn materialize_all(
         &self,
         num_rows: usize,
-        mode: FinalizationMode<'_>,
+        mode: FinalizationMode,
     ) -> Result<RecordBatch, BuilderError> {
         let mut schema_fields = Vec::with_capacity(self.plan.len());
         let mut arrays = Vec::with_capacity(self.plan.len());
@@ -434,15 +440,8 @@ fn null_column(name: &str, kind: FieldKind, num_rows: usize) -> (Field, ArrayRef
             (Field::new(name, DataType::Boolean, true), Arc::new(arr))
         }
         FieldKind::Utf8View => {
-            // Use StringBuilder for detached mode compatibility.
-            let mut builder = StringBuilder::with_capacity(0, 0);
-            for _ in 0..num_rows {
-                builder.append_null();
-            }
-            (
-                Field::new(name, DataType::Utf8, true),
-                Arc::new(builder.finish()),
-            )
+            let arr = StringViewArray::new_null(num_rows);
+            (Field::new(name, DataType::Utf8View, true), Arc::new(arr))
         }
         FieldKind::BinaryView | FieldKind::FixedBinary(_) => {
             let arr = NullArray::new(num_rows);
@@ -913,8 +912,8 @@ mod tests {
 
         let batch = b.finish_batch().unwrap();
         assert_eq!(batch.num_rows(), 2);
-        let col_a = batch.column_by_name("a").unwrap().as_string::<i32>();
-        let col_b = batch.column_by_name("b").unwrap().as_string::<i32>();
+        let col_a = batch.column_by_name("a").unwrap().as_string_view();
+        let col_b = batch.column_by_name("b").unwrap().as_string_view();
         assert_eq!(col_a.value(0), "hello");
         assert_eq!(col_a.value(1), "world");
         assert_eq!(col_b.value(0), "world");
@@ -946,8 +945,8 @@ mod tests {
 
         let batch = b.finish_batch().unwrap();
         assert_eq!(batch.num_rows(), 2);
-        let r = batch.column_by_name("ref_field").unwrap().as_string::<i32>();
-        let g = batch.column_by_name("gen_field").unwrap().as_string::<i32>();
+        let r = batch.column_by_name("ref_field").unwrap().as_string_view();
+        let g = batch.column_by_name("gen_field").unwrap().as_string_view();
         assert_eq!(r.value(0), "from-input");
         assert_eq!(r.value(1), "input");
         assert_eq!(g.value(0), "generated-value");

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -36,7 +36,7 @@ use crate::check_dup_bits;
 
 /// Errors from `ColumnarBatchBuilder` operations.
 #[derive(Debug)]
-pub(crate) enum BuilderError {
+pub enum BuilderError {
     /// Arrow error during RecordBatch construction.
     Arrow(ArrowError),
     /// String buffer exceeded u32 addressable range.
@@ -105,7 +105,7 @@ impl From<MaterializeError> for BuilderError {
 ///   dynamic → `ColumnAccumulator::Dynamic` (all vecs, conflict detection).
 /// - Dedup uses the same bitmask approach as `RowLifecycle::written_bits`.
 /// - `finish_batch` iterates fields and calls `accumulator.materialize()`.
-pub(crate) struct ColumnarBatchBuilder {
+pub struct ColumnarBatchBuilder {
     plan: BatchPlan,
     lifecycle: RowLifecycle,
     columns: Vec<ColumnAccumulator>,
@@ -118,7 +118,7 @@ impl ColumnarBatchBuilder {
     /// Create a builder from a plan.
     ///
     /// Allocates per-field storage matched to each field's schema mode.
-    pub(crate) fn new(plan: BatchPlan) -> Self {
+    pub fn new(plan: BatchPlan) -> Self {
         let columns: Vec<ColumnAccumulator> = plan
             .fields()
             .map(|(_handle, _name, mode)| match mode {
@@ -135,7 +135,7 @@ impl ColumnarBatchBuilder {
     }
 
     /// Start a new batch.
-    pub(crate) fn begin_batch(&mut self) {
+    pub fn begin_batch(&mut self) {
         self.lifecycle.begin_batch();
         for col in &mut self.columns {
             col.clear();
@@ -145,13 +145,13 @@ impl ColumnarBatchBuilder {
 
     /// Start a new row.
     #[inline]
-    pub(crate) fn begin_row(&mut self) {
+    pub fn begin_row(&mut self) {
         self.lifecycle.begin_row();
     }
 
     /// Finish the current row.
     #[inline]
-    pub(crate) fn end_row(&mut self) {
+    pub fn end_row(&mut self) {
         self.lifecycle.end_row();
     }
 
@@ -159,7 +159,7 @@ impl ColumnarBatchBuilder {
     ///
     /// This is the runtime field-discovery path for JSON/CRI-style producers.
     /// Returns a stable handle that can be used for writes in the current row.
-    pub(crate) fn resolve_dynamic(
+    pub fn resolve_dynamic(
         &mut self,
         name: &str,
         kind: FieldKind,
@@ -202,7 +202,7 @@ impl ColumnarBatchBuilder {
 
     /// Write an i64 value for the given field in the current row.
     #[inline]
-    pub(crate) fn write_i64(&mut self, handle: FieldHandle, value: i64) {
+    pub fn write_i64(&mut self, handle: FieldHandle, value: i64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
         if self.is_duplicate(handle) {
@@ -213,7 +213,7 @@ impl ColumnarBatchBuilder {
 
     /// Write an f64 value for the given field in the current row.
     #[inline]
-    pub(crate) fn write_f64(&mut self, handle: FieldHandle, value: f64) {
+    pub fn write_f64(&mut self, handle: FieldHandle, value: f64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
         if self.is_duplicate(handle) {
@@ -224,7 +224,7 @@ impl ColumnarBatchBuilder {
 
     /// Write a bool value for the given field in the current row.
     #[inline]
-    pub(crate) fn write_bool(&mut self, handle: FieldHandle, value: bool) {
+    pub fn write_bool(&mut self, handle: FieldHandle, value: bool) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
         if self.is_duplicate(handle) {
@@ -244,7 +244,7 @@ impl ColumnarBatchBuilder {
     ///
     /// Returns `Err` if the string buffer would exceed u32 addressable range.
     #[inline]
-    pub(crate) fn write_str(
+    pub fn write_str(
         &mut self,
         handle: FieldHandle,
         value: &str,
@@ -275,7 +275,7 @@ impl ColumnarBatchBuilder {
     /// Write a `StringRef` directly (for zero-copy producers that already
     /// have offsets into an input buffer).
     #[inline]
-    pub(crate) fn write_str_ref(&mut self, handle: FieldHandle, sref: StringRef) {
+    pub fn write_str_ref(&mut self, handle: FieldHandle, sref: StringRef) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
         if self.is_duplicate(handle) {
@@ -289,7 +289,7 @@ impl ColumnarBatchBuilder {
     /// Sparse fields are null by default; this just marks the field as
     /// written for dedup purposes.
     #[inline]
-    pub(crate) fn write_null(&mut self, handle: FieldHandle) {
+    pub fn write_null(&mut self, handle: FieldHandle) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
         let _ = self.is_duplicate(handle);
@@ -303,7 +303,7 @@ impl ColumnarBatchBuilder {
     ///
     /// Copies string data into `StringBuilder` arrays. The builder's internal
     /// buffers can be reused after this call.
-    pub(crate) fn finish_batch(&mut self) -> Result<RecordBatch, BuilderError> {
+    pub fn finish_batch(&mut self) -> Result<RecordBatch, BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InBatch);
         let num_rows = self.lifecycle.row_count() as usize;
 
@@ -324,7 +324,7 @@ impl ColumnarBatchBuilder {
     /// `original_len` is the length of the original buffer.
     /// Strings with `offset < original_len` reference the original buffer;
     /// strings with `offset >= original_len` reference the generated buffer.
-    pub(crate) fn finish_batch_view(
+    pub fn finish_batch_view(
         &mut self,
         original: Buffer,
         original_len: u32,
@@ -383,12 +383,12 @@ impl ColumnarBatchBuilder {
     }
 
     /// Number of completed rows in the current batch.
-    pub(crate) fn row_count(&self) -> u32 {
+    pub fn row_count(&self) -> u32 {
         self.lifecycle.row_count()
     }
 
     /// Reference to the underlying plan.
-    pub(crate) fn plan(&self) -> &BatchPlan {
+    pub fn plan(&self) -> &BatchPlan {
         &self.plan
     }
 }
@@ -1202,5 +1202,106 @@ mod tests {
         eprintln!("    FieldKind: {} bytes", size_of::<FieldKind>());
         eprintln!("    StringRef: {} bytes", size_of::<StringRef>());
         eprintln!("    BatchPlan: {} bytes\n", size_of::<BatchPlan>());
+    }
+
+    /// CPU breakdown: write phase vs materialization phase.
+    #[test]
+    fn cpu_breakdown_write_vs_materialize() {
+        let mut plan = BatchPlan::new();
+        let ts = plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap();
+        let sev_num = plan.declare_planned("severity_number", FieldKind::Int64).unwrap();
+        let sev_text = plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap();
+        let body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
+        let flags = plan.declare_planned("flags", FieldKind::Int64).unwrap();
+        let trace_id = plan.declare_planned("trace_id", FieldKind::Utf8View).unwrap();
+        let span_id = plan.declare_planned("span_id", FieldKind::Utf8View).unwrap();
+        let res_svc = plan.declare_planned("resource.service.name", FieldKind::Utf8View).unwrap();
+        let res_host = plan.declare_planned("resource.host.name", FieldKind::Utf8View).unwrap();
+        let scope_name = plan.declare_planned("scope.name", FieldKind::Utf8View).unwrap();
+        let scope_ver = plan.declare_planned("scope.version", FieldKind::Utf8View).unwrap();
+        let attr_method = plan.declare_planned("attributes.http.method", FieldKind::Utf8View).unwrap();
+        let attr_status = plan.declare_planned("attributes.http.status_code", FieldKind::Int64).unwrap();
+        let attr_dur = plan.declare_planned("attributes.duration_ms", FieldKind::Float64).unwrap();
+        let attr_path = plan.declare_planned("attributes.http.path", FieldKind::Utf8View).unwrap();
+
+        let handles_int = [ts, sev_num, flags, attr_status];
+        let handles_str = [sev_text, body, trace_id, span_id, res_svc, res_host,
+            scope_name, scope_ver, attr_method, attr_path];
+        let handles_float = [attr_dur];
+
+        let mut b = ColumnarBatchBuilder::new(plan);
+        let rows_per_batch: u32 = 1000;
+        let num_batches: u64 = 20;
+
+        // Warmup
+        b.begin_batch();
+        for row in 0..rows_per_batch {
+            b.begin_row();
+            for (i, &h) in handles_int.iter().enumerate() {
+                b.write_i64(h, row as i64 + i as i64);
+            }
+            for &h in &handles_str {
+                b.write_str(h, "warmup-string-value").unwrap();
+            }
+            for &h in &handles_float {
+                b.write_f64(h, row as f64);
+            }
+            b.end_row();
+        }
+        let _ = b.finish_batch().unwrap();
+
+        let mut total_write = std::time::Duration::ZERO;
+        let mut total_materialize = std::time::Duration::ZERO;
+
+        for batch_idx in 0..num_batches {
+            b.begin_batch();
+
+            let write_start = std::time::Instant::now();
+            for row in 0..rows_per_batch {
+                b.begin_row();
+                let base = (batch_idx as i64) * (rows_per_batch as i64) + row as i64;
+                for (i, &h) in handles_int.iter().enumerate() {
+                    b.write_i64(h, base + i as i64 * 1000);
+                }
+                for &h in &handles_str {
+                    b.write_str(h, "example-value-0123456789").unwrap();
+                }
+                for &h in &handles_float {
+                    b.write_f64(h, base as f64 * 0.001);
+                }
+                b.end_row();
+            }
+            total_write += write_start.elapsed();
+
+            let mat_start = std::time::Instant::now();
+            let batch = b.finish_batch().unwrap();
+            total_materialize += mat_start.elapsed();
+
+            assert_eq!(batch.num_rows(), rows_per_batch as usize);
+        }
+
+        let total_rows = u64::from(rows_per_batch) * num_batches;
+        let total = total_write + total_materialize;
+        let write_pct = total_write.as_nanos() as f64 / total.as_nanos() as f64 * 100.0;
+        let mat_pct = total_materialize.as_nanos() as f64 / total.as_nanos() as f64 * 100.0;
+
+        eprintln!("\n  CPU breakdown ({total_rows} rows, {num_batches} batches):");
+        eprintln!(
+            "    write phase:        {:.1?}  ({:.0} ns/row, {:.0}%)",
+            total_write,
+            total_write.as_nanos() as f64 / total_rows as f64,
+            write_pct,
+        );
+        eprintln!(
+            "    materialize phase:  {:.1?}  ({:.0} ns/row, {:.0}%)",
+            total_materialize,
+            total_materialize.as_nanos() as f64 / total_rows as f64,
+            mat_pct,
+        );
+        eprintln!(
+            "    total:              {:.1?}  ({:.0} ns/row)\n",
+            total,
+            total.as_nanos() as f64 / total_rows as f64,
+        );
     }
 }

--- a/crates/logfwd-arrow/src/columnar/mod.rs
+++ b/crates/logfwd-arrow/src/columnar/mod.rs
@@ -11,5 +11,7 @@
 //! See `dev-docs/research/columnar-batch-builder.md` for the design intent.
 
 #[allow(dead_code)]
+pub(crate) mod builder;
+#[allow(dead_code)]
 pub(crate) mod plan;
 pub(crate) mod row_protocol;

--- a/crates/logfwd-arrow/src/columnar/mod.rs
+++ b/crates/logfwd-arrow/src/columnar/mod.rs
@@ -11,9 +11,9 @@
 //! See `dev-docs/research/columnar-batch-builder.md` for the design intent.
 
 #[allow(dead_code)]
-pub(crate) mod accumulator;
+pub mod accumulator;
 #[allow(dead_code)]
-pub(crate) mod builder;
+pub mod builder;
 #[allow(dead_code)]
-pub(crate) mod plan;
+pub mod plan;
 pub(crate) mod row_protocol;

--- a/crates/logfwd-arrow/src/columnar/mod.rs
+++ b/crates/logfwd-arrow/src/columnar/mod.rs
@@ -11,6 +11,8 @@
 //! See `dev-docs/research/columnar-batch-builder.md` for the design intent.
 
 #[allow(dead_code)]
+pub(crate) mod accumulator;
+#[allow(dead_code)]
 pub(crate) mod builder;
 #[allow(dead_code)]
 pub(crate) mod plan;

--- a/crates/logfwd-arrow/src/columnar/mod.rs
+++ b/crates/logfwd-arrow/src/columnar/mod.rs
@@ -10,10 +10,7 @@
 //!
 //! See `dev-docs/research/columnar-batch-builder.md` for the design intent.
 
-#[allow(dead_code)]
 pub mod accumulator;
-#[allow(dead_code)]
 pub mod builder;
-#[allow(dead_code)]
 pub mod plan;
 pub(crate) mod row_protocol;

--- a/crates/logfwd-arrow/src/columnar/plan.rs
+++ b/crates/logfwd-arrow/src/columnar/plan.rs
@@ -239,11 +239,12 @@ impl BatchPlan {
                 }),
             }
         } else {
-            debug_assert_eq!(
-                self.fields.len(),
-                self.num_planned,
-                "declare_planned called after resolve_dynamic"
-            );
+            if self.fields.len() != self.num_planned {
+                return Err(PlanError::ModeMismatch {
+                    field: name.to_string(),
+                    reason: "planned fields must be declared before any dynamic resolution",
+                });
+            }
             let handle = self.alloc_handle()?;
             let shared_name: Arc<str> = Arc::from(name);
             self.fields.push(FieldEntry {
@@ -557,5 +558,19 @@ mod tests {
         let h = plan.resolve_dynamic("level", FieldKind::Int64).unwrap();
         assert_eq!(h.index(), 2);
         assert_eq!(plan.len(), 3);
+    }
+
+    #[test]
+    fn declare_planned_after_dynamic_is_error() {
+        let mut plan = BatchPlan::new();
+        plan.declare_planned("ts", FieldKind::Int64).unwrap();
+        plan.resolve_dynamic("level", FieldKind::Utf8View).unwrap();
+        let err = plan
+            .declare_planned("msg", FieldKind::Utf8View)
+            .unwrap_err();
+        assert!(
+            matches!(err, PlanError::ModeMismatch { .. }),
+            "expected ModeMismatch, got {err:?}"
+        );
     }
 }

--- a/crates/logfwd-arrow/src/columnar/plan.rs
+++ b/crates/logfwd-arrow/src/columnar/plan.rs
@@ -150,6 +150,12 @@ pub struct BatchPlan {
     index: HashMap<Arc<str>, FieldHandle>,
 }
 
+impl Default for BatchPlan {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BatchPlan {
     /// Create an empty plan.
     pub fn new() -> Self {

--- a/crates/logfwd-arrow/src/columnar/plan.rs
+++ b/crates/logfwd-arrow/src/columnar/plan.rs
@@ -208,7 +208,7 @@ impl BatchPlan {
                 }),
             }
         } else {
-            let handle = self.alloc_handle();
+            let handle = self.alloc_handle()?;
             let shared_name: Arc<str> = Arc::from(name);
             self.fields.push(FieldEntry {
                 name: Arc::clone(&shared_name),
@@ -243,7 +243,7 @@ impl BatchPlan {
                 }),
             }
         } else {
-            let handle = self.alloc_handle();
+            let handle = self.alloc_handle()?;
             let shared_name: Arc<str> = Arc::from(name);
             self.fields.push(FieldEntry {
                 name: Arc::clone(&shared_name),
@@ -275,10 +275,11 @@ impl BatchPlan {
         self.fields.iter().map(|e| (e.handle, &*e.name, &e.mode))
     }
 
-    fn alloc_handle(&self) -> FieldHandle {
-        FieldHandle(
-            u32::try_from(self.fields.len()).expect("BatchPlan field count exceeds u32::MAX"),
-        )
+    fn alloc_handle(&self) -> Result<FieldHandle, PlanError> {
+        let idx = u32::try_from(self.fields.len()).map_err(|_| PlanError::TooManyFields {
+            count: self.fields.len(),
+        })?;
+        Ok(FieldHandle(idx))
     }
 }
 
@@ -297,6 +298,8 @@ pub enum PlanError {
     },
     /// A field mode conflict (e.g., planned field resolved as dynamic).
     ModeMismatch { field: String, reason: &'static str },
+    /// The plan has more fields than can be addressed by `FieldHandle` (u32).
+    TooManyFields { count: usize },
 }
 
 impl std::fmt::Display for PlanError {
@@ -312,6 +315,9 @@ impl std::fmt::Display for PlanError {
             ),
             PlanError::ModeMismatch { field, reason } => {
                 write!(f, "field {field:?}: {reason}")
+            }
+            PlanError::TooManyFields { count } => {
+                write!(f, "too many fields: {count} exceeds u32::MAX")
             }
         }
     }

--- a/crates/logfwd-arrow/src/columnar/plan.rs
+++ b/crates/logfwd-arrow/src/columnar/plan.rs
@@ -30,7 +30,9 @@ pub enum FieldKind {
     Float64,
     /// Boolean.
     Bool,
-    /// Variable-length UTF-8 string backed by Arrow `StringViewArray`.
+    /// Variable-length UTF-8 string. When `utf8_trusted` is true (default),
+    /// materialized as `StringViewArray` (zero-copy). When false, materialized
+    /// as `StringArray` with full UTF-8 validation.
     Utf8View,
     /// Variable-length binary backed by Arrow `BinaryViewArray`.
     BinaryView,

--- a/crates/logfwd-arrow/src/columnar/plan.rs
+++ b/crates/logfwd-arrow/src/columnar/plan.rs
@@ -150,6 +150,9 @@ pub struct BatchPlan {
     /// Name → handle for O(1) lookup.  Keys share the same `Arc<str>`
     /// as the corresponding `FieldEntry::name` to avoid double-allocation.
     index: HashMap<Arc<str>, FieldHandle>,
+    /// Number of planned (schema-fixed) fields. These occupy the first
+    /// `num_planned` slots and are never removed by `reset_dynamic`.
+    num_planned: usize,
 }
 
 impl Default for BatchPlan {
@@ -164,6 +167,7 @@ impl BatchPlan {
         BatchPlan {
             fields: Vec::new(),
             index: HashMap::new(),
+            num_planned: 0,
         }
     }
 
@@ -172,6 +176,7 @@ impl BatchPlan {
         BatchPlan {
             fields: Vec::with_capacity(cap),
             index: HashMap::with_capacity(cap),
+            num_planned: 0,
         }
     }
 
@@ -185,11 +190,35 @@ impl BatchPlan {
         self.fields.is_empty()
     }
 
+    /// Number of planned (schema-fixed) fields.
+    pub fn num_planned(&self) -> usize {
+        self.num_planned
+    }
+
+    /// Remove all dynamic fields, keeping planned fields intact.
+    ///
+    /// Called by `ColumnarBatchBuilder::begin_batch` so that dynamic field
+    /// names are re-resolved from scratch each batch — matching
+    /// `StreamingBuilder`'s `field_index.clear()` behavior. Without this,
+    /// dynamic fields accumulate unboundedly across batches.
+    pub fn reset_dynamic(&mut self) {
+        // Remove dynamic entries from the name index.
+        for entry in &self.fields[self.num_planned..] {
+            self.index.remove(&entry.name);
+        }
+        // Truncate the field list to planned-only.
+        self.fields.truncate(self.num_planned);
+    }
+
     /// Declare a schema-fixed field.
     ///
     /// If the field already exists as planned with the same kind, returns
     /// the existing handle (idempotent).  If it exists with a different
     /// kind or as a dynamic field, returns `Err`.
+    ///
+    /// Planned fields must be declared before any dynamic fields are
+    /// resolved. They form a stable prefix of the field list that
+    /// `reset_dynamic` preserves.
     pub fn declare_planned(
         &mut self,
         name: &str,
@@ -210,6 +239,11 @@ impl BatchPlan {
                 }),
             }
         } else {
+            debug_assert_eq!(
+                self.fields.len(),
+                self.num_planned,
+                "declare_planned called after resolve_dynamic"
+            );
             let handle = self.alloc_handle()?;
             let shared_name: Arc<str> = Arc::from(name);
             self.fields.push(FieldEntry {
@@ -218,6 +252,7 @@ impl BatchPlan {
                 mode: FieldSchemaMode::new_planned(kind),
             });
             self.index.insert(shared_name, handle);
+            self.num_planned += 1;
             Ok(handle)
         }
     }
@@ -440,11 +475,11 @@ mod tests {
     fn fields_iterator_in_declaration_order() {
         let mut plan = BatchPlan::new();
         plan.declare_planned("z", FieldKind::Bool).unwrap();
-        plan.resolve_dynamic("a", FieldKind::Int64).unwrap();
         plan.declare_planned("m", FieldKind::Float64).unwrap();
+        plan.resolve_dynamic("a", FieldKind::Int64).unwrap();
 
         let names: Vec<&str> = plan.fields().map(|(_, name, _)| name).collect();
-        assert_eq!(names, vec!["z", "a", "m"]);
+        assert_eq!(names, vec!["z", "m", "a"]);
     }
 
     #[test]
@@ -494,5 +529,33 @@ mod tests {
             reason: "already dynamic",
         };
         assert!(err2.to_string().contains("already dynamic"));
+    }
+
+    #[test]
+    fn reset_dynamic_removes_dynamic_keeps_planned() {
+        let mut plan = BatchPlan::new();
+        plan.declare_planned("ts", FieldKind::Int64).unwrap();
+        plan.declare_planned("msg", FieldKind::Utf8View).unwrap();
+        plan.resolve_dynamic("level", FieldKind::Utf8View).unwrap();
+        plan.resolve_dynamic("code", FieldKind::Int64).unwrap();
+
+        assert_eq!(plan.len(), 4);
+        assert_eq!(plan.num_planned(), 2);
+
+        plan.reset_dynamic();
+
+        assert_eq!(plan.len(), 2);
+        assert_eq!(plan.num_planned(), 2);
+        // Planned fields survive.
+        assert!(plan.lookup("ts").is_some());
+        assert!(plan.lookup("msg").is_some());
+        // Dynamic fields are gone.
+        assert!(plan.lookup("level").is_none());
+        assert!(plan.lookup("code").is_none());
+
+        // Re-resolving dynamic fields works after reset.
+        let h = plan.resolve_dynamic("level", FieldKind::Int64).unwrap();
+        assert_eq!(h.index(), 2);
+        assert_eq!(plan.len(), 3);
     }
 }

--- a/crates/logfwd-arrow/src/columnar/plan.rs
+++ b/crates/logfwd-arrow/src/columnar/plan.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 /// OTLP field numbers, JSON mixed-type conflict logic, and CSV column
 /// indices do not belong here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum FieldKind {
+pub enum FieldKind {
     /// 64-bit signed integer (`Int64`).
     Int64,
     /// 64-bit IEEE 754 float (`Float64`).
@@ -48,12 +48,12 @@ pub(crate) enum FieldKind {
 /// handle regardless of when it was declared or resolved.  Producers store
 /// handles for repeated use across rows without re-resolving by name.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) struct FieldHandle(u32);
+pub struct FieldHandle(u32);
 
 impl FieldHandle {
     /// The underlying column index.
     #[inline(always)]
-    pub(crate) fn index(self) -> usize {
+    pub fn index(self) -> usize {
         self.0 as usize
     }
 }
@@ -68,7 +68,7 @@ impl FieldHandle {
 /// Dynamic fields accumulate observed kinds and may develop type conflicts
 /// (like JSON's mixed int/string columns).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum FieldSchemaMode {
+pub enum FieldSchemaMode {
     /// Producer declared the field with a fixed kind up front.
     /// Attempts to write a different kind are rejected (not silently
     /// promoted to a conflict column).
@@ -142,7 +142,7 @@ struct FieldEntry {
 /// - **Dynamic fields** are resolved by name + observed kind at write time
 ///   (like `StreamingBuilder::resolve_field` for JSON).  Multiple observed
 ///   kinds are accumulated and may produce conflict columns.
-pub(crate) struct BatchPlan {
+pub struct BatchPlan {
     /// Ordered field entries (index = handle value).
     fields: Vec<FieldEntry>,
     /// Name → handle for O(1) lookup.  Keys share the same `Arc<str>`
@@ -152,7 +152,7 @@ pub(crate) struct BatchPlan {
 
 impl BatchPlan {
     /// Create an empty plan.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         BatchPlan {
             fields: Vec::new(),
             index: HashMap::new(),
@@ -160,7 +160,7 @@ impl BatchPlan {
     }
 
     /// Create a plan with pre-allocated capacity.
-    pub(crate) fn with_capacity(cap: usize) -> Self {
+    pub fn with_capacity(cap: usize) -> Self {
         BatchPlan {
             fields: Vec::with_capacity(cap),
             index: HashMap::with_capacity(cap),
@@ -168,12 +168,12 @@ impl BatchPlan {
     }
 
     /// Number of fields in the plan.
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.fields.len()
     }
 
     /// Whether the plan is empty.
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.fields.is_empty()
     }
 
@@ -182,7 +182,7 @@ impl BatchPlan {
     /// If the field already exists as planned with the same kind, returns
     /// the existing handle (idempotent).  If it exists with a different
     /// kind or as a dynamic field, returns `Err`.
-    pub(crate) fn declare_planned(
+    pub fn declare_planned(
         &mut self,
         name: &str,
         kind: FieldKind,
@@ -219,7 +219,7 @@ impl BatchPlan {
     /// If the field already exists as dynamic, the observed kind is
     /// accumulated (for conflict detection).  If it exists as planned,
     /// returns `Err` — planned fields cannot become dynamic.
-    pub(crate) fn resolve_dynamic(
+    pub fn resolve_dynamic(
         &mut self,
         name: &str,
         kind: FieldKind,
@@ -250,22 +250,22 @@ impl BatchPlan {
     }
 
     /// Look up a field by name without creating it.
-    pub(crate) fn lookup(&self, name: &str) -> Option<FieldHandle> {
+    pub fn lookup(&self, name: &str) -> Option<FieldHandle> {
         self.index.get(name).copied()
     }
 
     /// Get the schema mode for a field handle.
-    pub(crate) fn field_mode(&self, handle: FieldHandle) -> Option<&FieldSchemaMode> {
+    pub fn field_mode(&self, handle: FieldHandle) -> Option<&FieldSchemaMode> {
         self.fields.get(handle.index()).map(|e| &e.mode)
     }
 
     /// Get the field name for a handle.
-    pub(crate) fn field_name(&self, handle: FieldHandle) -> Option<&str> {
+    pub fn field_name(&self, handle: FieldHandle) -> Option<&str> {
         self.fields.get(handle.index()).map(|e| &*e.name)
     }
 
     /// Iterate over all fields in declaration order.
-    pub(crate) fn fields(&self) -> impl Iterator<Item = (FieldHandle, &str, &FieldSchemaMode)> {
+    pub fn fields(&self) -> impl Iterator<Item = (FieldHandle, &str, &FieldSchemaMode)> {
         self.fields.iter().map(|e| (e.handle, &*e.name, &e.mode))
     }
 
@@ -282,7 +282,7 @@ impl BatchPlan {
 
 /// Error from `BatchPlan` field declaration or resolution.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum PlanError {
+pub enum PlanError {
     /// A planned field was re-declared with a different kind.
     KindMismatch {
         field: String,

--- a/crates/logfwd-arrow/src/columnar/row_protocol.rs
+++ b/crates/logfwd-arrow/src/columnar/row_protocol.rs
@@ -300,3 +300,126 @@ mod tests {
         lc.finish_batch();
     }
 }
+
+// ---------------------------------------------------------------------------
+// Kani proofs — exhaustive state machine verification
+// ---------------------------------------------------------------------------
+//
+// Pattern: symbolic action sequences (same technique as checkpoint_tracker.rs).
+// Explores all valid transition orderings to prove safety invariants hold
+// for every reachable state.
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    /// Dispatch a valid action based on current state.
+    /// Returns the action tag for coverage tracking.
+    fn symbolic_action(lc: &mut RowLifecycle) -> u8 {
+        let tag: u8 = kani::any();
+        match lc.state() {
+            // Idle: only begin_batch is valid.
+            BuilderState::Idle => {
+                kani::assume(tag == 0);
+                lc.begin_batch();
+            }
+            // InBatch: begin_row (1), finish_batch (2), or begin_batch restart (0).
+            BuilderState::InBatch => {
+                kani::assume(tag <= 2);
+                match tag {
+                    0 => lc.begin_batch(),
+                    1 => lc.begin_row(),
+                    _ => lc.finish_batch(),
+                }
+            }
+            // InRow: end_row is the only valid transition.
+            BuilderState::InRow => {
+                kani::assume(tag == 3);
+                lc.end_row();
+            }
+            _ => unreachable!(),
+        }
+        tag
+    }
+
+    /// Row count never decreases within a batch and resets on begin_batch.
+    ///
+    /// 8-step symbolic action sequence covers batches with 0–3 rows plus
+    /// cross-batch restart (begin_batch + 3×(begin_row+end_row) + finish = 8).
+    #[kani::proof]
+    #[kani::solver(kissat)]
+    #[kani::unwind(10)]
+    fn verify_row_count_monotonic() {
+        let mut lc = RowLifecycle::new();
+        let mut prev_count: u32 = 0;
+
+        for _ in 0..8 {
+            let tag = symbolic_action(&mut lc);
+            let count = lc.row_count();
+
+            if tag == 0 {
+                // begin_batch resets to 0.
+                assert_eq!(count, 0, "begin_batch must reset row_count");
+                prev_count = 0;
+            } else if tag == 3 {
+                // end_row increments by exactly 1.
+                assert_eq!(count, prev_count + 1, "end_row must increment by 1");
+                prev_count = count;
+            } else {
+                // Other actions preserve row_count.
+                assert_eq!(count, prev_count, "non-row actions preserve count");
+            }
+        }
+
+        kani::cover!(prev_count > 0, "at least one row completed");
+        kani::cover!(prev_count > 2, "multiple rows completed");
+    }
+
+    /// written_bits is zero at the start of every row.
+    #[kani::proof]
+    #[kani::solver(kissat)]
+    #[kani::unwind(7)]
+    fn verify_written_bits_reset_on_begin_row() {
+        let mut lc = RowLifecycle::new();
+
+        for _ in 0..5 {
+            let tag = symbolic_action(&mut lc);
+
+            if tag == 1 {
+                // begin_row just fired → bits must be zero.
+                assert_eq!(
+                    *lc.written_bits_mut(),
+                    0,
+                    "written_bits must be zero after begin_row"
+                );
+                // Simulate field writes in this row.
+                *lc.written_bits_mut() = kani::any();
+            }
+        }
+
+        kani::cover!(lc.row_count() > 0, "completed at least one row");
+    }
+
+    /// State machine only reaches valid states: Idle, InBatch, InRow.
+    #[kani::proof]
+    #[kani::solver(kissat)]
+    #[kani::unwind(9)]
+    fn verify_state_always_valid() {
+        let mut lc = RowLifecycle::new();
+
+        for _ in 0..7 {
+            symbolic_action(&mut lc);
+            let s = lc.state();
+            assert!(
+                matches!(
+                    s,
+                    BuilderState::Idle | BuilderState::InBatch | BuilderState::InRow
+                ),
+                "state must always be a valid RowLifecycle state"
+            );
+        }
+
+        kani::cover!(lc.state() == BuilderState::Idle, "reached Idle");
+        kani::cover!(lc.state() == BuilderState::InBatch, "reached InBatch");
+        kani::cover!(lc.state() == BuilderState::InRow, "reached InRow");
+    }
+}

--- a/crates/logfwd-arrow/src/columnar/row_protocol.rs
+++ b/crates/logfwd-arrow/src/columnar/row_protocol.rs
@@ -352,7 +352,6 @@ mod verification {
                 kani::assume(tag == 3);
                 lc.end_row();
             }
-            _ => unreachable!(),
         }
         tag
     }
@@ -446,7 +445,7 @@ mod verification {
                 1 => saw_begin_row = true,
                 2 => saw_finish_batch = true,
                 3 => saw_end_row = true,
-                _ => unreachable!(),
+                _ => {} // tag is bounded by assume() in symbolic_action
             }
         }
 

--- a/crates/logfwd-arrow/src/columnar/row_protocol.rs
+++ b/crates/logfwd-arrow/src/columnar/row_protocol.rs
@@ -307,13 +307,29 @@ mod tests {
 //
 // Pattern: symbolic action sequences (same technique as checkpoint_tracker.rs).
 // Explores all valid transition orderings to prove safety invariants hold
-// for every reachable state.
+// for every reachable state.  Each harness uses an invariant oracle
+// (`check_invariants`) verified after every step.
 #[cfg(kani)]
 mod verification {
     use super::*;
 
+    /// Invariant oracle — checked after every symbolic action.
+    /// Mirrors the checkpoint_tracker.rs `check_invariants()` pattern.
+    fn check_invariants(lc: &RowLifecycle) {
+        assert!(
+            matches!(
+                lc.state(),
+                BuilderState::Idle | BuilderState::InBatch | BuilderState::InRow
+            ),
+            "state must always be valid"
+        );
+        // In Idle state, row_count is stale from the last batch — no constraint.
+        // In InBatch/InRow, row_count is the running tally.
+    }
+
     /// Dispatch a valid action based on current state.
-    /// Returns the action tag for coverage tracking.
+    /// Returns the action tag for coverage tracking:
+    ///   0 = begin_batch, 1 = begin_row, 2 = finish_batch, 3 = end_row.
     fn symbolic_action(lc: &mut RowLifecycle) -> u8 {
         let tag: u8 = kani::any();
         match lc.state() {
@@ -343,17 +359,18 @@ mod verification {
 
     /// Row count never decreases within a batch and resets on begin_batch.
     ///
-    /// 8-step symbolic action sequence covers batches with 0–3 rows plus
-    /// cross-batch restart (begin_batch + 3×(begin_row+end_row) + finish = 8).
+    /// 8-step sequence: begin_batch + 3×(begin_row+end_row) + finish = 8.
+    /// Invariant oracle verified after every step.
     #[kani::proof]
     #[kani::solver(kissat)]
-    #[kani::unwind(10)]
+    #[kani::unwind(10)] // 8 iterations + 2 margin
     fn verify_row_count_monotonic() {
         let mut lc = RowLifecycle::new();
         let mut prev_count: u32 = 0;
 
         for _ in 0..8 {
             let tag = symbolic_action(&mut lc);
+            check_invariants(&lc);
             let count = lc.row_count();
 
             if tag == 0 {
@@ -365,24 +382,29 @@ mod verification {
                 assert_eq!(count, prev_count + 1, "end_row must increment by 1");
                 prev_count = count;
             } else {
-                // Other actions preserve row_count.
+                // begin_row (1) and finish_batch (2) preserve row_count.
                 assert_eq!(count, prev_count, "non-row actions preserve count");
             }
         }
 
         kani::cover!(prev_count > 0, "at least one row completed");
-        kani::cover!(prev_count > 2, "multiple rows completed");
+        kani::cover!(prev_count > 2, "three+ rows completed");
     }
 
-    /// written_bits is zero at the start of every row.
+    /// written_bits is zero at the start of every row, even after prior
+    /// rows wrote non-zero bits.
+    ///
+    /// 7-step sequence: enough for 2+ full row cycles with dirty bits.
     #[kani::proof]
     #[kani::solver(kissat)]
-    #[kani::unwind(7)]
+    #[kani::unwind(9)] // 7 iterations + 2 margin
     fn verify_written_bits_reset_on_begin_row() {
         let mut lc = RowLifecycle::new();
+        let mut begin_row_seen = false;
 
-        for _ in 0..5 {
+        for _ in 0..7 {
             let tag = symbolic_action(&mut lc);
+            check_invariants(&lc);
 
             if tag == 1 {
                 // begin_row just fired → bits must be zero.
@@ -393,33 +415,73 @@ mod verification {
                 );
                 // Simulate field writes in this row.
                 *lc.written_bits_mut() = kani::any();
+                begin_row_seen = true;
             }
         }
 
-        kani::cover!(lc.row_count() > 0, "completed at least one row");
+        kani::cover!(begin_row_seen, "begin_row was exercised");
+        kani::cover!(lc.row_count() > 1, "multiple rows completed");
+        kani::cover!(lc.state() == BuilderState::Idle, "returned to Idle");
     }
 
-    /// State machine only reaches valid states: Idle, InBatch, InRow.
+    /// State machine only reaches valid states via the invariant oracle.
+    ///
+    /// 7-step sequence exercises all transitions.
     #[kani::proof]
     #[kani::solver(kissat)]
-    #[kani::unwind(9)]
+    #[kani::unwind(9)] // 7 iterations + 2 margin
     fn verify_state_always_valid() {
         let mut lc = RowLifecycle::new();
+        let mut saw_begin_batch = false;
+        let mut saw_begin_row = false;
+        let mut saw_end_row = false;
+        let mut saw_finish_batch = false;
 
         for _ in 0..7 {
-            symbolic_action(&mut lc);
-            let s = lc.state();
-            assert!(
-                matches!(
-                    s,
-                    BuilderState::Idle | BuilderState::InBatch | BuilderState::InRow
-                ),
-                "state must always be a valid RowLifecycle state"
-            );
+            let tag = symbolic_action(&mut lc);
+            check_invariants(&lc);
+
+            match tag {
+                0 => saw_begin_batch = true,
+                1 => saw_begin_row = true,
+                2 => saw_finish_batch = true,
+                3 => saw_end_row = true,
+                _ => unreachable!(),
+            }
         }
 
         kani::cover!(lc.state() == BuilderState::Idle, "reached Idle");
         kani::cover!(lc.state() == BuilderState::InBatch, "reached InBatch");
         kani::cover!(lc.state() == BuilderState::InRow, "reached InRow");
+        kani::cover!(
+            saw_begin_batch && saw_begin_row && saw_end_row && saw_finish_batch,
+            "all four transitions exercised"
+        );
+    }
+
+    /// line_written_this_row resets on begin_row and persists through end_row.
+    #[kani::proof]
+    #[kani::solver(kissat)]
+    #[kani::unwind(9)] // 7 iterations + 2 margin
+    fn verify_line_written_reset_on_begin_row() {
+        let mut lc = RowLifecycle::new();
+
+        for _ in 0..7 {
+            let tag = symbolic_action(&mut lc);
+            check_invariants(&lc);
+
+            if tag == 1 {
+                // begin_row resets line_written flag.
+                assert!(
+                    !lc.line_written_this_row(),
+                    "line_written must be false after begin_row"
+                );
+                // Simulate writing a line.
+                lc.set_line_written();
+                assert!(lc.line_written_this_row(), "set_line_written must stick");
+            }
+        }
+
+        kani::cover!(lc.row_count() > 0, "at least one row completed");
     }
 }

--- a/crates/logfwd-arrow/src/lib.rs
+++ b/crates/logfwd-arrow/src/lib.rs
@@ -45,3 +45,67 @@ pub(crate) fn check_dup_bits(written_bits: &mut u64, idx: usize) -> bool {
 // Re-export scanner types for convenience
 pub use scanner::Scanner;
 pub use streaming_builder::StreamingBuilder;
+
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    /// Exhaustive proof: first call for a tracked index clears, second detects duplicate.
+    #[kani::proof]
+    fn verify_check_dup_bits_first_write_then_duplicate() {
+        let idx: usize = kani::any();
+        kani::assume(idx < 128);
+        let mut bits: u64 = 0;
+
+        let first = check_dup_bits(&mut bits, idx);
+        let second = check_dup_bits(&mut bits, idx);
+
+        if idx < 64 {
+            assert!(!first, "first write must not be flagged as duplicate");
+            assert!(second, "second write must be flagged as duplicate");
+            assert!(bits & (1u64 << idx) != 0, "bit must be set after write");
+        } else {
+            assert!(!first, "idx >= 64 always returns false");
+            assert!(!second, "idx >= 64 always returns false");
+            assert_eq!(bits, 0, "no bits modified for idx >= 64");
+        }
+
+        kani::cover!(idx < 64, "tracked field");
+        kani::cover!(idx >= 64, "untracked field");
+    }
+
+    /// Two distinct tracked indices never interfere with each other.
+    #[kani::proof]
+    fn verify_check_dup_bits_independence() {
+        let a: usize = kani::any();
+        let b: usize = kani::any();
+        kani::assume(a < 64 && b < 64 && a != b);
+
+        let mut bits: u64 = 0;
+        let first_a = check_dup_bits(&mut bits, a);
+        let first_b = check_dup_bits(&mut bits, b);
+        let dup_a = check_dup_bits(&mut bits, a);
+        let dup_b = check_dup_bits(&mut bits, b);
+
+        assert!(!first_a, "a first write is clean");
+        assert!(!first_b, "b first write is clean");
+        assert!(dup_a, "a second write is duplicate");
+        assert!(dup_b, "b second write is duplicate");
+    }
+
+    /// Pre-existing bits are preserved — setting idx doesn't clear other bits.
+    #[kani::proof]
+    fn verify_check_dup_bits_preserves_existing() {
+        let idx: usize = kani::any();
+        kani::assume(idx < 64);
+        let mut bits: u64 = kani::any();
+        let before = bits;
+
+        let _ = check_dup_bits(&mut bits, idx);
+
+        // All previously set bits remain set.
+        assert_eq!(bits & before, before, "existing bits must be preserved");
+        // The new bit is now set.
+        assert!(bits & (1u64 << idx) != 0, "target bit must be set");
+    }
+}

--- a/crates/logfwd-arrow/src/lib.rs
+++ b/crates/logfwd-arrow/src/lib.rs
@@ -7,6 +7,7 @@
 #[cfg(feature = "_test-internals")]
 pub mod columnar;
 #[cfg(not(feature = "_test-internals"))]
+#[allow(dead_code)]
 pub(crate) mod columnar;
 pub mod conflict_schema;
 pub mod materialize;

--- a/crates/logfwd-arrow/src/lib.rs
+++ b/crates/logfwd-arrow/src/lib.rs
@@ -5,6 +5,10 @@
 //! wrapper type that produces `RecordBatch`.
 
 #[cfg(feature = "_test-internals")]
+/// Columnar batch builder for structured producers (OTLP, CSV).
+///
+/// Feature-gated behind `_test-internals` for profiling and test access.
+/// Production code should not depend on this module directly.
 pub mod columnar;
 #[cfg(not(feature = "_test-internals"))]
 #[allow(dead_code)]

--- a/crates/logfwd-arrow/src/lib.rs
+++ b/crates/logfwd-arrow/src/lib.rs
@@ -51,6 +51,7 @@ mod verification {
     use super::*;
 
     /// Exhaustive proof: first call for a tracked index clears, second detects duplicate.
+    /// Covers both the tracked (idx < 64) and untracked (idx >= 64) branches.
     #[kani::proof]
     fn verify_check_dup_bits_first_write_then_duplicate() {
         let idx: usize = kani::any();
@@ -61,9 +62,11 @@ mod verification {
         let second = check_dup_bits(&mut bits, idx);
 
         if idx < 64 {
+            // Oracle: independently compute expected return and state.
+            let expected_bit = 1u64 << idx;
             assert!(!first, "first write must not be flagged as duplicate");
             assert!(second, "second write must be flagged as duplicate");
-            assert!(bits & (1u64 << idx) != 0, "bit must be set after write");
+            assert_eq!(bits, expected_bit, "exactly one bit must be set");
         } else {
             assert!(!first, "idx >= 64 always returns false");
             assert!(!second, "idx >= 64 always returns false");
@@ -72,9 +75,13 @@ mod verification {
 
         kani::cover!(idx < 64, "tracked field");
         kani::cover!(idx >= 64, "untracked field");
+        kani::cover!(idx == 0, "first index");
+        kani::cover!(idx == 63, "last tracked index");
+        kani::cover!(idx == 64, "first untracked index");
     }
 
     /// Two distinct tracked indices never interfere with each other.
+    /// Oracle: verifies that exactly the two target bits are set afterwards.
     #[kani::proof]
     fn verify_check_dup_bits_independence() {
         let a: usize = kani::any();
@@ -91,9 +98,17 @@ mod verification {
         assert!(!first_b, "b first write is clean");
         assert!(dup_a, "a second write is duplicate");
         assert!(dup_b, "b second write is duplicate");
+
+        // Oracle: exactly two bits set, at positions a and b.
+        let expected = (1u64 << a) | (1u64 << b);
+        assert_eq!(bits, expected, "exactly two bits must be set");
+
+        kani::cover!(a == 0 && b == 63, "boundary indices");
+        kani::cover!(a < 32 && b >= 32, "cross-halfword pair");
     }
 
     /// Pre-existing bits are preserved — setting idx doesn't clear other bits.
+    /// Oracle: the result is exactly `before | (1 << idx)`.
     #[kani::proof]
     fn verify_check_dup_bits_preserves_existing() {
         let idx: usize = kani::any();
@@ -101,11 +116,42 @@ mod verification {
         let mut bits: u64 = kani::any();
         let before = bits;
 
-        let _ = check_dup_bits(&mut bits, idx);
+        let was_dup = check_dup_bits(&mut bits, idx);
 
-        // All previously set bits remain set.
-        assert_eq!(bits & before, before, "existing bits must be preserved");
-        // The new bit is now set.
-        assert!(bits & (1u64 << idx) != 0, "target bit must be set");
+        // Oracle: independently compute expected state and return value.
+        let expected_bits = before | (1u64 << idx);
+        let expected_dup = (before & (1u64 << idx)) != 0;
+        assert_eq!(bits, expected_bits, "bits must be before | target");
+        assert_eq!(was_dup, expected_dup, "return must reflect prior state");
+
+        kani::cover!(before != 0, "non-zero existing bits");
+        kani::cover!((before & (1u64 << idx)) != 0, "target bit already set");
+        kani::cover!((before & (1u64 << idx)) == 0, "target bit initially clear");
+    }
+
+    /// Boundary proof: idx=63 is the last tracked index, idx=64 is the first
+    /// untracked. Third call with an already-duplicate returns true again.
+    #[kani::proof]
+    fn verify_check_dup_bits_boundary_at_64() {
+        let mut bits: u64 = 0;
+
+        // idx=63 is tracked: first clean, second dup, third still dup.
+        let first = check_dup_bits(&mut bits, 63);
+        let second = check_dup_bits(&mut bits, 63);
+        let third = check_dup_bits(&mut bits, 63);
+        assert!(!first, "63 first write clean");
+        assert!(second, "63 second write is dup");
+        assert!(third, "63 third write still dup (idempotent)");
+
+        // idx=64 is untracked: never modifies bits, never returns true.
+        let bits_before = bits;
+        let call_64 = check_dup_bits(&mut bits, 64);
+        assert!(!call_64, "idx=64 always false");
+        assert_eq!(bits, bits_before, "bits unchanged for idx=64");
+
+        // Large index: same behaviour.
+        let call_big = check_dup_bits(&mut bits, 10_000);
+        assert!(!call_big, "idx=10000 always false");
+        assert_eq!(bits, bits_before, "bits unchanged for large idx");
     }
 }

--- a/crates/logfwd-arrow/src/lib.rs
+++ b/crates/logfwd-arrow/src/lib.rs
@@ -4,6 +4,9 @@
 //! Contains `StreamingBuilder` (zero-copy hot path) and the `Scanner`
 //! wrapper type that produces `RecordBatch`.
 
+#[cfg(feature = "_test-internals")]
+pub mod columnar;
+#[cfg(not(feature = "_test-internals"))]
 pub(crate) mod columnar;
 pub mod conflict_schema;
 pub mod materialize;

--- a/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
+++ b/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
@@ -1,0 +1,465 @@
+//! Allocation profiling: ColumnarBatchBuilder vs StreamingBuilder.
+//!
+//! Run with: cargo test -p logfwd-arrow --features _test-internals \
+//!           --test columnar_alloc_profile -- --nocapture
+#![cfg(feature = "_test-internals")]
+//!
+//! Uses `stats_alloc` global allocator to count every heap allocation.
+//! Tests use `#[serial]` because the global counting allocator is shared.
+
+use serial_test::serial;
+use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
+use std::alloc::System;
+
+#[global_allocator]
+static GLOBAL: &StatsAlloc<System> = &INSTRUMENTED_SYSTEM;
+
+use logfwd_arrow::columnar::builder::ColumnarBatchBuilder;
+use logfwd_arrow::columnar::plan::{BatchPlan, FieldHandle, FieldKind};
+use logfwd_arrow::streaming_builder::StreamingBuilder;
+
+const ROWS_PER_BATCH: u32 = 1000;
+const NUM_BATCHES: u64 = 5;
+const FIELD_NAMES: [&str; 15] = [
+    "timestamp_ns",
+    "severity_number",
+    "severity_text",
+    "body",
+    "flags",
+    "trace_id",
+    "span_id",
+    "resource.service.name",
+    "resource.host.name",
+    "scope.name",
+    "scope.version",
+    "attributes.http.method",
+    "attributes.http.status_code",
+    "attributes.duration_ms",
+    "attributes.http.path",
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn print_stats(label: &str, stats: &stats_alloc::Stats, total_rows: u64) {
+    let allocs_per_row = stats.allocations as f64 / total_rows as f64;
+    let bytes_per_row = stats.bytes_allocated as f64 / total_rows as f64;
+    let reallocs_per_row = stats.reallocations as f64 / total_rows as f64;
+    eprintln!("  {label}:");
+    eprintln!(
+        "    allocations:   {:>8} total  ({:.2}/row)",
+        stats.allocations, allocs_per_row
+    );
+    eprintln!(
+        "    bytes alloc'd: {:>8}        ({:.0} B/row)",
+        stats.bytes_allocated, bytes_per_row
+    );
+    eprintln!(
+        "    reallocations: {:>8} total  ({:.3}/row)",
+        stats.reallocations, reallocs_per_row
+    );
+    eprintln!(
+        "    bytes freed:   {:>8}        ({:.0} B/row)",
+        stats.bytes_deallocated,
+        stats.bytes_deallocated as f64 / total_rows as f64
+    );
+}
+
+// ---------------------------------------------------------------------------
+// StreamingBuilder workload runners
+// ---------------------------------------------------------------------------
+
+fn run_streaming_detached(warmup: bool) -> stats_alloc::Stats {
+    let mut sb = StreamingBuilder::new(None);
+
+    if warmup {
+        let dummy = bytes::Bytes::from_static(b"");
+        sb.begin_batch(dummy);
+        let indices: Vec<usize> = FIELD_NAMES
+            .iter()
+            .map(|name| sb.resolve_field(name.as_bytes()))
+            .collect();
+        for row in 0..ROWS_PER_BATCH {
+            sb.begin_row();
+            for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
+                sb.append_i64_value_by_idx(idx, row as i64);
+            }
+            for &idx in &[
+                indices[2], indices[3], indices[5], indices[6], indices[7],
+                indices[8], indices[9], indices[10], indices[11], indices[14],
+            ] {
+                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+            }
+            sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
+            sb.end_row();
+        }
+        let _ = sb.finish_batch_detached().unwrap();
+    }
+
+    let region = Region::new(GLOBAL);
+
+    for _batch in 0..NUM_BATCHES {
+        let dummy = bytes::Bytes::from_static(b"");
+        sb.begin_batch(dummy);
+        let indices: Vec<usize> = FIELD_NAMES
+            .iter()
+            .map(|name| sb.resolve_field(name.as_bytes()))
+            .collect();
+
+        for row in 0..ROWS_PER_BATCH {
+            sb.begin_row();
+            for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
+                sb.append_i64_value_by_idx(idx, row as i64);
+            }
+            for &idx in &[
+                indices[2], indices[3], indices[5], indices[6], indices[7],
+                indices[8], indices[9], indices[10], indices[11], indices[14],
+            ] {
+                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+            }
+            sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
+            sb.end_row();
+        }
+        let batch = sb.finish_batch_detached().unwrap();
+        assert_eq!(batch.num_rows(), ROWS_PER_BATCH as usize);
+    }
+
+    region.change()
+}
+
+fn run_streaming_view(warmup: bool) -> stats_alloc::Stats {
+    let mut sb = StreamingBuilder::new(None);
+
+    if warmup {
+        let dummy = bytes::Bytes::from_static(b"");
+        sb.begin_batch(dummy);
+        let indices: Vec<usize> = FIELD_NAMES
+            .iter()
+            .map(|name| sb.resolve_field(name.as_bytes()))
+            .collect();
+        for row in 0..ROWS_PER_BATCH {
+            sb.begin_row();
+            for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
+                sb.append_i64_value_by_idx(idx, row as i64);
+            }
+            for &idx in &[
+                indices[2], indices[3], indices[5], indices[6], indices[7],
+                indices[8], indices[9], indices[10], indices[11], indices[14],
+            ] {
+                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+            }
+            sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
+            sb.end_row();
+        }
+        let _ = sb.finish_batch().unwrap();
+    }
+
+    let region = Region::new(GLOBAL);
+
+    for _batch in 0..NUM_BATCHES {
+        let dummy = bytes::Bytes::from_static(b"");
+        sb.begin_batch(dummy);
+        let indices: Vec<usize> = FIELD_NAMES
+            .iter()
+            .map(|name| sb.resolve_field(name.as_bytes()))
+            .collect();
+
+        for row in 0..ROWS_PER_BATCH {
+            sb.begin_row();
+            for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
+                sb.append_i64_value_by_idx(idx, row as i64);
+            }
+            for &idx in &[
+                indices[2], indices[3], indices[5], indices[6], indices[7],
+                indices[8], indices[9], indices[10], indices[11], indices[14],
+            ] {
+                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
+            }
+            sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
+            sb.end_row();
+        }
+        let batch = sb.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), ROWS_PER_BATCH as usize);
+    }
+
+    region.change()
+}
+
+// ---------------------------------------------------------------------------
+// ColumnarBatchBuilder workload runners
+// ---------------------------------------------------------------------------
+
+fn make_columnar_plan() -> (BatchPlan, [FieldHandle; 4], [FieldHandle; 10], [FieldHandle; 1]) {
+    let mut plan = BatchPlan::new();
+    let int_handles: [FieldHandle; 4] = [
+        plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap(),
+        plan.declare_planned("severity_number", FieldKind::Int64).unwrap(),
+        plan.declare_planned("flags", FieldKind::Int64).unwrap(),
+        plan.declare_planned("attributes.http.status_code", FieldKind::Int64).unwrap(),
+    ];
+    let str_handles: [FieldHandle; 10] = [
+        plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("body", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("trace_id", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("span_id", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("resource.service.name", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("resource.host.name", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("scope.name", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("scope.version", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("attributes.http.method", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("attributes.http.path", FieldKind::Utf8View).unwrap(),
+    ];
+    let float_handles: [FieldHandle; 1] = [
+        plan.declare_planned("attributes.duration_ms", FieldKind::Float64).unwrap(),
+    ];
+    (plan, int_handles, str_handles, float_handles)
+}
+
+fn run_columnar_detached(warmup: bool) -> stats_alloc::Stats {
+    let (plan, int_handles, str_handles, float_handles) = make_columnar_plan();
+    let mut b = ColumnarBatchBuilder::new(plan);
+
+    if warmup {
+        // Full warmup batch to prime all vec capacities
+        b.begin_batch();
+        for row in 0..ROWS_PER_BATCH {
+            b.begin_row();
+            for &h in &int_handles {
+                b.write_i64(h, row as i64);
+            }
+            for &h in &str_handles {
+                b.write_str(h, "example-value-0123456789").unwrap();
+            }
+            for &h in &float_handles {
+                b.write_f64(h, row as f64 * 0.001);
+            }
+            b.end_row();
+        }
+        let _ = b.finish_batch().unwrap();
+    }
+
+    let region = Region::new(GLOBAL);
+
+    for _batch in 0..NUM_BATCHES {
+        b.begin_batch();
+        for row in 0..ROWS_PER_BATCH {
+            b.begin_row();
+            for &h in &int_handles {
+                b.write_i64(h, row as i64);
+            }
+            for &h in &str_handles {
+                b.write_str(h, "example-value-0123456789").unwrap();
+            }
+            for &h in &float_handles {
+                b.write_f64(h, row as f64 * 0.001);
+            }
+            b.end_row();
+        }
+        let batch = b.finish_batch().unwrap();
+        assert_eq!(batch.num_rows(), ROWS_PER_BATCH as usize);
+    }
+
+    region.change()
+}
+
+fn run_columnar_view(warmup: bool) -> stats_alloc::Stats {
+    let (plan, int_handles, str_handles, float_handles) = make_columnar_plan();
+    let mut b = ColumnarBatchBuilder::new(plan);
+
+    if warmup {
+        b.begin_batch();
+        for row in 0..ROWS_PER_BATCH {
+            b.begin_row();
+            for &h in &int_handles {
+                b.write_i64(h, row as i64);
+            }
+            for &h in &str_handles {
+                b.write_str(h, "example-value-0123456789").unwrap();
+            }
+            for &h in &float_handles {
+                b.write_f64(h, row as f64 * 0.001);
+            }
+            b.end_row();
+        }
+        let _ = b
+            .finish_batch_view(arrow::buffer::Buffer::from(b"" as &[u8]), 0)
+            .unwrap();
+    }
+
+    let region = Region::new(GLOBAL);
+
+    for _batch in 0..NUM_BATCHES {
+        b.begin_batch();
+        for row in 0..ROWS_PER_BATCH {
+            b.begin_row();
+            for &h in &int_handles {
+                b.write_i64(h, row as i64);
+            }
+            for &h in &str_handles {
+                b.write_str(h, "example-value-0123456789").unwrap();
+            }
+            for &h in &float_handles {
+                b.write_f64(h, row as f64 * 0.001);
+            }
+            b.end_row();
+        }
+        let batch = b
+            .finish_batch_view(arrow::buffer::Buffer::from(b"" as &[u8]), 0)
+            .unwrap();
+        assert_eq!(batch.num_rows(), ROWS_PER_BATCH as usize);
+    }
+
+    region.change()
+}
+
+// ---------------------------------------------------------------------------
+// Profile tests
+// ---------------------------------------------------------------------------
+
+/// Full allocation profile for both builders, cold and warm.
+#[test]
+#[serial]
+fn allocation_profile() {
+    let total_rows = u64::from(ROWS_PER_BATCH) * NUM_BATCHES;
+
+    eprintln!("\n=== StreamingBuilder ({total_rows} rows, {NUM_BATCHES} batches) ===\n");
+    eprintln!("  -- Cold start --");
+    print_stats("detached (cold)", &run_streaming_detached(false), total_rows);
+    print_stats("view (cold)", &run_streaming_view(false), total_rows);
+    eprintln!("\n  -- Steady state (warmed) --");
+    print_stats("detached (warm)", &run_streaming_detached(true), total_rows);
+    print_stats("view (warm)", &run_streaming_view(true), total_rows);
+
+    eprintln!("\n=== ColumnarBatchBuilder ({total_rows} rows, {NUM_BATCHES} batches) ===\n");
+    eprintln!("  -- Cold start --");
+    print_stats("detached (cold)", &run_columnar_detached(false), total_rows);
+    print_stats("view (cold)", &run_columnar_view(false), total_rows);
+    eprintln!("\n  -- Steady state (warmed) --");
+    print_stats("detached (warm)", &run_columnar_detached(true), total_rows);
+    print_stats("view (warm)", &run_columnar_view(true), total_rows);
+    eprintln!();
+}
+
+/// Side-by-side warm-state comparison table.
+#[test]
+#[serial]
+fn allocation_comparison() {
+    let total_rows = u64::from(ROWS_PER_BATCH) * NUM_BATCHES;
+
+    let sb_det = run_streaming_detached(true);
+    let sb_view = run_streaming_view(true);
+    let cb_det = run_columnar_detached(true);
+    let cb_view = run_columnar_view(true);
+
+    eprintln!("\n=== Allocation Comparison — warm, {total_rows} rows ===\n");
+    eprintln!(
+        "  {:>32} {:>10} {:>12} {:>10}",
+        "Builder", "Allocs", "Bytes", "Reallocs"
+    );
+    eprintln!(
+        "  {:>32} {:>10} {:>12} {:>10}",
+        "StreamingBuilder detached",
+        sb_det.allocations,
+        sb_det.bytes_allocated,
+        sb_det.reallocations
+    );
+    eprintln!(
+        "  {:>32} {:>10} {:>12} {:>10}",
+        "StreamingBuilder view",
+        sb_view.allocations,
+        sb_view.bytes_allocated,
+        sb_view.reallocations
+    );
+    eprintln!(
+        "  {:>32} {:>10} {:>12} {:>10}",
+        "ColumnarBatch detached",
+        cb_det.allocations,
+        cb_det.bytes_allocated,
+        cb_det.reallocations
+    );
+    eprintln!(
+        "  {:>32} {:>10} {:>12} {:>10}",
+        "ColumnarBatch view",
+        cb_view.allocations,
+        cb_view.bytes_allocated,
+        cb_view.reallocations
+    );
+
+    // Summarize
+    if sb_det.bytes_allocated > 0 {
+        let byte_ratio = cb_det.bytes_allocated as f64 / sb_det.bytes_allocated as f64;
+        let alloc_ratio = cb_det.allocations as f64 / sb_det.allocations as f64;
+        eprintln!(
+            "\n  Columnar/Streaming (detached): {:.1}x bytes, {:.1}x allocs",
+            byte_ratio, alloc_ratio
+        );
+    }
+    if sb_view.bytes_allocated > 0 {
+        let byte_ratio = cb_view.bytes_allocated as f64 / sb_view.bytes_allocated as f64;
+        let alloc_ratio = cb_view.allocations as f64 / sb_view.allocations as f64;
+        eprintln!(
+            "  Columnar/Streaming (view):     {:.1}x bytes, {:.1}x allocs\n",
+            byte_ratio, alloc_ratio
+        );
+    }
+}
+
+/// Allocation scaling: verify sub-linear growth with row count.
+#[test]
+#[serial]
+fn columnar_alloc_scaling() {
+    let (plan, int_handles, str_handles, float_handles) = make_columnar_plan();
+    let mut b = ColumnarBatchBuilder::new(plan);
+
+    // Warmup
+    b.begin_batch();
+    b.begin_row();
+    b.end_row();
+    let _ = b.finish_batch().unwrap();
+
+    let measure = |b: &mut ColumnarBatchBuilder, rows: u32| -> stats_alloc::Stats {
+        let region = Region::new(GLOBAL);
+        b.begin_batch();
+        for row in 0..rows {
+            b.begin_row();
+            for &h in &int_handles {
+                b.write_i64(h, row as i64);
+            }
+            for &h in &str_handles {
+                b.write_str(h, "example-value-0123456789").unwrap();
+            }
+            for &h in &float_handles {
+                b.write_f64(h, row as f64 * 0.001);
+            }
+            b.end_row();
+        }
+        let _ = b.finish_batch().unwrap();
+        region.change()
+    };
+
+    let r500 = measure(&mut b, 500);
+    let r5000 = measure(&mut b, 5000);
+
+    let alloc_ratio = r5000.allocations as f64 / r500.allocations.max(1) as f64;
+    let bytes_ratio = r5000.bytes_allocated as f64 / r500.bytes_allocated.max(1) as f64;
+
+    eprintln!("\n=== ColumnarBatchBuilder Scaling ===");
+    eprintln!(
+        "  500 rows:  {} allocs, {} bytes",
+        r500.allocations, r500.bytes_allocated,
+    );
+    eprintln!(
+        "  5000 rows: {} allocs, {} bytes",
+        r5000.allocations, r5000.bytes_allocated,
+    );
+    eprintln!(
+        "  10x rows → {:.1}x allocs, {:.1}x bytes\n",
+        alloc_ratio, bytes_ratio,
+    );
+
+    assert!(
+        alloc_ratio < 15.0,
+        "Allocations grew super-linearly: {alloc_ratio:.1}x for 10x rows"
+    );
+}

--- a/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
+++ b/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
@@ -8,7 +8,7 @@
 //! Tests use `#[serial]` because the global counting allocator is shared.
 
 use serial_test::serial;
-use stats_alloc::{Region, StatsAlloc, INSTRUMENTED_SYSTEM};
+use stats_alloc::{INSTRUMENTED_SYSTEM, Region, StatsAlloc};
 use std::alloc::System;
 
 #[global_allocator]
@@ -86,8 +86,16 @@ fn run_streaming_detached(warmup: bool) -> stats_alloc::Stats {
                 sb.append_i64_value_by_idx(idx, row as i64);
             }
             for &idx in &[
-                indices[2], indices[3], indices[5], indices[6], indices[7],
-                indices[8], indices[9], indices[10], indices[11], indices[14],
+                indices[2],
+                indices[3],
+                indices[5],
+                indices[6],
+                indices[7],
+                indices[8],
+                indices[9],
+                indices[10],
+                indices[11],
+                indices[14],
             ] {
                 sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
             }
@@ -113,8 +121,16 @@ fn run_streaming_detached(warmup: bool) -> stats_alloc::Stats {
                 sb.append_i64_value_by_idx(idx, row as i64);
             }
             for &idx in &[
-                indices[2], indices[3], indices[5], indices[6], indices[7],
-                indices[8], indices[9], indices[10], indices[11], indices[14],
+                indices[2],
+                indices[3],
+                indices[5],
+                indices[6],
+                indices[7],
+                indices[8],
+                indices[9],
+                indices[10],
+                indices[11],
+                indices[14],
             ] {
                 sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
             }
@@ -144,8 +160,16 @@ fn run_streaming_view(warmup: bool) -> stats_alloc::Stats {
                 sb.append_i64_value_by_idx(idx, row as i64);
             }
             for &idx in &[
-                indices[2], indices[3], indices[5], indices[6], indices[7],
-                indices[8], indices[9], indices[10], indices[11], indices[14],
+                indices[2],
+                indices[3],
+                indices[5],
+                indices[6],
+                indices[7],
+                indices[8],
+                indices[9],
+                indices[10],
+                indices[11],
+                indices[14],
             ] {
                 sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
             }
@@ -171,8 +195,16 @@ fn run_streaming_view(warmup: bool) -> stats_alloc::Stats {
                 sb.append_i64_value_by_idx(idx, row as i64);
             }
             for &idx in &[
-                indices[2], indices[3], indices[5], indices[6], indices[7],
-                indices[8], indices[9], indices[10], indices[11], indices[14],
+                indices[2],
+                indices[3],
+                indices[5],
+                indices[6],
+                indices[7],
+                indices[8],
+                indices[9],
+                indices[10],
+                indices[11],
+                indices[14],
             ] {
                 sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
             }
@@ -190,29 +222,46 @@ fn run_streaming_view(warmup: bool) -> stats_alloc::Stats {
 // ColumnarBatchBuilder workload runners
 // ---------------------------------------------------------------------------
 
-fn make_columnar_plan() -> (BatchPlan, [FieldHandle; 4], [FieldHandle; 10], [FieldHandle; 1]) {
+fn make_columnar_plan() -> (
+    BatchPlan,
+    [FieldHandle; 4],
+    [FieldHandle; 10],
+    [FieldHandle; 1],
+) {
     let mut plan = BatchPlan::new();
     let int_handles: [FieldHandle; 4] = [
-        plan.declare_planned("timestamp_ns", FieldKind::Int64).unwrap(),
-        plan.declare_planned("severity_number", FieldKind::Int64).unwrap(),
+        plan.declare_planned("timestamp_ns", FieldKind::Int64)
+            .unwrap(),
+        plan.declare_planned("severity_number", FieldKind::Int64)
+            .unwrap(),
         plan.declare_planned("flags", FieldKind::Int64).unwrap(),
-        plan.declare_planned("attributes.http.status_code", FieldKind::Int64).unwrap(),
+        plan.declare_planned("attributes.http.status_code", FieldKind::Int64)
+            .unwrap(),
     ];
     let str_handles: [FieldHandle; 10] = [
-        plan.declare_planned("severity_text", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("severity_text", FieldKind::Utf8View)
+            .unwrap(),
         plan.declare_planned("body", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("trace_id", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("span_id", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("resource.service.name", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("resource.host.name", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("scope.name", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("scope.version", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("attributes.http.method", FieldKind::Utf8View).unwrap(),
-        plan.declare_planned("attributes.http.path", FieldKind::Utf8View).unwrap(),
+        plan.declare_planned("trace_id", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("span_id", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("resource.service.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("resource.host.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("scope.name", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("scope.version", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("attributes.http.method", FieldKind::Utf8View)
+            .unwrap(),
+        plan.declare_planned("attributes.http.path", FieldKind::Utf8View)
+            .unwrap(),
     ];
-    let float_handles: [FieldHandle; 1] = [
-        plan.declare_planned("attributes.duration_ms", FieldKind::Float64).unwrap(),
-    ];
+    let float_handles: [FieldHandle; 1] = [plan
+        .declare_planned("attributes.duration_ms", FieldKind::Float64)
+        .unwrap()];
     (plan, int_handles, str_handles, float_handles)
 }
 
@@ -325,7 +374,11 @@ fn allocation_profile() {
 
     eprintln!("\n=== StreamingBuilder ({total_rows} rows, {NUM_BATCHES} batches) ===\n");
     eprintln!("  -- Cold start --");
-    print_stats("detached (cold)", &run_streaming_detached(false), total_rows);
+    print_stats(
+        "detached (cold)",
+        &run_streaming_detached(false),
+        total_rows,
+    );
     print_stats("view (cold)", &run_streaming_view(false), total_rows);
     eprintln!("\n  -- Steady state (warmed) --");
     print_stats("detached (warm)", &run_streaming_detached(true), total_rows);
@@ -373,17 +426,11 @@ fn allocation_comparison() {
     );
     eprintln!(
         "  {:>32} {:>10} {:>12} {:>10}",
-        "ColumnarBatch detached",
-        cb_det.allocations,
-        cb_det.bytes_allocated,
-        cb_det.reallocations
+        "ColumnarBatch detached", cb_det.allocations, cb_det.bytes_allocated, cb_det.reallocations
     );
     eprintln!(
         "  {:>32} {:>10} {:>12} {:>10}",
-        "ColumnarBatch view",
-        cb_view.allocations,
-        cb_view.bytes_allocated,
-        cb_view.reallocations
+        "ColumnarBatch view", cb_view.allocations, cb_view.bytes_allocated, cb_view.reallocations
     );
 
     // Summarize

--- a/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
+++ b/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
@@ -331,9 +331,7 @@ fn run_columnar_view(warmup: bool) -> stats_alloc::Stats {
             }
             b.end_row();
         }
-        let _ = b
-            .finish_batch_view(arrow::buffer::Buffer::from(b"" as &[u8]), 0)
-            .unwrap();
+        let _ = b.finish_batch().unwrap();
     }
 
     let region = Region::new(GLOBAL);
@@ -353,9 +351,7 @@ fn run_columnar_view(warmup: bool) -> stats_alloc::Stats {
             }
             b.end_row();
         }
-        let batch = b
-            .finish_batch_view(arrow::buffer::Buffer::from(b"" as &[u8]), 0)
-            .unwrap();
+        let batch = b.finish_batch().unwrap();
         assert_eq!(batch.num_rows(), ROWS_PER_BATCH as usize);
     }
 

--- a/dev-docs/verification/kani-boundary-contract.toml
+++ b/dev-docs/verification/kani-boundary-contract.toml
@@ -179,3 +179,21 @@ path = "crates/logfwd-runtime/src/pipeline/health.rs"
 status = "required"
 reason = "Pipeline input-loop health transitions are an isolated local reducer with bounded Kani invariants."
 issue = 1440
+
+[[seams]]
+path = "crates/logfwd-arrow/src/lib.rs"
+status = "required"
+reason = "check_dup_bits bitmask logic is a bounded pure seam with oracle-verified Kani proofs."
+issue = 2072
+
+[[seams]]
+path = "crates/logfwd-arrow/src/columnar/accumulator.rs"
+status = "required"
+reason = "make_string_view u128 packing and buffer selection are bounded pure seams with oracle-verified Kani proofs."
+issue = 2072
+
+[[seams]]
+path = "crates/logfwd-arrow/src/columnar/row_protocol.rs"
+status = "required"
+reason = "RowLifecycle state machine transitions are bounded pure seams with symbolic action sequence proofs."
+issue = 2072

--- a/justfile
+++ b/justfile
@@ -160,7 +160,7 @@ miri-types:
 # Run the required Kani crate set enforced by CI guardrails.
 kani-required:
     RUSTC_WRAPPER="" cargo kani -p logfwd-core -Z function-contracts -Z mem-predicates -Z stubbing
-    RUSTC_WRAPPER="" cargo kani -p logfwd-arrow -Z function-contracts -Z mem-predicates -Z stubbing
+    RUSTC_WRAPPER="" cargo kani -p logfwd-arrow --lib -Z function-contracts -Z mem-predicates -Z stubbing
     RUSTC_WRAPPER="" cargo kani -p logfwd-types -Z function-contracts -Z mem-predicates -Z stubbing
     RUSTC_WRAPPER="" cargo kani -p logfwd-io -Z function-contracts -Z mem-predicates -Z stubbing
     RUSTC_WRAPPER="" cargo kani -p logfwd-output -Z function-contracts -Z mem-predicates -Z stubbing

--- a/scripts/verify_verification_trigger_contract.py
+++ b/scripts/verify_verification_trigger_contract.py
@@ -204,6 +204,9 @@ def extract_paths_filter_entries(ci_text: str, filter_name: str) -> set[str]:
 def extract_kani_args_crates(ci_text: str) -> set[str]:
     kani_block = extract_job_block(ci_text, "kani")
 
+    crates: set[str] = set()
+
+    # Collect crates from kani-github-action args blocks.
     for idx, line in enumerate(kani_block):
         stripped = line.strip()
         if not ("uses:" in stripped and "model-checking/kani-github-action@" in stripped):
@@ -229,18 +232,22 @@ def extract_kani_args_crates(ci_text: str) -> set[str]:
                     break
                 args_lines.append(step_stripped)
 
-        if not args_lines:
-            raise ValueError(
-                "ci.yml kani job missing args block for model-checking/kani-github-action"
-            )
-
         joined = " ".join(args_lines)
-        crates = set(re.findall(r"-p\s+([A-Za-z0-9_-]+)", joined))
-        if not crates:
-            raise ValueError("ci.yml kani args missing -p crate entries")
-        return crates
+        crates |= set(re.findall(r"-p\s+([A-Za-z0-9_-]+)", joined))
 
-    raise ValueError("ci.yml kani job missing model-checking/kani-github-action step")
+    # Also collect crates from raw `run: cargo kani -p ...` steps
+    # (used when a package needs flags like --lib that can't be mixed
+    # with other packages in a single kani-github-action invocation).
+    for line in kani_block:
+        stripped = line.strip()
+        if stripped.startswith("run:"):
+            cmd = stripped.removeprefix("run:").strip()
+            if "cargo kani" in cmd or "cargo-kani" in cmd:
+                crates |= set(re.findall(r"-p\s+([A-Za-z0-9_-]+)", cmd))
+
+    if not crates:
+        raise ValueError("ci.yml kani job missing -p crate entries")
+    return crates
 
 
 def extract_guardrail_scripts(ci_text: str) -> set[str]:


### PR DESCRIPTION
# Summary

ColumnarBatchBuilder prototype that validates the `BatchPlan` + `FieldHandle` typed-write API for shared columnar Arrow construction. This is a spike branch exploring the architecture described in `dev-docs/research/columnar-batch-builder.md`.

## What it does

Adds a new `ColumnarBatchBuilder` alongside the existing `StreamingBuilder`. Producers declare a `BatchPlan` with typed fields up front, get `FieldHandle` tokens, then write typed values per-row. The builder materializes Arrow `RecordBatch` with zero-copy `StringViewArray` for known-UTF8 sources.

### Architecture

```
BatchPlan::declare_planned("field_name", FieldKind::Int64) → FieldHandle
    ↓
ColumnarBatchBuilder::write_i64(handle, value)  // typed writes per row
ColumnarBatchBuilder::write_str(handle, "text") // string writes
    ↓
finish_batch() → RecordBatch  // Arrow materialization
```

Key design decisions:
- **ColumnAccumulator typed enum** — eliminates 3/4 dead vecs per planned field vs uniform storage
- **FinalizationMode** — separates detached buffer ownership from storage strategy
- **UTF-8 trusted boundary** — validate once at scanner ingestion, `debug_assert` in dev, `new_unchecked` in release
- **StringViewArray zero-copy** — u128 views reference source buffers directly, no per-string copy
- **Dense fast paths** — when all rows present (planned fields), skip NullBuffer entirely
- **Optional dedup bypass** — producers that guarantee single-write-per-field skip bitmap overhead

### Performance (callgrind, 50 batches × 1000 rows, 15 OTLP fields)

| Version | Zero-copy insns | Generated insns | vs Streaming |
|---------|----------------|-----------------|-------------|
| v1 (StringBuilder) | — | 156.8M | −20% |
| v2 (bulk UTF-8) | — | 114.7M | −42% |
| v3 (dense/skip) | — | 100.6M | −49% |
| v4 (trusted boundary) | 76.1M | 90.1M | −62% |
| v5 (StringViewArray) | 65.6M | 94.0M | −68% |
| **v6 (dedup+dense)** | **59.0M** | **86.7M** | **−71%** |
| Streaming baseline | 201.9M | 203.7M | — |

### Memory (DHAT, 20 batches × 1000 rows)

| Scenario | Columnar peak | Streaming peak | Δ |
|----------|--------------|---------------|---|
| Zero-copy | 417K / 132 blocks | 691K / 226 blocks | −40% peak, −42% blocks |
| Generated | 1,050K / 131 blocks | 1,084K / 224 blocks | −3% peak, −42% blocks |

### Files

- `crates/logfwd-arrow/src/columnar/accumulator.rs` — ColumnAccumulator typed enum + materialization
- `crates/logfwd-arrow/src/columnar/builder.rs` — ColumnarBatchBuilder write API + batch lifecycle
- `crates/logfwd-arrow/src/columnar/plan.rs` — BatchPlan + FieldHandle + FieldKind (expanded)
- `crates/logfwd-arrow/src/bin/builder_profile.rs` — valgrind/callgrind/DHAT profiling harness
- `crates/logfwd-arrow/tests/columnar_alloc_profile.rs` — allocation profiling integration tests
- `crates/logfwd-arrow/src/lib.rs` — `_test-internals` feature gate
- `crates/logfwd-arrow/Cargo.toml` — feature + bin declarations

### What this is NOT

This is a spike/prototype, not a production integration. The existing `StreamingBuilder` and scanner pipeline are unchanged. No config changes, no pipeline wiring, no OTLP integration. Those are follow-on issues.

## Relates to

Relates to #1838
Relates to #1844

## Test plan

- [x] 61 unit tests covering all field types, sparse/dense paths, multi-batch reuse, error cases
- [x] 3 integration tests for allocation profiling (columnar vs streaming comparison)
- [x] Clippy clean with `-D warnings`
- [x] `cargo fmt --check` passes
- [x] Callgrind + DHAT profiling validates performance claims

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ColumnarBatchBuilder` for typed columnar Arrow batch construction
> - Introduces [`ColumnarBatchBuilder`](https://github.com/strawgate/memagent/pull/2072/files#diff-d319f6a8aa2761b26f0d390a13e1169007daa93e1a5b5293271066f35b793159) with per-field typed accumulation (`i64`, `f64`, `bool`, `str`), per-row deduplication, and Arrow `RecordBatch` materialization.
> - Adds [`ColumnAccumulator`](https://github.com/strawgate/memagent/pull/2072/files#diff-41b79f99ae1f7fd4f98545794a773da1bfeb0b7b6fac100feeac992e956c7e02) as the per-field storage layer with `StringRef` for compact zero-copy string references into an input buffer.
> - Extends [`BatchPlan`](https://github.com/strawgate/memagent/pull/2072/files#diff-a011956f5010954e5ba04ca64dc46a3c8181c8c7c424cec79b37ae24994631ad) with `reset_dynamic()`, `num_planned()`, a `TooManyFields` error, and an ordering invariant that requires planned fields to be declared before dynamic ones.
> - Adds a [`builder_profile`](https://github.com/strawgate/memagent/pull/2072/files#diff-151a7003602e05468e24a0efe6275e05de1ab75f0db344e71a90fcd63e8d10b3) binary and allocation profiling tests (both gated behind `_test-internals`) for comparing `ColumnarBatchBuilder` vs `StreamingBuilder`.
> - Adds Kani proof harnesses for `check_dup_bits` bitmask logic, `RowLifecycle` state transitions, and `make_string_view` packing, with CI updated to run `cargo kani -p logfwd-arrow --lib` separately.
> - Behavioral Change: `BatchPlan::declare_planned` now returns `PlanError::ModeMismatch` if called after any dynamic fields have been resolved; previously this was not enforced.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1bb939.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->