### PR TITLE
fix: N correctness bugs - star_schema LargeUtf8 gap and Arrow IPC Sink silent gzip no-op

### DIFF
--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -546,7 +546,10 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
     // severity_text → level
     if let Ok(sev_idx) = logs_schema.index_of("severity_text") {
         let sev_arr = star.logs.column(sev_idx);
-        if !matches!(sev_arr.data_type(), DataType::Utf8 | DataType::Utf8View) {
+        if !matches!(
+            sev_arr.data_type(),
+            DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8
+        ) {
             return Err(ArrowError::SchemaError(format!(
                 "severity_text must be Utf8 or Utf8View, got {}",
                 sev_arr.data_type()
@@ -569,7 +572,10 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
     // body_str → message
     if let Ok(body_idx) = logs_schema.index_of("body_str") {
         let body_arr = star.logs.column(body_idx);
-        if !matches!(body_arr.data_type(), DataType::Utf8 | DataType::Utf8View) {
+        if !matches!(
+            body_arr.data_type(),
+            DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8
+        ) {
             return Err(ArrowError::SchemaError(format!(
                 "body_str must be Utf8 or Utf8View, got {}",
                 body_arr.data_type()
@@ -920,6 +926,11 @@ fn str_from_array(arr: &dyn Array, row: usize) -> String {
         DataType::Utf8View => arr
             .as_any()
             .downcast_ref::<arrow::array::StringViewArray>()
+            .map(|a| a.value(row).to_string())
+            .unwrap_or_default(),
+        DataType::LargeUtf8 => arr
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
             .map(|a| a.value(row).to_string())
             .unwrap_or_default(),
         _ => String::new(),

--- a/crates/logfwd-output/src/arrow_ipc_sink.rs
+++ b/crates/logfwd-output/src/arrow_ipc_sink.rs
@@ -19,6 +19,9 @@ use logfwd_types::diagnostics::ComponentStats;
 use super::sink::{SendResult, Sink, SinkFactory};
 use super::{BatchMetadata, Compression};
 use crate::http_classify::{DEFAULT_RETRY_AFTER_SECS, parse_retry_after};
+use flate2::Compression as GzLevel;
+use flate2::write::GzEncoder;
+use std::io::Write;
 
 /// Content-Type for uncompressed Arrow IPC stream.
 const CONTENT_TYPE_ARROW: &str = "application/vnd.apache.arrow.stream";
@@ -101,7 +104,12 @@ impl ArrowIpcSink {
     fn maybe_compress(&self) -> io::Result<Vec<u8>> {
         match self.config.compression {
             Compression::Zstd => zstd::bulk::compress(&self.ipc_buf, 1).map_err(io::Error::other),
-            Compression::None | Compression::Gzip => Ok(self.ipc_buf.clone()),
+            Compression::Gzip => {
+                let mut encoder = GzEncoder::new(Vec::new(), GzLevel::default());
+                encoder.write_all(&self.ipc_buf)?;
+                encoder.finish()
+            }
+            Compression::None => Ok(self.ipc_buf.clone()),
         }
     }
 
@@ -122,6 +130,8 @@ impl ArrowIpcSink {
 
         if self.config.compression == Compression::Zstd {
             req = req.header("Content-Encoding", "zstd");
+        } else if self.config.compression == Compression::Gzip {
+            req = req.header("Content-Encoding", "gzip");
         }
 
         for (k, v) in &self.config.headers {


### PR DESCRIPTION
Fixes two high-severity bugs identified during autonomous reconnaissance:
1. **logfwd-arrow/star_schema DataType::LargeUtf8 gaps**: Values in `DataType::LargeUtf8` columns were dropped during `flat_to_star` conversion because `str_from_array` and column validation only handled `Utf8` and `Utf8View`. Fixed by adding `LargeUtf8` matching blocks.
2. **logfwd-output/arrow_ipc_sink silent gzip compression no-op**: Configuring an Arrow IPC sink with `compression: gzip` resulted in uncompressed data without `Content-Encoding` headers due to a shared match arm with `Compression::None`. Fixed by implementing gzip via `flate2::write::GzEncoder` and setting the necessary headers.

---
*PR created automatically by Jules for task [11305255171907702821](https://jules.google.com/task/11305255171907702821) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `LargeUtf8` handling in `star_to_flat` and gzip no-op in `ArrowIpcSink`
> - [`star_schema.rs`](https://github.com/strawgate/memagent/pull/2132/files#diff-fb28eb9d8306708fff07b41c8d2b450df493a129ad9ffa16eceed5676b3a0f62): `star_to_flat` now accepts `DataType::LargeUtf8` for `severity_text` and `body_str` fields (mapping to `level` and `message`) instead of returning a schema error; `str_from_array` also handles `LargeStringArray` instead of silently returning empty strings.
> - [`arrow_ipc_sink.rs`](https://github.com/strawgate/memagent/pull/2132/files#diff-2a04098124b0d9ce8f3fdf8c46bb58320a9e1994c82a8cee9795d01015659d77): `maybe_compress` now actually gzip-compresses the IPC buffer via `flate2::write::GzEncoder` when `Compression::Gzip` is configured; previously it was a no-op that returned uncompressed bytes.
> - `do_send` now also sets the `Content-Encoding: gzip` header when gzip compression is active.
> - Behavioral Change: payloads sent with `Compression::Gzip` configured will now be compressed and correctly labeled, changing wire output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56a876e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->