### PR TITLE
test: add FrameOutput::is_empty() assertions to framer tests

### DIFF
--- a/crates/logfwd-core/src/framer.rs
+++ b/crates/logfwd-core/src/framer.rs
@@ -120,6 +120,7 @@ mod tests {
         let input = b"line one\nline two\nline three\n";
         let output = NewlineFramer.frame(input);
         assert_eq!(output.len(), 3);
+        assert!(!output.is_empty());
         assert_eq!(
             &input[output.line_range(0).0..output.line_range(0).1],
             b"line one"
@@ -152,6 +153,7 @@ mod tests {
     fn newline_framer_empty() {
         let output = NewlineFramer.frame(b"");
         assert_eq!(output.len(), 0);
+        assert!(output.is_empty());
         assert_eq!(output.remainder_offset, 0);
     }
 
@@ -160,6 +162,7 @@ mod tests {
         let input = b"no newline at all";
         let output = NewlineFramer.frame(input);
         assert_eq!(output.len(), 0);
+        assert!(output.is_empty());
         assert_eq!(output.remainder_offset, 0);
         assert_eq!(&input[output.remainder_offset..], b"no newline at all");
     }


### PR DESCRIPTION
## Summary
- Add `is_empty()` assertions to 3 existing framer tests to close a mutation testing gap

## Test plan
- [x] `cargo test -p logfwd-core -- framer` passes (5/5)
- [x] cargo-mutants confirms all 3 previously-missed mutants on `FrameOutput::is_empty()` are now caught
- [ ] CI green

## Context
cargo-mutants evaluation (#666) found that `FrameOutput::is_empty()` had zero test coverage — mutating it to always return `true`, always return `false`, or flipping `==` to `!=` all passed tests. This 3-line fix closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `FrameOutput::is_empty()` assertions to framer tests
> Adds explicit `is_empty()` checks to three tests in [framer.rs](https://github.com/strawgate/memagent/pull/2079/files#diff-090acea1e1f60f999a42c0cdf36f7e73a915710c14d7c570d0e0dcc161e26405) to verify expected emptiness or non-emptiness of framer output. This strengthens test coverage by making output state assertions explicit rather than implicit.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 490ce94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->