### PR TITLE
fix(ci): add missing lychee excludes for how-it-works and quick-start routes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
             --root-dir .
             --exclude 'mailto:'
             --exclude-loopback
-            --exclude '^file:///.*/(architecture|configuration|deployment|development|getting-started|troubleshooting)(/|#|$)'
+            --exclude '^file:///.*/(architecture|configuration|deployment|development|getting-started|how-it-works|quick-start|troubleshooting)(/|#|$)'
             --exclude '^https://opentelemetry.io/docs/'
             README.md book/src/content/docs dev-docs docs
 


### PR DESCRIPTION
## Summary
- Add `how-it-works` and `quick-start` to the lychee link checker exclude pattern in the Deploy Docs workflow

## Problem
The Deploy Docs workflow has been failing on every run (19 broken links) since the Starlight `how-it-works` pages were added. Lychee resolves absolute Starlight routes like `/memagent/how-it-works/scanner` as filesystem paths, which don't exist. The exclude pattern already covered other route prefixes (architecture, configuration, etc.) but was missing these two.

## Test plan
- [ ] Deploy Docs workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `how-it-works` and `quick-start` excludes to lychee link checker
> Updates the `--exclude` regex in [docs.yml](.github/workflows/docs.yml) to skip `file:///` links under `how-it-works` and `quick-start` paths, matching the pattern already used for other excluded routes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0aab4e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->