### PR TITLE
feat(input/generator): add missing configuration options

### DIFF
--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -274,6 +274,15 @@ pub struct HttpInputConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct GeneratorInputConfig {
+    #[serde(default)]
+    pub events_per_second: Option<u64>,
+    #[serde(default)]
+    pub num_lines: Option<u64>,
+    #[serde(default)]
+    pub message_template: Option<String>,
+    #[serde(default)]
+    pub field_count: Option<usize>,
+
     pub events_per_sec: Option<u64>,
     pub batch_size: Option<usize>,
     pub total_events: Option<u64>,

--- a/crates/logfwd-io/src/generator/logs.rs
+++ b/crates/logfwd-io/src/generator/logs.rs
@@ -23,6 +23,8 @@ pub(super) fn write_logs_event(
     counter: u64,
     complexity: GeneratorComplexity,
     timestamp: &GeneratorTimestamp,
+    message_template: Option<&str>,
+    field_count: Option<usize>,
     done: &mut bool,
 ) {
     let seq = counter;
@@ -52,11 +54,28 @@ pub(super) fn write_logs_event(
     };
     let (year, month, day, hour, min, sec, msec) = super::epoch_ms_to_parts(event_ms);
 
+    let mut msg_buf = String::new();
+    let msg_str = if let Some(template) = message_template {
+        template
+    } else {
+        use std::fmt::Write;
+        let _ = write!(&mut msg_buf, "{method} {path}/{id} {status}");
+        &msg_buf
+    };
+
+    let mut synthetic_fields = String::new();
+    if let Some(count) = field_count {
+        use std::fmt::Write;
+        for i in 0..count {
+            let _ = write!(&mut synthetic_fields, r#","field_{}":"val_{}""#, i, i);
+        }
+    }
+
     match complexity {
         GeneratorComplexity::Simple => {
             let _ = write!(
                 buf,
-                r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{method} {path}/{id} {status}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status}}}"#,
+                r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{msg_str}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status}{synthetic_fields}}}"#,
             );
         }
         GeneratorComplexity::Complex => {
@@ -65,18 +84,18 @@ pub(super) fn write_logs_event(
             if seq.is_multiple_of(5) {
                 let _ = write!(
                     buf,
-                    r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{method} {path}/{id} {status}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out},"headers":{{"content-type":"application/json","x-request-id":"{rid:016x}"}},"tags":["web","{service}","{level}"]}}"#,
+                    r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{msg_str}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out},"headers":{{"content-type":"application/json","x-request-id":"{rid:016x}"}},"tags":["web","{service}","{level}"]{synthetic_fields}}}"#,
                 );
             } else if seq.is_multiple_of(7) {
                 let upstream_ms = 1 + seq.wrapping_mul(19) % 200;
                 let _ = write!(
                     buf,
-                    r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{method} {path}/{id} {status}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out},"upstream":[{{"host":"10.0.0.1","latency_ms":{upstream_ms}}},{{"host":"10.0.0.2","latency_ms":{dur}}}]}}"#,
+                    r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{msg_str}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out},"upstream":[{{"host":"10.0.0.1","latency_ms":{upstream_ms}}},{{"host":"10.0.0.2","latency_ms":{dur}}}]{synthetic_fields}}}"#,
                 );
             } else {
                 let _ = write!(
                     buf,
-                    r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{method} {path}/{id} {status}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out}}}"#,
+                    r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{msg_str}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out}{synthetic_fields}}}"#,
                 );
             }
         }

--- a/crates/logfwd-io/src/generator/mod.rs
+++ b/crates/logfwd-io/src/generator/mod.rs
@@ -106,6 +106,10 @@ pub struct GeneratorConfig {
     pub batch_size: usize,
     /// Total events to generate. 0 = infinite.
     pub total_events: u64,
+    /// Template for message string.
+    pub message_template: Option<String>,
+    /// Number of extra synthetic fields.
+    pub field_count: Option<usize>,
     /// Controls the size and shape of generated JSON lines.
     pub complexity: GeneratorComplexity,
     /// Which event shape to emit.
@@ -128,6 +132,8 @@ impl Default for GeneratorConfig {
             events_per_sec: 0,
             batch_size: 1000,
             total_events: 0,
+            message_template: None,
+            field_count: None,
             complexity: GeneratorComplexity::default(),
             profile: GeneratorProfile::default(),
             attributes: HashMap::new(),
@@ -424,6 +430,8 @@ impl GeneratorInput {
                     self.counter,
                     self.config.complexity,
                     &self.config.timestamp,
+                    self.config.message_template.as_deref(),
+                    self.config.field_count,
                     &mut self.done,
                 );
             }
@@ -1074,6 +1082,59 @@ mod tests {
                     "line {i} is not valid JSON: {line}"
                 );
             }
+        } else {
+            panic!("expected Data event");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests_custom_generator {
+    use super::*;
+
+    #[test]
+    fn custom_message_template() {
+        let mut input = GeneratorInput::new(
+            "test-template",
+            GeneratorConfig {
+                batch_size: 1,
+                total_events: 1,
+                message_template: Some("custom static message".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let events = input.poll().unwrap();
+        assert_eq!(events.len(), 1);
+        if let InputEvent::Data { bytes, .. } = &events[0] {
+            let text = String::from_utf8_lossy(bytes);
+            let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(val["message"], "custom static message");
+        } else {
+            panic!("expected Data event");
+        }
+    }
+
+    #[test]
+    fn custom_field_count() {
+        let mut input = GeneratorInput::new(
+            "test-field-count",
+            GeneratorConfig {
+                batch_size: 1,
+                total_events: 1,
+                field_count: Some(2),
+                ..Default::default()
+            },
+        );
+
+        let events = input.poll().unwrap();
+        assert_eq!(events.len(), 1);
+        if let InputEvent::Data { bytes, .. } = &events[0] {
+            let text = String::from_utf8_lossy(bytes);
+            let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(val["field_0"], "val_0");
+            assert_eq!(val["field_1"], "val_1");
+            assert_eq!(val.get("field_2"), None);
         } else {
             panic!("expected Data event");
         }

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -212,11 +212,19 @@ pub(super) fn build_input_state(
             };
             let generator_cfg = g.generator.as_ref();
             let config = GeneratorConfig {
-                events_per_sec: generator_cfg.and_then(|c| c.events_per_sec).unwrap_or(0),
+                events_per_sec: generator_cfg
+                    .and_then(|c| c.events_per_second)
+                    .or_else(|| generator_cfg.and_then(|c| c.events_per_sec))
+                    .unwrap_or(0),
                 batch_size: generator_cfg
                     .and_then(|c| c.batch_size)
                     .unwrap_or(DEFAULT_GENERATOR_BATCH_SIZE),
-                total_events: generator_cfg.and_then(|c| c.total_events).unwrap_or(0),
+                total_events: generator_cfg
+                    .and_then(|c| c.num_lines)
+                    .or_else(|| generator_cfg.and_then(|c| c.total_events))
+                    .unwrap_or(0),
+                message_template: generator_cfg.and_then(|c| c.message_template.clone()),
+                field_count: generator_cfg.and_then(|c| c.field_count),
                 complexity: match generator_cfg.and_then(|c| c.complexity.clone()) {
                     Some(GeneratorComplexityConfig::Complex) => GeneratorComplexity::Complex,
                     Some(GeneratorComplexityConfig::Simple) | None => GeneratorComplexity::Simple,


### PR DESCRIPTION
Adds support for custom message templates, dynamic field injection via `field_count`, and aliases for generator configuration `events_per_second` and `num_lines`.

---
*PR created automatically by Jules for task [16383865408511983045](https://jules.google.com/task/16383865408511983045) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `message_template`, `field_count`, `events_per_second`, and `num_lines` config options to the generator input
> - Adds `message_template` and `field_count` fields to `GeneratorConfig` and `GeneratorInputConfig`, allowing log events to carry a custom message and arbitrary synthetic fields (`field_0`..`field_{n-1}`).
> - Adds `events_per_second` and `num_lines` as preferred aliases for the existing `events_per_sec` and `total_events` fields; the old names remain as fallbacks.
> - Updates [`logs.rs`](https://github.com/strawgate/memagent/pull/2154/files#diff-e73022431f73b8174002ebd672364e295b85abd531455b06787fbfb670485155) `write_logs_event` to build message and synthetic fields from the new config, falling back to original behavior when not set.
> - Adds two unit tests covering custom message template and field count behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 059e193. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->