### PR TITLE
fix(runtime): make pprof init non-fatal when profiling is unavailable

### DIFF
--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -106,15 +106,18 @@ pub async fn run_pipelines(
     let profiler = dhat::Profiler::new_heap();
 
     #[cfg(feature = "cpu-profiling")]
-    let pprof_guard = pprof::ProfilerGuardBuilder::default()
-        .frequency(999)
-        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
-        .build()
-        .map_err(|e| {
-            RuntimeError::Io(io::Error::other(format!(
-                "failed to initialize pprof profiler: {e}"
-            )))
-        })?;
+    let pprof_guard: Option<pprof::ProfilerGuard<'static>> =
+        match pprof::ProfilerGuardBuilder::default()
+            .frequency(999)
+            .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+            .build()
+        {
+            Ok(guard) => Some(guard),
+            Err(e) => {
+                eprintln!("warn: cpu profiling unavailable, continuing without it: {e}");
+                None
+            }
+        };
 
     let shutdown_for_signal = shutdown.clone();
     let use_color = options.use_color;
@@ -148,8 +151,8 @@ pub async fn run_pipelines(
         }
 
         #[cfg(feature = "cpu-profiling")]
-        {
-            if let Ok(report) = _pprof_to_drop.report().build() {
+        if let Some(guard) = _pprof_to_drop {
+            if let Ok(report) = guard.report().build() {
                 // Write flamegraph for local/quick inspection
                 if let Ok(file) = std::fs::File::create("flamegraph.svg") {
                     if let Err(e) = report.flamegraph(file) {


### PR DESCRIPTION
## Summary

pprof's `ProfilerGuardBuilder::build()` calls `perf_event_open` which is blocked by the `RuntimeDefault` seccomp profile in Kubernetes pods. Previously this caused logfwd to crash at startup with:

```
error: failed to initialize pprof profiler: create profiler error
```

This was breaking all logfwd benchmark lanes in the e2e kind harness (all pods entering CrashLoopBackOff).

## Fix

Change the guard from a hard `?` propagation to `Option<ProfilerGuard>`. When initialization fails, log a warning to stderr and continue without CPU profiling. Profiles are only collected on shutdown if initialization succeeded.

## Test Plan

- Built locally with `--features cpu-profiling`: compiles clean
- Existing CI runs without the feature are unaffected (cfg-gated)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make pprof profiler initialization non-fatal in `run_pipelines`
> Previously, a failure to initialize `pprof::ProfilerGuard` caused `run_pipelines` to return an error. Now it prints a warning to stderr and continues with profiling disabled. Flamegraph and pprof report generation at shutdown only runs when the guard was successfully created.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized af0f167.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->