### PR TITLE
feat: extract BlockStore from 2-buffer string management

### DIFF
--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -419,6 +419,13 @@ pub enum MaterializeError {
     InvalidUtf8 { offset: u32, len: u32 },
     /// Concatenated string bytes exceed `i32::MAX`, making Utf8 offsets invalid.
     OffsetOverflow,
+    /// A `StringRef` spans the original/generated boundary (start in original,
+    /// end past original_len). This is always a bug in the producer.
+    StringRefSpansBoundary {
+        offset: u32,
+        len: u32,
+        original_len: usize,
+    },
 }
 
 impl std::fmt::Display for MaterializeError {
@@ -441,6 +448,14 @@ impl std::fmt::Display for MaterializeError {
                     "string data exceeds i32::MAX bytes for Utf8 offset array"
                 )
             }
+            MaterializeError::StringRefSpansBoundary {
+                offset,
+                len,
+                original_len,
+            } => write!(
+                f,
+                "StringRef(offset={offset}, len={len}) spans original/generated boundary (original_len={original_len})"
+            ),
         }
     }
 }
@@ -454,10 +469,8 @@ impl std::error::Error for MaterializeError {}
 /// Controls how string columns are built at finalization.
 #[derive(Clone)]
 pub struct FinalizationMode {
-    /// Original input buffer (e.g., protobuf wire bytes, scanner input).
-    pub original_buf: Buffer,
-    /// Generated/decoded buffer (e.g., JSON-unescaped strings).
-    pub generated_buf: Buffer,
+    /// Backing buffers for string references.
+    pub blocks: super::block_store::BlockStore,
     /// When true, all string data is known to be valid UTF-8 (validated
     /// at the ingestion boundary — scanner, OTLP decoder, etc.). Enables
     /// zero-copy StringViewArray construction.  When false, copies bytes
@@ -600,21 +613,9 @@ fn build_string(
     dedup: bool,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
     if mode.utf8_trusted {
-        build_string_view_trusted(
-            facts,
-            num_rows,
-            &mode.original_buf,
-            &mode.generated_buf,
-            dedup,
-        )
+        build_string_view_trusted(facts, num_rows, &mode.blocks, dedup)
     } else {
-        build_string_array_validated(
-            facts,
-            num_rows,
-            &mode.original_buf,
-            &mode.generated_buf,
-            dedup,
-        )
+        build_string_array_validated(facts, num_rows, &mode.blocks, dedup)
     }
 }
 
@@ -632,24 +633,13 @@ fn build_string(
 fn build_string_view_trusted(
     facts: &[(u32, StringRef)],
     num_rows: usize,
-    original_buf: &Buffer,
-    generated_buf: &Buffer,
+    blocks: &super::block_store::BlockStore,
     dedup: bool,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
-    let original_len = original_buf.len();
     let dense = is_dense(facts, num_rows, dedup);
 
     // Register source buffers as StringViewArray blocks.
-    // block 0 = original, block 1 = generated (if non-empty).
-    let mut buffers: Vec<Buffer> = Vec::with_capacity(2);
-    let orig_block: u32 = 0;
-    buffers.push(original_buf.clone()); // O(1) Arc bump
-    let gen_block = if generated_buf.is_empty() {
-        None
-    } else {
-        buffers.push(generated_buf.clone()); // O(1) Arc bump
-        Some(1u32)
-    };
+    let (buffers, orig_block, gen_block) = blocks.register_blocks();
 
     // Pre-zero + indexed write is faster than collect() because memset_avx2
     // zeroes 16KB in ~200 instructions while the Result iterator adapter
@@ -664,14 +654,7 @@ fn build_string_view_trusted(
             "dense path requires consecutive rows starting at 0"
         );
         for (i, &(_, sref)) in facts.iter().enumerate() {
-            views[i] = make_string_view(
-                sref,
-                original_buf,
-                generated_buf,
-                original_len,
-                orig_block,
-                gen_block,
-            )?;
+            views[i] = blocks.make_string_view(sref, orig_block, gen_block)?;
         }
     } else {
         // Sparse: iterate all facts, assign by row index (last-write-wins for duplicates).
@@ -679,14 +662,7 @@ fn build_string_view_trusted(
         for &(row, sref) in facts {
             let r = row as usize;
             if r < num_rows {
-                views[r] = make_string_view(
-                    sref,
-                    original_buf,
-                    generated_buf,
-                    original_len,
-                    orig_block,
-                    gen_block,
-                )?;
+                views[r] = blocks.make_string_view(sref, orig_block, gen_block)?;
                 valid[r] = true;
             }
         }
@@ -698,7 +674,7 @@ fn build_string_view_trusted(
             // Validate UTF-8 for all referenced string bytes in debug builds.
             let mut ok = true;
             for &(_, sref) in facts {
-                if let Ok(bytes) = read_str_bytes(original_buf, generated_buf, original_len, sref)
+                if let Ok(bytes) = blocks.read_str_bytes(sref)
                     && std::str::from_utf8(bytes).is_err()
                 {
                     ok = false;
@@ -719,82 +695,6 @@ fn build_string_view_trusted(
     Ok((Arc::new(array), DataType::Utf8View))
 }
 
-/// Construct a u128 StringView for a given StringRef.
-///
-/// Strings ≤ 12 bytes are inlined. Longer strings reference a buffer block.
-#[inline(always)]
-fn make_string_view(
-    sref: StringRef,
-    original_buf: &[u8],
-    generated_buf: &[u8],
-    original_len: usize,
-    orig_block: u32,
-    gen_block: Option<u32>,
-) -> Result<u128, MaterializeError> {
-    let len = sref.len;
-    if len == 0 {
-        return Ok(0u128);
-    }
-
-    let start = sref.offset as usize;
-
-    // Resolve buffer, block index, and local offset.
-    let (buf, block_idx, local_offset) = if start < original_len {
-        (original_buf, orig_block, sref.offset)
-    } else {
-        let dec_start = (start - original_len) as u32;
-        match gen_block {
-            Some(gb) => (generated_buf, gb, dec_start),
-            None => {
-                return Err(MaterializeError::StringRefOutOfBounds {
-                    offset: sref.offset,
-                    len: sref.len,
-                    buffer_len: 0,
-                });
-            }
-        }
-    };
-
-    let local_start = local_offset as usize;
-    let local_end =
-        local_start
-            .checked_add(len as usize)
-            .ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: buf.len(),
-            })?;
-    if local_end > buf.len() {
-        return Err(MaterializeError::StringRefOutOfBounds {
-            offset: sref.offset,
-            len: sref.len,
-            buffer_len: buf.len(),
-        });
-    }
-
-    // Build the u128 view using arithmetic — avoids byte array + copy_from_slice.
-    Ok(if len <= 12 {
-        // Inline: [len:4][data:12] packed little-endian.
-        let mut view_bytes = [0u8; 16];
-        view_bytes[0..4].copy_from_slice(&len.to_le_bytes());
-        view_bytes[4..4 + len as usize].copy_from_slice(&buf[local_start..local_end]);
-        u128::from_le_bytes(view_bytes)
-    } else {
-        // Buffer ref: [len:4][prefix:4][block_idx:4][offset:4] packed little-endian.
-        // Use arithmetic to avoid array copies.
-        let prefix = u32::from_le_bytes([
-            buf[local_start],
-            buf[local_start + 1],
-            buf[local_start + 2],
-            buf[local_start + 3],
-        ]);
-        (len as u128)
-            | ((prefix as u128) << 32)
-            | ((block_idx as u128) << 64)
-            | ((local_offset as u128) << 96)
-    })
-}
-
 /// Build a `StringArray` with full UTF-8 validation (untrusted path).
 ///
 /// Copies string bytes into a contiguous values buffer. Used when the ingestion
@@ -802,11 +702,9 @@ fn make_string_view(
 fn build_string_array_validated(
     facts: &[(u32, StringRef)],
     num_rows: usize,
-    original_buf: &Buffer,
-    generated_buf: &Buffer,
+    blocks: &super::block_store::BlockStore,
     dedup: bool,
 ) -> Result<(ArrayRef, DataType), MaterializeError> {
-    let original_len = original_buf.len();
     let dense = is_dense(facts, num_rows, dedup);
     let mut offsets: Vec<i32> = Vec::with_capacity(num_rows + 1);
     let mut values: Vec<u8> =
@@ -822,7 +720,7 @@ fn build_string_array_validated(
         for &(_, sref) in facts {
             let off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
             offsets.push(off);
-            let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
+            let bytes = blocks.read_str_bytes(sref)?;
             values.extend_from_slice(bytes);
         }
     } else {
@@ -841,7 +739,7 @@ fn build_string_array_validated(
             offsets.push(off);
             if let Some(fi) = entry {
                 let sref = facts[*fi].1;
-                let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
+                let bytes = blocks.read_str_bytes(sref)?;
                 values.extend_from_slice(bytes);
                 validity.push(true);
             } else {
@@ -853,7 +751,8 @@ fn build_string_array_validated(
     offsets.push(final_off);
 
     // Validate UTF-8 for external bytes.
-    if !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {
+    let has_original = blocks.original_len() > 0;
+    if has_original && std::str::from_utf8(&values).is_err() {
         // Identify which row contains the invalid UTF-8.
         for row in 0..num_rows {
             let start = offsets[row] as usize;
@@ -875,54 +774,14 @@ fn build_string_array_validated(
     let offset_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
     let values_buf = Buffer::from_vec(values);
 
-    if original_buf.is_empty() {
+    if has_original {
+        let array = StringArray::new(offset_buf, values_buf, nulls);
+        Ok((Arc::new(array), DataType::Utf8))
+    } else {
         // All data from write_str(&str) — valid UTF-8 by Rust's type system.
         // SAFETY: offsets built sequentially, source is &str.
         let array = unsafe { StringArray::new_unchecked(offset_buf, values_buf, nulls) };
         Ok((Arc::new(array), DataType::Utf8))
-    } else {
-        let array = StringArray::new(offset_buf, values_buf, nulls);
-        Ok((Arc::new(array), DataType::Utf8))
-    }
-}
-
-/// Read string bytes from the 2-buffer system without UTF-8 validation.
-///
-/// Returns the raw bytes referenced by `sref`. Callers must validate UTF-8
-/// externally (e.g., once over the concatenated output).
-fn read_str_bytes<'a>(
-    original: &'a [u8],
-    generated: &'a [u8],
-    original_len: usize,
-    sref: StringRef,
-) -> Result<&'a [u8], MaterializeError> {
-    let start = sref.offset as usize;
-    let end =
-        start
-            .checked_add(sref.len as usize)
-            .ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: original.len() + generated.len(),
-            })?;
-    if start < original_len {
-        original
-            .get(start..end)
-            .ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: original.len(),
-            })
-    } else {
-        let dec_start = start - original_len;
-        let dec_end = end - original_len;
-        generated
-            .get(dec_start..dec_end)
-            .ok_or(MaterializeError::StringRefOutOfBounds {
-                offset: sref.offset,
-                len: sref.len,
-                buffer_len: generated.len(),
-            })
     }
 }
 
@@ -986,6 +845,7 @@ fn build_conflict_struct(
 mod tests {
     use std::mem::size_of_val;
 
+    use super::super::block_store::BlockStore;
     use super::*;
     use arrow::array::{Array, AsArray};
     use arrow::datatypes::Int64Type;
@@ -997,8 +857,7 @@ mod tests {
         acc.push_i64(2, 300);
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&[] as &[u8]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&[] as &[u8]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("ts", 3, mode, true).unwrap().unwrap();
@@ -1017,8 +876,7 @@ mod tests {
         acc.push_str(1, StringRef { offset: 6, len: 5 }); // "world"
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&input[..]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&input[..]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("msg", 2, mode, true).unwrap().unwrap();
@@ -1035,8 +893,7 @@ mod tests {
         acc.push_str(1, StringRef { offset: 6, len: 5 });
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&input[..]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&input[..]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("msg", 2, mode, true).unwrap().unwrap();
@@ -1064,8 +921,7 @@ mod tests {
         );
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&input[..]),
-            generated_buf: Buffer::from(&generated[..]),
+            blocks: BlockStore::new(Buffer::from(&input[..]), Buffer::from(&generated[..])),
             utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("msg", 2, mode, true).unwrap().unwrap();
@@ -1081,8 +937,7 @@ mod tests {
         acc.push_i64(1, 99);
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&[] as &[u8]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&[] as &[u8]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("x", 2, mode, true).unwrap().unwrap();
@@ -1101,8 +956,7 @@ mod tests {
         acc.push_str(1, StringRef { offset: 0, len: 2 });
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&input[..]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&input[..]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         let (field, arr) = acc.materialize("status", 2, mode, true).unwrap().unwrap();
@@ -1118,8 +972,7 @@ mod tests {
     fn empty_accumulator_returns_none() {
         let acc = ColumnAccumulator::for_planned(FieldKind::Int64);
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&[] as &[u8]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&[] as &[u8]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         assert!(acc.materialize("x", 3, mode, true).unwrap().is_none());
@@ -1133,8 +986,7 @@ mod tests {
         acc.push_bool(0, true); // no-op for Int64
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&[] as &[u8]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&[] as &[u8]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         assert!(acc.materialize("x", 1, mode, true).unwrap().is_none()); // no int facts → None
@@ -1148,8 +1000,7 @@ mod tests {
         acc.push_i64(0, 200);
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&[] as &[u8]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&[] as &[u8]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         let (_, arr) = acc.materialize("x", 1, mode, true).unwrap().unwrap();
@@ -1196,8 +1047,7 @@ mod tests {
         );
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(b"short" as &[u8]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(b"short" as &[u8]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         let result = acc.materialize("x", 1, mode, true);
@@ -1216,8 +1066,7 @@ mod tests {
         acc.push_str(0, StringRef { offset: 0, len: 4 });
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(bad_bytes),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(bad_bytes), Buffer::from(&[] as &[u8])),
             utf8_trusted: false,
         };
         let result = acc.materialize("x", 1, mode, true);
@@ -1243,8 +1092,7 @@ mod tests {
         );
 
         let mode = FinalizationMode {
-            original_buf: Buffer::from(&input[..]),
-            generated_buf: Buffer::from(&[] as &[u8]),
+            blocks: BlockStore::new(Buffer::from(&input[..]), Buffer::from(&[] as &[u8])),
             utf8_trusted: true,
         };
         let result = acc.materialize("x", 1, mode, true);
@@ -1266,6 +1114,7 @@ mod tests {
 // timeouts (>10 min for read_str_bytes on [u8; 16]).
 #[cfg(kani)]
 mod verification {
+    use super::super::block_store::{make_string_view_raw, read_str_bytes_raw};
     use super::*;
 
     // ── make_string_view ────────────────────────────────────────────────────
@@ -1287,7 +1136,7 @@ mod verification {
 
         let sref = StringRef { offset: 0, len };
         let view =
-            make_string_view(sref, &buf[..len as usize], &[], len as usize, 0, None).unwrap();
+            make_string_view_raw(sref, &buf[..len as usize], &[], len as usize, 0, None).unwrap();
 
         // Oracle: independently decode the u128 and verify every field.
         let view_bytes = view.to_le_bytes();
@@ -1317,7 +1166,7 @@ mod verification {
     #[kani::proof]
     fn verify_make_string_view_zero_length() {
         let sref = StringRef { offset: 0, len: 0 };
-        let view = make_string_view(sref, &[], &[], 0, 0, None).unwrap();
+        let view = make_string_view_raw(sref, &[], &[], 0, 0, None).unwrap();
         assert_eq!(view, 0u128, "zero-length string must be all-zero view");
     }
 
@@ -1350,7 +1199,8 @@ mod verification {
             offset: local_offset,
             len,
         };
-        let view = make_string_view(sref, &buf[..buf_len], &[], buf_len, block_idx, None).unwrap();
+        let view =
+            make_string_view_raw(sref, &buf[..buf_len], &[], buf_len, block_idx, None).unwrap();
 
         // Oracle: independently recompute expected u128 from the spec.
         let expected_prefix =
@@ -1385,7 +1235,7 @@ mod verification {
         // Fixed-size array avoids CBMC symbolic-allocation explosion.
         let buf = [0u8; 64];
         let sref = StringRef { offset, len };
-        let result = make_string_view(sref, &buf[..buf_len], &[], buf_len, 0, None);
+        let result = make_string_view_raw(sref, &buf[..buf_len], &[], buf_len, 0, None);
         assert!(result.is_err(), "OOB reference must return error");
 
         kani::cover!(offset == 0, "zero offset with large len");
@@ -1412,7 +1262,7 @@ mod verification {
             len,
         };
         let result_orig =
-            make_string_view(sref_orig, &original, &generated, original_len, 0, Some(1));
+            make_string_view_raw(sref_orig, &original, &generated, original_len, 0, Some(1));
         assert!(result_orig.is_ok(), "valid original ref must succeed");
 
         // Generated buffer path: offset >= original_len.
@@ -1423,7 +1273,7 @@ mod verification {
             len,
         };
         let result_gen =
-            make_string_view(sref_gen, &original, &generated, original_len, 0, Some(1));
+            make_string_view_raw(sref_gen, &original, &generated, original_len, 0, Some(1));
         assert!(result_gen.is_ok(), "valid generated ref must succeed");
 
         // No generated buffer + offset in generated range → error.
@@ -1431,7 +1281,8 @@ mod verification {
             offset: original_len as u32,
             len: 1,
         };
-        let result_no_gen = make_string_view(sref_no_gen, &original, &[], original_len, 0, None);
+        let result_no_gen =
+            make_string_view_raw(sref_no_gen, &original, &[], original_len, 0, None);
         assert!(
             result_no_gen.is_err(),
             "generated offset with no generated buffer must error"
@@ -1543,7 +1394,7 @@ mod verification {
         kani::assume((offset as usize) + (len as usize) <= orig_len);
 
         let sref = StringRef { offset, len };
-        let result = read_str_bytes(&original, &generated, orig_len, sref);
+        let result = read_str_bytes_raw(&original, &generated, orig_len, sref);
         assert!(result.is_ok(), "valid original ref must succeed");
         let bytes = result.unwrap();
         assert_eq!(bytes.len(), len as usize);
@@ -1570,7 +1421,7 @@ mod verification {
             offset: orig_len as u32 + gen_offset,
             len,
         };
-        let result = read_str_bytes(&original, &generated, orig_len, sref);
+        let result = read_str_bytes_raw(&original, &generated, orig_len, sref);
         assert!(result.is_ok(), "valid generated ref must succeed");
         let bytes = result.unwrap();
         assert_eq!(bytes.len(), len as usize);
@@ -1594,7 +1445,7 @@ mod verification {
         kani::assume((offset as usize) + (len as usize) > orig_len);
 
         let sref = StringRef { offset, len };
-        let result = read_str_bytes(&original, &generated, orig_len, sref);
+        let result = read_str_bytes_raw(&original, &generated, orig_len, sref);
         assert!(result.is_err(), "spanning reference must be rejected");
 
         kani::cover!(offset == 0, "span from start");
@@ -1653,6 +1504,7 @@ mod verification {
 // ---------------------------------------------------------------------------
 #[cfg(test)]
 mod proptests {
+    use super::super::block_store::read_str_bytes_raw;
     use super::*;
     use arrow::array::Array;
     use proptest::prelude::*;
@@ -1934,7 +1786,7 @@ mod proptests {
             let generated: Vec<u8> = vec![0xDDu8; 16];
 
             let sref = StringRef { offset, len };
-            let result = read_str_bytes(&original, &generated, orig_len, sref);
+            let result = read_str_bytes_raw(&original, &generated, orig_len, sref);
             prop_assert!(result.is_ok());
             let bytes = result.unwrap();
             prop_assert_eq!(bytes.len(), len as usize);
@@ -1959,7 +1811,7 @@ mod proptests {
                 offset: orig_len as u32 + gen_offset,
                 len,
             };
-            let result = read_str_bytes(&original, &generated, orig_len, sref);
+            let result = read_str_bytes_raw(&original, &generated, orig_len, sref);
             prop_assert!(result.is_ok());
             let bytes = result.unwrap();
             prop_assert_eq!(bytes.len(), len as usize);
@@ -1981,7 +1833,7 @@ mod proptests {
             let original = [0xCCu8; 8];
             let generated = [0xDDu8; 8];
             let sref = StringRef { offset, len };
-            let result = read_str_bytes(&original, &generated, orig_len, sref);
+            let result = read_str_bytes_raw(&original, &generated, orig_len, sref);
             prop_assert!(result.is_err(), "spanning strings must be rejected");
         }
 
@@ -1994,7 +1846,7 @@ mod proptests {
             let original = [0xCCu8; 8];
             let generated = [0xDDu8; 8];
             let sref = StringRef { offset, len };
-            let result = read_str_bytes(&original, &generated, 8, sref);
+            let result = read_str_bytes_raw(&original, &generated, 8, sref);
             prop_assert!(result.is_err());
         }
     }

--- a/crates/logfwd-arrow/src/columnar/block_store.rs
+++ b/crates/logfwd-arrow/src/columnar/block_store.rs
@@ -91,6 +91,16 @@ pub(super) fn make_string_view_raw(
     }
 
     let start = sref.offset as usize;
+    let end = start.wrapping_add(len as usize);
+
+    // Detect spanning references before resolving to a single buffer.
+    if start < original_len && end > original_len {
+        return Err(MaterializeError::StringRefSpansBoundary {
+            offset: sref.offset,
+            len: sref.len,
+            original_len,
+        });
+    }
 
     // Resolve buffer, block index, and local offset.
     let (buf, block_idx, local_offset) = if start < original_len {

--- a/crates/logfwd-arrow/src/columnar/block_store.rs
+++ b/crates/logfwd-arrow/src/columnar/block_store.rs
@@ -1,0 +1,434 @@
+// block_store.rs — Manages string backing buffers for columnar construction.
+//
+// The builder's 2-buffer model: "original" (input/wire bytes) + "generated"
+// (write_str output / decoded strings).  StringRef offsets below original_len
+// point into the original buffer; offsets at or above point into the generated
+// buffer shifted by original_len.
+//
+// This type owns the buffers and provides:
+//   - resolve: offset → (block_idx, local_offset, slice)
+//   - registration of buffers for Arrow StringViewArray blocks
+//   - read_str_bytes: safe byte extraction from the 2-buffer system
+//
+// By centralizing buffer management, ColumnarBatchBuilder, StreamingBuilder,
+// and future producers can share the same finalization code paths.
+
+use arrow::buffer::Buffer;
+
+use super::accumulator::{MaterializeError, StringRef};
+
+// ---------------------------------------------------------------------------
+// Pure helper functions — no heap allocation, Kani-friendly
+// ---------------------------------------------------------------------------
+
+/// Read string bytes from a 2-buffer system without UTF-8 validation.
+///
+/// `original` and `generated` are raw byte slices; `original_len` is the
+/// boundary between the two buffers in the StringRef offset space.
+///
+/// Returns `Ok(slice)` for valid references, `Err` for out-of-bounds or
+/// spanning references (start in original, end in generated).
+pub(super) fn read_str_bytes_raw<'a>(
+    original: &'a [u8],
+    generated: &'a [u8],
+    original_len: usize,
+    sref: StringRef,
+) -> Result<&'a [u8], MaterializeError> {
+    let start = sref.offset as usize;
+    let end =
+        start
+            .checked_add(sref.len as usize)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: original.len() + generated.len(),
+            })?;
+
+    if start < original_len {
+        if end > original_len {
+            return Err(MaterializeError::StringRefSpansBoundary {
+                offset: sref.offset,
+                len: sref.len,
+                original_len,
+            });
+        }
+        original
+            .get(start..end)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: original.len(),
+            })
+    } else {
+        let gen_start = start - original_len;
+        let gen_end = end - original_len;
+        generated
+            .get(gen_start..gen_end)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: generated.len(),
+            })
+    }
+}
+
+/// Construct a u128 StringView for a given StringRef against raw byte slices.
+///
+/// Strings ≤ 12 bytes are inlined. Longer strings reference a buffer block.
+/// `orig_block` and `gen_block` are the Arrow buffer indices.
+#[inline(always)]
+pub(super) fn make_string_view_raw(
+    sref: StringRef,
+    original_buf: &[u8],
+    generated_buf: &[u8],
+    original_len: usize,
+    orig_block: u32,
+    gen_block: Option<u32>,
+) -> Result<u128, MaterializeError> {
+    let len = sref.len;
+    if len == 0 {
+        return Ok(0u128);
+    }
+
+    let start = sref.offset as usize;
+
+    // Resolve buffer, block index, and local offset.
+    let (buf, block_idx, local_offset) = if start < original_len {
+        (original_buf, orig_block, sref.offset)
+    } else {
+        let dec_start = (start - original_len) as u32;
+        match gen_block {
+            Some(gb) => (generated_buf, gb, dec_start),
+            None => {
+                return Err(MaterializeError::StringRefOutOfBounds {
+                    offset: sref.offset,
+                    len: sref.len,
+                    buffer_len: 0,
+                });
+            }
+        }
+    };
+
+    let local_start = local_offset as usize;
+    let local_end =
+        local_start
+            .checked_add(len as usize)
+            .ok_or(MaterializeError::StringRefOutOfBounds {
+                offset: sref.offset,
+                len: sref.len,
+                buffer_len: buf.len(),
+            })?;
+    if local_end > buf.len() {
+        return Err(MaterializeError::StringRefOutOfBounds {
+            offset: sref.offset,
+            len: sref.len,
+            buffer_len: buf.len(),
+        });
+    }
+
+    // Build the u128 view using arithmetic — avoids byte array + copy_from_slice.
+    Ok(if len <= 12 {
+        // Inline: [len:4][data:12] packed little-endian.
+        let mut view_bytes = [0u8; 16];
+        view_bytes[0..4].copy_from_slice(&len.to_le_bytes());
+        view_bytes[4..4 + len as usize].copy_from_slice(&buf[local_start..local_end]);
+        u128::from_le_bytes(view_bytes)
+    } else {
+        // Buffer ref: [len:4][prefix:4][block_idx:4][offset:4].
+        let prefix = u32::from_le_bytes([
+            buf[local_start],
+            buf[local_start + 1],
+            buf[local_start + 2],
+            buf[local_start + 3],
+        ]);
+        (len as u128)
+            | ((prefix as u128) << 32)
+            | ((block_idx as u128) << 64)
+            | ((local_offset as u128) << 96)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// BlockStore — 2-buffer string backing
+// ---------------------------------------------------------------------------
+
+/// Manages the string backing buffers for columnar batch construction.
+///
+/// Two logical blocks:
+/// - **Block 0 ("original")**: Input buffer — protobuf wire bytes, scanner
+///   input, CSV chunk, etc. Set once at batch start, immutable during writes.
+/// - **Block 1 ("generated")**: Append-only buffer for strings produced by
+///   `write_str` — JSON-unescaped values, formatted fields, constants, etc.
+///
+/// The offset encoding is zero-cost: `StringRef.offset < original_len` → block 0,
+/// `offset >= original_len` → block 1 at `offset - original_len`.
+#[derive(Clone)]
+pub struct BlockStore {
+    /// Input buffer (e.g., protobuf wire bytes, scanner input).
+    /// Stored as Arrow `Buffer` (ref-counted) — O(1) to pass to StringViewArray.
+    original: Buffer,
+    /// Generated/decoded buffer.
+    generated: Buffer,
+}
+
+impl BlockStore {
+    /// Create a `BlockStore` from an original buffer and a generated buffer.
+    ///
+    /// Both buffers are moved (O(1) ref-count bump for `Buffer`).
+    pub fn new(original: Buffer, generated: Buffer) -> Self {
+        Self {
+            original,
+            generated,
+        }
+    }
+
+    /// Create an empty `BlockStore` (both buffers empty).
+    pub fn empty() -> Self {
+        Self {
+            original: Buffer::from(Vec::<u8>::new()),
+            generated: Buffer::from(Vec::<u8>::new()),
+        }
+    }
+
+    /// Length of the original (input) buffer.
+    #[inline]
+    pub fn original_len(&self) -> usize {
+        self.original.len()
+    }
+
+    /// Length of the generated buffer.
+    #[inline]
+    pub fn generated_len(&self) -> usize {
+        self.generated.len()
+    }
+
+    /// Original buffer reference.
+    #[inline]
+    pub fn original(&self) -> &Buffer {
+        &self.original
+    }
+
+    /// Generated buffer reference.
+    #[inline]
+    pub fn generated(&self) -> &Buffer {
+        &self.generated
+    }
+
+    /// Resolve a `StringRef` to the raw bytes it references.
+    ///
+    /// Returns `Ok(slice)` for valid references, `Err` for out-of-bounds or
+    /// spanning references (start in original, end in generated).
+    pub fn read_str_bytes(&self, sref: StringRef) -> Result<&[u8], MaterializeError> {
+        read_str_bytes_raw(&self.original, &self.generated, self.original.len(), sref)
+    }
+
+    /// Build the Arrow `StringViewArray` u128 view word for a string reference.
+    ///
+    /// Returns the packed view (inlined for ≤12 bytes, buffer-ref for longer).
+    /// `orig_block` and `gen_block` are the Arrow buffer indices from
+    /// `register_blocks`.
+    pub fn make_string_view(
+        &self,
+        sref: StringRef,
+        orig_block: u32,
+        gen_block: Option<u32>,
+    ) -> Result<u128, MaterializeError> {
+        make_string_view_raw(
+            sref,
+            &self.original,
+            &self.generated,
+            self.original.len(),
+            orig_block,
+            gen_block,
+        )
+    }
+
+    /// Register the blocks with an Arrow `StringViewBuilder`-style consumer.
+    ///
+    /// Returns `(buffers_vec, orig_block_idx, gen_block_idx_or_none)`.
+    /// The generated block is only registered if non-empty.
+    pub fn register_blocks(&self) -> (Vec<Buffer>, u32, Option<u32>) {
+        let mut buffers: Vec<Buffer> = Vec::with_capacity(2);
+        let orig_block: u32 = 0;
+        buffers.push(self.original.clone()); // O(1) Arc bump
+        let gen_block = if self.generated.is_empty() {
+            None
+        } else {
+            buffers.push(self.generated.clone()); // O(1) Arc bump
+            Some(1u32)
+        };
+        (buffers, orig_block, gen_block)
+    }
+}
+
+impl std::fmt::Debug for BlockStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlockStore")
+            .field("original_len", &self.original.len())
+            .field("generated_len", &self.generated.len())
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_str_bytes_original_buffer() {
+        let original = Buffer::from_vec(b"hello world".to_vec());
+        let generated = Buffer::from(Vec::<u8>::new());
+        let store = BlockStore::new(original, generated);
+
+        let sref = StringRef { offset: 0, len: 5 };
+        assert_eq!(store.read_str_bytes(sref).unwrap(), b"hello");
+
+        let sref = StringRef { offset: 6, len: 5 };
+        assert_eq!(store.read_str_bytes(sref).unwrap(), b"world");
+    }
+
+    #[test]
+    fn read_str_bytes_generated_buffer() {
+        let original = Buffer::from_vec(b"orig".to_vec());
+        let generated = Buffer::from_vec(b"generated".to_vec());
+        let store = BlockStore::new(original, generated);
+
+        // offset = original_len (4) + 0 = 4 → generated[0..3] = "gen"
+        let sref = StringRef { offset: 4, len: 3 };
+        assert_eq!(store.read_str_bytes(sref).unwrap(), b"gen");
+
+        // offset = 4 + 3 = 7 → generated[3..9] = "erated"
+        let sref = StringRef { offset: 7, len: 6 };
+        assert_eq!(store.read_str_bytes(sref).unwrap(), b"erated");
+    }
+
+    #[test]
+    fn read_str_bytes_spanning_rejected() {
+        let original = Buffer::from_vec(b"orig".to_vec());
+        let generated = Buffer::from_vec(b"gen".to_vec());
+        let store = BlockStore::new(original, generated);
+
+        // Starts in original (offset=2), but len=4 extends past original_len=4.
+        let sref = StringRef { offset: 2, len: 4 };
+        assert!(store.read_str_bytes(sref).is_err());
+    }
+
+    #[test]
+    fn read_str_bytes_out_of_bounds() {
+        let original = Buffer::from_vec(b"orig".to_vec());
+        let generated = Buffer::from_vec(b"gen".to_vec());
+        let store = BlockStore::new(original, generated);
+
+        // Past generated buffer.
+        let sref = StringRef {
+            offset: 4 + 3,
+            len: 1,
+        };
+        assert!(store.read_str_bytes(sref).is_err());
+    }
+
+    #[test]
+    fn read_str_bytes_empty_string() {
+        let store = BlockStore::empty();
+        let sref = StringRef { offset: 0, len: 0 };
+        // Empty string at offset 0 should succeed — no bytes to read.
+        // read_str_bytes checks bounds, and 0+0 <= 0 passes.
+        assert_eq!(store.read_str_bytes(sref).unwrap(), b"");
+    }
+
+    #[test]
+    fn make_string_view_inline() {
+        let original = Buffer::from_vec(b"hello".to_vec());
+        let store = BlockStore::new(original, Buffer::from(Vec::<u8>::new()));
+
+        let sref = StringRef { offset: 0, len: 5 };
+        let view = store.make_string_view(sref, 0, None).unwrap();
+
+        // Inline: len in lowest 4 bytes.
+        assert_eq!((view & 0xFFFF_FFFF) as u32, 5);
+        // Bytes 4..9 should be "hello".
+        let bytes = view.to_le_bytes();
+        assert_eq!(&bytes[4..9], b"hello");
+    }
+
+    #[test]
+    fn make_string_view_buffer_ref() {
+        let long_str = b"this is a string longer than twelve bytes";
+        let original = Buffer::from_vec(long_str.to_vec());
+        let store = BlockStore::new(original, Buffer::from(Vec::<u8>::new()));
+
+        let sref = StringRef {
+            offset: 0,
+            len: long_str.len() as u32,
+        };
+        let view = store.make_string_view(sref, 0, None).unwrap();
+
+        // Buffer ref: len in bits [0..32], prefix in [32..64], block in [64..96], offset in [96..128].
+        let len = (view & 0xFFFF_FFFF) as u32;
+        assert_eq!(len, long_str.len() as u32);
+
+        let prefix_val = ((view >> 32) & 0xFFFF_FFFF) as u32;
+        let expected_prefix =
+            u32::from_le_bytes([long_str[0], long_str[1], long_str[2], long_str[3]]);
+        assert_eq!(prefix_val, expected_prefix);
+
+        let block = ((view >> 64) & 0xFFFF_FFFF) as u32;
+        assert_eq!(block, 0); // original block
+
+        let offset = ((view >> 96) & 0xFFFF_FFFF) as u32;
+        assert_eq!(offset, 0);
+    }
+
+    #[test]
+    fn make_string_view_generated_block() {
+        let original = Buffer::from_vec(b"orig".to_vec());
+        let gen_data = b"this is a generated string longer than 12";
+        let generated = Buffer::from_vec(gen_data.to_vec());
+        let store = BlockStore::new(original, generated);
+
+        // offset = 4 (original_len) → generated buffer, local offset 0
+        let sref = StringRef {
+            offset: 4,
+            len: gen_data.len() as u32,
+        };
+        let view = store.make_string_view(sref, 0, Some(1)).unwrap();
+
+        let block = ((view >> 64) & 0xFFFF_FFFF) as u32;
+        assert_eq!(block, 1); // generated block
+
+        let offset = ((view >> 96) & 0xFFFF_FFFF) as u32;
+        assert_eq!(offset, 0); // local offset into generated
+    }
+
+    #[test]
+    fn make_string_view_empty() {
+        let store = BlockStore::empty();
+        let sref = StringRef { offset: 0, len: 0 };
+        assert_eq!(store.make_string_view(sref, 0, None).unwrap(), 0);
+    }
+
+    #[test]
+    fn register_blocks_original_only() {
+        let original = Buffer::from_vec(b"data".to_vec());
+        let store = BlockStore::new(original, Buffer::from(Vec::<u8>::new()));
+        let (buffers, orig, gen_block) = store.register_blocks();
+        assert_eq!(buffers.len(), 1);
+        assert_eq!(orig, 0);
+        assert!(gen_block.is_none());
+    }
+
+    #[test]
+    fn register_blocks_both() {
+        let original = Buffer::from_vec(b"orig".to_vec());
+        let generated = Buffer::from_vec(b"gen".to_vec());
+        let store = BlockStore::new(original, generated);
+        let (buffers, orig, gen_block) = store.register_blocks();
+        assert_eq!(buffers.len(), 2);
+        assert_eq!(orig, 0);
+        assert_eq!(gen_block, Some(1));
+    }
+}

--- a/crates/logfwd-arrow/src/columnar/block_store.rs
+++ b/crates/logfwd-arrow/src/columnar/block_store.rs
@@ -1,17 +1,17 @@
-// block_store.rs — Manages string backing buffers for columnar construction.
-//
-// The builder's 2-buffer model: "original" (input/wire bytes) + "generated"
-// (write_str output / decoded strings).  StringRef offsets below original_len
-// point into the original buffer; offsets at or above point into the generated
-// buffer shifted by original_len.
-//
-// This type owns the buffers and provides:
-//   - resolve: offset → (block_idx, local_offset, slice)
-//   - registration of buffers for Arrow StringViewArray blocks
-//   - read_str_bytes: safe byte extraction from the 2-buffer system
-//
-// By centralizing buffer management, ColumnarBatchBuilder, StreamingBuilder,
-// and future producers can share the same finalization code paths.
+//! String backing buffer management for columnar construction.
+//!
+//! The builder's 2-buffer model: "original" (input/wire bytes) + "generated"
+//! (`write_str` output / decoded strings). [`StringRef`] offsets below
+//! `original_len` point into the original buffer; offsets at or above point
+//! into the generated buffer shifted by `original_len`.
+//!
+//! [`BlockStore`] owns the buffers and provides:
+//! - [`BlockStore::read_str_bytes`]: safe byte extraction from the 2-buffer system
+//! - [`BlockStore::make_string_view`]: Arrow StringView u128 construction
+//! - [`BlockStore::register_blocks`]: buffer registration for `StringViewArray`
+//!
+//! By centralizing buffer management, `ColumnarBatchBuilder`, `StreamingBuilder`,
+//! and future producers can share the same finalization code paths.
 
 use arrow::buffer::Buffer;
 

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -412,8 +412,7 @@ impl ColumnarBatchBuilder {
         let generated = Buffer::from_vec(std::mem::take(&mut self.string_buf));
 
         let mode = FinalizationMode {
-            original_buf: original,
-            generated_buf: generated,
+            blocks: super::block_store::BlockStore::new(original, generated),
             utf8_trusted: self.utf8_trusted,
         };
 

--- a/crates/logfwd-arrow/src/columnar/mod.rs
+++ b/crates/logfwd-arrow/src/columnar/mod.rs
@@ -11,6 +11,7 @@
 //! See `dev-docs/research/columnar-batch-builder.md` for the design intent.
 
 pub mod accumulator;
+pub mod block_store;
 pub mod builder;
 pub mod plan;
 pub(crate) mod row_protocol;


### PR DESCRIPTION
## Summary

Extract the 2-buffer string backing (original + generated) into a dedicated `BlockStore` type under `logfwd-arrow::columnar::block_store`.

Closes #1844

## Changes

- **New `BlockStore` type** (`block_store.rs`): Owns original (input) and generated (`write_str`) Arrow Buffers with:
  - `read_str_bytes(sref)` — resolves StringRef to byte slice
  - `make_string_view(sref, orig_block, gen_block)` — builds Arrow StringView u128
  - `register_blocks()` — returns buffers for StringViewArray construction
  - 11 unit tests covering original/generated dispatch, spanning rejection, inline/buffer-ref views

- **`FinalizationMode` simplified**: Replaced `original_buf` + `generated_buf` fields with single `blocks: BlockStore`

- **Pure helpers for Kani**: `make_string_view_raw` and `read_str_bytes_raw` as `pub(super)` free functions — identical logic without Buffer allocation, so Kani proofs avoid CBMC heap explosion

- **`builder.rs`**: `finish_batch()` constructs `BlockStore::new(original, generated)` at finalization

- **All proofs/tests updated**: Kani proofs call `_raw` helpers, proptests call `_raw` helpers, unit tests construct `FinalizationMode` with `BlockStore::new(...)`

## Test plan

- `cargo test -p logfwd-arrow --lib -- columnar`: 97 pass
- `just test`: 1596 pass, 42 skipped
- `just fmt && just clippy`: clean

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `BlockStore` to centralize 2-buffer string management in columnar accumulator
> - Introduces a new [`block_store.rs`](https://github.com/strawgate/memagent/pull/2143/files#diff-77e092704591bb94d55461c84d5348153149c1a1ad4cab190940809c39301bd3) module with a `BlockStore` struct that owns the `original` and `generated` Arrow buffers previously managed separately in [`accumulator.rs`](https://github.com/strawgate/memagent/pull/2143/files#diff-41b79f99ae1f7fd4f98545794a773da1bfeb0b7b6fac100feeac992e956c7e02).
> - Moves `read_str_bytes` and `make_string_view` helpers into `block_store` as `read_str_bytes_raw` and `make_string_view_raw`, with `BlockStore` wrapping them for high-level access.
> - Adds a new `MaterializeError::StringRefSpansBoundary` variant returned when a `StringRef` starts in the original buffer but ends past its boundary, replacing a generic out-of-bounds error.
> - `FinalizationMode` in [`accumulator.rs`](https://github.com/strawgate/memagent/pull/2143/files#diff-41b79f99ae1f7fd4f98545794a773da1bfeb0b7b6fac100feeac992e956c7e02) now holds a `BlockStore` instead of two separate `Buffer` fields; call sites in [`builder.rs`](https://github.com/strawgate/memagent/pull/2143/files#diff-d319f6a8aa2761b26f0d390a13e1169007daa93e1a5b5293271066f35b793159) construct `BlockStore::new(original, generated)` accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8d529c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->