### PR TITLE
perf: SIMD fast-path in write_json_string via memchr2

### DIFF
--- a/crates/logfwd-output/src/row_json.rs
+++ b/crates/logfwd-output/src/row_json.rs
@@ -6,6 +6,7 @@ use arrow::array::{
 use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 use arrow::util::display::array_value_to_string;
+use memchr::memchr2;
 
 use crate::conflict_columns::{ColInfo, get_array, is_null};
 
@@ -44,22 +45,74 @@ pub(crate) fn coalesce_as_str(batch: &RecordBatch, row: usize, col: &ColInfo) ->
     Some(s)
 }
 
+/// Return the index of the first byte in `bytes` that requires JSON escaping,
+/// or `bytes.len()` if there are none.
+///
+/// Uses `memchr2` (SIMD-accelerated on x86-64 and ARM64) to quickly find `"`
+/// or `\` — the most common escape triggers — then checks the range up to that
+/// hit for control characters (< 0x20) that memchr2 cannot directly find.
+/// When the string contains no special bytes at all, a single `memchr2` pass
+/// returning `None` is the only work done, so the caller can bulk-copy the
+/// entire string with one `extend_from_slice`.
+#[inline]
+fn first_escape_pos(bytes: &[u8]) -> usize {
+    // Quickly find the next '"' or '\\' using SIMD memchr2.
+    let hit = memchr2(b'"', b'\\', bytes);
+    // Scan for control chars (< 0x20) only up to the memchr2 hit position;
+    // beyond that we know there's already an escape to handle.
+    let scan_end = hit.unwrap_or(bytes.len());
+    // Tight loop the compiler can auto-vectorize.
+    for (i, &b) in bytes[..scan_end].iter().enumerate() {
+        if b < 0x20 {
+            return i;
+        }
+    }
+    hit.unwrap_or(bytes.len())
+}
+
 /// Write a JSON string value with RFC 8259 escaping.
+///
+/// **Hot path optimization**: most log field values (timestamps, service names,
+/// HTTP paths, hex IDs, etc.) contain zero bytes requiring JSON escaping.  This
+/// implementation uses [`first_escape_pos`] to find the first special byte with
+/// a SIMD-accelerated scan, then falls through to a bulk `extend_from_slice`
+/// for the safe prefix (one optimized `memcpy` instead of N individual byte
+/// pushes).  Only when an escape byte is actually found does the slow per-byte
+/// path run for that single byte.
+///
+/// Benchmark impact (wide/10K): ~2–3× throughput improvement over the prior
+/// byte-by-byte loop.
 pub(crate) fn write_json_string(out: &mut Vec<u8>, v: &str) -> io::Result<()> {
     out.push(b'"');
-    for &b in v.as_bytes() {
-        match b {
+    let bytes = v.as_bytes();
+    let mut start = 0;
+
+    while start < bytes.len() {
+        let remaining = &bytes[start..];
+        let rel_pos = first_escape_pos(remaining);
+
+        // Bulk-copy the safe prefix — compiles to a single `memcpy`.
+        if rel_pos > 0 {
+            out.extend_from_slice(&remaining[..rel_pos]);
+        }
+
+        if rel_pos == remaining.len() {
+            // No more bytes needing escaping — we're done.
+            break;
+        }
+
+        // Handle the one byte at `start + rel_pos` that needs escaping.
+        match remaining[rel_pos] {
             b'"' => out.extend_from_slice(b"\\\""),
             b'\\' => out.extend_from_slice(b"\\\\"),
             b'\n' => out.extend_from_slice(b"\\n"),
             b'\r' => out.extend_from_slice(b"\\r"),
             b'\t' => out.extend_from_slice(b"\\t"),
-            b if b < 0x20 => {
-                Write::write_fmt(out, format_args!("\\u{:04x}", b))?;
-            }
-            _ => out.push(b),
+            b => Write::write_fmt(out, format_args!("\\u{:04x}", b))?,
         }
+        start += rel_pos + 1;
     }
+
     out.push(b'"');
     Ok(())
 }


### PR DESCRIPTION
## Summary

Use `memchr2` (SIMD-accelerated on x86-64/ARM64) to find the first byte requiring JSON escaping in `write_json_string`, then bulk-copy the safe prefix with a single `extend_from_slice` instead of N individual byte pushes.

For typical log data (timestamps, service names, HTTP paths, hex IDs), the vast majority of field bytes require no escaping. The prior implementation called `out.push(b)` for each byte — N individual Vec pushes per field value. The new implementation reduces the common case to one `memchr2` scan + one `memcpy`.

## Benchmark Results (logfwd-bench json_lines)

| Scenario | Before | After | Speedup |
|---|---|---|---|
| `narrow/1000` | 1,087,178 r/s | 1,332,222 r/s | **+23%** |
| `narrow/10000` | 1,065,756 r/s | 1,294,281 r/s | **+21%** |
| `wide/1000` | 171,340 r/s | 210,598 r/s | **+23%** |
| `wide/10000` | **77,137 r/s** | **192,879 r/s** | **+150%** ✅ |

The wide/10K case (many string columns, large batches) showed **2.5× improvement**. This was identified as the root cause of the ~110K EPS ceiling for the `logfwd-capture` sink in the e2e benchmarks.

## No new dependencies

`memchr` is already a transitive dependency (via multiple existing crates). This adds it as a direct dep of `logfwd-output` — no new external crates.

## Testing

- All 245 `logfwd-output` tests pass (including `snapshot_special_char_strings`)
- Clippy clean (`-D warnings`)
- Allocation regression tests pass (`write_row_json_stable_across_batches`)

## Self-review

- ✅ `first_escape_pos` correctly identifies all RFC 8259 escape bytes (< 0x20, `"`, `\`)
- ✅ UTF-8 multi-byte sequences (all bytes ≥ 0x80) pass through unchanged
- ✅ Loop termination guaranteed: `start` monotonically increases by ≥1 each iteration

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SIMD fast-path to `write_json_string` via `memchr2`
> Replaces the byte-by-byte match loop in [`write_json_string`](https://github.com/strawgate/memagent/pull/2086/files#diff-52251238e3d45cad7a8da16b9b815d0dc8b6429621b6712d05140d96919832e2) with a chunked approach that bulk-copies safe byte ranges and only processes escape-worthy bytes individually.
>
> - Adds `first_escape_pos` helper that uses `memchr2` to locate `"` or `\` then scans up to that point for control characters (`< 0x20`), returning the index of the first byte needing escaping.
> - Each loop iteration bulk-copies the safe prefix via `extend_from_slice`, then emits a single escaped sequence for `"`, `\`, `\n`, `\r`, `\t`, or `\uXXXX` for other control bytes.
> - Escaping semantics and function signature are unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8382f43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->