### PR TITLE
fix(bench): create writable home dir for nonroot user in e2e image

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -27,8 +27,11 @@ RUN --mount=type=cache,target=/src/target \
     cp target/release/logfwd /logfwd
 
 FROM debian:12-slim
-RUN useradd --system --no-create-home --uid 65532 nonroot
+RUN useradd --system --no-create-home --uid 65532 nonroot \
+    && mkdir -p /home/nonroot \
+    && chown nonroot:nonroot /home/nonroot
 COPY --from=builder /logfwd /usr/local/bin/logfwd
 USER nonroot
+ENV HOME=/home/nonroot
 EXPOSE 9090
 ENTRYPOINT ["logfwd"]


### PR DESCRIPTION
## Problem

The e2e benchmark image (`Dockerfile.e2e`) was updated in #2128 to use `debian:12-slim` instead of `gcr.io/distroless/cc-debian12:nonroot`. The `useradd --no-create-home` flag was used but this left the `nonroot` user (UID 65532) with no writable home directory.

logfwd's `default_data_dir()` function (in `logfwd-io/src/checkpoint.rs`) selects the checkpoint data dir as:
1. `$LOGFWD_DATA_DIR` if set
2. `/var/lib/logfwd` if running as root
3. `$HOME/.logfwd` if HOME is set
4. `.logfwd` (relative to CWD) otherwise

On `debian:12-slim` without a home directory, this fell through to case 4 (CWD-relative `.logfwd`), where CWD defaults to `/`. Since `/` is not writable by `nonroot`, `std::fs::create_dir_all("/.logfwd")` failed with `Permission denied (os error 13)`.

The old `distroless:nonroot` image sets `HOME=/home/nonroot` and creates that directory, so `$HOME/.logfwd` was used and worked correctly.

## Fix

- Extend the `RUN useradd` step to also create `/home/nonroot` with correct ownership
- Add `ENV HOME=/home/nonroot` to match distroless behavior

## Testing

This is a pure Dockerfile change. The nightly e2e suite (which was failing with `Permission denied`) should pass once the new image is built and published.

Closes #273 (e2e nightly failures — all 7 scenarios failing with `result.json missing`)
Closes #274 (bench nightly — all logfwd file lanes failing with `n/a` EPS)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Create writable home directory for nonroot user in e2e image
> The [Dockerfile.e2e](https://github.com/strawgate/memagent/pull/2171/files#diff-6a44760ef8623aacfb197f34a33a30d7d86ba096e84be607869ee2ea8f20cafc) previously created the nonroot user with `--no-create-home` and no `HOME` env var. It now creates `/home/nonroot`, assigns ownership to `nonroot:nonroot`, and sets `ENV HOME=/home/nonroot` in the runtime stage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 488d402.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->