### PR TITLE
fix(ci): cancel stale CI runs on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: # manual trigger
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: e2e-${{ github.head_ref || github.run_id }}
+  group: e2e-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary
- Fix CI concurrency group key so main pushes cancel stale in-progress runs
- Affects: `ci.yml`, `e2e.yml`, `compliance.yml`

## Problem
The concurrency group used `github.head_ref || github.run_id`. For push events to main, `head_ref` is empty, so each push got a unique group via `run_id` — nothing ever cancelled. This caused 20+ CI runs to queue up when merging PRs in batches.

## Fix
Changed to `github.head_ref || github.ref`:
- **PRs**: `head_ref` = branch name (unchanged behavior, cancels stale PR runs)
- **Main pushes**: `github.ref` = `refs/heads/main` (new: stale main runs get cancelled)

`docs.yml` already used `github.ref` correctly — aligned the others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cancel stale CI runs on main branch pushes
> Replaces `github.run_id` with `github.ref` in the concurrency group expression across [ci.yml](.github/workflows/ci.yml), [compliance.yml](.github/workflows/compliance.yml), and [e2e.yml](.github/workflows/e2e.yml). Previously, non-PR (e.g. main branch) pushes each got a unique concurrency group, so stale runs were never cancelled. Now they share a group by ref, matching the behavior already applied to PRs via `github.head_ref`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 588cd2a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->