### PR TITLE
fix(ci): add 'learn' to docs link check exclude

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
             --root-dir .
             --exclude 'mailto:'
             --exclude-loopback
-            --exclude '^file:///.*/(architecture|configuration|deployment|development|getting-started|how-it-works|quick-start|troubleshooting)(/|#|$)'
+            --exclude '^file:///.*/(architecture|configuration|deployment|development|getting-started|how-it-works|learn|quick-start|troubleshooting)(/|#|$)'
             --exclude '^https://opentelemetry.io/docs/'
             README.md book/src/content/docs dev-docs docs
 


### PR DESCRIPTION
Docs restore (#2211) moved pages back to learn/ but lychee exclude pattern still only had how-it-works/. Adds learn to the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'learn' to docs link checker exclude list in CI
> Updates the lychee `--exclude` regex in [docs.yml](.github/workflows/docs.yml) to skip links under `learn` path sections, matching the pattern used for other doc sections like `architecture` and `quick-start`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0583f85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->