### PR TITLE
fix(nightly): fix bench compile errors, master→main, turmoil noise, fuzz toolchain

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -397,7 +397,7 @@ jobs:
       # Commit bench data to the bench-data branch so the dashboard can fetch
       # it live via raw.githubusercontent.com — no Pages redeploy needed.
       - name: Commit results to bench-data branch
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ github.run_id }}
@@ -518,7 +518,7 @@ jobs:
           BODY="$(cat <<HEREDOC
           ## Benchmark Results --- ${DATE}
 
-          **Commit:** \`${COMMIT}\` on \`master\`
+          **Commit:** \`${COMMIT}\` on \`main\`
           **Runner:** \`ubuntu-latest\` (matrix: agent x scenario)
           **Iterations:** ${{ env.ITERATIONS }} per cell
           **Dashboard:** https://strawgate.github.io/memagent/bench/

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -184,6 +184,14 @@ jobs:
             echo "- No shard artifacts captured." >>"$summary_file"
           fi
 
+          # Only open an issue when there are genuine seed failures.
+          # If shards failed due to infra/compile errors, total_fail_count and
+          # failed_shards will both be zero — skip the noisy empty report.
+          if [ "$total_fail_count" -eq 0 ] && [ "$failed_shards" -eq 0 ]; then
+            echo "No seed failures to report (shards may have failed for infra/compile reasons — check the run URL for details)."
+            exit 0
+          fi
+
           body_file="$(mktemp)"
           cat >"$body_file" <<EOF
           Nightly turmoil seed sweep failed.
@@ -213,15 +221,15 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo +nightly install cargo-fuzz
         env:
           RUSTC_WRAPPER: ""
       - name: Run fuzz targets
         run: |
           cd crates/logfwd-core
-          for target in $(cargo fuzz list 2>/dev/null); do
+          for target in $(cargo +nightly fuzz list 2>/dev/null); do
             echo "=== Fuzzing $target for 5 minutes ==="
-            cargo fuzz run "$target" -- -max_total_time=300
+            cargo +nightly fuzz run "$target" -- -max_total_time=300
           done
 
   fuzz-extended:
@@ -233,13 +241,13 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo +nightly install cargo-fuzz
         env:
           RUSTC_WRAPPER: ""
       - name: Run fuzz targets
         run: |
           cd crates/logfwd-core
-          for target in $(cargo fuzz list 2>/dev/null); do
+          for target in $(cargo +nightly fuzz list 2>/dev/null); do
             echo "=== Fuzzing $target for 30 minutes ==="
-            cargo fuzz run "$target" -- -max_total_time=1800
+            cargo +nightly fuzz run "$target" -- -max_total_time=1800
           done

--- a/crates/logfwd-bench/benches/file_io.rs
+++ b/crates/logfwd-bench/benches/file_io.rs
@@ -14,7 +14,8 @@ use std::io::Write;
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 use logfwd_bench::generators;
-use logfwd_core::cri::{CriReassembler, ReassembleResult, parse_cri_line};
+use logfwd_core::cri::{CriReassembler, parse_cri_line};
+use logfwd_core::reassembler::AggregateResult;
 use logfwd_core::framer::NewlineFramer;
 
 // ---------------------------------------------------------------------------
@@ -146,15 +147,15 @@ fn bench_cri_framing(c: &mut Criterion) {
                         let end =
                             memchr::memchr(b'\n', &buf[start..]).map_or(buf.len(), |p| start + p);
                         if let Some(cri) = parse_cri_line(&buf[start..end]) {
-                            match reassembler.feed(&cri) {
-                                ReassembleResult::Complete(msg)
-                                | ReassembleResult::Truncated(msg) => {
+                            match reassembler.feed(cri.message, cri.is_full) {
+                                AggregateResult::Complete(msg)
+                                | AggregateResult::Truncated(msg) => {
                                     json_buf.extend_from_slice(msg);
                                     json_buf.push(b'\n');
                                     count += 1;
                                     reassembler.reset();
                                 }
-                                ReassembleResult::Pending => {}
+                                AggregateResult::Pending => {}
                             }
                         }
                         start = end + 1;

--- a/crates/logfwd-bench/benches/full_chain.rs
+++ b/crates/logfwd-bench/benches/full_chain.rs
@@ -13,7 +13,8 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 
 use logfwd_arrow::scanner::Scanner;
 use logfwd_bench::{NullSink, generators, make_otlp_sink};
-use logfwd_core::cri::{CriReassembler, ReassembleResult, parse_cri_line};
+use logfwd_core::cri::{CriReassembler, parse_cri_line};
+use logfwd_core::reassembler::AggregateResult;
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_output::Compression;
 use logfwd_transform::SqlTransform;
@@ -30,13 +31,13 @@ fn cri_to_json(data: &[u8], reassembler: &mut CriReassembler, json_buf: &mut Vec
     while start < data.len() {
         let end = memchr::memchr(b'\n', &data[start..]).map_or(data.len(), |p| start + p);
         if let Some(cri) = parse_cri_line(&data[start..end]) {
-            match reassembler.feed(&cri) {
-                ReassembleResult::Complete(msg) | ReassembleResult::Truncated(msg) => {
+            match reassembler.feed(cri.message, cri.is_full) {
+                AggregateResult::Complete(msg) | AggregateResult::Truncated(msg) => {
                     json_buf.extend_from_slice(msg);
                     json_buf.push(b'\n');
                     reassembler.reset();
                 }
-                ReassembleResult::Pending => {}
+                AggregateResult::Pending => {}
             }
         }
         start = end + 1;


### PR DESCRIPTION
## Fixes

### 1. `logfwd-bench` compile errors (Issue #2161)
`ReassembleResult` was renamed to `AggregateResult` and `CriReassembler::feed()` signature changed from `feed(&CriLine)` to `feed(message, is_full)`. Updated `full_chain.rs` and `file_io.rs`.

### 2. `bench.yml`: `master` → `main` (Issue #2161)
The bench-data branch commit gate and issue body text still referenced `master`. The repo default branch is `main`.

### 3. Turmoil report: skip empty issues (Issue #2141)
The failure report job was posting issues even when 0 seeds failed and 0 artifacts were captured — happening when shards failed for infra/compile reasons. Added guard: skip issue creation when both `total_fail_count` and `failed_shards` are 0.

### 4. Fuzz jobs: use `cargo +nightly fuzz`
`rust-toolchain.toml` pins `stable`, which overrides the `dtolnay/rust-toolchain@nightly` action. `cargo fuzz` requires nightly for `-Zsanitizer=address`. Fixed by using `cargo +nightly fuzz` explicitly in both `fuzz-short` and `fuzz-extended` jobs.

Closes #2141
Relates to #2161

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix nightly bench compile errors, branch references, turmoil noise, and fuzz toolchain
> - Updates bench files ([file_io.rs](https://github.com/strawgate/memagent/pull/2173/files#diff-527ae735134b6fdf62fe779ce8561ed21ce698e20bca37cae9c138cb2230db9a), [full_chain.rs](https://github.com/strawgate/memagent/pull/2173/files#diff-71527d59cf3f4a5e9bb7225070cf2d3f0f3c4455bcefb5d1979999c5aec4a4d1)) to use the new `CriReassembler.feed(message, is_full)` API and `AggregateResult` enum instead of the removed `ReassembleResult`.
> - Changes branch references in [bench.yml](https://github.com/strawgate/memagent/pull/2173/files#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7) and [nightly-testing.yml](https://github.com/strawgate/memagent/pull/2173/files#diff-f9941ccca923bf4b7a47243d258bc06d456585fd74b6b26a0594a29463b56657) from `master` to `main`.
> - Fuzz jobs now explicitly use the nightly toolchain (`cargo +nightly fuzz ...`) for install, list, and run steps.
> - Skips opening a GitHub issue in the TLA+ PipelineMachine nightly job when there are no failures or failed shards.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1926b77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->