### PR TITLE
feat: migrate core e2e scenarios

### DIFF
--- a/.github/workflows/e2e-scenarios.yml
+++ b/.github/workflows/e2e-scenarios.yml
@@ -1,0 +1,43 @@
+name: E2E Scenarios (Smoke)
+
+on:
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-scenarios-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: ${{ matrix.scenario }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - kind-cri-smoke
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build e2e image
+        run: docker build -t logfwd:e2e -f Dockerfile.e2e .
+
+      - name: Install KIND
+        run: |
+          KIND_VERSION="v0.24.0"
+          curl -Lo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+
+      - name: Run scenario
+        run: bash tests/e2e/run-scenario.sh ${{ matrix.scenario }}
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ matrix.scenario }}-results
+          path: tests/e2e/results/${{ matrix.scenario }}/
+          retention-days: 7

--- a/reporting/__init__.py
+++ b/reporting/__init__.py
@@ -1,0 +1,5 @@
+"""Shared reporting helpers for markdown and summary rendering."""
+
+from .markdown import MarkdownTableAlign, markdown_table
+
+__all__ = ["MarkdownTableAlign", "markdown_table"]

--- a/reporting/markdown.py
+++ b/reporting/markdown.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import Literal
+
+MarkdownTableAlign = Literal["left", "center", "right"]
+
+_ALIGN_DIVIDER: dict[MarkdownTableAlign, str] = {
+    "left": "---",
+    "center": ":---:",
+    "right": "---:",
+}
+
+
+def _escape_cell(value: object) -> str:
+    text = str(value)
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def markdown_table(
+    *,
+    headers: Sequence[str],
+    rows: Iterable[Sequence[object]],
+    align: Sequence[MarkdownTableAlign] | None = None,
+) -> list[str]:
+    if not headers:
+        raise ValueError("headers must not be empty")
+    if align is not None and len(align) != len(headers):
+        raise ValueError("align length must match headers length")
+
+    effective_align = align or ["left"] * len(headers)
+    divider_cells = [_ALIGN_DIVIDER[cell_align] for cell_align in effective_align]
+
+    lines = [
+        f"| {' | '.join(_escape_cell(header) for header in headers)} |",
+        f"| {' | '.join(divider_cells)} |",
+    ]
+    for row in rows:
+        if len(row) != len(headers):
+            raise ValueError("row length must match headers length")
+        lines.append(f"| {' | '.join(_escape_cell(cell) for cell in row)} |")
+    return lines

--- a/tests/e2e/lib/capture_tcp.py
+++ b/tests/e2e/lib/capture_tcp.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import socketserver
+import threading
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Capture newline-delimited TCP output into a file.")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=9000)
+    parser.add_argument("--output-dir", required=True)
+    return parser.parse_args()
+
+
+class CaptureHandler(socketserver.BaseRequestHandler):
+    def handle(self) -> None:
+        while True:
+            chunk = self.request.recv(65536)
+            if not chunk:
+                return
+            with self.server.lock:
+                with self.server.output_path.open("ab") as handle:
+                    handle.write(chunk)
+
+
+class CaptureServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(self, server_address: tuple[str, int], handler_cls: type[CaptureHandler], output_path: Path):
+        super().__init__(server_address, handler_cls)
+        self.output_path = output_path
+        self.lock = threading.Lock()
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "captured.ndjson"
+    output_path.write_text("", encoding="utf-8")
+
+    with CaptureServer((args.host, args.port), CaptureHandler, output_path) as server:
+        print(f"capture-tcp listening on {args.host}:{args.port}, writing to {output_path}", flush=True)
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/lib/check_scenarios.py
+++ b/tests/e2e/lib/check_scenarios.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+FAMILY_DEFAULTS = {
+    "compose": {"up", "down", "collect", "verify"},
+    "kind": set(),
+    "otlp": {"up", "down", "collect"},
+    "custom": set(),
+}
+
+FAMILY_REQUIRED_FILES = {
+    "compose": {"compose.yaml", "memagent.yaml", "oracle.json", "run_workload.sh"},
+    "kind": {"oracle.json", "run_workload.sh"},
+    "otlp": {"run_workload.sh", "verify.sh"},
+    "custom": {"run_workload.sh"},
+}
+
+PHASES = ("up", "run_workload", "verify", "collect", "down")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate memagent-e2e scenario layout and workflow wiring.")
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--scenario-id")
+    return parser.parse_args()
+
+
+def detect_family(scenario_id: str) -> str:
+    if scenario_id.startswith("compose-"):
+        return "compose"
+    if scenario_id.startswith("kind-"):
+        return "kind"
+    if scenario_id.startswith("otlp-"):
+        return "otlp"
+    return "custom"
+
+
+def validate_scenario(repo_root: Path, scenario_id: str) -> list[str]:
+    scenario_dir = repo_root / "tests" / "e2e" / "scenarios" / scenario_id
+    family = detect_family(scenario_id)
+    errors: list[str] = []
+
+    if not scenario_dir.is_dir():
+        return [f"missing scenario directory: {scenario_dir}"]
+
+    for relative_path in sorted(FAMILY_REQUIRED_FILES[family]):
+        if not (scenario_dir / relative_path).exists():
+            errors.append(f"{scenario_id}: missing required file {relative_path}")
+
+    for phase in PHASES:
+        script_name = f"{phase}.sh"
+        if (scenario_dir / script_name).exists():
+            continue
+        if phase in FAMILY_DEFAULTS[family]:
+            continue
+        errors.append(f"{scenario_id}: missing {script_name} and no {family} default exists")
+
+    workflow_path = repo_root / ".github" / "workflows" / f"e2e-{scenario_id}.yml"
+    if not workflow_path.exists():
+        errors.append(f"{scenario_id}: missing workflow {workflow_path.name}")
+
+    return errors
+
+
+def main() -> None:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    scenarios_root = repo_root / "tests" / "e2e" / "scenarios"
+
+    if args.scenario_id:
+        scenario_ids = [args.scenario_id]
+    else:
+        scenario_ids = sorted(path.name for path in scenarios_root.iterdir() if path.is_dir())
+
+    errors: list[str] = []
+    for scenario_id in scenario_ids:
+        errors.extend(validate_scenario(repo_root, scenario_id))
+
+    if errors:
+        for error in errors:
+            print(error)
+        raise SystemExit(1)
+
+    print(f"validated {len(scenario_ids)} scenario(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/lib/common.sh
+++ b/tests/e2e/lib/common.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${REPO_ROOT:-}" ]]; then
+    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+fi
+
+if [[ -z "${MEMAGENT_REPO_ROOT:-}" ]]; then
+    MEMAGENT_REPO_ROOT="$REPO_ROOT"
+fi
+
+if [[ -z "${SCENARIO_DIR:-}" && -n "${SCENARIO_ID:-}" ]]; then
+    SCENARIO_DIR="$REPO_ROOT/tests/e2e/scenarios/$SCENARIO_ID"
+fi
+
+if [[ -z "${SCENARIO_ID:-}" ]]; then
+    SCENARIO_ID="$(basename "${SCENARIO_DIR:-$(pwd)}")"
+fi
+
+if [[ -z "${SCENARIO_DIR:-}" ]]; then
+    SCENARIO_DIR="$REPO_ROOT/tests/e2e/scenarios/$SCENARIO_ID"
+fi
+
+if [[ -z "${E2E_RESULTS_DIR:-}" ]]; then
+    E2E_RESULTS_DIR="$REPO_ROOT/tests/e2e/results/$SCENARIO_ID"
+fi
+
+export REPO_ROOT
+export MEMAGENT_REPO_ROOT
+export SCENARIO_ID
+export SCENARIO_DIR
+export E2E_RESULTS_DIR
+export E2E_LOG_DIR="${E2E_RESULTS_DIR}/logs"
+
+mkdir -p "$E2E_RESULTS_DIR" "$E2E_LOG_DIR"
+
+detect_scenario_family() {
+    case "$SCENARIO_ID" in
+        compose-*) echo "compose" ;;
+        kind-*) echo "kind" ;;
+        otlp-*) echo "otlp" ;;
+        *) echo "custom" ;;
+    esac
+}
+
+export SCENARIO_FAMILY="${SCENARIO_FAMILY:-$(detect_scenario_family)}"
+
+compose() {
+    # Ensure logfwd:e2e image exists
+    if [[ -z "$(docker images -q logfwd:e2e 2>/dev/null)" ]]; then
+        echo "Building logfwd:e2e from $MEMAGENT_REPO_ROOT..."
+        docker build -t logfwd:e2e -f "$MEMAGENT_REPO_ROOT/Dockerfile.e2e" "$MEMAGENT_REPO_ROOT"
+    fi
+    docker compose -p "memagent-${SCENARIO_ID}" -f "$SCENARIO_DIR/compose.yaml" "$@"
+}
+
+wait_for_http() {
+    local url="$1"
+    local timeout="${2:-30}"
+    local deadline=$((SECONDS + timeout))
+    while (( SECONDS < deadline )); do
+        if curl --connect-timeout 1 --max-time 2 -fsS "$url" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "Timed out waiting for HTTP endpoint: $url" >&2
+    return 1
+}
+
+wait_for_file() {
+    local path="$1"
+    local timeout="${2:-30}"
+    local deadline=$((SECONDS + timeout))
+    while (( SECONDS < deadline )); do
+        if [[ -s "$path" ]]; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "Timed out waiting for file: $path" >&2
+    return 1
+}
+
+run_oracle_verify() {
+    local actual_ndjson="${1:-$E2E_RESULTS_DIR/captured.ndjson}"
+    wait_for_file "$actual_ndjson" 30
+    local oracle_args=(
+        --config "$SCENARIO_DIR/oracle.json"
+        --expected "$E2E_RESULTS_DIR/expected_rows.json"
+        --actual-ndjson "$actual_ndjson"
+        --results-dir "$E2E_RESULTS_DIR"
+    )
+    if [[ -f "$E2E_RESULTS_DIR/source_rows.json" ]]; then
+        oracle_args+=(--source-json "$E2E_RESULTS_DIR/source_rows.json")
+    fi
+    python3 "$REPO_ROOT/tests/e2e/lib/oracle.py" "${oracle_args[@]}"
+}
+
+run_default_phase() {
+    local phase="$1"
+
+    case "${SCENARIO_FAMILY}:${phase}" in
+        compose:up)
+            compose up -d --wait --remove-orphans
+            ;;
+        compose:down)
+            compose down -v --remove-orphans >/dev/null 2>&1 || true
+            ;;
+        compose:collect)
+            compose logs --no-color >"$E2E_RESULTS_DIR/compose.log" 2>&1 || true
+            ;;
+        compose:verify)
+            run_oracle_verify
+            ;;
+        otlp:up)
+            ;;
+        otlp:down)
+            ;;
+        otlp:collect)
+            ;;
+        *)
+            echo "No default implementation for phase '${phase}' in family '${SCENARIO_FAMILY}'" >&2
+            return 1
+            ;;
+    esac
+}

--- a/tests/e2e/lib/oracle.py
+++ b/tests/e2e/lib/oracle.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare expected and actual e2e rows.")
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--expected", required=True)
+    parser.add_argument("--actual-ndjson", required=True)
+    parser.add_argument("--source-json")
+    parser.add_argument("--results-dir", required=True)
+    return parser.parse_args()
+
+
+def load_json(path: str) -> Any:
+    with open(path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_ndjson(path: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not Path(path).exists():
+        return rows
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def project_row(row: dict[str, Any], keys: list[str]) -> dict[str, Any]:
+    return {key: row.get(key) for key in keys}
+
+
+def encode_row(row: dict[str, Any]) -> str:
+    return json.dumps(row, sort_keys=True)
+
+
+def multiset_difference(left: list[dict[str, Any]], right: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    difference: list[dict[str, Any]] = []
+    right_counter = Counter(encode_row(row) for row in right)
+    for row in left:
+        encoded = encode_row(row)
+        if right_counter[encoded] > 0:
+            right_counter[encoded] -= 1
+        else:
+            difference.append(row)
+    return difference
+
+
+def count_duplicates(rows: list[dict[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
+    counter = Counter(encode_row(row) for row in rows)
+    duplicates: list[dict[str, Any]] = []
+    duplicate_count = 0
+    for row in rows:
+        encoded = encode_row(row)
+        if counter[encoded] > 1:
+            duplicate_count += 1
+            counter[encoded] = 0
+            duplicates.append(row)
+    return duplicate_count, duplicates
+
+
+def count_null_violations(rows: list[dict[str, Any]], required_fields: list[str]) -> tuple[int, list[dict[str, Any]]]:
+    violations: list[dict[str, Any]] = []
+    for row in rows:
+        if any(row.get(field) is None for field in required_fields):
+            violations.append(row)
+    return len(violations), violations
+
+
+def count_order_violations(rows: list[dict[str, Any]], order_key: str, source_key: str | None) -> int:
+    order_violations = 0
+    last_seen: dict[str, Any] = {}
+    for row in rows:
+        current = row.get(order_key)
+        if current is None:
+            continue
+        source = str(row.get(source_key)) if source_key else "__global__"
+        if source in last_seen and current < last_seen[source]:
+            order_violations += 1
+        last_seen[source] = current
+    return order_violations
+
+
+def evaluate_rows(
+    *,
+    expected_rows: list[dict[str, Any]],
+    actual_rows: list[dict[str, Any]],
+    compare_keys: list[str],
+    identity_keys: list[str],
+    required_fields: list[str],
+    policy: str,
+    order_key: str,
+    source_key: str | None,
+    max_extra_rows: int,
+) -> dict[str, Any]:
+    projected_expected = [project_row(row, compare_keys) for row in expected_rows]
+    projected_actual = [project_row(row, compare_keys) for row in actual_rows]
+    identity_actual = [project_row(row, identity_keys) for row in actual_rows]
+
+    missing_rows = multiset_difference(projected_expected, projected_actual)
+    extra_rows = multiset_difference(projected_actual, projected_expected)
+    duplicate_count, duplicate_preview = count_duplicates(identity_actual)
+    null_field_violations, null_field_preview = count_null_violations(actual_rows, required_fields)
+    order_violations = count_order_violations(actual_rows, order_key, source_key)
+    extra_count = len(extra_rows)
+
+    passed = False
+    if policy == "exact_once_ordered":
+        passed = (
+            projected_actual == projected_expected
+            and duplicate_count == 0
+            and null_field_violations == 0
+            and order_violations == 0
+        )
+    elif policy == "exact_once_unordered":
+        passed = Counter(encode_row(row) for row in projected_actual) == Counter(
+            encode_row(row) for row in projected_expected
+        )
+        passed = passed and duplicate_count == 0 and null_field_violations == 0
+    elif policy == "at_least_once_bounded_duplicates":
+        expected_index = 0
+        for row in projected_actual:
+            if expected_index < len(projected_expected) and row == projected_expected[expected_index]:
+                expected_index += 1
+        passed = (
+            expected_index == len(projected_expected)
+            and extra_count <= max_extra_rows
+            and null_field_violations == 0
+            and order_violations == 0
+        )
+    else:
+        raise SystemExit(f"unsupported oracle policy: {policy}")
+
+    return {
+        "passed": passed,
+        "projected_expected": projected_expected,
+        "projected_actual": projected_actual,
+        "missing_rows": missing_rows,
+        "extra_rows": extra_rows,
+        "duplicate_count": duplicate_count,
+        "duplicate_preview": duplicate_preview,
+        "extra_count": extra_count,
+        "order_violations": order_violations,
+        "null_field_violations": null_field_violations,
+        "null_field_preview": null_field_preview,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_json(args.config)
+    expected_rows = load_json(args.expected)
+    actual_rows = load_ndjson(args.actual_ndjson)
+    source_rows = load_json(args.source_json) if args.source_json and Path(args.source_json).exists() else None
+
+    selector = config.get("selector") or {}
+    selector_field = selector.get("field")
+    selector_value = selector.get("value")
+    if selector_field:
+        actual_rows = [row for row in actual_rows if row.get(selector_field) == selector_value]
+
+    compare_keys = config.get("compare_keys")
+    if not compare_keys:
+        all_keys = set()
+        for row in expected_rows:
+            all_keys.update(row.keys())
+        compare_keys = sorted(all_keys)
+
+    identity_keys = config.get("identity_keys") or compare_keys
+    required_fields = config.get("required_fields") or identity_keys
+    source_key = config.get("source_key")
+
+    policy = config["policy"]
+    order_key = config.get("order_key", "seq")
+    sink_eval = evaluate_rows(
+        expected_rows=expected_rows,
+        actual_rows=actual_rows,
+        compare_keys=compare_keys,
+        identity_keys=identity_keys,
+        required_fields=required_fields,
+        policy=policy,
+        order_key=order_key,
+        source_key=source_key,
+        max_extra_rows=int(config.get("max_extra_rows", len(expected_rows))),
+    )
+
+    source_eval = None
+    if source_rows is not None:
+        source_compare_keys = config.get("source_compare_keys") or identity_keys
+        source_identity_keys = config.get("source_identity_keys") or identity_keys
+        source_required_fields = config.get("source_required_fields") or source_compare_keys
+        source_policy = config.get("source_policy", "exact_once_unordered")
+        source_order_key = config.get("source_order_key", order_key)
+        source_eval = evaluate_rows(
+            expected_rows=expected_rows,
+            actual_rows=source_rows,
+            compare_keys=source_compare_keys,
+            identity_keys=source_identity_keys,
+            required_fields=source_required_fields,
+            policy=source_policy,
+            order_key=source_order_key,
+            source_key=source_key,
+            max_extra_rows=int(config.get("source_max_extra_rows", len(expected_rows))),
+        )
+
+    passed = sink_eval["passed"] and (source_eval["passed"] if source_eval else True)
+
+    results_dir = Path(args.results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+    actual_rows_path = results_dir / "actual_rows.json"
+    result_path = results_dir / "result.json"
+    summary_path = results_dir / "summary.md"
+
+    actual_rows_path.write_text(json.dumps(sink_eval["projected_actual"], indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    result = {
+        "scenario": config.get("scenario"),
+        "policy": policy,
+        "passed": passed,
+        "reason": (
+            "source-evidence-mismatch"
+            if source_eval and not source_eval["passed"]
+            else "forwarder-mismatch"
+            if not sink_eval["passed"]
+            else None
+        ),
+        "expected_count": len(sink_eval["projected_expected"]),
+        "actual_count": len(sink_eval["projected_actual"]),
+        "missing_count": len(sink_eval["missing_rows"]),
+        "duplicate_count": sink_eval["duplicate_count"],
+        "extra_count": sink_eval["extra_count"],
+        "order_violations": sink_eval["order_violations"],
+        "null_field_violations": sink_eval["null_field_violations"],
+        "identity_keys": identity_keys,
+        "compare_keys": compare_keys,
+        "missing_preview": sink_eval["missing_rows"][:10],
+        "duplicate_preview": sink_eval["duplicate_preview"][:10],
+        "extra_preview": sink_eval["extra_rows"][:10],
+        "null_field_preview": sink_eval["null_field_preview"][:10],
+        "source_checked": source_eval is not None,
+        "source_passed": source_eval["passed"] if source_eval else None,
+        "source_policy": source_policy if source_eval else None,
+        "source_compare_keys": source_compare_keys if source_eval else None,
+        "source_expected_count": len(source_eval["projected_expected"]) if source_eval else 0,
+        "source_actual_count": len(source_eval["projected_actual"]) if source_eval else 0,
+        "source_missing_count": len(source_eval["missing_rows"]) if source_eval else 0,
+        "source_duplicate_count": source_eval["duplicate_count"] if source_eval else 0,
+        "source_extra_count": source_eval["extra_count"] if source_eval else 0,
+        "source_order_violations": source_eval["order_violations"] if source_eval else 0,
+        "source_null_field_violations": source_eval["null_field_violations"] if source_eval else 0,
+        "source_missing_preview": source_eval["missing_rows"][:10] if source_eval else [],
+        "source_duplicate_preview": source_eval["duplicate_preview"][:10] if source_eval else [],
+        "source_extra_preview": source_eval["extra_rows"][:10] if source_eval else [],
+        "source_null_field_preview": source_eval["null_field_preview"][:10] if source_eval else [],
+    }
+    result_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    status = "PASS" if passed else "FAIL"
+    summary_lines = [
+        f"## {config.get('scenario', 'e2e-scenario')}",
+        "",
+        f"- Status: `{status}`",
+        f"- Policy: `{policy}`",
+        f"- Expected rows: `{len(sink_eval['projected_expected'])}`",
+        f"- Actual rows: `{len(sink_eval['projected_actual'])}`",
+        f"- Missing rows: `{len(sink_eval['missing_rows'])}`",
+        f"- Duplicate rows: `{sink_eval['duplicate_count']}`",
+        f"- Extra rows: `{sink_eval['extra_count']}`",
+        f"- Order violations: `{sink_eval['order_violations']}`",
+        f"- Null field violations: `{sink_eval['null_field_violations']}`",
+        f"- Identity keys: `{', '.join(identity_keys)}`",
+        f"- Compare keys: `{', '.join(compare_keys)}`",
+    ]
+    if source_eval:
+        summary_lines.extend(
+            [
+                f"- Source evidence: `{'PASS' if source_eval['passed'] else 'FAIL'}`",
+                f"- Source policy: `{source_policy}`",
+                f"- Source actual rows: `{len(source_eval['projected_actual'])}`",
+                f"- Source missing rows: `{len(source_eval['missing_rows'])}`",
+                f"- Source duplicate rows: `{source_eval['duplicate_count']}`",
+                f"- Source extra rows: `{source_eval['extra_count']}`",
+                f"- Source null field violations: `{source_eval['null_field_violations']}`",
+            ]
+        )
+    if sink_eval["missing_rows"]:
+        summary_lines.extend(["", "### Missing Preview", "", "```json", json.dumps(sink_eval["missing_rows"][:5], indent=2, sort_keys=True), "```"])
+    if sink_eval["duplicate_preview"]:
+        summary_lines.extend(["", "### Duplicate Preview", "", "```json", json.dumps(sink_eval["duplicate_preview"][:5], indent=2, sort_keys=True), "```"])
+    if sink_eval["extra_rows"]:
+        summary_lines.extend(["", "### Extra Preview", "", "```json", json.dumps(sink_eval["extra_rows"][:5], indent=2, sort_keys=True), "```"])
+    if sink_eval["null_field_preview"]:
+        summary_lines.extend(["", "### Null Field Preview", "", "```json", json.dumps(sink_eval["null_field_preview"][:5], indent=2, sort_keys=True), "```"])
+    if source_eval and source_eval["missing_rows"]:
+        summary_lines.extend(["", "### Source Missing Preview", "", "```json", json.dumps(source_eval["missing_rows"][:5], indent=2, sort_keys=True), "```"])
+    if source_eval and source_eval["extra_rows"]:
+        summary_lines.extend(["", "### Source Extra Preview", "", "```json", json.dumps(source_eval["extra_rows"][:5], indent=2, sort_keys=True), "```"])
+    summary_path.write_text("\n".join(summary_lines) + "\n", encoding="utf-8")
+
+    if not passed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/lib/otlp_oracle.sh
+++ b/tests/e2e/lib/otlp_oracle.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+run_otlp_oracle_test() {
+    local test_name="$1"
+    set +e
+    cargo test -p logfwd-io --test it "$test_name" --manifest-path "$MEMAGENT_REPO_ROOT/Cargo.toml" -- --ignored --exact --nocapture \
+        >"$E2E_RESULTS_DIR/test.log" 2>&1
+    local status=$?
+    set -e
+    printf '%s\n' "$status" >"$E2E_RESULTS_DIR/test.exitcode"
+    printf '[]\n' >"$E2E_RESULTS_DIR/expected_rows.json"
+}
+
+verify_otlp_oracle_result() {
+    local scenario_id="$1"
+    local status
+    status="$(cat "$E2E_RESULTS_DIR/test.exitcode")"
+    printf '[]\n' >"$E2E_RESULTS_DIR/actual_rows.json"
+    python3 - <<'PY' "$E2E_RESULTS_DIR" "$status" "$scenario_id"
+import json
+import pathlib
+import sys
+
+results = pathlib.Path(sys.argv[1])
+status = int(sys.argv[2])
+scenario = sys.argv[3]
+result = {
+    "scenario": scenario,
+    "policy": "external-oracle",
+    "passed": status == 0,
+    "expected_count": 1,
+    "actual_count": 1 if status == 0 else 0,
+}
+(results / "result.json").write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+summary = [
+    f"## {scenario}",
+    "",
+    f"- Status: `{'PASS' if status == 0 else 'FAIL'}`",
+    "- Mode: `cargo test ignored external oracle`",
+    f"- Log: `{results / 'test.log'}`",
+]
+(results / "summary.md").write_text("\n".join(summary) + "\n", encoding="utf-8")
+sys.exit(0 if status == 0 else 1)
+PY
+}

--- a/tests/e2e/lib/render_issue_summary.py
+++ b/tests/e2e/lib/render_issue_summary.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import sys
+
+try:
+    from reporting.markdown import markdown_table
+except ModuleNotFoundError:
+    REPO_ROOT = Path(__file__).resolve().parents[3]
+    sys.path.insert(0, str(REPO_ROOT))
+    from reporting.markdown import markdown_table
+
+
+@dataclass
+class ScenarioResult:
+    artifact_name: str
+    scenario: str
+    policy: str
+    passed: bool
+    expected_count: int
+    actual_count: int
+    missing_count: int
+    duplicate_count: int
+    extra_count: int
+    order_violations: int
+    null_field_violations: int
+    source_checked: bool
+    source_passed: bool | None
+    source_missing_count: int
+    source_duplicate_count: int
+    source_extra_count: int
+    source_null_field_violations: int
+    reason: str | None
+    missing_preview: list[dict[str, Any]]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render a suite summary from downloaded e2e artifacts.")
+    parser.add_argument("--artifacts-root", required=True)
+    parser.add_argument("--suite-name", required=True)
+    parser.add_argument("--suite-key", required=True)
+    parser.add_argument("--memagent-ref", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--output-markdown", required=True)
+    parser.add_argument("--output-json", required=True)
+    return parser.parse_args()
+
+
+def load_result(path: Path, artifact_name: str) -> ScenarioResult:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    scenario = payload.get("scenario") or artifact_name
+    return ScenarioResult(
+        artifact_name=artifact_name,
+        scenario=scenario,
+        policy=payload.get("policy", "unknown"),
+        passed=bool(payload.get("passed")),
+        expected_count=int(payload.get("expected_count", 0)),
+        actual_count=int(payload.get("actual_count", 0)),
+        missing_count=int(payload.get("missing_count", 0)),
+        duplicate_count=int(payload.get("duplicate_count", 0)),
+        extra_count=int(payload.get("extra_count", 0)),
+        order_violations=int(payload.get("order_violations", 0)),
+        null_field_violations=int(payload.get("null_field_violations", 0)),
+        source_checked=bool(payload.get("source_checked")),
+        source_passed=payload.get("source_passed"),
+        source_missing_count=int(payload.get("source_missing_count", 0)),
+        source_duplicate_count=int(payload.get("source_duplicate_count", 0)),
+        source_extra_count=int(payload.get("source_extra_count", 0)),
+        source_null_field_violations=int(payload.get("source_null_field_violations", 0)),
+        reason=payload.get("reason"),
+        missing_preview=payload.get("missing_preview") or [],
+    )
+
+
+def scan_artifacts(root: Path) -> list[ScenarioResult]:
+    results: list[ScenarioResult] = []
+    if not root.exists():
+        return results
+    for artifact_dir in sorted(path for path in root.iterdir() if path.is_dir()):
+        result_path = artifact_dir / "result.json"
+        if result_path.exists():
+            results.append(load_result(result_path, artifact_dir.name))
+    return results
+
+
+def render_markdown(
+    suite_name: str,
+    suite_key: str,
+    memagent_ref: str,
+    run_url: str,
+    results: list[ScenarioResult],
+) -> str:
+    total = len(results)
+    passed = sum(1 for result in results if result.passed)
+    failed = total - passed
+    status = "PASS" if failed == 0 and total > 0 else "FAIL"
+    updated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    lines = [
+        f"# {suite_name} Report",
+        "",
+        f"- Status: `{status}`",
+        f"- Suite key: `{suite_key}`",
+        f"- Memagent ref: `{memagent_ref}`",
+        f"- Updated: `{updated_at}`",
+        f"- Workflow run: [view run]({run_url})",
+        f"- Scenarios: `{total}` total, `{passed}` passed, `{failed}` failed",
+    ]
+
+    table_rows: list[list[str]] = []
+    if not results:
+        table_rows.append(["_none_", "FAIL", "n/a", "unknown", "0", "0", "0", "0", "0", "0", "0"])
+    else:
+        for result in results:
+            source_status = "PASS" if result.source_passed else "FAIL" if result.source_checked else "n/a"
+            table_rows.append(
+                [
+                    result.scenario,
+                    "PASS" if result.passed else "FAIL",
+                    source_status,
+                    f"`{result.policy}`",
+                    str(result.expected_count),
+                    str(result.actual_count),
+                    str(result.missing_count),
+                    str(result.duplicate_count),
+                    str(result.extra_count),
+                    str(result.order_violations),
+                    str(result.null_field_violations),
+                ]
+            )
+
+    lines.append("")
+    lines.extend(
+        markdown_table(
+            headers=[
+                "Scenario",
+                "Status",
+                "Source",
+                "Policy",
+                "Expected",
+                "Actual",
+                "Missing",
+                "Duplicates",
+                "Extras",
+                "Order Violations",
+                "Null Violations",
+            ],
+            rows=table_rows,
+            align=["left", "left", "left", "left", "right", "right", "right", "right", "right", "right", "right"],
+        )
+    )
+
+    failing = [result for result in results if not result.passed]
+    if failing:
+        lines.extend(["", "## Failures", ""])
+        for result in failing:
+            lines.append(f"### {result.scenario}")
+            lines.append("")
+            if result.reason:
+                lines.append(f"- Reason: `{result.reason}`")
+            lines.append(f"- Policy: `{result.policy}`")
+            lines.append(f"- Counts: expected `{result.expected_count}`, actual `{result.actual_count}`, missing `{result.missing_count}`")
+            lines.append(
+                f"- Duplicates / extras / order / nulls: `{result.duplicate_count}` / `{result.extra_count}` / `{result.order_violations}` / `{result.null_field_violations}`"
+            )
+            if result.source_checked:
+                lines.append(
+                    f"- Source evidence: `{'PASS' if result.source_passed else 'FAIL'}` with missing / duplicates / extras / nulls `{result.source_missing_count}` / `{result.source_duplicate_count}` / `{result.source_extra_count}` / `{result.source_null_field_violations}`"
+                )
+            if result.missing_preview:
+                lines.extend(["", "Missing preview:", "", "```json", json.dumps(result.missing_preview[:5], indent=2, sort_keys=True), "```"])
+            lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> None:
+    args = parse_args()
+    artifacts_root = Path(args.artifacts_root)
+    results = scan_artifacts(artifacts_root)
+
+    summary_payload = {
+        "suite_name": args.suite_name,
+        "suite_key": args.suite_key,
+        "memagent_ref": args.memagent_ref,
+        "run_url": args.run_url,
+        "scenario_count": len(results),
+        "passed_count": sum(1 for result in results if result.passed),
+        "failed_count": sum(1 for result in results if not result.passed),
+        "results": [
+            {
+                "artifact_name": result.artifact_name,
+                "scenario": result.scenario,
+                "policy": result.policy,
+                "passed": result.passed,
+                "expected_count": result.expected_count,
+                "actual_count": result.actual_count,
+                "missing_count": result.missing_count,
+                "duplicate_count": result.duplicate_count,
+                "extra_count": result.extra_count,
+                "order_violations": result.order_violations,
+                "null_field_violations": result.null_field_violations,
+                "source_checked": result.source_checked,
+                "source_passed": result.source_passed,
+                "source_missing_count": result.source_missing_count,
+                "source_duplicate_count": result.source_duplicate_count,
+                "source_extra_count": result.source_extra_count,
+                "source_null_field_violations": result.source_null_field_violations,
+                "reason": result.reason,
+                "missing_preview": result.missing_preview,
+            }
+            for result in results
+        ],
+    }
+
+    markdown = render_markdown(
+        suite_name=args.suite_name,
+        suite_key=args.suite_key,
+        memagent_ref=args.memagent_ref,
+        run_url=args.run_url,
+        results=results,
+    )
+
+    Path(args.output_markdown).write_text(markdown, encoding="utf-8")
+    Path(args.output_json).write_text(json.dumps(summary_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/lib/source_evidence.py
+++ b/tests/e2e/lib/source_evidence.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build normalized source evidence rows from service logs.")
+    parser.add_argument("--mode", required=True, choices=["nginx-access", "redis-monitor", "memcached-verbose", "json-lines"])
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--source-id", required=True)
+    return parser.parse_args()
+
+
+def derive_seq(event_id: str) -> int | None:
+    match = re.search(r":(\d+)$", event_id)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def parse_nginx_access(path: Path, scenario: str, source_id: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    prefix = f"/e2e/{scenario}/"
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line or not line.startswith(prefix):
+                continue
+            log_path, _, status_text = line.partition("|")
+            event_id = log_path.removeprefix(prefix)
+            rows.append(
+                {
+                    "scenario": scenario,
+                    "source_id": source_id,
+                    "event_id": event_id,
+                    "seq": derive_seq(event_id),
+                    "method": "GET",
+                    "path": log_path,
+                    "status": int(status_text),
+                }
+            )
+    return rows
+
+
+def parse_redis_monitor(path: Path, scenario: str, source_id: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    pattern = re.compile(r'"(?P<command>[A-Z]+)" "(?P<key>[^"]+)" "(?P<value>[^"]+)"')
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if scenario not in line or '"SET"' not in line:
+                continue
+            match = pattern.search(line)
+            if not match:
+                continue
+            key = match.group("key")
+            rows.append(
+                {
+                    "scenario": scenario,
+                    "source_id": source_id,
+                    "event_id": key,
+                    "seq": derive_seq(key),
+                    "command": match.group("command"),
+                    "key": key,
+                    "value": match.group("value"),
+                }
+            )
+    return rows
+
+
+def parse_memcached_verbose(path: Path, scenario: str, source_id: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    pattern = re.compile(r"\b(?P<command>set|get)\s+(?P<key>[^ ]+)")
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if scenario not in line:
+                continue
+            match = pattern.search(line)
+            if not match:
+                continue
+            key = match.group("key")
+            rows.append(
+                {
+                    "scenario": scenario,
+                    "source_id": source_id,
+                    "event_id": key,
+                    "seq": derive_seq(key),
+                    "command": match.group("command"),
+                    "key": key,
+                }
+            )
+    return rows
+
+
+def parse_json_lines(path: Path, scenario: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            if row.get("scenario") == scenario:
+                rows.append(row)
+    return rows
+
+
+def main() -> None:
+    args = parse_args()
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    if args.mode == "nginx-access":
+        rows = parse_nginx_access(input_path, args.scenario, args.source_id)
+    elif args.mode == "redis-monitor":
+        rows = parse_redis_monitor(input_path, args.scenario, args.source_id)
+    elif args.mode == "memcached-verbose":
+        rows = parse_memcached_verbose(input_path, args.scenario, args.source_id)
+    else:
+        rows = parse_json_lines(input_path, args.scenario)
+
+    output_path.write_text(json.dumps(rows, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/lib/upsert_issue.sh
+++ b/tests/e2e/lib/upsert_issue.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+trim() {
+    local value="$1"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    printf '%s' "$value"
+}
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+    echo "GH_TOKEN must be set" >&2
+    exit 2
+fi
+
+if [[ -z "${ISSUE_TITLE_BASE:-}" ]]; then
+    echo "ISSUE_TITLE_BASE must be set" >&2
+    exit 2
+fi
+
+if [[ -z "${ISSUE_BODY_FILE:-}" ]]; then
+    echo "ISSUE_BODY_FILE must be set" >&2
+    exit 2
+fi
+
+if [[ ! -f "${ISSUE_BODY_FILE}" ]]; then
+    echo "Issue body file not found: ${ISSUE_BODY_FILE}" >&2
+    exit 2
+fi
+
+if [[ -z "${ISSUE_SUITE_KEY:-}" ]]; then
+    echo "ISSUE_SUITE_KEY must be set" >&2
+    exit 2
+fi
+
+summary_file="${ISSUE_SUMMARY_JSON_FILE:-}"
+issue_status="UNKNOWN"
+issue_detail=""
+
+if [[ -n "${summary_file}" ]]; then
+    if [[ ! -f "${summary_file}" ]]; then
+        echo "Issue summary file not found: ${summary_file}" >&2
+        exit 2
+    fi
+    parsed_summary="$(
+        python3 - "${summary_file}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+failed = payload.get("failed_count")
+total = payload.get("scenario_count")
+if total is None:
+    total = payload.get("benchmark_count")
+if total is None:
+    total = payload.get("total_count")
+
+status = "UNKNOWN"
+detail = ""
+if isinstance(failed, int):
+    if failed > 0:
+        status = "FAIL"
+        if isinstance(total, int) and total > 0:
+            detail = f"{failed}/{total} failing"
+        else:
+            detail = f"{failed} failing"
+    else:
+        if isinstance(total, int) and total > 0:
+            status = "PASS"
+            detail = f"all {total} passing"
+        else:
+            status = "FAIL"
+            detail = "no results"
+
+print(status)
+print(detail)
+PY
+    )"
+    parsed_lines=()
+    while IFS= read -r line; do
+        parsed_lines+=("${line}")
+    done <<<"${parsed_summary}"
+    if [[ "${#parsed_lines[@]}" -ge 1 ]]; then
+        issue_status="$(trim "${parsed_lines[0]}")"
+    fi
+    if [[ "${#parsed_lines[@]}" -ge 2 ]]; then
+        issue_detail="$(trim "${parsed_lines[1]}")"
+    fi
+fi
+
+issue_title="[${issue_status}] ${ISSUE_TITLE_BASE}"
+if [[ -n "${issue_detail}" ]]; then
+    issue_title="${issue_title} (${issue_detail})"
+fi
+
+label_csv="$(trim "${ISSUE_LABELS:-live-suite-report}")"
+IFS=',' read -r -a raw_labels <<<"${label_csv}"
+labels=()
+for raw_label in "${raw_labels[@]}"; do
+    label="$(trim "${raw_label}")"
+    if [[ -n "${label}" ]]; then
+        labels+=("${label}")
+        gh label create "${label}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --color "0E8A16" \
+            --description "Live suite reporting issue" \
+            --force >/dev/null 2>&1 || true
+    fi
+done
+
+marker="live-suite-key:${ISSUE_SUITE_KEY}"
+existing_issue_number="$(
+    gh issue list \
+        --repo "${GITHUB_REPOSITORY}" \
+        --state open \
+        --search "\"${marker}\" in:body" \
+        --json number \
+        --jq '.[0].number // empty'
+)"
+
+issue_body_with_meta="$(mktemp)"
+trap 'rm -f "${issue_body_with_meta}"' EXIT
+
+{
+    echo "<!-- ${marker} -->"
+    echo "<!-- live-suite-status:${issue_status} -->"
+    echo "<!-- live-suite-updated:${GITHUB_RUN_ID:-unknown} -->"
+    echo ""
+    cat "${ISSUE_BODY_FILE}"
+} >"${issue_body_with_meta}"
+
+label_args=()
+for label in "${labels[@]}"; do
+    label_args+=(--label "${label}")
+done
+
+if [[ -n "${existing_issue_number}" ]]; then
+    echo "Updating existing issue #${existing_issue_number}..."
+    gh issue edit "${existing_issue_number}" \
+        --repo "${GITHUB_REPOSITORY}" \
+        --title "${issue_title}" \
+        --body-file "${issue_body_with_meta}" \
+        "${label_args[@]}" >/dev/null
+    echo "Updated live issue #${existing_issue_number}"
+else
+    echo "Creating new issue..."
+    new_issue_url="$(
+        gh issue create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${issue_title}" \
+            --body-file "${issue_body_with_meta}" \
+            "${label_args[@]}"
+    )"
+    echo "Created live issue: ${new_issue_url}"
+fi

--- a/tests/e2e/run-scenario.sh
+++ b/tests/e2e/run-scenario.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 <scenario-id>" >&2
+    exit 2
+fi
+
+SCENARIO_ID="$1"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SCENARIO_DIR="$REPO_ROOT/tests/e2e/scenarios/$SCENARIO_ID"
+E2E_RESULTS_DIR="${E2E_RESULTS_DIR:-$REPO_ROOT/tests/e2e/results/$SCENARIO_ID}"
+
+if [[ ! -d "$SCENARIO_DIR" ]]; then
+    echo "unknown e2e scenario: $SCENARIO_ID" >&2
+    exit 2
+fi
+
+export REPO_ROOT
+export SCENARIO_ID
+export SCENARIO_DIR
+export E2E_RESULTS_DIR
+
+source "$REPO_ROOT/tests/e2e/lib/common.sh"
+
+mkdir -p "$E2E_RESULTS_DIR"
+
+run_phase() {
+    local phase="$1"
+    local script_path="$SCENARIO_DIR/${phase}.sh"
+
+    if [[ -x "$script_path" ]]; then
+        "$script_path"
+        return 0
+    fi
+
+    run_default_phase "$phase"
+}
+
+cleanup() {
+    run_phase collect || true
+    run_phase down || true
+}
+trap cleanup EXIT
+
+run_phase up
+"$SCENARIO_DIR/run_workload.sh"
+run_phase verify

--- a/tests/e2e/scenarios/kind-cri-smoke/collect.sh
+++ b/tests/e2e/scenarios/kind-cri-smoke/collect.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "$0")/../.." && pwd)/lib/common.sh"
+
+CLUSTER_NAME="${E2E_CLUSTER_NAME:-$SCENARIO_ID}"
+KUBE_CONTEXT="kind-${CLUSTER_NAME}"
+NAMESPACE="e2e-logfwd"
+
+kubectl --context "$KUBE_CONTEXT" get pods -n "$NAMESPACE" -o wide >"$E2E_RESULTS_DIR/pods.txt" 2>&1 || true
+kubectl --context "$KUBE_CONTEXT" get events -n "$NAMESPACE" --sort-by='.lastTimestamp' >"$E2E_RESULTS_DIR/events.txt" 2>&1 || true
+kubectl --context "$KUBE_CONTEXT" logs -n "$NAMESPACE" -l app=logfwd --tail=-1 >"$E2E_RESULTS_DIR/logfwd.log" 2>&1 || true
+kubectl --context "$KUBE_CONTEXT" logs -n "$NAMESPACE" -l app=capture-receiver --tail=-1 >"$E2E_RESULTS_DIR/capture.log" 2>&1 || true
+kubectl --context "$KUBE_CONTEXT" logs -n "$NAMESPACE" log-generator --tail=-1 >"$E2E_RESULTS_DIR/log-generator.log" 2>&1 || true

--- a/tests/e2e/scenarios/kind-cri-smoke/down.sh
+++ b/tests/e2e/scenarios/kind-cri-smoke/down.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "$0")/../.." && pwd)/lib/common.sh"
+
+CLUSTER_NAME="${E2E_CLUSTER_NAME:-$SCENARIO_ID}"
+KUBE_CONTEXT="kind-${CLUSTER_NAME}"
+NAMESPACE="e2e-logfwd"
+
+kubectl --context "$KUBE_CONTEXT" delete namespace "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+if [[ -f "$E2E_RESULTS_DIR/cluster-created" ]]; then
+    kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+fi

--- a/tests/e2e/scenarios/kind-cri-smoke/manifests/capture-receiver.yaml
+++ b/tests/e2e/scenarios/kind-cri-smoke/manifests/capture-receiver.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capture-receiver
+  labels:
+    app: capture-receiver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: capture-receiver
+  template:
+    metadata:
+      labels:
+        app: capture-receiver
+    spec:
+      containers:
+        - name: capture
+          image: python:3.12-alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - python
+            - /opt/capture/capture_tcp.py
+            - --port
+            - "9000"
+            - --output-dir
+            - /artifacts
+          ports:
+            - containerPort: 9000
+          volumeMounts:
+            - name: capture-script
+              mountPath: /opt/capture
+              readOnly: true
+            - name: capture-data
+              mountPath: /artifacts
+      volumes:
+        - name: capture-script
+          configMap:
+            name: capture-tcp-script
+        - name: capture-data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: capture-receiver
+spec:
+  selector:
+    app: capture-receiver
+  ports:
+    - port: 9000
+      targetPort: 9000

--- a/tests/e2e/scenarios/kind-cri-smoke/manifests/log-generator.yaml
+++ b/tests/e2e/scenarios/kind-cri-smoke/manifests/log-generator.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: log-generator
+  labels:
+    app: log-generator
+spec:
+  restartPolicy: Never
+  containers:
+    - name: generator
+      image: busybox:1.36
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          sleep 5
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0001","message":"KIND_E2E_MARKER_001","level":"INFO","seq":1}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0002","message":"KIND_E2E_MARKER_002","level":"INFO","seq":2}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0003","message":"KIND_E2E_MARKER_003","level":"WARN","seq":3}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0004","message":"KIND_E2E_MARKER_004","level":"INFO","seq":4}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0005","message":"KIND_E2E_MARKER_005","level":"ERROR","seq":5}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0006","message":"KIND_E2E_MARKER_006","level":"INFO","seq":6}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0007","message":"KIND_E2E_MARKER_007","level":"DEBUG","seq":7}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0008","message":"KIND_E2E_MARKER_008","level":"INFO","seq":8}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0009","message":"KIND_E2E_MARKER_009","level":"WARN","seq":9}'
+          echo '{"scenario":"kind-cri-smoke","source_id":"log-generator","event_id":"kind-cri-smoke:0010","message":"KIND_E2E_MARKER_010","level":"INFO","seq":10}'
+          sleep 3600

--- a/tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-config.yaml
+++ b/tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logfwd-config
+data:
+  config.yaml: |
+    server:
+      diagnostics: "0.0.0.0:9090"
+      log_level: debug
+
+    storage:
+      data_dir: /var/lib/logfwd
+
+    input:
+      type: file
+      path: /var/log/pods/**/*.log
+      format: cri
+
+    transform: >-
+      SELECT scenario, source_id, event_id, seq, level, message
+      FROM logs
+      WHERE scenario = 'kind-cri-smoke'
+
+    output:
+      type: tcp
+      endpoint: capture-receiver.e2e-logfwd.svc.cluster.local:9000
+      format: json

--- a/tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-daemonset.yaml
+++ b/tests/e2e/scenarios/kind-cri-smoke/manifests/logfwd-daemonset.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: logfwd
+  labels:
+    app: logfwd
+spec:
+  selector:
+    matchLabels:
+      app: logfwd
+  template:
+    metadata:
+      labels:
+        app: logfwd
+    spec:
+      automountServiceAccountToken: false
+      tolerations:
+        - operator: Exists
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: logfwd
+          image: logfwd:e2e
+          imagePullPolicy: IfNotPresent
+          args: ["run", "--config", "/etc/logfwd/config.yaml"]
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          ports:
+            - containerPort: 9090
+              name: diagnostics
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: diagnostics
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: config
+              mountPath: /etc/logfwd
+              readOnly: true
+            - name: state
+              mountPath: /var/lib/logfwd
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+            type: Directory
+        - name: config
+          configMap:
+            name: logfwd-config
+        - name: state
+          emptyDir: {}

--- a/tests/e2e/scenarios/kind-cri-smoke/oracle.json
+++ b/tests/e2e/scenarios/kind-cri-smoke/oracle.json
@@ -1,0 +1,16 @@
+{
+  "scenario": "kind-cri-smoke",
+  "policy": "exact_once_ordered",
+  "selector": {
+    "field": "scenario",
+    "value": "kind-cri-smoke"
+  },
+  "order_key": "seq",
+  "source_key": "source_id",
+  "identity_keys": ["scenario", "source_id", "event_id"],
+  "required_fields": ["scenario", "source_id", "event_id", "seq", "level", "message"],
+  "compare_keys": ["scenario", "source_id", "event_id", "seq", "level", "message"],
+  "source_policy": "exact_once_ordered",
+  "source_compare_keys": ["scenario", "source_id", "event_id", "seq", "level", "message"],
+  "source_required_fields": ["scenario", "source_id", "event_id", "seq", "level", "message"]
+}

--- a/tests/e2e/scenarios/kind-cri-smoke/run_workload.sh
+++ b/tests/e2e/scenarios/kind-cri-smoke/run_workload.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "$0")/../.." && pwd)/lib/common.sh"
+
+CLUSTER_NAME="${E2E_CLUSTER_NAME:-$SCENARIO_ID}"
+KUBE_CONTEXT="kind-${CLUSTER_NAME}"
+NAMESPACE="e2e-logfwd"
+
+python3 - <<'PY' >"$E2E_RESULTS_DIR/expected_rows.json"
+import json
+rows = [
+    {
+        "scenario": "kind-cri-smoke",
+        "source_id": "log-generator",
+        "event_id": f"kind-cri-smoke:{i:04d}",
+        "seq": i,
+        "level": level,
+        "message": f"KIND_E2E_MARKER_{i:03d}",
+    }
+    for i, level in enumerate(["INFO", "INFO", "WARN", "INFO", "ERROR", "INFO", "DEBUG", "INFO", "WARN", "INFO"], start=1)
+]
+print(json.dumps(rows, indent=2))
+PY
+
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" delete pod log-generator --ignore-not-found >/dev/null 2>&1 || true
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" apply -f "$SCENARIO_DIR/manifests/log-generator.yaml"
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" wait pod/log-generator --for=condition=Ready --timeout=60s
+sleep 5
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" logs log-generator >"$E2E_RESULTS_DIR/log-generator-source.ndjson"
+python3 "$REPO_ROOT/tests/e2e/lib/source_evidence.py" \
+    --mode json-lines \
+    --input "$E2E_RESULTS_DIR/log-generator-source.ndjson" \
+    --output "$E2E_RESULTS_DIR/source_rows.json" \
+    --scenario "$SCENARIO_ID" \
+    --source-id "log-generator"

--- a/tests/e2e/scenarios/kind-cri-smoke/up.sh
+++ b/tests/e2e/scenarios/kind-cri-smoke/up.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "$0")/../.." && pwd)/lib/common.sh"
+
+CLUSTER_NAME="${E2E_CLUSTER_NAME:-$SCENARIO_ID}"
+KUBE_CONTEXT="kind-${CLUSTER_NAME}"
+NAMESPACE="e2e-logfwd"
+
+if ! kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+    kind create cluster --name "$CLUSTER_NAME" --wait 60s
+    printf 'created\n' >"$E2E_RESULTS_DIR/cluster-created"
+fi
+
+kind load docker-image logfwd:e2e --name "$CLUSTER_NAME"
+
+kubectl --context "$KUBE_CONTEXT" delete namespace "$NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+kubectl --context "$KUBE_CONTEXT" create namespace "$NAMESPACE"
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" create configmap capture-tcp-script \
+    --from-file=capture_tcp.py="$REPO_ROOT/tests/e2e/lib/capture_tcp.py"
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" apply -f "$SCENARIO_DIR/manifests/capture-receiver.yaml"
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" apply -f "$SCENARIO_DIR/manifests/logfwd-config.yaml"
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" apply -f "$SCENARIO_DIR/manifests/logfwd-daemonset.yaml"
+
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" wait deployment/capture-receiver --for=condition=available --timeout=120s
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" rollout status daemonset/logfwd --timeout=120s

--- a/tests/e2e/scenarios/kind-cri-smoke/verify.sh
+++ b/tests/e2e/scenarios/kind-cri-smoke/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "$0")/../.." && pwd)/lib/common.sh"
+
+CLUSTER_NAME="${E2E_CLUSTER_NAME:-$SCENARIO_ID}"
+KUBE_CONTEXT="kind-${CLUSTER_NAME}"
+NAMESPACE="e2e-logfwd"
+CAPTURE_POD="$(kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" get pods -l app=capture-receiver -o jsonpath='{.items[0].metadata.name}')"
+CAPTURE_PATH="/artifacts/captured.ndjson"
+
+deadline=$((SECONDS + 30))
+while (( SECONDS < deadline )); do
+    if kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" exec "$CAPTURE_POD" -- test -s "$CAPTURE_PATH" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+kubectl --context "$KUBE_CONTEXT" -n "$NAMESPACE" exec "$CAPTURE_POD" -- cat "$CAPTURE_PATH" >"$E2E_RESULTS_DIR/captured.ndjson"
+
+python3 - "$E2E_RESULTS_DIR/captured.ndjson" >"$E2E_RESULTS_DIR/stats.json" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+lines = path.read_text(encoding="utf-8").splitlines()
+print(json.dumps({"lines": len(lines), "bytes": path.stat().st_size}, indent=2))
+PY
+
+run_oracle_verify "$E2E_RESULTS_DIR/captured.ndjson"


### PR DESCRIPTION
Migrate correctness scenarios from memagent-e2e to core repo for faster PR-level feedback.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add KIND-based E2E smoke test scenario with oracle verification
> - Introduces a full E2E test framework under `tests/e2e/` with a shared runner ([run-scenario.sh](https://github.com/strawgate/memagent/pull/2133/files#diff-310583efb180798c8024591e1c2b364f7e610434d2433b1e5d75568c15b6e8b5)), common shell helpers ([common.sh](https://github.com/strawgate/memagent/pull/2133/files#diff-373741b2b077fa360308d57ab292cbb9fe0fd5eb3cc58a15ff9c8b3f781a3b61)), and a Python oracle ([oracle.py](https://github.com/strawgate/memagent/pull/2133/files#diff-c5ac6b9cf26b2d66c976f14677d8b2c87620f2ccb809bf3e1e4834392845eb6f)) that validates exact-once ordered delivery semantics.
> - Adds the `kind-cri-smoke` scenario, which spins up a KIND cluster, deploys logfwd as a DaemonSet, generates structured JSON log lines, forwards them over TCP to an in-cluster capture receiver, and verifies delivery against expected rows.
> - Adds a GitHub Actions workflow ([e2e-scenarios.yml](https://github.com/strawgate/memagent/pull/2133/files#diff-af6ce8ae96f7c862d3c0d74d1b508ea02df1da30aac8519e1cb4bd0acf700cf1)) that builds a `logfwd:e2e` Docker image, runs the scenario matrix, and uploads per-scenario artifacts for 7 days.
> - Adds supporting CLI tools: `capture_tcp.py` (TCP sink), `source_evidence.py` (log normalization), `render_issue_summary.py` (Markdown suite report), and `upsert_issue.sh` (GitHub issue upsert with deduplication).
> - Risk: the workflow installs KIND v0.24.0 and requires a Docker daemon with image build access; failures in cluster setup will not fall back gracefully.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 48f856f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->