### PR TITLE
fix(config-builder): handle WASM load failure, quote YAML scalars, clarify SQL validation

### DIFF
--- a/book/src/components/ConfigBuilder.astro
+++ b/book/src/components/ConfigBuilder.astro
@@ -772,14 +772,16 @@ const wasmBase = import.meta.env.BASE_URL.replace(/\/$/, '') + '/wasm/logfwd-con
 
   // ── YAML scalar serializer ────────────────────────────────────
   // Quotes a value when it contains characters that would break YAML structure:
-  // ': ' (ambiguous key separator), leading '#' (comment), newlines, or
-  // leading/trailing whitespace. Escapes backslash and double-quote inside.
+  // empty string (YAML null without quotes), ': ' (key separator), ' #' or
+  // leading '#' (comment trigger), newlines, or leading/trailing whitespace.
+  // Coerces to string defensively so number/boolean defaults don't throw.
   function yamlScalar(val) {
-    if (/: |^#|\n|\r/.test(val) || val !== val.trim()) {
-      return '"' + val.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-                      .replace(/\n/g, '\\n').replace(/\r/g, '\\r') + '"';
+    const s = val == null ? '' : String(val);
+    if (s === '' || /: | #|^#|\n|\r/.test(s) || s !== s.trim()) {
+      return '"' + s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+                    .replace(/\n/g, '\\n').replace(/\r/g, '\\r') + '"';
     }
-    return val;
+    return s;
   }
 
   // ── Apply field values to a YAML snippet ──────────────────────
@@ -954,9 +956,11 @@ const wasmBase = import.meta.env.BASE_URL.replace(/\/$/, '') + '/wasm/logfwd-con
 
   setup();
 })().catch(e => {
+  console.error(e);
+  const message = e instanceof Error ? e.message : String(e);
   const st = document.getElementById('cb-status');
   if (st) {
-    st.textContent = `Failed to load config builder: ${String(e)}`;
+    st.textContent = `Failed to load config builder: ${message}`;
     st.style.color = 'var(--sl-color-red)';
   }
 });

--- a/book/src/components/ConfigBuilder.astro
+++ b/book/src/components/ConfigBuilder.astro
@@ -584,6 +584,7 @@ const wasmBase = import.meta.env.BASE_URL.replace(/\/$/, '') + '/wasm/logfwd-con
 </style>
 
 <script type="module">
+(async () => {
   // Resolve WASM path from the data attribute set by Astro's frontmatter.
   // This makes the path work both in dev (base='/') and on GitHub Pages (base='/memagent').
   const wasmBase = document.getElementById('config-builder').dataset.wasmBase;
@@ -769,6 +770,18 @@ const wasmBase = import.meta.env.BASE_URL.replace(/\/$/, '') + '/wasm/logfwd-con
     }
   }
 
+  // ── YAML scalar serializer ────────────────────────────────────
+  // Quotes a value when it contains characters that would break YAML structure:
+  // ': ' (ambiguous key separator), leading '#' (comment), newlines, or
+  // leading/trailing whitespace. Escapes backslash and double-quote inside.
+  function yamlScalar(val) {
+    if (/: |^#|\n|\r/.test(val) || val !== val.trim()) {
+      return '"' + val.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+                      .replace(/\n/g, '\\n').replace(/\r/g, '\\r') + '"';
+    }
+    return val;
+  }
+
   // ── Apply field values to a YAML snippet ──────────────────────
   // Matches "key: defaultValue" in the snippet to avoid collisions when the
   // default value appears elsewhere (e.g. "json" in both path and format).
@@ -780,7 +793,7 @@ const wasmBase = import.meta.env.BASE_URL.replace(/\/$/, '') + '/wasm/logfwd-con
         ? values[field.key]
         : field.default;
       const search  = field.key + ': ' + field.default;
-      const replace = field.key + ': ' + val;
+      const replace = field.key + ': ' + yamlScalar(val);
       result = result.split(search).join(replace);
     }
     return result;
@@ -813,7 +826,8 @@ const wasmBase = import.meta.env.BASE_URL.replace(/\/$/, '') + '/wasm/logfwd-con
 
     try {
       validate_config(yaml);
-      validationBadge.textContent = '✓ valid';
+      // SQL syntax is not validated server-side in WASM — make that visible.
+      validationBadge.textContent = sql ? '✓ valid (SQL not verified)' : '✓ valid';
       validationBadge.className = 'cb-badge cb-valid';
       validationMsg.hidden = true;
     } catch (err) {
@@ -939,4 +953,11 @@ const wasmBase = import.meta.env.BASE_URL.replace(/\/$/, '') + '/wasm/logfwd-con
   }
 
   setup();
+})().catch(e => {
+  const st = document.getElementById('cb-status');
+  if (st) {
+    st.textContent = `Failed to load config builder: ${String(e)}`;
+    st.style.color = 'var(--sl-color-red)';
+  }
+});
 </script>


### PR DESCRIPTION
## Summary

Follow-up to #2127 addressing post-merge feedback from the bot review:

- **WASM import failure leaves spinner stuck** — The top-level `await import(...)` was uncaught; wrap entire script in an async IIFE with `.catch()` so any load error (bad base path, network failure, missing WASM file) surfaces as a readable message instead of a frozen spinner
- **YAML injection in `applyValues`** — User-typed values containing `': '`, `'#'`, newlines, or surrounding whitespace were spliced directly into the YAML template, potentially breaking structure; add `yamlScalar()` that double-quotes such values before substitution
- **SQL validation appears stronger than it is** — `Config::load_str` does not parse or plan SQL transforms; badge now reads `✓ valid (SQL not verified)` when a transform is present, so users know to run `logfwd validate` locally

## Test plan

- [ ] Open config builder, confirm it loads normally (no regression)
- [ ] Type a value containing `: ` in a path field (e.g. `host: 9200`), confirm YAML output is properly quoted and still validates
- [ ] Add SQL in the transform box, confirm badge shows `✓ valid (SQL not verified)`
- [ ] Serve from a path where the WASM files are missing, confirm spinner is replaced with an error message (not frozen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix WASM load failure handling, YAML scalar quoting, and SQL validation label in ConfigBuilder
> - Wraps the module bootstrap in an async IIFE with a `.catch` handler that displays a failure message in `#cb-status` when WASM fails to load, instead of silently failing.
> - Adds a `yamlScalar` utility in [ConfigBuilder.astro](https://github.com/strawgate/memagent/pull/2138/files#diff-76579b98492621d5cc25a88e0544a9e5baddec53e6dcf54684480ffe251b87e8) that double-quotes and escapes YAML values containing special characters (empty strings, `: `, `#`, newlines, or leading/trailing whitespace).
> - Uses `yamlScalar` when applying field values to YAML snippets, preventing malformed output from user inputs.
> - Changes the validation success badge to `✓ valid (SQL not verified)` when a SQL field is present, making clear that SQL content is not validated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 277e0dd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->