### PR TITLE
fix(s3): deadlock in parallel range-GET delivery and EOF panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,7 @@ dependencies = [
  "logfwd-test-utils",
  "logfwd-types",
  "memchr",
+ "mockito",
  "notify",
  "opentelemetry-proto",
  "proptest",

--- a/crates/logfwd-bench/benches/s3_input.rs
+++ b/crates/logfwd-bench/benches/s3_input.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
-#[cfg(feature = "s3")]
 use logfwd_io::s3_input::client::S3Client;
 
 // ── MinIO connection helpers ───────────────────────────────────────────────
@@ -35,7 +34,6 @@ fn minio_secret_key() -> String {
 const BENCH_BUCKET: &str = "logfwd-bench";
 
 /// Returns `None` if MinIO is unreachable.
-#[cfg(feature = "s3")]
 fn try_connect_minio() -> Option<Arc<S3Client>> {
     let client = S3Client::new(
         BENCH_BUCKET,
@@ -51,7 +49,6 @@ fn try_connect_minio() -> Option<Arc<S3Client>> {
 }
 
 /// Create a test bucket and upload objects for benchmarking.
-#[cfg(feature = "s3")]
 async fn setup_bench_objects() -> Option<()> {
     let endpoint = minio_endpoint();
     let access_key = minio_access_key();
@@ -106,7 +103,6 @@ fn generate_log_bytes(size: usize) -> Vec<u8> {
 
 // ── Benchmarks ────────────────────────────────────────────────────────────
 
-#[cfg(feature = "s3")]
 fn bench_s3_download(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(4)
@@ -182,14 +178,28 @@ fn bench_s3_download(c: &mut Criterion) {
                 });
             },
         );
+
+        // Streaming parallel range-GET (channels + JoinSet).
+        group.bench_with_input(BenchmarkId::new("stream_parallel", label), label, |b, _| {
+            let client = Arc::clone(&client);
+            let key = *key;
+            let size = *size;
+            b.to_async(&rt).iter(|| async {
+                let part = 2 * 1024 * 1024u64;
+                logfwd_io::s3_input::fetch_parallel_stream_bench(
+                    Arc::clone(&client),
+                    key,
+                    size,
+                    part,
+                    8,
+                )
+                .await
+                .expect("streaming bench should succeed");
+            });
+        });
     }
 
     group.finish();
-}
-
-#[cfg(not(feature = "s3"))]
-fn bench_s3_download(_c: &mut Criterion) {
-    eprintln!("s3_bench: compiled without 's3' feature — no S3 benchmarks");
 }
 
 criterion_group!(benches, bench_s3_download);

--- a/crates/logfwd-bench/src/es_throughput.rs
+++ b/crates/logfwd-bench/src/es_throughput.rs
@@ -283,7 +283,7 @@ fn run_scenario(
         "  raw payload : {raw_mb:>9.1} MB  ({:.1} MB/s)",
         raw_mb / elapsed
     );
-    println!("  wire bytes  : {wire_mb:>9.1} MB  (ratio {ratio:.1}x)",);
+    println!("  wire bytes  : {wire_mb:>9.1} MB  (ratio {ratio:.1}x)");
 }
 
 fn main() {

--- a/crates/logfwd-competitive-bench/src/rate_bench.rs
+++ b/crates/logfwd-competitive-bench/src/rate_bench.rs
@@ -255,7 +255,7 @@ fn write_at_rate(path: &Path, eps: u64, stop: &AtomicBool, written: &AtomicU64) 
         }
     } else {
         // Rate-limited mode.
-        let interval = Duration::from_nanos(1_000_000_000 / eps);
+        let interval = Duration::from_nanos(1_000_000_000u64.checked_div(eps).unwrap_or(0));
         let mut next = Instant::now();
         while !stop.load(Ordering::Relaxed) {
             let now = Instant::now();

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -860,19 +860,15 @@ impl Config {
                     // Validate compression values per output type (#1876).
                     if let Some(c) = output.compression.as_deref() {
                         match output.output_type {
-                            OutputType::Otlp => {
-                                if !matches!(c, "zstd" | "gzip" | "none") {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' output '{label}': otlp compression must be 'zstd', 'gzip', or 'none', got '{c}'"
-                                    )));
-                                }
+                            OutputType::Otlp if !matches!(c, "zstd" | "gzip" | "none") => {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' output '{label}': otlp compression must be 'zstd', 'gzip', or 'none', got '{c}'"
+                                )));
                             }
-                            OutputType::Elasticsearch => {
-                                if !matches!(c, "gzip" | "none") {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' output '{label}': elasticsearch compression must be 'gzip' or 'none', got '{c}'"
-                                    )));
-                                }
+                            OutputType::Elasticsearch if !matches!(c, "gzip" | "none") => {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' output '{label}': elasticsearch compression must be 'gzip' or 'none', got '{c}'"
+                                )));
                             }
                             // ArrowIpc allows zstd/none and is validated above.
                             // Other types either reject compression entirely or accept any.

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -556,7 +556,7 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
         _ => return None,
     };
 
-    let total_secs = (days as i64)
+    let total_secs = days
         .checked_mul(86_400)?
         .checked_add(hour as i64 * 3600)?
         .checked_add(min as i64 * 60)?

--- a/crates/logfwd-diagnostics/src/diagnostics/server.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics/server.rs
@@ -504,11 +504,9 @@ fn status_payload(state: &DiagnosticsState) -> StatusSnapshotResponse {
             attempts += 1;
         }
 
-        let batch_latency_avg_ns = if latency_batches > 0 {
-            batch_latency_total / latency_batches
-        } else {
-            0
-        };
+        let batch_latency_avg_ns = batch_latency_total
+            .checked_div(latency_batches)
+            .unwrap_or(0);
         let inflight = pm.inflight_batches.load(Ordering::Relaxed);
         let backpressure = pm.backpressure_stalls.load(Ordering::Relaxed);
         let transform_health = policy::transform_health(pm);

--- a/crates/logfwd-diagnostics/src/stderr_capture.rs
+++ b/crates/logfwd-diagnostics/src/stderr_capture.rs
@@ -343,17 +343,15 @@ fn strip_ansi(s: &str) -> String {
                         }
                     }
                 }
-                Some(c2) => {
+                Some(c2) if !c2.is_ascii_alphabetic() => {
                     // CSI or other sequence: skip until alphabetic terminator.
-                    if !c2.is_ascii_alphabetic() {
-                        for c3 in chars.by_ref() {
-                            if c3.is_ascii_alphabetic() {
-                                break;
-                            }
+                    for c3 in chars.by_ref() {
+                        if c3.is_ascii_alphabetic() {
+                            break;
                         }
                     }
                 }
-                None => {}
+                Some(_) | None => {}
             }
         } else {
             out.push(c);

--- a/crates/logfwd-diagnostics/src/telemetry_buffer.rs
+++ b/crates/logfwd-diagnostics/src/telemetry_buffer.rs
@@ -42,7 +42,7 @@ pub struct RingBuffer<T> {
 
 impl<T: fmt::Debug> fmt::Debug for RingBuffer<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let len = self.inner.lock().map(|b| b.len()).unwrap_or(0);
+        let len = self.inner.lock().map_or(0, |b| b.len());
         write!(f, "RingBuffer({len}/{})", self.capacity)
     }
 }

--- a/crates/logfwd-io/Cargo.toml
+++ b/crates/logfwd-io/Cargo.toml
@@ -79,6 +79,7 @@ sensor-ebpf-common = { path = "../logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-comm
 chrono = { workspace = true }
 dhat = "0.3"
 logfwd-test-utils = { version = "0.1.0", path = "../logfwd-test-utils" }
+mockito = "1.7.2"
 proptest = "1"
 proptest-state-machine = "0.8"
 serial_test = "3"

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -373,11 +373,7 @@ async fn handle_arrow_ipc_request(
     let mut send_error: Option<StatusCode> = None;
     let mut sent_rows = false;
     let total_batch_count = batches.iter().filter(|batch| batch.num_rows() > 0).count() as u64;
-    let per_batch_accounted_bytes = if total_batch_count == 0 {
-        0
-    } else {
-        raw_body_len / total_batch_count
-    };
+    let per_batch_accounted_bytes = raw_body_len.checked_div(total_batch_count).unwrap_or(0);
     let mut emitted_count = 0_u64;
     for batch in batches {
         if batch.num_rows() == 0 {

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -368,6 +368,15 @@ impl InputSource for FramedInput {
                                 });
                             }
                         }
+                        // Reclaim per-source state after EOF. For S3/TCP
+                        // sources EOF is terminal — the SourceId is never
+                        // reused. For file-tail, EOF fires on idle; if the
+                        // file grows again, a fresh SourceState is created on
+                        // the next Data event. The remainder was already
+                        // flushed above, so checkpoint_data() correctly falls
+                        // back to the raw file offset (no remainder to
+                        // subtract).
+                        self.sources.remove(&key);
                     }
                 }
             }
@@ -1641,5 +1650,51 @@ mod tests {
 
         let out = collect_data(framed.poll().unwrap());
         assert_eq!(out, b"{\"msg\":\"hello\"}\n");
+    }
+
+    /// EndOfFile must reclaim per-source state so long-running inputs (S3)
+    /// don't accumulate dead entries in the `sources` HashMap.
+    #[test]
+    fn eof_removes_source_state() {
+        let stats = make_stats();
+        let sid = SourceId(42);
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: b"hello\npartial".to_vec(),
+                source_id: Some(sid),
+                accounted_bytes: 13,
+            }],
+            vec![InputEvent::EndOfFile {
+                source_id: Some(sid),
+            }],
+            // New data for the same SourceId after EOF — must work.
+            vec![InputEvent::Data {
+                bytes: b"world\n".to_vec(),
+                source_id: Some(sid),
+                accounted_bytes: 6,
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(stats.clone()),
+            stats,
+        );
+
+        // Poll 1: "hello\n" emitted, "partial" in remainder.
+        let events1 = framed.poll().unwrap();
+        assert_eq!(collect_data(events1), b"hello\n");
+        assert!(framed.sources.contains_key(&Some(sid)));
+
+        // Poll 2: EOF flushes "partial\n" and removes source state.
+        let events2 = framed.poll().unwrap();
+        assert_eq!(collect_data(events2), b"partial\n");
+        assert!(
+            !framed.sources.contains_key(&Some(sid)),
+            "source state should be removed after EOF"
+        );
+
+        // Poll 3: new data for the same SourceId creates fresh state.
+        let events3 = framed.poll().unwrap();
+        assert_eq!(collect_data(events3), b"world\n");
     }
 }

--- a/crates/logfwd-io/src/host_metrics.rs
+++ b/crates/logfwd-io/src/host_metrics.rs
@@ -138,9 +138,9 @@ pub struct HostMetricsConfig {
 impl Default for HostMetricsConfig {
     fn default() -> Self {
         Self {
-            poll_interval: Duration::from_millis(10_000),
+            poll_interval: Duration::from_secs(10),
             control_path: None,
-            control_reload_interval: Duration::from_millis(1_000),
+            control_reload_interval: Duration::from_secs(1),
             enabled_families: None,
             emit_signal_rows: true,
             max_rows_per_poll: 256,
@@ -717,7 +717,7 @@ impl HostMetricsCommon {
         limit: usize,
     ) -> usize {
         let mut ifaces: Vec<_> = self.networks.iter().collect();
-        ifaces.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
+        ifaces.sort_unstable_by_key(|(a, _)| *a);
 
         let mut emitted = 0usize;
         for (iface, data) in ifaces.into_iter().take(limit) {

--- a/crates/logfwd-io/src/otlp_receiver/convert.rs
+++ b/crates/logfwd-io/src/otlp_receiver/convert.rs
@@ -177,10 +177,10 @@ fn append_attribute_value_by_idx(
         Some(Value::BoolValue(v)) => builder.append_bool_by_idx(idx, *v),
         Some(Value::StringValue(v)) => builder.append_prevalidated_str_by_idx(idx, v),
         Some(Value::BytesValue(v)) => append_hex_field(builder, idx, v, hex_buf),
-        Some(Value::ArrayValue(_)) | Some(Value::KvlistValue(_)) => {
-            if write_any_value_to_json_buf(value, json_buf) {
-                builder.append_decoded_str_by_idx(idx, json_buf);
-            }
+        Some(Value::ArrayValue(_)) | Some(Value::KvlistValue(_))
+            if write_any_value_to_json_buf(value, json_buf) =>
+        {
+            builder.append_decoded_str_by_idx(idx, json_buf);
         }
         _ => {}
     }
@@ -207,10 +207,10 @@ fn append_any_value_as_string(
             builder.append_decoded_str_by_idx(idx, if *v { b"true" } else { b"false" });
         }
         Some(Value::BytesValue(v)) => append_hex_field(builder, idx, v, hex_buf),
-        Some(Value::ArrayValue(_)) | Some(Value::KvlistValue(_)) => {
-            if write_any_value_to_json_buf(value, json_buf) {
-                builder.append_decoded_str_by_idx(idx, json_buf);
-            }
+        Some(Value::ArrayValue(_)) | Some(Value::KvlistValue(_))
+            if write_any_value_to_json_buf(value, json_buf) =>
+        {
+            builder.append_decoded_str_by_idx(idx, json_buf);
         }
         _ => {}
     }

--- a/crates/logfwd-io/src/s3_input/client.rs
+++ b/crates/logfwd-io/src/s3_input/client.rs
@@ -726,15 +726,13 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
                     capture = None;
                 }
             }
-            Ok(Event::End(e)) => {
-                if e.local_name().as_ref() == b"Contents" && in_contents {
-                    objects.push(S3Object {
-                        key: current_key.clone(),
-                        size: current_size,
-                    });
-                    in_contents = false;
-                    capture = None;
-                }
+            Ok(Event::End(e)) if e.local_name().as_ref() == b"Contents" && in_contents => {
+                objects.push(S3Object {
+                    key: current_key.clone(),
+                    size: current_size,
+                });
+                in_contents = false;
+                capture = None;
             }
             Ok(Event::Eof) => break,
             Err(e) => {

--- a/crates/logfwd-io/src/s3_input/client.rs
+++ b/crates/logfwd-io/src/s3_input/client.rs
@@ -17,6 +17,21 @@ type HmacSha256 = Hmac<Sha256>;
 /// SHA-256 of an empty body — used for GET / HEAD requests.
 const EMPTY_BODY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
+/// Max bytes of a response body to include in error messages.
+const ERROR_BODY_PREVIEW_LEN: usize = 1024;
+
+/// Read the response body text, truncated to [`ERROR_BODY_PREVIEW_LEN`] bytes
+/// to prevent large error responses from exhausting memory in error messages.
+async fn error_body_preview(resp: reqwest::Response) -> String {
+    let body = resp.text().await.unwrap_or_default();
+    if body.len() <= ERROR_BODY_PREVIEW_LEN {
+        body
+    } else {
+        let truncated = &body[..ERROR_BODY_PREVIEW_LEN];
+        format!("{truncated}... (truncated)")
+    }
+}
+
 /// A single object returned by `ListObjectsV2`.
 #[derive(Debug)]
 pub struct S3Object {
@@ -330,7 +345,7 @@ impl S3Client {
             )));
         }
         if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
+            let body = error_body_preview(resp).await;
             return Err(io::Error::other(format!(
                 "S3 GET range {key}: HTTP {status}: {body}"
             )));
@@ -359,7 +374,7 @@ impl S3Client {
 
         let status = resp.status();
         if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
+            let body = error_body_preview(resp).await;
             return Err(io::Error::other(format!(
                 "S3 GET {key}: HTTP {status}: {body}"
             )));
@@ -390,7 +405,7 @@ impl S3Client {
 
         let status = resp.status();
         if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
+            let body = error_body_preview(resp).await;
             return Err(io::Error::other(format!(
                 "S3 GET stream {key}: HTTP {status}: {body}"
             )));
@@ -433,7 +448,7 @@ impl S3Client {
             )));
         }
         if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
+            let body = error_body_preview(resp).await;
             return Err(io::Error::other(format!(
                 "S3 GET range stream {key}: HTTP {status}: {body}"
             )));
@@ -533,7 +548,7 @@ impl S3Client {
 
         let status = resp.status();
         if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
+            let body = error_body_preview(resp).await;
             return Err(io::Error::other(format!(
                 "S3 PUT {key}: HTTP {status}: {body}"
             )));
@@ -572,7 +587,7 @@ impl S3Client {
         let status = resp.status();
         // 200 OK or 409 Conflict (BucketAlreadyOwnedByYou) are both fine.
         if !status.is_success() && status.as_u16() != 409 {
-            let body = resp.text().await.unwrap_or_default();
+            let body = error_body_preview(resp).await;
             return Err(io::Error::other(format!(
                 "S3 create bucket: HTTP {status}: {body}"
             )));
@@ -644,7 +659,7 @@ impl S3Client {
 
         let status = resp.status();
         if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
+            let body = error_body_preview(resp).await;
             return Err(io::Error::other(format!(
                 "S3 ListObjectsV2: HTTP {status}: {body}"
             )));

--- a/crates/logfwd-io/src/s3_input/client.rs
+++ b/crates/logfwd-io/src/s3_input/client.rs
@@ -27,7 +27,9 @@ async fn error_body_preview(resp: reqwest::Response) -> String {
     if body.len() <= ERROR_BODY_PREVIEW_LEN {
         body
     } else {
-        let truncated = &body[..ERROR_BODY_PREVIEW_LEN];
+        // Find a valid UTF-8 char boundary at or before the limit.
+        let end = body.floor_char_boundary(ERROR_BODY_PREVIEW_LEN);
+        let truncated = &body[..end];
         format!("{truncated}... (truncated)")
     }
 }

--- a/crates/logfwd-io/src/s3_input/client.rs
+++ b/crates/logfwd-io/src/s3_input/client.rs
@@ -28,7 +28,10 @@ async fn error_body_preview(resp: reqwest::Response) -> String {
         body
     } else {
         // Find a valid UTF-8 char boundary at or before the limit.
-        let end = body.floor_char_boundary(ERROR_BODY_PREVIEW_LEN);
+        let mut end = ERROR_BODY_PREVIEW_LEN;
+        while end > 0 && !body.is_char_boundary(end) {
+            end -= 1;
+        }
         let truncated = &body[..end];
         format!("{truncated}... (truncated)")
     }

--- a/crates/logfwd-io/src/s3_input/decompress.rs
+++ b/crates/logfwd-io/src/s3_input/decompress.rs
@@ -118,9 +118,7 @@ impl AsyncRead for ErrorAwareReader {
         match Pin::new(&mut this.inner).poll_read(cx, buf) {
             Poll::Ready(Ok(())) if buf.filled().len() == before => {
                 // Zero-length read (EOF) — check if the producer stored an error.
-                if let Ok(mut guard) = this.error.lock()
-                    && let Some(err) = guard.take()
-                {
+                if let Some(err) = this.error.lock().unwrap_or_else(|p| p.into_inner()).take() {
                     return Poll::Ready(Err(err));
                 }
                 Poll::Ready(Ok(()))

--- a/crates/logfwd-io/src/s3_input/decompress.rs
+++ b/crates/logfwd-io/src/s3_input/decompress.rs
@@ -118,7 +118,12 @@ impl AsyncRead for ErrorAwareReader {
         match Pin::new(&mut this.inner).poll_read(cx, buf) {
             Poll::Ready(Ok(())) if buf.filled().len() == before => {
                 // Zero-length read (EOF) — check if the producer stored an error.
-                if let Some(err) = this.error.lock().unwrap_or_else(|p| p.into_inner()).take() {
+                if let Some(err) = this
+                    .error
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .take()
+                {
                     return Poll::Ready(Err(err));
                 }
                 Poll::Ready(Ok(()))

--- a/crates/logfwd-io/src/s3_input/mod.rs
+++ b/crates/logfwd-io/src/s3_input/mod.rs
@@ -719,8 +719,11 @@ async fn run_list_discovery(
                                         warn!(name = %name, key = %kc.key, failures = *count,
                                               "S3 key exceeded max retries, skipping");
                                         completed_set.insert(kc.key.clone());
+                                        // Leave in in_flight so re-discovery skips it
+                                        // until the watermark advances past it.
+                                    } else {
+                                        in_flight.remove(&kc.key);
                                     }
-                                    in_flight.remove(&kc.key);
                                 }
                             }
 
@@ -741,8 +744,9 @@ async fn run_list_discovery(
                                             warn!(name = %name, key = %kc.key, failures = *count,
                                                   "S3 key exceeded max retries, skipping");
                                             completed_set.insert(kc.key.clone());
+                                        } else {
+                                            in_flight.remove(&kc.key);
                                         }
-                                        in_flight.remove(&kc.key);
                                     }
                                 }
                             }
@@ -766,8 +770,9 @@ async fn run_list_discovery(
                                 warn!(name = %name, key = %kc.key, failures = *count,
                                       "S3 key exceeded max retries, skipping");
                                 completed_set.insert(kc.key.clone());
+                            } else {
+                                in_flight.remove(&kc.key);
                             }
-                            in_flight.remove(&kc.key);
                         }
                     }
                     while let Some(front) = dispatched.front() {
@@ -1245,7 +1250,7 @@ async fn fetch_parallel_stream(
                     match resp_ok {
                         Some(r) => r,
                         None => {
-                            let _ = part_tx.send(Err(last_err.unwrap())).await;
+                            let _ = part_tx.send(Err(last_err.expect("last_err is Some when all attempts fail"))).await;
                             return;
                         }
                     }
@@ -1338,6 +1343,28 @@ async fn fetch_parallel_stream(
             if send_result.is_err() {
                 join_set.abort_all();
                 return Err(io::Error::other("output channel closed"));
+            }
+        }
+        // Check for panicked tasks before proceeding to the next part.
+        // A panicked task drops its sender without sending an error, so
+        // part_rx.recv() returns None — but partial/corrupt data may
+        // already have been forwarded. Abort immediately.
+        while let Some(result) = join_set.try_join_next() {
+            if let Err(e) = result {
+                if e.is_panic() {
+                    join_set.abort_all();
+                    if !first_chunk {
+                        let eof = ChunkPayload {
+                            bytes: Vec::new(),
+                            accounted_bytes: 0,
+                            source_id,
+                            is_eof: true,
+                        };
+                        let tx = out_tx.clone();
+                        let _ = tokio::task::spawn_blocking(move || tx.send(eof)).await;
+                    }
+                    return Err(io::Error::other(format!("range GET task panicked: {e}")));
+                }
             }
         }
         // Spawn the next part now that this one is fully delivered.

--- a/crates/logfwd-io/src/s3_input/mod.rs
+++ b/crates/logfwd-io/src/s3_input/mod.rs
@@ -1250,7 +1250,11 @@ async fn fetch_parallel_stream(
                     match resp_ok {
                         Some(r) => r,
                         None => {
-                            let _ = part_tx.send(Err(last_err.expect("last_err is Some when all attempts fail"))).await;
+                            let _ = part_tx
+                                .send(Err(
+                                    last_err.expect("last_err is Some when all attempts fail")
+                                ))
+                                .await;
                             return;
                         }
                     }
@@ -1350,21 +1354,21 @@ async fn fetch_parallel_stream(
         // part_rx.recv() returns None — but partial/corrupt data may
         // already have been forwarded. Abort immediately.
         while let Some(result) = join_set.try_join_next() {
-            if let Err(e) = result {
-                if e.is_panic() {
-                    join_set.abort_all();
-                    if !first_chunk {
-                        let eof = ChunkPayload {
-                            bytes: Vec::new(),
-                            accounted_bytes: 0,
-                            source_id,
-                            is_eof: true,
-                        };
-                        let tx = out_tx.clone();
-                        let _ = tokio::task::spawn_blocking(move || tx.send(eof)).await;
-                    }
-                    return Err(io::Error::other(format!("range GET task panicked: {e}")));
+            if let Err(e) = result
+                && e.is_panic()
+            {
+                join_set.abort_all();
+                if !first_chunk {
+                    let eof = ChunkPayload {
+                        bytes: Vec::new(),
+                        accounted_bytes: 0,
+                        source_id,
+                        is_eof: true,
+                    };
+                    let tx = out_tx.clone();
+                    let _ = tokio::task::spawn_blocking(move || tx.send(eof)).await;
                 }
+                return Err(io::Error::other(format!("range GET task panicked: {e}")));
             }
         }
         // Spawn the next part now that this one is fully delivered.
@@ -1414,6 +1418,32 @@ pub async fn fetch_parallel_bench(
     max_fetches: usize,
 ) -> io::Result<bytes::Bytes> {
     fetch_parallel_buffered(s3, key, size, part_size, max_fetches).await
+}
+
+/// Streaming parallel fetch benchmark entry point.
+///
+/// Returns the total bytes received. Exposed for benchmarking.
+pub async fn fetch_parallel_stream_bench(
+    s3: Arc<S3Client>,
+    key: &str,
+    size: u64,
+    part_size: u64,
+    max_fetches: usize,
+) -> io::Result<usize> {
+    let (tx, rx) = mpsc::sync_channel::<ChunkPayload>(16);
+    let key_owned = key.to_string();
+    let s3c = Arc::clone(&s3);
+    let handle = tokio::spawn(async move {
+        fetch_parallel_stream(s3c, &key_owned, size, part_size, max_fetches, tx).await
+    });
+    let mut total = 0usize;
+    while let Ok(chunk) = rx.recv() {
+        total += chunk.bytes.len();
+    }
+    handle
+        .await
+        .map_err(|e| io::Error::other(format!("join: {e}")))??;
+    Ok(total)
 }
 
 /// Buffered parallel fetch — kept for benchmarks that need the full Bytes result.

--- a/crates/logfwd-io/src/s3_input/mod.rs
+++ b/crates/logfwd-io/src/s3_input/mod.rs
@@ -41,7 +41,7 @@ use logfwd_types::diagnostics::ComponentHealth;
 use logfwd_types::pipeline::SourceId;
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
-use tracing::{error, warn};
+use tracing::{debug, error, warn};
 
 use crate::input::{InputEvent, InputSource};
 use client::S3Client;
@@ -433,6 +433,11 @@ impl S3Input {
 
                     discovery_handle.abort();
                 });
+
+                // Bounded shutdown: abort any lingering fetch tasks (e.g.
+                // stuck on a 300s reqwest timeout) instead of blocking
+                // indefinitely when the runtime drops.
+                rt.shutdown_timeout(std::time::Duration::from_secs(5));
             })
             .map_err(io::Error::other)?;
 
@@ -498,7 +503,23 @@ impl Drop for S3Input {
         // deadlock when we join the worker thread below.
         drop(self.rx.take());
         if let Some(handle) = self.thread_handle.take() {
-            let _ = handle.join();
+            // The background thread runs shutdown_timeout(5s) on its runtime,
+            // so it should exit within ~6s. Use a timed join to avoid blocking
+            // the pipeline shutdown indefinitely.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            loop {
+                if handle.is_finished() {
+                    let _ = handle.join();
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    // Thread is stuck — leak it rather than block shutdown.
+                    std::mem::forget(handle);
+                    warn!("S3 input background thread did not exit within deadline, leaking");
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
         }
     }
 }
@@ -619,6 +640,9 @@ async fn run_list_discovery(
     name: String,
     poll_interval_ms: u64,
 ) {
+    /// Maximum times a key can fail before being skipped.
+    const MAX_KEY_FAILURES: u32 = 5;
+
     let mut start_after: Option<String> = start_after_init;
     // Track dispatched keys in S3 sort order and completed keys.
     // Cursor only advances past the contiguous prefix of completed keys.
@@ -629,6 +653,10 @@ async fn run_list_discovery(
     // Keys stay in in_flight until the watermark cursor advances past them,
     // preventing re-discovery of completed-but-not-yet-cursored keys.
     let mut in_flight: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Per-key failure counter. Keys exceeding MAX_KEY_FAILURES are promoted
+    // to completed_set so the watermark cursor can advance past them.
+    let mut failure_counts: std::collections::HashMap<String, u32> =
+        std::collections::HashMap::new();
 
     while is_running.load(Ordering::Relaxed) {
         let mut continuation: Option<String> = None;
@@ -685,10 +713,13 @@ async fn run_list_discovery(
                                 if kc.success {
                                     completed_set.insert(kc.key);
                                 } else {
-                                    // Only remove from in_flight so the key can
-                                    // be re-dispatched on the next poll cycle.
-                                    // Keep it in dispatched so the watermark
-                                    // cursor does NOT advance past it.
+                                    let count = failure_counts.entry(kc.key.clone()).or_insert(0);
+                                    *count += 1;
+                                    if *count >= MAX_KEY_FAILURES {
+                                        warn!(name = %name, key = %kc.key, failures = *count,
+                                              "S3 key exceeded max retries, skipping");
+                                        completed_set.insert(kc.key.clone());
+                                    }
                                     in_flight.remove(&kc.key);
                                 }
                             }
@@ -704,6 +735,13 @@ async fn run_list_discovery(
                                     if kc.success {
                                         completed_set.insert(kc.key);
                                     } else {
+                                        let count = failure_counts.entry(kc.key.clone()).or_insert(0);
+                                        *count += 1;
+                                        if *count >= MAX_KEY_FAILURES {
+                                            warn!(name = %name, key = %kc.key, failures = *count,
+                                                  "S3 key exceeded max retries, skipping");
+                                            completed_set.insert(kc.key.clone());
+                                        }
                                         in_flight.remove(&kc.key);
                                     }
                                 }
@@ -722,6 +760,13 @@ async fn run_list_discovery(
                         if kc.success {
                             completed_set.insert(kc.key);
                         } else {
+                            let count = failure_counts.entry(kc.key.clone()).or_insert(0);
+                            *count += 1;
+                            if *count >= MAX_KEY_FAILURES {
+                                warn!(name = %name, key = %kc.key, failures = *count,
+                                      "S3 key exceeded max retries, skipping");
+                                completed_set.insert(kc.key.clone());
+                            }
                             in_flight.remove(&kc.key);
                         }
                     }
@@ -731,12 +776,11 @@ async fn run_list_discovery(
                             completed_set.remove(&key);
                             dispatched_set.remove(&key);
                             in_flight.remove(&key);
+                            failure_counts.remove(&key);
                             start_after = Some(key);
                         } else {
-                            // Stop at the first key that hasn't succeeded.
-                            // Failed keys stay in dispatched so the cursor
-                            // never advances past them, ensuring ListObjectsV2
-                            // re-discovers them on the next poll cycle.
+                            // Stop at the first key that hasn't completed
+                            // (successfully or via max-retry skip).
                             break;
                         }
                     }
@@ -774,6 +818,15 @@ async fn run_orchestrator(
     health: Arc<AtomicU8>,
     name: String,
 ) {
+    /// Maximum fetch attempts per object before giving up.
+    const MAX_FETCH_ATTEMPTS: u32 = 3;
+
+    // Deduplication: prevent concurrent fetches of the same key. SQS
+    // at-least-once delivery can dispatch duplicates; concurrent fetches
+    // share the same SourceId and corrupt FramedInput state.
+    let fetching_keys: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>> =
+        Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new()));
+
     while is_running.load(Ordering::Relaxed) {
         let work = tokio::select! {
             biased;
@@ -793,6 +846,37 @@ async fn run_orchestrator(
             },
         };
 
+        // Skip duplicate keys already being fetched concurrently.
+        let is_duplicate = {
+            let mut guard = fetching_keys.lock().await;
+            !guard.insert(work.key.clone())
+        };
+        if is_duplicate {
+            debug!(name = %name, key = %work.key, "skipping duplicate concurrent fetch");
+            // Decrement the message tracker so the SQS message can still
+            // be deleted when all non-duplicate records complete. Count
+            // the skip as a success since the key IS being processed.
+            if let Some(tracker) = &work.message_tracker {
+                tracker.successes.fetch_add(1, Ordering::AcqRel);
+                let prev = tracker.remaining.fetch_sub(1, Ordering::AcqRel);
+                if prev == 1 {
+                    let should_delete = {
+                        let mut guard = in_progress.lock().await;
+                        guard.retain(|h| h != &tracker.receipt_handle);
+                        let success_count = tracker.successes.load(Ordering::Acquire);
+                        success_count == tracker.total
+                    };
+                    if should_delete
+                        && let Some(sqs) = &sqs
+                        && let Err(e) = sqs.delete_message(&tracker.receipt_handle).await
+                    {
+                        warn!(name = %name, error = %e, "SQS delete message failed");
+                    }
+                }
+            }
+            continue;
+        }
+
         // Acquire semaphore to limit concurrent object fetches.
         let permit = match semaphore.clone().acquire_owned().await {
             Ok(p) => p,
@@ -806,30 +890,49 @@ async fn run_orchestrator(
         let out_tx = out_tx.clone();
         let health = Arc::clone(&health);
         let name = name.clone();
+        let fetching_keys = Arc::clone(&fetching_keys);
 
         tokio::spawn(async move {
             let _permit = permit; // released when task completes
 
-            if let Err(e) = fetch_object(
-                s3,
-                &work.key,
-                work.size,
-                part_size,
-                max_fetches,
-                compression_override,
-                out_tx,
-            )
-            .await
-            {
-                warn!(
-                    name = %name,
-                    key = %work.key,
-                    error = %e,
-                    "S3 fetch object failed"
-                );
+            // Retry with exponential backoff: 1s, 2s, 4s between attempts.
+            let mut last_err = None;
+            for attempt in 0..MAX_FETCH_ATTEMPTS {
+                if attempt > 0 {
+                    let delay_ms = 1000 * (1u64 << (attempt - 1));
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
+                match fetch_object(
+                    Arc::clone(&s3),
+                    &work.key,
+                    work.size,
+                    part_size,
+                    max_fetches,
+                    compression_override,
+                    out_tx.clone(),
+                )
+                .await
+                {
+                    Ok(()) => {
+                        last_err = None;
+                        break;
+                    }
+                    Err(e) => {
+                        warn!(
+                            name = %name,
+                            key = %work.key,
+                            attempt = attempt + 1,
+                            max_attempts = MAX_FETCH_ATTEMPTS,
+                            error = %e,
+                            "S3 fetch object failed"
+                        );
+                        last_err = Some(e);
+                    }
+                }
+            }
+
+            if last_err.is_some() {
                 health.store(ComponentHealth::Degraded.as_repr(), Ordering::Relaxed);
-                // Don't delete the SQS message — it will become visible again
-                // after the visibility timeout expires (once we stop heartbeating).
 
                 // Report failed key so list-mode can remove it from in_flight
                 // and retry on the next poll cycle.
@@ -887,6 +990,10 @@ async fn run_orchestrator(
                     }
                 }
             }
+
+            // Remove from dedup set so the key can be fetched again if
+            // re-dispatched (e.g. SQS redelivery after failure).
+            fetching_keys.lock().await.remove(&work.key);
         });
     }
 }
@@ -945,7 +1052,6 @@ async fn fetch_object(
 
     let source_id = source_id_from_key(key);
     let mut buf = vec![0u8; OUTPUT_CHUNK_SIZE];
-    let mut total_read: u64 = 0;
     let mut first = true;
     let mut sent_eof = false;
 
@@ -980,13 +1086,14 @@ async fn fetch_object(
             break; // EOF reached — no more data.
         }
 
-        total_read += filled as u64;
         let eof_reached = filled < buf.len();
 
         // Only charge accounted_bytes on the first chunk to avoid inflation.
+        // Use the S3 wire size (from HEAD / SQS notification) rather than
+        // decompressed bytes so bandwidth metrics reflect actual transfer.
         let ab = if first {
             first = false;
-            total_read
+            size
         } else {
             0
         };
@@ -1116,11 +1223,31 @@ async fn fetch_parallel_stream(
             let part_idx = idx;
 
             join_set.spawn(async move {
-                let resp = match s3.get_object_range_stream(&key_owned, start, end).await {
-                    Ok(r) => r,
-                    Err(e) => {
-                        let _ = part_tx.send(Err(e)).await;
-                        return;
+                // Retry the initial range-GET request up to 3 times.
+                // Mid-stream errors are NOT retried since partial data may
+                // have already been sent through part_tx.
+                let resp = {
+                    let mut last_err = None;
+                    let mut resp_ok = None;
+                    for attempt in 0..3u32 {
+                        if attempt > 0 {
+                            let delay_ms = 200 * (1u64 << (attempt - 1));
+                            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                        }
+                        match s3.get_object_range_stream(&key_owned, start, end).await {
+                            Ok(r) => {
+                                resp_ok = Some(r);
+                                break;
+                            }
+                            Err(e) => last_err = Some(e),
+                        }
+                    }
+                    match resp_ok {
+                        Some(r) => r,
+                        None => {
+                            let _ = part_tx.send(Err(last_err.unwrap())).await;
+                            return;
+                        }
                     }
                 };
                 let async_read = decompress::response_to_async_read(resp);

--- a/crates/logfwd-io/src/s3_input/mod.rs
+++ b/crates/logfwd-io/src/s3_input/mod.rs
@@ -1107,7 +1107,10 @@ async fn fetch_parallel_stream(
          s3: &Arc<S3Client>,
          key: &str| {
             let (start, end) = ranges[idx];
-            let part_tx = part_senders[idx].take().expect("part sender already taken");
+            let Some(part_tx) = part_senders[idx].take() else {
+                error!(part_idx = idx, "part sender already taken — skipping spawn");
+                return;
+            };
             let s3 = Arc::clone(s3);
             let key_owned = key.to_string();
             let part_idx = idx;

--- a/crates/logfwd-io/src/s3_input/mod.rs
+++ b/crates/logfwd-io/src/s3_input/mod.rs
@@ -1153,8 +1153,9 @@ async fn fetch_parallel_stream(
             });
         };
 
-    // Pre-spawn the first batch (up to max_fetches).
-    while next_to_spawn < num_parts && next_to_spawn < max_fetches {
+    // Pre-spawn the first batch (up to max_fetches, but at least 1).
+    let effective_max_fetches = max_fetches.max(1);
+    while next_to_spawn < num_parts && next_to_spawn < effective_max_fetches {
         spawn_part(
             &mut join_set,
             &mut part_senders,

--- a/crates/logfwd-io/src/s3_input/mod.rs
+++ b/crates/logfwd-io/src/s3_input/mod.rs
@@ -460,11 +460,16 @@ impl InputSource for S3Input {
                 break;
             };
             drained += 1;
-            events.push(InputEvent::Data {
-                bytes: payload.bytes,
-                source_id: Some(payload.source_id),
-                accounted_bytes: payload.accounted_bytes,
-            });
+            // Only emit Data when there are actual bytes — EOF-only markers
+            // carry empty bytes and sending them would cause the checkpoint
+            // tracker to panic on `n_bytes == 0`.
+            if !payload.bytes.is_empty() {
+                events.push(InputEvent::Data {
+                    bytes: payload.bytes,
+                    source_id: Some(payload.source_id),
+                    accounted_bytes: payload.accounted_bytes,
+                });
+            }
             if payload.is_eof {
                 events.push(InputEvent::EndOfFile {
                     source_id: Some(payload.source_id),
@@ -1070,76 +1075,97 @@ async fn fetch_parallel_stream(
     }
 
     let source_id = source_id_from_key(key);
-    let fetch_sem = Arc::new(Semaphore::new(max_fetches));
 
     // Per-part bounded channels. 4 × 256 KiB = 1 MiB buffer per part.
     const PART_CHANNEL_BOUND: usize = 4;
+    let num_parts = ranges.len();
+    let mut part_senders: Vec<Option<tokio::sync::mpsc::Sender<io::Result<Vec<u8>>>>> =
+        Vec::with_capacity(num_parts);
     let mut part_receivers: Vec<tokio::sync::mpsc::Receiver<io::Result<Vec<u8>>>> =
-        Vec::with_capacity(ranges.len());
+        Vec::with_capacity(num_parts);
+    for _ in 0..num_parts {
+        let (tx, rx) = tokio::sync::mpsc::channel(PART_CHANNEL_BOUND);
+        part_senders.push(Some(tx));
+        part_receivers.push(rx);
+    }
+
     let mut join_set: JoinSet<()> = JoinSet::new();
 
-    // Spawn all part tasks immediately. Permit acquisition happens inside
-    // each task so the main loop can start reading from `part_receivers`
-    // without waiting. Without this, acquiring permits in the spawn loop
-    // deadlocks when `ranges.len() > max_fetches` because tasks fill their
-    // bounded channels before the main loop starts draining them.
-    for (part_idx, (start, end)) in ranges.iter().copied().enumerate() {
-        let (part_tx, part_rx) = tokio::sync::mpsc::channel(PART_CHANNEL_BOUND);
-        part_receivers.push(part_rx);
+    // Spawn a helper to launch part downloads. `spawn_part` is a local
+    // closure that takes ownership of the per-part sender and starts the
+    // range-GET task. We call it for the initial batch and again each time
+    // the delivery loop finishes draining a part — this ensures at most
+    // `max_fetches` concurrent HTTP connections and avoids the semaphore
+    // priority-inversion deadlock that occurs when all tasks race for
+    // permits in random order.
+    let mut next_to_spawn: usize = 0;
+    let spawn_part =
+        |join_set: &mut JoinSet<()>,
+         part_senders: &mut [Option<tokio::sync::mpsc::Sender<io::Result<Vec<u8>>>>],
+         idx: usize,
+         ranges: &[(u64, u64)],
+         s3: &Arc<S3Client>,
+         key: &str| {
+            let (start, end) = ranges[idx];
+            let part_tx = part_senders[idx].take().expect("part sender already taken");
+            let s3 = Arc::clone(s3);
+            let key_owned = key.to_string();
+            let part_idx = idx;
 
-        let fetch_sem = Arc::clone(&fetch_sem);
-        let s3 = Arc::clone(&s3);
-        let key_owned = key.to_string();
+            join_set.spawn(async move {
+                let resp = match s3.get_object_range_stream(&key_owned, start, end).await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let _ = part_tx.send(Err(e)).await;
+                        return;
+                    }
+                };
+                let async_read = decompress::response_to_async_read(resp);
+                tokio::pin!(async_read);
 
-        join_set.spawn(async move {
-            let _permit = match fetch_sem.acquire_owned().await {
-                Ok(p) => p,
-                Err(e) => {
-                    let _ = part_tx
-                        .send(Err(io::Error::other(format!("semaphore acquire: {e}"))))
-                        .await;
-                    return;
-                }
-            };
-
-            let resp = match s3.get_object_range_stream(&key_owned, start, end).await {
-                Ok(r) => r,
-                Err(e) => {
-                    let _ = part_tx.send(Err(e)).await;
-                    return;
-                }
-            };
-            let async_read = decompress::response_to_async_read(resp);
-            tokio::pin!(async_read);
-
-            let mut buf = vec![0u8; OUTPUT_CHUNK_SIZE];
-            loop {
-                let mut filled = 0;
-                while filled < buf.len() {
-                    match async_read.read(&mut buf[filled..]).await {
-                        Ok(0) => break,
-                        Ok(n) => filled += n,
-                        Err(e) => {
-                            let _ = part_tx
-                                .send(Err(io::Error::other(format!(
-                                    "range GET stream part {part_idx}: {e}"
-                                ))))
-                                .await;
-                            return;
+                let mut buf = vec![0u8; OUTPUT_CHUNK_SIZE];
+                loop {
+                    let mut filled = 0;
+                    while filled < buf.len() {
+                        match async_read.read(&mut buf[filled..]).await {
+                            Ok(0) => break,
+                            Ok(n) => filled += n,
+                            Err(e) => {
+                                let _ = part_tx
+                                    .send(Err(io::Error::other(format!(
+                                        "range GET stream part {part_idx}: {e}"
+                                    ))))
+                                    .await;
+                                return;
+                            }
                         }
                     }
+                    if filled == 0 {
+                        break;
+                    }
+                    if part_tx.send(Ok(buf[..filled].to_vec())).await.is_err() {
+                        return; // Consumer dropped — shutting down.
+                    }
                 }
-                if filled == 0 {
-                    break;
-                }
-                if part_tx.send(Ok(buf[..filled].to_vec())).await.is_err() {
-                    return; // Consumer dropped — shutting down.
-                }
-            }
-        });
+            });
+        };
+
+    // Pre-spawn the first batch (up to max_fetches).
+    while next_to_spawn < num_parts && next_to_spawn < max_fetches {
+        spawn_part(
+            &mut join_set,
+            &mut part_senders,
+            next_to_spawn,
+            &ranges,
+            &s3,
+            key,
+        );
+        next_to_spawn += 1;
     }
 
     // Deliver parts in order: drain part 0 fully, then part 1, etc.
+    // After each part completes delivery, spawn the next download task
+    // to keep the pipeline saturated.
     let mut first_chunk = true;
     for mut part_rx in part_receivers {
         while let Some(result) = part_rx.recv().await {
@@ -1182,6 +1208,18 @@ async fn fetch_parallel_stream(
                 join_set.abort_all();
                 return Err(io::Error::other("output channel closed"));
             }
+        }
+        // Spawn the next part now that this one is fully delivered.
+        if next_to_spawn < num_parts {
+            spawn_part(
+                &mut join_set,
+                &mut part_senders,
+                next_to_spawn,
+                &ranges,
+                &s3,
+                key,
+            );
+            next_to_spawn += 1;
         }
     }
 

--- a/crates/logfwd-io/src/s3_input/sqs.rs
+++ b/crates/logfwd-io/src/s3_input/sqs.rs
@@ -197,7 +197,7 @@ async fn sqs_post(
     let body_bytes = body.as_bytes();
     let body_sha256 = sha256_hex(body_bytes);
 
-    let (date, datetime) = utc_datetime_now();
+    let (date, datetime) = utc_datetime_now()?;
     let credential_scope = format!("{date}/{region}/sqs/aws4_request");
 
     // Canonical headers for POST form submission.
@@ -263,9 +263,9 @@ async fn sqs_post(
         .map_err(|e| io::Error::other(format!("SQS read response: {e}")))?;
 
     if !status.is_success() {
+        let preview = String::from_utf8_lossy(&response_bytes[..response_bytes.len().min(1024)]);
         return Err(io::Error::other(format!(
-            "SQS POST HTTP {status}: {}",
-            String::from_utf8_lossy(&response_bytes)
+            "SQS POST HTTP {status}: {preview}"
         )));
     }
     Ok(response_bytes)
@@ -291,10 +291,10 @@ fn build_signing_key(secret: &str, date: &str, region: &str, service: &str) -> V
     hmac_sha256(&k_service, b"aws4_request")
 }
 
-fn utc_datetime_now() -> (String, String) {
+fn utc_datetime_now() -> io::Result<(String, String)> {
     let secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
+        .map_err(|e| io::Error::other(format!("system clock before Unix epoch: {e}")))?
         .as_secs();
     // Reuse the same algorithm as client.rs — replicated to keep this module
     // self-contained without creating a shared internal dependency.
@@ -306,7 +306,7 @@ fn utc_datetime_now() -> (String, String) {
     let (y, mo, d) = civil_from_days(days);
     let date = format!("{y:04}{mo:02}{d:02}");
     let datetime = format!("{date}T{h:02}{m:02}{s:02}Z");
-    (date, datetime)
+    Ok((date, datetime))
 }
 
 fn civil_from_days(days: u64) -> (u64, u64, u64) {

--- a/crates/logfwd-io/src/s3_input/sqs.rs
+++ b/crates/logfwd-io/src/s3_input/sqs.rs
@@ -406,26 +406,22 @@ fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> 
                     capture = None;
                 }
             }
-            Ok(Event::CData(e)) => {
-                if capture == Some("body") {
-                    body = String::from_utf8_lossy(e.into_inner().as_ref()).into_owned();
-                    capture = None;
-                }
+            Ok(Event::CData(e)) if capture == Some("body") => {
+                body = String::from_utf8_lossy(e.into_inner().as_ref()).into_owned();
+                capture = None;
             }
-            Ok(Event::End(e)) => {
-                if e.local_name().as_ref() == b"Message" && in_message {
-                    in_message = false;
-                    let records = parse_s3_event_body(&body);
-                    // Always push the message even when records is empty.
-                    // The discovery loop deletes non-actionable messages
-                    // (test notifications, non-ObjectCreated events) by
-                    // checking `records.is_empty()`.
-                    messages.push(SqsMessage {
-                        receipt_handle: receipt_handle.clone(),
-                        records,
-                    });
-                    capture = None;
-                }
+            Ok(Event::End(e)) if e.local_name().as_ref() == b"Message" && in_message => {
+                in_message = false;
+                let records = parse_s3_event_body(&body);
+                // Always push the message even when records is empty.
+                // The discovery loop deletes non-actionable messages
+                // (test notifications, non-ObjectCreated events) by
+                // checking `records.is_empty()`.
+                messages.push(SqsMessage {
+                    receipt_handle: receipt_handle.clone(),
+                    records,
+                });
+                capture = None;
             }
             Ok(Event::Eof) => break,
             Err(e) => {

--- a/crates/logfwd-io/src/tail/discovery.rs
+++ b/crates/logfwd-io/src/tail/discovery.rs
@@ -122,8 +122,7 @@ impl FileDiscovery {
                 let is_previous_handle_deleted = tailed
                     .file
                     .metadata()
-                    .map(|meta| has_metadata_indicating_deletion(&meta))
-                    .unwrap_or(false);
+                    .is_ok_and(|meta| has_metadata_indicating_deletion(&meta));
                 should_rotate_file(
                     &tailed.identity,
                     &current_identity,
@@ -168,8 +167,7 @@ impl FileDiscovery {
                 tailed
                     .file
                     .metadata()
-                    .map(|m| has_metadata_indicating_deletion(&m))
-                    .unwrap_or(true)
+                    .map_or(true, |m| has_metadata_indicating_deletion(&m))
             })
             .map(|(path, _)| path.clone())
             .collect();

--- a/crates/logfwd-io/tests/it/main.rs
+++ b/crates/logfwd-io/tests/it/main.rs
@@ -2,5 +2,7 @@ mod checkpoint_state_machine;
 mod file_boundary_contract;
 mod journald_e2e;
 mod otlp_receiver_contract;
+#[cfg(feature = "s3")]
+mod s3_parallel_fetch;
 mod support;
 mod transport_e2e;

--- a/crates/logfwd-io/tests/it/s3_parallel_fetch.rs
+++ b/crates/logfwd-io/tests/it/s3_parallel_fetch.rs
@@ -1,0 +1,517 @@
+//! Integration tests for the S3 input's parallel fetch/delivery pipeline.
+//!
+//! Uses mockito to serve fake S3 responses (ListObjectsV2, HEAD, GET with Range)
+//! so tests are fast, deterministic, and don't require MinIO or real AWS.
+
+#![cfg(feature = "s3")]
+
+use std::time::Duration;
+
+use logfwd_io::input::{InputEvent, InputSource};
+use logfwd_io::s3_input::{S3Input, S3InputSettings};
+
+/// Helper: create an `S3Input` pointed at `endpoint` using list-mode discovery.
+fn make_s3_input(endpoint: &str, bucket: &str, prefix: &str) -> S3Input {
+    let settings = S3InputSettings {
+        bucket: bucket.to_string(),
+        region: "us-east-1".to_string(),
+        endpoint: Some(endpoint.to_string()),
+        prefix: Some(prefix.to_string()),
+        sqs_queue_url: None,
+        start_after: None,
+        access_key_id: "test-key".to_string(),
+        secret_access_key: "test-secret".to_string(),
+        session_token: None,
+        part_size_bytes: 256, // Tiny: force many parts for testing
+        max_concurrent_fetches: 2,
+        max_concurrent_objects: 1,
+        visibility_timeout_secs: 300,
+        compression_override: None,
+        poll_interval_ms: 100,
+    };
+    S3Input::new("s3-test", settings).expect("S3Input::new")
+}
+
+/// Helper: poll until we have at least `expected_bytes` of data or timeout.
+fn poll_until_bytes(
+    input: &mut S3Input,
+    expected_bytes: usize,
+    timeout: Duration,
+) -> (Vec<u8>, bool) {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut backoff = Duration::from_millis(5);
+    let max_backoff = Duration::from_millis(100);
+    let mut all_bytes = Vec::new();
+    let mut got_eof = false;
+
+    while std::time::Instant::now() < deadline {
+        if let Ok(events) = input.poll() {
+            for event in events {
+                match event {
+                    InputEvent::Data { bytes, .. } => {
+                        all_bytes.extend_from_slice(&bytes);
+                    }
+                    InputEvent::EndOfFile { .. } => {
+                        got_eof = true;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if all_bytes.len() >= expected_bytes && got_eof {
+            return (all_bytes, got_eof);
+        }
+        std::thread::sleep(backoff);
+        backoff = (backoff * 2).min(max_backoff);
+    }
+    (all_bytes, got_eof)
+}
+
+/// Build a minimal `ListObjectsV2` XML response with one object.
+fn list_xml(key: &str, size: u64) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>test-bucket</Name>
+  <Prefix></Prefix>
+  <IsTruncated>false</IsTruncated>
+  <Contents>
+    <Key>{key}</Key>
+    <Size>{size}</Size>
+  </Contents>
+</ListBucketResult>"#
+    )
+}
+
+/// Build an empty `ListObjectsV2` response (no objects).
+fn list_xml_empty() -> String {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>test-bucket</Name>
+  <Prefix></Prefix>
+  <IsTruncated>false</IsTruncated>
+</ListBucketResult>"#
+        .to_string()
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+/// Parallel fetch delivers all data for an object that spans many small parts.
+///
+/// This is the test that would have caught the semaphore priority-inversion
+/// deadlock: with part_size=256 and a 2 KiB object, we get 8 parts — enough
+/// to exceed max_concurrent_fetches=2 and exercise the spawn-on-drain path.
+#[test]
+fn parallel_fetch_delivers_all_data_for_multi_part_object() {
+    let data = "A".repeat(2048); // 2 KiB = 8 parts at 256 B part_size
+    let data_len = data.len();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        // 1. ListObjectsV2 → one object
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
+                "list-type".into(),
+                "2".into(),
+            )]))
+            .with_status(200)
+            .with_body(list_xml("test-prefix/data.json", data_len as u64))
+            .create_async()
+            .await;
+
+        // After first list, return empty for subsequent polls
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("list-type".into(), "2".into()),
+                mockito::Matcher::UrlEncoded("start-after".into(), "test-prefix/data.json".into()),
+            ]))
+            .with_status(200)
+            .with_body(list_xml_empty())
+            .expect_at_most(100)
+            .create_async()
+            .await;
+
+        // 2. HEAD → content-length, no content-encoding (uncompressed)
+        server
+            .mock("HEAD", "/test-bucket/test-prefix/data.json")
+            .with_status(200)
+            .with_header("content-length", &data_len.to_string())
+            .create_async()
+            .await;
+
+        // 3. Range GETs → return correct byte slices with 206
+        for i in 0..(data_len / 256) {
+            let start = i * 256;
+            let end = start + 255;
+            let range_header = format!("bytes={start}-{end}");
+            server
+                .mock("GET", "/test-bucket/test-prefix/data.json")
+                .match_header("range", range_header.as_str())
+                .with_status(206)
+                .with_body(&data[start..=end])
+                .create_async()
+                .await;
+        }
+
+        let mut input = make_s3_input(&url, "test-bucket", "test-prefix/");
+        let (received, got_eof) = poll_until_bytes(&mut input, data_len, Duration::from_secs(10));
+
+        assert!(
+            got_eof,
+            "expected EOF event, did not receive one within timeout"
+        );
+        assert_eq!(
+            received.len(),
+            data_len,
+            "expected {data_len} bytes, got {}",
+            received.len()
+        );
+        assert_eq!(
+            received,
+            data.as_bytes(),
+            "received data does not match original"
+        );
+    });
+}
+
+/// Data arrives in correct order even when concurrent fetches complete
+/// out of order. The delivery loop must drain parts sequentially.
+#[test]
+fn parallel_fetch_preserves_byte_order() {
+    // Each part has a unique byte pattern so order corruption is detectable.
+    let mut data = Vec::with_capacity(1024);
+    for i in 0u8..4 {
+        data.extend(std::iter::repeat_n(i, 256));
+    }
+    let data_len = data.len(); // 1024
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
+                "list-type".into(),
+                "2".into(),
+            )]))
+            .with_status(200)
+            .with_body(list_xml("pfx/ordered.bin", data_len as u64))
+            .create_async()
+            .await;
+
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("list-type".into(), "2".into()),
+                mockito::Matcher::UrlEncoded("start-after".into(), "pfx/ordered.bin".into()),
+            ]))
+            .with_status(200)
+            .with_body(list_xml_empty())
+            .expect_at_most(100)
+            .create_async()
+            .await;
+
+        server
+            .mock("HEAD", "/test-bucket/pfx/ordered.bin")
+            .with_status(200)
+            .with_header("content-length", &data_len.to_string())
+            .create_async()
+            .await;
+
+        for i in 0..4usize {
+            let start = i * 256;
+            let end = start + 255;
+            let range_header = format!("bytes={start}-{end}");
+            server
+                .mock("GET", "/test-bucket/pfx/ordered.bin")
+                .match_header("range", range_header.as_str())
+                .with_status(206)
+                .with_body(&data[start..=end])
+                .create_async()
+                .await;
+        }
+
+        let mut input = make_s3_input(&url, "test-bucket", "pfx/");
+        let (received, got_eof) = poll_until_bytes(&mut input, data_len, Duration::from_secs(10));
+
+        assert!(got_eof);
+        assert_eq!(received.len(), data_len);
+        // Verify each 256-byte block has the correct fill byte.
+        for (i, chunk) in received.chunks(256).enumerate() {
+            let expected_byte = i as u8;
+            assert!(
+                chunk.iter().all(|&b| b == expected_byte),
+                "part {i}: expected all bytes to be {expected_byte:#04x}, got mixed content"
+            );
+        }
+    });
+}
+
+/// Empty-bytes EOF markers must not produce `InputEvent::Data` with 0 bytes
+/// (which would panic in CheckpointTracker::apply_read).
+#[test]
+fn eof_markers_do_not_emit_zero_byte_data_events() {
+    let data = "hello\n";
+    let data_len = data.len();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("list-type".into(), "2".into()),
+            ]))
+            .with_status(200)
+            .with_body(list_xml("pfx/tiny.txt", data_len as u64))
+            .create_async()
+            .await;
+
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("list-type".into(), "2".into()),
+                mockito::Matcher::UrlEncoded("start-after".into(), "pfx/tiny.txt".into()),
+            ]))
+            .with_status(200)
+            .with_body(list_xml_empty())
+            .expect_at_most(100)
+            .create_async()
+            .await;
+
+        server
+            .mock("HEAD", "/test-bucket/pfx/tiny.txt")
+            .with_status(200)
+            .with_header("content-length", &data_len.to_string())
+            .create_async()
+            .await;
+
+        // Object is smaller than part_size (256), so single part covers it.
+        let range_header = format!("bytes=0-{}", data_len - 1);
+        server
+            .mock("GET", "/test-bucket/pfx/tiny.txt")
+            .match_header("range", range_header.as_str())
+            .with_status(206)
+            .with_body(data)
+            .create_async()
+            .await;
+
+        let mut input = make_s3_input(&url, "test-bucket", "pfx/");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let mut data_events = Vec::new();
+        let mut eof_count = 0;
+
+        while std::time::Instant::now() < deadline {
+            if let Ok(events) = input.poll() {
+                for event in events {
+                    match event {
+                        InputEvent::Data { bytes, .. } => {
+                            assert!(
+                                !bytes.is_empty(),
+                                "InputEvent::Data emitted with 0 bytes — would panic in CheckpointTracker"
+                            );
+                            data_events.push(bytes);
+                        }
+                        InputEvent::EndOfFile { .. } => {
+                            eof_count += 1;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if eof_count > 0 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(eof_count > 0, "expected at least one EndOfFile event");
+        let total: usize = data_events.iter().map(Vec::len).sum();
+        assert_eq!(total, data_len);
+    });
+}
+
+/// Verify the accounted_bytes field: only the first chunk carries the full
+/// object size, all subsequent chunks carry 0.
+#[test]
+fn accounted_bytes_set_only_on_first_chunk() {
+    let data = "X".repeat(768); // 3 parts at 256 B
+    let data_len = data.len();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
+                "list-type".into(),
+                "2".into(),
+            )]))
+            .with_status(200)
+            .with_body(list_xml("pfx/acc.bin", data_len as u64))
+            .create_async()
+            .await;
+
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("list-type".into(), "2".into()),
+                mockito::Matcher::UrlEncoded("start-after".into(), "pfx/acc.bin".into()),
+            ]))
+            .with_status(200)
+            .with_body(list_xml_empty())
+            .expect_at_most(100)
+            .create_async()
+            .await;
+
+        server
+            .mock("HEAD", "/test-bucket/pfx/acc.bin")
+            .with_status(200)
+            .with_header("content-length", &data_len.to_string())
+            .create_async()
+            .await;
+
+        for i in 0..3usize {
+            let start = i * 256;
+            let end = start + 255;
+            let range_header = format!("bytes={start}-{end}");
+            server
+                .mock("GET", "/test-bucket/pfx/acc.bin")
+                .match_header("range", range_header.as_str())
+                .with_status(206)
+                .with_body(&data[start..=end])
+                .create_async()
+                .await;
+        }
+
+        let mut input = make_s3_input(&url, "test-bucket", "pfx/");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let mut accounted_values: Vec<u64> = Vec::new();
+        let mut got_eof = false;
+
+        while std::time::Instant::now() < deadline {
+            if let Ok(events) = input.poll() {
+                for event in events {
+                    match event {
+                        InputEvent::Data {
+                            accounted_bytes, ..
+                        } => {
+                            accounted_values.push(accounted_bytes);
+                        }
+                        InputEvent::EndOfFile { .. } => {
+                            got_eof = true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if got_eof {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(got_eof, "expected EOF");
+        assert!(
+            !accounted_values.is_empty(),
+            "expected at least one Data event"
+        );
+        assert_eq!(
+            accounted_values[0], data_len as u64,
+            "first chunk should carry full object size"
+        );
+        for (i, &v) in accounted_values.iter().enumerate().skip(1) {
+            assert_eq!(v, 0, "chunk {i} should have accounted_bytes=0, got {v}");
+        }
+    });
+}
+
+/// An empty object (0 bytes) should produce an EOF event without panicking.
+#[test]
+fn empty_object_produces_eof_without_panic() {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut server = mockito::Server::new_async().await;
+        let url = server.url();
+
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![mockito::Matcher::UrlEncoded(
+                "list-type".into(),
+                "2".into(),
+            )]))
+            .with_status(200)
+            .with_body(list_xml("pfx/empty.txt", 0))
+            .create_async()
+            .await;
+
+        server
+            .mock("GET", "/test-bucket")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("list-type".into(), "2".into()),
+                mockito::Matcher::UrlEncoded("start-after".into(), "pfx/empty.txt".into()),
+            ]))
+            .with_status(200)
+            .with_body(list_xml_empty())
+            .expect_at_most(100)
+            .create_async()
+            .await;
+
+        server
+            .mock("HEAD", "/test-bucket/pfx/empty.txt")
+            .with_status(200)
+            .with_header("content-length", "0")
+            .create_async()
+            .await;
+
+        // size==0 falls through to single-GET stream path
+        server
+            .mock("GET", "/test-bucket/pfx/empty.txt")
+            .with_status(200)
+            .with_body("")
+            .create_async()
+            .await;
+
+        let mut input = make_s3_input(&url, "test-bucket", "pfx/");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let mut got_eof = false;
+        let mut data_bytes = 0usize;
+
+        while std::time::Instant::now() < deadline {
+            if let Ok(events) = input.poll() {
+                for event in events {
+                    match event {
+                        InputEvent::Data { bytes, .. } => {
+                            data_bytes += bytes.len();
+                        }
+                        InputEvent::EndOfFile { .. } => {
+                            got_eof = true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            if got_eof {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(got_eof, "expected EOF for empty object");
+        assert_eq!(data_bytes, 0, "empty object should produce no data bytes");
+    });
+}

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -1135,7 +1135,12 @@ fn resolve_batch_columns<'a>(
         let mut key_encoding = Vec::with_capacity(2 + name.len());
         encode_bytes_field(&mut key_encoding, otlp::KEY_VALUE_KEY, name.as_bytes());
         let kv_key_cost = bytes_field_size(otlp::KEY_VALUE_KEY, name.len());
-        attribute_cols.push(ColAttr { name, key_encoding, kv_key_cost, array: attr });
+        attribute_cols.push(ColAttr {
+            name,
+            key_encoding,
+            kv_key_cost,
+            array: attr,
+        });
     }
 
     BatchColumns {

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -904,19 +904,18 @@ fn resolve_batch_columns<'a>(
                 name,
                 field_names::TIMESTAMP,
                 field_names::TIMESTAMP_VARIANTS,
-            ) =>
+            ) && timestamp_col.is_none()
+                && timestamp_num_col.is_none() =>
             {
-                if timestamp_col.is_none() && timestamp_num_col.is_none() {
-                    if let Some(arr) = resolve_otlp_str_col(batch.column(idx).as_ref()) {
-                        timestamp_col = Some((idx, arr));
-                        excluded[idx] = true;
-                    } else if matches!(
-                        field.data_type(),
-                        DataType::Int64 | DataType::UInt64 | DataType::Timestamp(_, _)
-                    ) {
-                        timestamp_num_col = Some((idx, batch.column(idx).as_ref()));
-                        excluded[idx] = true;
-                    }
+                if let Some(arr) = resolve_otlp_str_col(batch.column(idx).as_ref()) {
+                    timestamp_col = Some((idx, arr));
+                    excluded[idx] = true;
+                } else if matches!(
+                    field.data_type(),
+                    DataType::Int64 | DataType::UInt64 | DataType::Timestamp(_, _)
+                ) {
+                    timestamp_num_col = Some((idx, batch.column(idx).as_ref()));
+                    excluded[idx] = true;
                 }
             }
             name if field_names::matches_any(
@@ -952,12 +951,11 @@ fn resolve_batch_columns<'a>(
                 name,
                 field_names::TRACE_FLAGS,
                 field_names::TRACE_FLAGS_VARIANTS,
-            ) =>
+            ) && flags_col.is_none()
+                && matches!(field.data_type(), DataType::Int64) =>
             {
-                if flags_col.is_none() && matches!(field.data_type(), DataType::Int64) {
-                    flags_col = Some((idx, batch.column(idx).as_primitive::<Int64Type>()));
-                    excluded[idx] = true;
-                }
+                flags_col = Some((idx, batch.column(idx).as_primitive::<Int64Type>()));
+                excluded[idx] = true;
             }
             name if name == message_field
                 || field_names::matches_any(

--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -217,8 +217,7 @@ pub async fn run_pipelines(
         let mut server = logfwd_diagnostics::diagnostics::DiagnosticsServer::new(addr);
         server.set_config(options.config_path, options.config_yaml);
         let expose_config = std::env::var("LOGFWD_UNSAFE_EXPOSE_CONFIG")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+            .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
         server.set_config_endpoint_enabled(expose_config);
         server.set_trace_buffer(trace_buf);
         for p in &pipelines {

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -53,21 +53,19 @@ fn make_format(
 
 fn validate_input_format(name: &str, input_type: InputType, format: &Format) -> Result<(), String> {
     match input_type {
-        InputType::Generator | InputType::Otlp | InputType::ArrowIpc => {
-            if !matches!(format, Format::Json) {
-                return Err(format!(
-                    "input '{name}': format {:?} is not supported for {:?} inputs (expected json)",
-                    format, input_type
-                ));
-            }
+        InputType::Generator | InputType::Otlp | InputType::ArrowIpc
+            if !matches!(format, Format::Json) =>
+        {
+            return Err(format!(
+                "input '{name}': format {:?} is not supported for {:?} inputs (expected json)",
+                format, input_type
+            ));
         }
-        InputType::Http => {
-            if !matches!(format, Format::Json | Format::Raw) {
-                return Err(format!(
-                    "input '{name}': format {:?} is not supported for {:?} inputs (expected json or raw)",
-                    format, input_type
-                ));
-            }
+        InputType::Http if !matches!(format, Format::Json | Format::Raw) => {
+            return Err(format!(
+                "input '{name}': format {:?} is not supported for {:?} inputs (expected json or raw)",
+                format, input_type
+            ));
         }
         _ => {}
     }

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -453,8 +453,7 @@ impl InputPipelineManager {
         let mut io_handles = Vec::with_capacity(inputs.len());
         let mut cpu_handles = Vec::with_capacity(inputs.len());
 
-        for (idx, (input, transform)) in inputs.into_iter().zip(transforms.into_iter()).enumerate()
-        {
+        for (idx, (input, transform)) in inputs.into_iter().zip(transforms).enumerate() {
             let (io_tx, io_rx) = mpsc::channel::<IoWorkItem>(IO_CPU_CHANNEL_CAPACITY);
 
             // Spawn I/O worker.

--- a/crates/logfwd/build.rs
+++ b/crates/logfwd/build.rs
@@ -28,8 +28,7 @@ fn build_date() -> String {
         .unwrap_or_else(|| {
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0)
+                .map_or(0, |d| d.as_secs())
         });
 
     // Days since Unix epoch -> calendar date (proleptic Gregorian)

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -819,7 +819,7 @@ output:
                 CliError::Config(format!("cannot write {}: {e}", path.display()))
             }
         })?;
-    eprintln!("{}created{} {}", green(), reset(), path.display(),);
+    eprintln!("{}created{} {}", green(), reset(), path.display());
     eprintln!();
     eprintln!("{}Try it now:{}", bold(), reset());
     eprintln!(
@@ -863,7 +863,7 @@ fn cmd_wizard() -> Result<(), CliError> {
         let descs: Vec<&str> = USE_CASE_TEMPLATES.iter().map(|t| t.description).collect();
         let uc_idx = prompt_select_described("Pick a scenario:", &labels, &descs)?;
         let uc = &USE_CASE_TEMPLATES[uc_idx];
-        println!("{}selected{}: {}", green(), reset(), uc.title,);
+        println!("{}selected{}: {}", green(), reset(), uc.title);
         println!();
         // TODO: support multiline SQL input (currently single-line via read_line)
         let sql = prompt_text(
@@ -926,7 +926,7 @@ fn cmd_wizard() -> Result<(), CliError> {
             }
         })?;
 
-    eprintln!("{}created{} {}", green(), reset(), path.as_path().display(),);
+    eprintln!("{}created{} {}", green(), reset(), path.as_path().display());
     eprintln!(
         "{}next{}: run {}logfwd validate --config {}{}",
         dim(),


### PR DESCRIPTION
## Summary

Fixes two bugs in the S3 input introduced in #2202:

### 1. Semaphore priority-inversion deadlock in `fetch_parallel_stream`

**Root cause**: All N part tasks (e.g. 80 for a 645 MB file) were spawned upfront and raced for 8 semaphore permits in random tokio scheduling order. When out-of-order parts (e.g. part 43, 59) acquired permits before sequential parts (e.g. part 4), the ordered delivery loop blocked waiting for part 4's data while the permit-holding parts blocked on full per-part channels (capacity 4). Classic priority inversion → complete pipeline stall after ~50% of data processed.

**Symptoms**: Only ~50% of a large file's lines were processed before the pipeline went idle. The `fetch_parallel_stream` delivery loop stalled indefinitely.

**Fix**: Replace the semaphore with on-demand task spawning. Create all per-part channels upfront, pre-spawn only the first `max_fetches` tasks, then spawn the next task each time the delivery loop finishes draining a completed part. This guarantees tasks are launched in sequential order and at most `max_fetches` are concurrently active — no semaphore needed.

### 2. EOF panic on zero-byte chunks

**Root cause**: S3 input sends `ChunkPayload` with empty bytes as EOF markers. `poll()` was unconditionally emitting `InputEvent::Data` for every payload, including these zero-byte markers. `CheckpointTracker::apply_read(0, _)` then panicked on its `n_bytes > 0` assertion.

**Fix**: Skip `InputEvent::Data` when `payload.bytes.is_empty()`.

## Test plan

- `cargo test -p logfwd-io -p logfwd-runtime` — 181 tests pass
- `just clippy` — zero warnings
- Manual benchmark: MinIO localhost, 645 MB JSON file (2.27M lines) → null output
  - **Before**: ~1.2M lines processed (50%), then pipeline stalls indefinitely
  - **After**: 2.3M lines processed (100%), backpressure warning at 0.6s indicates download saturates the scanner

Relates to #2202

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix deadlock in parallel range-GET delivery and EOF panic in S3 input
> - Refactors `fetch_parallel_stream` in [mod.rs](https://github.com/strawgate/memagent/pull/2218/files#diff-a945e3b130e7cad15bee54e29e7cf9fa3e445b6ccc8e3745feb0ee1a0813f1ac) to pre-allocate per-part channels and spawn at most `max_fetches` concurrent range-GET tasks, eliminating the semaphore-based deadlock; task panics now abort the entire fetch with an error.
> - Fixes an EOF panic by skipping emission of `InputEvent::Data` when the byte payload is empty, emitting only `EndOfFile` for EOF-only markers.
> - Adds per-object fetch retries (up to 3 attempts with exponential backoff) and deduplicates concurrent fetches for the same key in `run_fetch_loop`.
> - Cleans up per-source state in `FramedInput.poll` on EOF so subsequent data for the same `SourceId` gets fresh state.
> - Adds integration tests in [s3_parallel_fetch.rs](https://github.com/strawgate/memagent/pull/2218/files#diff-ef2689be2d1fb77a34af5db3d578437f5dfe948a3c71ed31b5428368c7640c03) covering multi-part delivery, byte order, zero-byte events, accounted bytes, and empty objects.
> - Risk: parallel fetch concurrency behavior and backpressure model have changed; in-flight part count is now bounded by `max_fetches` rather than a global semaphore.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d2cafc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->