### PR TITLE
fix(ci): add flate2 to machete ignore list

### DIFF
--- a/crates/logfwd-runtime/Cargo.toml
+++ b/crates/logfwd-runtime/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 doctest = false
 
 [package.metadata.cargo-machete]
-ignored = ["turmoil"]
+ignored = ["turmoil", "flate2"]  # flate2 is optional (cpu-profiling feature)
 
 [features]
 default = ["datafusion"]


### PR DESCRIPTION
flate2 is optional (behind `cpu-profiling` feature). cargo-machete reports it as unused, breaking lint on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `flate2` to cargo-machete ignore list in `logfwd-runtime`
> Adds `flate2` to the `[package.metadata.cargo-machete]` ignored list in [Cargo.toml](https://github.com/strawgate/memagent/pull/2212/files#diff-a46fda5a81299dc8bb77daf4fb4c38aec15ebe7cd01474bb187d97e9f6488a00) to prevent false-positive unused-dependency warnings. The dependency is only activated via the `cpu-profiling` optional feature, which machete does not detect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e8706a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->