### PR TITLE
docs: fix examples and reference (second batch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ERROR  request handled POST /api/v1/orders/10121  status=503 duration_ms=78
 ...
 ```
 
-Only error records with slow durations made it through — everything else was filtered by the SQL transform. See the [Quick Start guide](book/src/content/docs/getting-started/quickstart.md) to keep going.
+Only error records with slow durations made it through — everything else was filtered by the SQL transform. See the [Quick Start guide](book/src/content/docs/quick-start.mdx) to keep going.
 
 ---
 
@@ -124,7 +124,7 @@ cargo build --release -p logfwd
 cargo build --release -p logfwd --no-default-features
 ```
 
-See [Installation](book/src/content/docs/getting-started/installation.mdx) for all platforms and options.
+See [Quick Start](book/src/content/docs/quick-start.mdx) for installation details.
 
 ---
 
@@ -247,18 +247,16 @@ For ready-made starters, see [`examples/use-cases/`](examples/use-cases/README.m
 
 **Start here by goal**
 
-- Not sure where to begin: [Choose the Right Guide](book/src/content/docs/getting-started/which-guide.md)
-- Run logfwd quickly: [Quick Start](book/src/content/docs/getting-started/quickstart.md)
-- Build a safer production baseline: [Your First Pipeline](book/src/content/docs/getting-started/first-pipeline.md)
+- Not sure where to begin: [Overview](book/src/content/docs/index.mdx)
+- Run logfwd quickly: [Quick Start](book/src/content/docs/quick-start.mdx)
 - Debug failures: [Troubleshooting](book/src/content/docs/troubleshooting.md)
 
 **User guides** — [book/src/content/docs/](book/src/content/docs/)
 
 | Guide | Description |
 |-------|-------------|
-| [Choose the Right Guide](book/src/content/docs/getting-started/which-guide.md) | Goal-based chooser for operators, contributors, and evaluators |
-| [Quick Start](book/src/content/docs/getting-started/quickstart.md) | Working pipeline in 10 minutes with copy/paste commands |
-| [Your First Pipeline](book/src/content/docs/getting-started/first-pipeline.md) | Production config with monitoring and validation |
+| [Overview](book/src/content/docs/index.mdx) | Overview for operators, contributors, and evaluators |
+| [Quick Start](book/src/content/docs/quick-start.mdx) | Working pipeline in 10 minutes with copy/paste commands |
 | [Configuration Reference](book/src/content/docs/configuration/reference.mdx) | All YAML fields, input/output types, SQL transforms, UDFs, enrichment |
 | [SQL Transforms](book/src/content/docs/configuration/sql-transforms.md) | DataFusion SQL examples, column naming, UDFs |
 | [Deployment](book/src/content/docs/deployment/kubernetes.md) | Kubernetes DaemonSet, Docker, resource sizing |

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -519,11 +519,7 @@ Special columns added by the scanner / input format layer:
 | `body` | string | Original input line (when input line capture is enabled, e.g. `line_field: body`, or when a non-JSON CRI line is wrapped for scanner safety). |
 | `_timestamp` | string | Timestamp from the CRI header as an RFC 3339 string (CRI inputs only). |
 | `_stream` | string | CRI stream name (`stdout` / `stderr`). |
-
-For file-backed inputs with JSON-object rows (formats: `json`, `cri`, or `auto`),
-source-path metadata is injected as `_source_path` and can be used in SQL joins
-(for example with `k8s_path` enrichment). Raw and text-format inputs do not
-inject `_source_path`.
+| `_source_path` | string | Path of the file being tailed (file-backed inputs only). |
 
 ### Built-in UDFs
 
@@ -573,8 +569,7 @@ enrichment:
 Parses Kubernetes pod log paths (e.g.
 `/var/log/pods/<namespace>_<pod>_<uid>/<container>/`) to extract metadata.
 The source-path metadata is automatically injected into the `logs` table as
-`_source_path` for file-backed inputs when the decoder produces JSON objects
-(for example, `json`, `cri`, or `auto` formats).
+`_source_path` for file-backed inputs.
 
 Columns exposed by `k8s`:
 

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -520,8 +520,10 @@ Special columns added by the scanner / input format layer:
 | `_timestamp` | string | Timestamp from the CRI header as an RFC 3339 string (CRI inputs only). |
 | `_stream` | string | CRI stream name (`stdout` / `stderr`). |
 
-File-backed source-path metadata is not yet exposed as a SQL column. Track that
-gap in [issue #1346](https://github.com/strawgate/memagent/issues/1346).
+For file-backed inputs with JSON-object rows (formats: `json`, `cri`, or `auto`),
+source-path metadata is injected as `_source_path` and can be used in SQL joins
+(for example with `k8s_path` enrichment). Raw and text-format inputs do not
+inject `_source_path`.
 
 ### Built-in UDFs
 
@@ -571,7 +573,8 @@ enrichment:
 Parses Kubernetes pod log paths (e.g.
 `/var/log/pods/<namespace>_<pod>_<uid>/<container>/`) to extract metadata.
 The source-path metadata is automatically injected into the `logs` table as
-`_source_path` for file-backed inputs.
+`_source_path` for file-backed inputs when the decoder produces JSON objects
+(for example, `json`, `cri`, or `auto` formats).
 
 Columns exposed by `k8s`:
 

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -529,7 +529,7 @@ gap in [issue #1346](https://github.com/strawgate/memagent/issues/1346).
 |----------|-----------|-------------|
 | `int(expr)` | `int(any) → int64` | Cast any value to int64. Returns NULL on failure. |
 | `float(expr)` | `float(any) → float64` | Cast any value to float64. Returns NULL on failure. |
-| `grok(pattern, input)` | `grok(utf8, utf8) → utf8` | Apply a Grok pattern to `input` and return the first capture as JSON. |
+| `grok(column, pattern)` | `grok(utf8, utf8) → struct` | Apply a Grok pattern to `column` and return the captures as a struct. |
 | `regexp_extract(input, pattern, group)` | `regexp_extract(utf8, utf8, int64) → utf8` | Return capture group `group` from a regex match. |
 
 Examples:
@@ -539,7 +539,7 @@ Examples:
 SELECT int(status) AS status FROM logs
 
 -- Extract a field with Grok
-SELECT grok('%{IP:client} %{WORD:method} %{URIPATHPARAM:path}', message) AS parsed FROM logs
+SELECT grok(message, '%{IP:client} %{WORD:method} %{URIPATHPARAM:path}') AS parsed FROM logs
 
 -- Extract a named group with regex
 SELECT regexp_extract(message, 'user=([a-z]+)', 1) AS user FROM logs
@@ -570,11 +570,8 @@ enrichment:
 
 Parses Kubernetes pod log paths (e.g.
 `/var/log/pods/<namespace>_<pod>_<uid>/<container>/`) to extract metadata.
-
-This enrichment table is ready to expose path-derived metadata, but file-backed
-inputs do not yet inject a source-path column into the `logs` table. The join
-shown in older docs is therefore not wired end to end today. Track that runtime
-gap in [issue #1346](https://github.com/strawgate/memagent/issues/1346).
+The source-path metadata is automatically injected into the `logs` table as
+`_source_path` for file-backed inputs.
 
 Columns exposed by `k8s`:
 

--- a/book/src/content/docs/configuration/sql-transforms.md
+++ b/book/src/content/docs/configuration/sql-transforms.md
@@ -126,6 +126,7 @@ Use `get_field()` to extract individual fields:
 ```yaml
 enrichment:
   - type: geo_database
+    format: mmdb
     path: /data/GeoLite2-City.mmdb
 transform: |
   SELECT *, get_field(geo, 'city') AS city, get_field(geo, 'country_code') AS country

--- a/book/src/content/docs/deployment/docker.md
+++ b/book/src/content/docs/deployment/docker.md
@@ -64,8 +64,8 @@ bind mount eliminates both problems.
 Your configuration must reference the same directory:
 
 ```yaml
-server:
-  checkpoint_dir: /var/lib/logfwd
+storage:
+  data_dir: /var/lib/logfwd
 ```
 
 ## Resource constraints

--- a/book/src/content/docs/deployment/kubernetes.md
+++ b/book/src/content/docs/deployment/kubernetes.md
@@ -172,8 +172,8 @@ every log record:
 
 ```yaml
 enrichment:
-  k8s:
-    type: k8s_path
+  - type: k8s_path
+    table_name: k8s
 
 transform: |
   SELECT

--- a/crates/logfwd/src/config_templates.rs
+++ b/crates/logfwd/src/config_templates.rs
@@ -95,7 +95,7 @@ pub(crate) const OUTPUT_TEMPLATES: &[OutputTemplate] = &[
         id: "elasticsearch",
         label: "Elasticsearch",
         description: "Index logs in Elasticsearch for full-text search.",
-        snippet: "output:\n  type: elasticsearch\n  endpoint: http://localhost:9200\n  index: logs-%Y.%m.%d\n",
+        snippet: "output:\n  type: elasticsearch\n  endpoint: http://localhost:9200\n  index: logs\n",
     },
     OutputTemplate {
         id: "stdout",

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,11 +6,9 @@ This directory provides stable entry links for user docs and points to canonical
 
 Recommended reading order for new users:
 
-1. [Choose the Right Guide](../book/src/content/docs/getting-started/which-guide.md)
-2. [Installation](../book/src/content/docs/getting-started/installation.mdx)
-3. [Quick Start](../book/src/content/docs/getting-started/quickstart.md)
-4. [Your First Pipeline](../book/src/content/docs/getting-started/first-pipeline.md)
-5. [Configuration Reference](CONFIG_REFERENCE.md)
+1. [Overview](../book/src/content/docs/index.mdx)
+2. [Quick Start](../book/src/content/docs/quick-start.mdx)
+3. [Configuration Reference](CONFIG_REFERENCE.md)
 6. [Deployment](DEPLOYMENT.md)
 7. [Troubleshooting](TROUBLESHOOTING.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Recommended reading order for new users:
 1. [Overview](../book/src/content/docs/index.mdx)
 2. [Quick Start](../book/src/content/docs/quick-start.mdx)
 3. [Configuration Reference](CONFIG_REFERENCE.md)
-6. [Deployment](DEPLOYMENT.md)
-7. [Troubleshooting](TROUBLESHOOTING.md)
+4. [Deployment](DEPLOYMENT.md)
+5. [Troubleshooting](TROUBLESHOOTING.md)
 
 Contributor/reviewer policy docs live in `dev-docs/`.

--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -96,26 +96,26 @@ Route different log types to different indices:
 ```yaml
 pipelines:
   errors:
-    input:
-      type: file
-      path: /var/log/app/*.log
-      format: json
+    inputs:
+      - type: file
+        path: /var/log/app/*.log
+        format: json
     transform: SELECT * FROM logs WHERE level = 'ERROR'
-    output:
-      type: elasticsearch
-      endpoint: http://elasticsearch:9200
-      index: app-errors
+    outputs:
+      - type: elasticsearch
+        endpoint: http://elasticsearch:9200
+        index: app-errors
 
   access_logs:
-    input:
-      type: file
-      path: /var/log/nginx/access.log
-      format: json
+    inputs:
+      - type: file
+        path: /var/log/nginx/access.log
+        format: json
     transform: SELECT * FROM logs WHERE status >= 200
-    output:
-      type: elasticsearch
-      endpoint: http://elasticsearch:9200
-      index: nginx-access
+    outputs:
+      - type: elasticsearch
+        endpoint: http://elasticsearch:9200
+        index: nginx-access
 ```
 
 ## Performance Tuning

--- a/examples/elasticsearch/with-auth-and-filter.yaml
+++ b/examples/elasticsearch/with-auth-and-filter.yaml
@@ -5,13 +5,13 @@ input:
 
 transform: |
   SELECT
-    level_str,
-    message_str,
-    status_int,
-    duration_ms_float
+    level,
+    message,
+    status,
+    duration_ms
   FROM logs
-  WHERE level_str IN ('ERROR', 'WARN')
-    OR status_int >= 400
+  WHERE level IN ('ERROR', 'WARN')
+    OR status >= 400
 
 output:
   type: elasticsearch


### PR DESCRIPTION
This PR fixes ten documentation bugs identified in the second batch of examples and reference work-unit. Changes include fixing broken links in the README and docs/ directory, correcting YAML schema errors in enrichment and multi-pipeline examples, updating stale field names and SQL suffixes, and aligning UDF documentation with the actual implementation.

Fixes #2094

---
*PR created automatically by Jules for task [7560356135960907966](https://jules.google.com/task/7560356135960907966) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix documentation examples and configuration references in second batch of doc corrections
> - Updates `_source_path` as a documented special column in [reference.mdx](https://github.com/strawgate/memagent/pull/2112/files#diff-6a69bd5c38c92acca3dd194d75d77551f1b8f6b98890da7e56f2c9cbe564aac4), corrects the Grok UDF signature from `grok(pattern, input) → utf8` to `grok(column, pattern) → struct`, and removes stale limitation notes.
> - Fixes the Elasticsearch config generator template in [config_templates.rs](https://github.com/strawgate/memagent/pull/2112/files#diff-9c0e72b36d9b794d256277c36d905b58f7a378bcd0f09f1be721a399752bd3d6) to use `index: logs` instead of `index: logs-%Y.%m.%d`.
> - Corrects `inputs`/`outputs` array keys in the [elasticsearch example README](https://github.com/strawgate/memagent/pull/2112/files#diff-68f2421a351e6e5726390efe9439fa89dfc919a6885816ab015454d86863e311) and renames SQL transform columns to plain names in [with-auth-and-filter.yaml](https://github.com/strawgate/memagent/pull/2112/files#diff-2d1ce6676f8f3fdd10248b108452342087fb427f3861c9291387847a8ded27aa).
> - Updates deployment config keys (`storage.data_dir` replacing `server.checkpoint_dir`) in [docker.md](https://github.com/strawgate/memagent/pull/2112/files#diff-7f7b67227f2ed32566676ecc01b912079de8a09804be39bee854591ee33b1a90) and fixes k8s enrichment config structure in [kubernetes.md](https://github.com/strawgate/memagent/pull/2112/files#diff-1e32ff9d041f47b03ef9b50d88b1d61d28890c05919c093263ef76899d93d289).
> - Behavioral Change: the `elasticsearch` preset in the config generator now produces `index: logs` by default instead of a date-formatted index name.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fdecc8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->