### PR TITLE
fix: correct lz4 IPC decoding, OTLP body limit default, generator JSON escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2932,6 +2932,7 @@ dependencies = [
  "logfwd-otap-proto",
  "logfwd-test-utils",
  "logfwd-types",
+ "lz4_flex",
  "memchr",
  "notify",
  "opentelemetry-proto",

--- a/crates/logfwd-io/Cargo.toml
+++ b/crates/logfwd-io/Cargo.toml
@@ -66,6 +66,7 @@ serde_json = "1"
 sonic-rs = { workspace = true }
 socket2 = { version = "0.6", features = ["all"] }
 tiny_http = { workspace = true }
+lz4_flex = "0.13"
 zstd = "0.13"
 xxhash-rust = { version = "0.8.15", features = ["xxh32", "xxh64"] }
 sysinfo = { workspace = true }

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -270,19 +270,26 @@ fn decompress_zstd(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>
     }
 }
 
-/// Decompress lz4 (frame format) body with size limit.
+/// Decompress lz4 (size-prepended block format) body with size limit.
+///
+/// `lz4_flex::decompress_size_prepended` reads the first 4 bytes as a LE u32
+/// declared size and pre-allocates that much memory. We validate the declared
+/// size against `max_message_size_bytes` *before* calling it to prevent a
+/// forged prefix from triggering an unbounded allocation (DoS vector).
 fn decompress_lz4(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>, InputError> {
+    if body.len() < 4 {
+        return Err(InputError::Receiver(
+            "lz4 decompression failed: missing size prefix".to_string(),
+        ));
+    }
+    let declared_len = u32::from_le_bytes([body[0], body[1], body[2], body[3]]) as usize;
+    if declared_len > max_message_size_bytes {
+        return Err(InputError::Receiver(
+            "decompressed payload too large".to_string(),
+        ));
+    }
     lz4_flex::decompress_size_prepended(body)
         .map_err(|e| InputError::Receiver(format!("lz4 decompression failed: {e}")))
-        .and_then(|decompressed| {
-            if decompressed.len() > max_message_size_bytes {
-                Err(InputError::Receiver(
-                    "decompressed payload too large".to_string(),
-                ))
-            } else {
-                Ok(decompressed)
-            }
-        })
 }
 
 /// Decode an Arrow IPC stream from bytes into RecordBatches.
@@ -499,6 +506,9 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<ContentEncodingF
         has_token = true;
     }
     if !has_token {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    if flags.has_zstd && flags.has_lz4 {
         return Err(StatusCode::BAD_REQUEST);
     }
     Ok(Some(flags))
@@ -1148,5 +1158,116 @@ mod tests {
     fn decode_ipc_stream_invalid_body() {
         let result = decode_ipc_stream(b"not arrow data");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn receiver_accepts_lz4_compressed_arrow_ipc() {
+        let receiver = ArrowIpcReceiver::new_with_capacity(
+            "test-lz4",
+            "127.0.0.1:0",
+            ArrowIpcReceiverOptions::default(),
+            16,
+        )
+        .expect("bind should succeed");
+        let addr = receiver.local_addr();
+
+        let batch = make_test_batch();
+        let ipc_bytes = serialize_batch(&batch);
+        let compressed = lz4_flex::compress_prepend_size(&ipc_bytes);
+
+        let url = format!("http://{addr}/v1/arrow");
+        let response = ureq::post(&url)
+            .header("Content-Type", "application/vnd.apache.arrow.stream")
+            .header("Content-Encoding", "lz4")
+            .send(&compressed)
+            .expect("POST should succeed");
+        assert_eq!(response.status().as_u16(), 200);
+
+        let received = receiver
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("should receive a batch");
+        assert_eq!(received.num_rows(), 2);
+    }
+
+    #[test]
+    fn receiver_accepts_lz4_content_type() {
+        let receiver = ArrowIpcReceiver::new_with_capacity(
+            "test-lz4-ct",
+            "127.0.0.1:0",
+            ArrowIpcReceiverOptions::default(),
+            16,
+        )
+        .expect("bind should succeed");
+        let addr = receiver.local_addr();
+
+        let batch = make_test_batch();
+        let ipc_bytes = serialize_batch(&batch);
+        let compressed = lz4_flex::compress_prepend_size(&ipc_bytes);
+
+        let url = format!("http://{addr}/v1/arrow");
+        let response = ureq::post(&url)
+            .header("Content-Type", "application/vnd.apache.arrow.stream+lz4")
+            .send(&compressed)
+            .expect("POST should succeed");
+        assert_eq!(response.status().as_u16(), 200);
+
+        let received = receiver
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("should receive a batch");
+        assert_eq!(received.num_rows(), 2);
+    }
+
+    #[test]
+    fn decompress_lz4_rejects_oversized_declared_length() {
+        // Forge a 4-byte prefix claiming 1 GB, followed by minimal data.
+        let mut forged = Vec::new();
+        forged.extend_from_slice(&(1_073_741_824_u32).to_le_bytes());
+        forged.extend_from_slice(b"tiny");
+
+        let result = decompress_lz4(&forged, 10 * 1024 * 1024);
+        assert!(result.is_err());
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("too large"),
+            "expected 'too large' error, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn decompress_lz4_rejects_missing_prefix() {
+        let result = decompress_lz4(b"abc", 10 * 1024 * 1024);
+        assert!(result.is_err());
+        let err_msg = format!("{:?}", result.unwrap_err());
+        assert!(
+            err_msg.contains("missing size prefix"),
+            "expected 'missing size prefix' error, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn receiver_rejects_conflicting_zstd_and_lz4_content_encoding() {
+        let receiver = ArrowIpcReceiver::new_with_capacity(
+            "test-conflict-encoding",
+            "127.0.0.1:0",
+            ArrowIpcReceiverOptions::default(),
+            16,
+        )
+        .expect("bind should succeed");
+        let addr = receiver.local_addr();
+
+        let batch = make_test_batch();
+        let ipc_bytes = serialize_batch(&batch);
+
+        let url = format!("http://{addr}/v1/arrow");
+        let result = ureq::post(&url)
+            .header("Content-Type", "application/vnd.apache.arrow.stream")
+            .header("Content-Encoding", "zstd, lz4")
+            .send(&ipc_bytes);
+        let status = match result {
+            Ok(resp) => resp.status().as_u16(),
+            Err(ureq::Error::StatusCode(code)) => code,
+            Err(e) => panic!("unexpected error: {e}"),
+        };
+        assert_eq!(status, 400);
     }
 }

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -6,9 +6,10 @@
 //!
 //! Endpoint: POST /v1/arrow
 //!
-//! Content-Type: `application/vnd.apache.arrow.stream` (uncompressed)
-//! or `application/vnd.apache.arrow.stream+zstd` (zstd compressed).
-//! Also supports `Content-Encoding: zstd` header.
+//! Content-Type: `application/vnd.apache.arrow.stream` (uncompressed),
+//! `application/vnd.apache.arrow.stream+zstd` (zstd compressed), or
+//! `application/vnd.apache.arrow.stream+lz4` (lz4 compressed).
+//! Also supports `Content-Encoding: zstd` and `Content-Encoding: lz4` headers.
 
 use std::io;
 use std::io::Read as _;
@@ -269,6 +270,21 @@ fn decompress_zstd(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>
     }
 }
 
+/// Decompress lz4 (frame format) body with size limit.
+fn decompress_lz4(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>, InputError> {
+    lz4_flex::decompress_size_prepended(body)
+        .map_err(|e| InputError::Receiver(format!("lz4 decompression failed: {e}")))
+        .and_then(|decompressed| {
+            if decompressed.len() > max_message_size_bytes {
+                Err(InputError::Receiver(
+                    "decompressed payload too large".to_string(),
+                ))
+            } else {
+                Ok(decompressed)
+            }
+        })
+}
+
 /// Decode an Arrow IPC stream from bytes into RecordBatches.
 fn decode_ipc_stream(body: &[u8]) -> Result<Vec<RecordBatch>, InputError> {
     if body.is_empty() {
@@ -341,9 +357,16 @@ async fn handle_arrow_ipc_request(
     let has_zstd_content_encoding = content_encodings
         .as_ref()
         .is_some_and(|encoding| encoding.has_zstd);
+    let has_lz4_content_encoding = content_encodings
+        .as_ref()
+        .is_some_and(|encoding| encoding.has_lz4);
     let is_zstd = has_zstd_content_encoding
         || content_type.as_ref().is_some_and(|media_type| {
             media_type.eq_ignore_ascii_case("application/vnd.apache.arrow.stream+zstd")
+        });
+    let is_lz4 = has_lz4_content_encoding
+        || content_type.as_ref().is_some_and(|media_type| {
+            media_type.eq_ignore_ascii_case("application/vnd.apache.arrow.stream+lz4")
         });
 
     let body = if is_zstd {
@@ -358,6 +381,16 @@ async fn handle_arrow_ipc_request(
                     "zstd decompression failed: invalid header",
                 )
                     .into_response();
+            }
+        }
+    } else if is_lz4 {
+        match decompress_lz4(&body, state.max_message_size_bytes) {
+            Ok(body) => body,
+            Err(InputError::Receiver(msg)) => {
+                return (StatusCode::BAD_REQUEST, msg).into_response();
+            }
+            Err(_) => {
+                return (StatusCode::BAD_REQUEST, "lz4 decompression failed").into_response();
             }
         }
     } else {
@@ -446,6 +479,7 @@ async fn handle_arrow_ipc_request(
 #[derive(Debug, Default, Eq, PartialEq)]
 struct ContentEncodingFlags {
     has_zstd: bool,
+    has_lz4: bool,
 }
 
 fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<ContentEncodingFlags>, StatusCode> {
@@ -461,6 +495,8 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<ContentEncodingF
         }
         if token.eq_ignore_ascii_case("zstd") {
             flags.has_zstd = true;
+        } else if token.eq_ignore_ascii_case("lz4") {
+            flags.has_lz4 = true;
         } else if !token.eq_ignore_ascii_case("identity") {
             return Err(StatusCode::BAD_REQUEST);
         }

--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -97,6 +97,11 @@ pub struct GeneratorConfig {
     pub event_created_unix_nano_field: Option<String>,
     /// Timestamp configuration for the `logs` profile.
     pub timestamp: GeneratorTimestamp,
+    /// Optional template string used as the `message` field value in generated
+    /// log events. When `None`, the default synthetic message is used.
+    /// The string is JSON-escaped before embedding so special characters
+    /// (quotes, backslashes, newlines, etc.) produce valid JSON.
+    pub message_template: Option<String>,
 }
 
 impl Default for GeneratorConfig {
@@ -111,6 +116,7 @@ impl Default for GeneratorConfig {
             sequence: None,
             event_created_unix_nano_field: None,
             timestamp: GeneratorTimestamp::default(),
+            message_template: None,
         }
     }
 }
@@ -125,6 +131,9 @@ pub struct GeneratorInput {
     last_refill: std::time::Instant,
     rate_credit_events: f64,
     record_fields: RecordFields,
+    /// Pre-escaped `message_template` bytes (the inner JSON string content,
+    /// without surrounding quotes). `None` means use the default message.
+    message_template_escaped: Option<Vec<u8>>,
 }
 
 const LEVELS: [&str; 4] = ["INFO", "DEBUG", "WARN", "ERROR"];
@@ -288,6 +297,12 @@ impl GeneratorInput {
                 }),
             event_created_unix_nano_field: config.event_created_unix_nano_field.clone(),
         };
+        // Pre-escape the message_template so we don't re-escape on every event.
+        let message_template_escaped = config.message_template.as_deref().map(|tmpl| {
+            let mut escaped = Vec::with_capacity(tmpl.len() + 4);
+            write_json_escaped_string_contents(&mut escaped, tmpl);
+            escaped
+        });
         Self {
             name,
             buf: Vec::with_capacity(batch_size * 512),
@@ -299,6 +314,7 @@ impl GeneratorInput {
             // Seed one batch worth of credits so the first poll() can emit
             // immediately in rate-limited mode.
             rate_credit_events: initial_rate_credit_events,
+            message_template_escaped,
         }
     }
 
@@ -371,11 +387,40 @@ impl GeneratorInput {
         };
         let (year, month, day, hour, min, sec, msec) = epoch_ms_to_parts(event_ms);
 
+        // Write the "message" JSON field value: either the pre-escaped template
+        // or the default computed message string.
+        let write_message = |buf: &mut Vec<u8>,
+                             method: &str,
+                             path: &str,
+                             id: u64,
+                             status: u32,
+                             tmpl: &Option<Vec<u8>>| {
+            buf.extend_from_slice(b"\"message\":\"");
+            if let Some(escaped) = tmpl {
+                buf.extend_from_slice(escaped);
+            } else {
+                let _ = write!(buf, "{method} {path}/{id} {status}");
+            }
+            buf.push(b'"');
+        };
+
         match self.config.complexity {
             GeneratorComplexity::Simple => {
                 let _ = write!(
                     self.buf,
-                    r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{method} {path}/{id} {status}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status}}}"#,
+                    r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","#,
+                );
+                write_message(
+                    &mut self.buf,
+                    method,
+                    path,
+                    id,
+                    status,
+                    &self.message_template_escaped,
+                );
+                let _ = write!(
+                    self.buf,
+                    r#","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status}}}"#,
                 );
             }
             GeneratorComplexity::Complex => {
@@ -384,18 +429,54 @@ impl GeneratorInput {
                 if seq.is_multiple_of(5) {
                     let _ = write!(
                         self.buf,
-                        r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{method} {path}/{id} {status}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out},"headers":{{"content-type":"application/json","x-request-id":"{rid:016x}"}},"tags":["web","{service}","{level}"]}}"#,
+                        r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","#,
+                    );
+                    write_message(
+                        &mut self.buf,
+                        method,
+                        path,
+                        id,
+                        status,
+                        &self.message_template_escaped,
+                    );
+                    let _ = write!(
+                        self.buf,
+                        r#","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out},"headers":{{"content-type":"application/json","x-request-id":"{rid:016x}"}},"tags":["web","{service}","{level}"]}}"#,
                     );
                 } else if seq.is_multiple_of(7) {
                     let upstream_ms = 1 + seq.wrapping_mul(19) % 200;
                     let _ = write!(
                         self.buf,
-                        r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{method} {path}/{id} {status}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out},"upstream":[{{"host":"10.0.0.1","latency_ms":{upstream_ms}}},{{"host":"10.0.0.2","latency_ms":{dur}}}]}}"#,
+                        r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","#,
+                    );
+                    write_message(
+                        &mut self.buf,
+                        method,
+                        path,
+                        id,
+                        status,
+                        &self.message_template_escaped,
+                    );
+                    let _ = write!(
+                        self.buf,
+                        r#","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out},"upstream":[{{"host":"10.0.0.1","latency_ms":{upstream_ms}}},{{"host":"10.0.0.2","latency_ms":{dur}}}]}}"#,
                     );
                 } else {
                     let _ = write!(
                         self.buf,
-                        r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","message":"{method} {path}/{id} {status}","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out}}}"#,
+                        r#"{{"timestamp":"{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}.{msec:03}Z","level":"{level}","#,
+                    );
+                    write_message(
+                        &mut self.buf,
+                        method,
+                        path,
+                        id,
+                        status,
+                        &self.message_template_escaped,
+                    );
+                    let _ = write!(
+                        self.buf,
+                        r#","duration_ms":{dur},"request_id":"{rid:016x}","service":"{service}","status":{status},"bytes_in":{bytes_in},"bytes_out":{bytes_out}}}"#,
                     );
                 }
             }

--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -1142,6 +1142,52 @@ mod tests {
     }
 
     #[test]
+    fn message_template_with_special_chars_produces_valid_json() {
+        // Regression test: message_template with quotes, backslashes, newlines,
+        // and control chars must still produce valid JSON.
+        let templates = [
+            r#"quotes "here" and 'there'"#,
+            "backslash \\ and tab \t inside",
+            "newline\ninside template",
+            "carriage\r\nreturn",
+            "control\x01chars\x1f",
+            r#"mixed "all" \types\ of 'special' chars"#,
+        ];
+        for tmpl in &templates {
+            for complexity in [GeneratorComplexity::Simple, GeneratorComplexity::Complex] {
+                let mut generator = GeneratorInput::new(
+                    "test",
+                    GeneratorConfig {
+                        batch_size: 10,
+                        total_events: 10,
+                        complexity,
+                        message_template: Some(tmpl.to_string()),
+                        ..Default::default()
+                    },
+                );
+                let events = generator.poll().unwrap();
+                let InputEvent::Data { bytes, .. } = &events[0] else {
+                    panic!("expected Data event");
+                };
+                let text = String::from_utf8(bytes.clone()).unwrap();
+                for (i, line) in text.trim().lines().enumerate() {
+                    let parsed: serde_json::Value = serde_json::from_str(line).unwrap_or_else(
+                        |e| {
+                            panic!(
+                                "invalid JSON at event {i} with template {tmpl:?} ({complexity:?}): {e}\n{line}"
+                            )
+                        },
+                    );
+                    let msg = parsed["message"]
+                        .as_str()
+                        .expect("message field should be a string");
+                    assert_eq!(msg, *tmpl, "message content should match template");
+                }
+            }
+        }
+    }
+
+    #[test]
     fn events_generated_counter() {
         let mut input = GeneratorInput::new(
             "test",

--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -91,6 +91,8 @@ struct OtlpServerState {
     resource_prefix: String,
     protobuf_decode_mode: OtlpProtobufDecodeMode,
     stats: Option<Arc<ComponentStats>>,
+    /// Maximum request body size. Defaults to `MAX_REQUEST_BODY_SIZE` (10 MiB).
+    max_message_size_bytes: usize,
 }
 
 impl OtlpReceiverInput {
@@ -176,6 +178,25 @@ impl OtlpReceiverInput {
         )
     }
 
+    #[cfg(test)]
+    fn new_with_capacity_stats_and_max_size(
+        name: impl Into<String>,
+        addr: &str,
+        capacity: usize,
+        stats: Option<Arc<ComponentStats>>,
+        max_message_size_bytes: Option<usize>,
+    ) -> io::Result<Self> {
+        Self::new_with_capacity_stats_prefix_and_decode_mode(
+            name,
+            addr,
+            capacity,
+            stats,
+            field_names::DEFAULT_RESOURCE_PREFIX.to_string(),
+            OtlpProtobufDecodeMode::Prost,
+            max_message_size_bytes,
+        )
+    }
+
     fn new_with_capacity_stats_and_prefix(
         name: impl Into<String>,
         addr: &str,
@@ -190,6 +211,27 @@ impl OtlpReceiverInput {
             stats,
             resource_prefix,
             OtlpProtobufDecodeMode::Prost,
+            None,
+        )
+    }
+
+    /// Like [`Self::new_with_stats_and_resource_prefix`], but allows overriding
+    /// the maximum request body size. Pass `None` to keep the 10 MiB default.
+    pub fn new_with_stats_resource_prefix_and_max_size(
+        name: impl Into<String>,
+        addr: &str,
+        stats: Arc<ComponentStats>,
+        resource_prefix: impl Into<String>,
+        max_message_size_bytes: Option<usize>,
+    ) -> io::Result<Self> {
+        Self::new_with_capacity_stats_prefix_and_decode_mode(
+            name,
+            addr,
+            CHANNEL_BOUND,
+            Some(stats),
+            resource_prefix.into(),
+            OtlpProtobufDecodeMode::Prost,
+            max_message_size_bytes,
         )
     }
 
@@ -209,6 +251,7 @@ impl OtlpReceiverInput {
             stats,
             resource_prefix.into(),
             protobuf_decode_mode,
+            None,
         )
     }
 
@@ -219,7 +262,10 @@ impl OtlpReceiverInput {
         stats: Option<Arc<ComponentStats>>,
         resource_prefix: String,
         protobuf_decode_mode: OtlpProtobufDecodeMode,
+        max_message_size_bytes: Option<usize>,
     ) -> io::Result<Self> {
+        use crate::receiver_http::MAX_REQUEST_BODY_SIZE;
+        let max_message_size_bytes = max_message_size_bytes.unwrap_or(MAX_REQUEST_BODY_SIZE);
         let std_listener = std::net::TcpListener::bind(addr)
             .map_err(|e| io::Error::other(format!("OTLP receiver bind {addr}: {e}")))?;
         let bound_addr = std_listener.local_addr()?;
@@ -237,6 +283,7 @@ impl OtlpReceiverInput {
             resource_prefix,
             protobuf_decode_mode,
             stats,
+            max_message_size_bytes,
         });
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let state_for_server = Arc::clone(&state);

--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -178,25 +178,6 @@ impl OtlpReceiverInput {
         )
     }
 
-    #[cfg(test)]
-    fn new_with_capacity_stats_and_max_size(
-        name: impl Into<String>,
-        addr: &str,
-        capacity: usize,
-        stats: Option<Arc<ComponentStats>>,
-        max_message_size_bytes: Option<usize>,
-    ) -> io::Result<Self> {
-        Self::new_with_capacity_stats_prefix_and_decode_mode(
-            name,
-            addr,
-            capacity,
-            stats,
-            field_names::DEFAULT_RESOURCE_PREFIX.to_string(),
-            OtlpProtobufDecodeMode::Prost,
-            max_message_size_bytes,
-        )
-    }
-
     fn new_with_capacity_stats_and_prefix(
         name: impl Into<String>,
         addr: &str,

--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -13,7 +13,6 @@ use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use prost::Message;
 
 use crate::InputError;
-use crate::receiver_http::MAX_REQUEST_BODY_SIZE;
 
 use super::OtlpProtobufDecodeMode;
 use super::convert::{
@@ -24,28 +23,39 @@ use super::convert::{
 #[cfg(any(feature = "otlp-research", test))]
 use super::projection::ProjectionError;
 
-pub(super) fn decompress_zstd(body: &[u8]) -> Result<Vec<u8>, InputError> {
+pub(super) fn decompress_zstd(body: &[u8], max_body_size: usize) -> Result<Vec<u8>, InputError> {
     let decoder = zstd::Decoder::new(body)
         .map_err(|_| InputError::Receiver("zstd decompression failed".to_string()))?;
-    read_decompressed_body(decoder, body.len(), "zstd decompression failed")
+    read_decompressed_body(
+        decoder,
+        body.len(),
+        max_body_size,
+        "zstd decompression failed",
+    )
 }
 
-pub(super) fn decompress_gzip(body: &[u8]) -> Result<Vec<u8>, InputError> {
+pub(super) fn decompress_gzip(body: &[u8], max_body_size: usize) -> Result<Vec<u8>, InputError> {
     let decoder = GzDecoder::new(body);
-    read_decompressed_body(decoder, body.len(), "gzip decompression failed")
+    read_decompressed_body(
+        decoder,
+        body.len(),
+        max_body_size,
+        "gzip decompression failed",
+    )
 }
 
 pub(super) fn read_decompressed_body(
     reader: impl io::Read,
     compressed_len: usize,
+    max_body_size: usize,
     error_label: &str,
 ) -> Result<Vec<u8>, InputError> {
-    let mut decompressed = Vec::with_capacity(compressed_len.min(MAX_REQUEST_BODY_SIZE));
+    let mut decompressed = Vec::with_capacity(compressed_len.min(max_body_size));
     match reader
-        .take(MAX_REQUEST_BODY_SIZE as u64 + 1)
+        .take(max_body_size as u64 + 1)
         .read_to_end(&mut decompressed)
     {
-        Ok(n) if n > MAX_REQUEST_BODY_SIZE => Err(InputError::Io(io::Error::new(
+        Ok(n) if n > max_body_size => Err(InputError::Io(io::Error::new(
             io::ErrorKind::InvalidData,
             "payload too large",
         ))),

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -67,7 +67,7 @@ pub(super) async fn handle_otlp_request(
 
     let accounted_bytes = body.len() as u64;
     body = match content_encoding.as_deref() {
-        Some("zstd") => match decompress_zstd(&body) {
+        Some("zstd") => match decompress_zstd(&body, max_body) {
             Ok(body) => body,
             Err(InputError::Receiver(msg)) => {
                 record_error(state.stats.as_ref());
@@ -82,7 +82,7 @@ pub(super) async fn handle_otlp_request(
                 return (StatusCode::BAD_REQUEST, "zstd decompression failed").into_response();
             }
         },
-        Some("gzip") => match decompress_gzip(&body) {
+        Some("gzip") => match decompress_gzip(&body, max_body) {
             Ok(body) => body,
             Err(InputError::Receiver(msg)) => {
                 record_error(state.stats.as_ref());

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -12,9 +12,7 @@ use bytes::Bytes;
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 
 use crate::InputError;
-use crate::receiver_http::{
-    MAX_REQUEST_BODY_SIZE, parse_content_length, parse_content_type, read_limited_body,
-};
+use crate::receiver_http::{parse_content_length, parse_content_type, read_limited_body};
 
 use super::decode::{
     decode_otlp_json, decode_otlp_protobuf, decode_otlp_protobuf_bytes_with_mode, decompress_gzip,
@@ -39,8 +37,9 @@ pub(super) async fn handle_otlp_request(
     headers: HeaderMap,
     body: Body,
 ) -> Response {
+    let max_body = state.max_message_size_bytes;
     let content_length = parse_content_length(&headers);
-    if content_length.is_some_and(|body_len| body_len > MAX_REQUEST_BODY_SIZE as u64) {
+    if content_length.is_some_and(|body_len| body_len > max_body as u64) {
         record_error(state.stats.as_ref());
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
@@ -53,7 +52,7 @@ pub(super) async fn handle_otlp_request(
         }
     };
 
-    let mut body = match read_limited_body(body, MAX_REQUEST_BODY_SIZE, content_length).await {
+    let mut body = match read_limited_body(body, max_body, content_length).await {
         Ok(body) => body,
         Err(status) => {
             record_error(state.stats.as_ref());

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -244,6 +244,7 @@ pub(super) fn build_input_state(
                 }),
                 event_created_unix_nano_field: generator_cfg
                     .and_then(|c| c.event_created_unix_nano_field.clone()),
+                message_template: generator_cfg.and_then(|c| c.message_template.clone()),
                 timestamp: match generator_cfg.and_then(|c| c.timestamp.as_ref()) {
                     None => GeneratorTimestamp::default(),
                     Some(ts) => {
@@ -294,11 +295,12 @@ pub(super) fn build_input_state(
             .map_err(|e| format!("input '{name}': failed to start OTLP receiver: {e}"))?;
             #[cfg(not(feature = "otlp-research"))]
             let source =
-                logfwd_io::otlp_receiver::OtlpReceiverInput::new_with_stats_and_resource_prefix(
+                logfwd_io::otlp_receiver::OtlpReceiverInput::new_with_stats_resource_prefix_and_max_size(
                     name,
                     addr,
                     Arc::clone(&stats),
                     resource_prefix,
+                    o.max_recv_message_size_bytes,
                 )
                 .map_err(|e| format!("input '{name}': failed to start OTLP receiver: {e}"))?;
             #[cfg(not(feature = "otlp-research"))]


### PR DESCRIPTION
## Summary

Three post-merge correctness fixes:

- **Arrow IPC lz4 (#2184)**: receiver now accepts and decompresses `lz4` content-encoding; previously returned HTTP 400 for every lz4-compressed batch
- **OTLP body limit (#2185)**: restores 10MB default (`max_recv_message_size_bytes: None` is now a true no-op, not `Some(4MB)`); deployments seeing 413s on 4–10MB payloads after upgrading will recover
- **Generator template escaping (#2186)**: `message_template` strings containing `"`, `\`, or newlines no longer produce malformed JSON

Closes #2184, #2185, #2186

## Test plan
- [ ] CI passes
- [ ] Arrow IPC: configure `compression: lz4` on an Arrow IPC output; batches are accepted by receiver
- [ ] OTLP: default OTLP input handles 8MB payload without 413
- [ ] Generator: template with quotes produces valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix lz4 Arrow IPC decoding, OTLP body size limit, and generator JSON escaping
> - Adds LZ4 decompression to the Arrow IPC HTTP handler in [arrow_ipc_receiver.rs](https://github.com/strawgate/memagent/pull/2219/files#diff-09612a16750832e6b7a4b59dbdd6a982a63b88557c06b3d49e74545813f8a46b), supporting size-prepended block format via `Content-Encoding: lz4` or `application/vnd.apache.arrow.stream+lz4`; conflicting `lz4`+`zstd` encodings return 400.
> - Replaces the global `MAX_REQUEST_BODY_SIZE` constant in the OTLP receiver with a per-instance configurable limit, exposed via a new `OtlpReceiverInput::new_with_stats_resource_prefix_and_max_size` constructor and propagated through decompression in [server.rs](https://github.com/strawgate/memagent/pull/2219/files#diff-79c2aa47d4a6663c41f6d4600ae976eb353c7067c59848773f702daddf493d40) and [decode.rs](https://github.com/strawgate/memagent/pull/2219/files#diff-1104a97c31865187f0a65affb5b8e2440e9db24cacdb3f9c1d24db1595686898).
> - Adds an optional `message_template` field to `GeneratorConfig` in [generator.rs](https://github.com/strawgate/memagent/pull/2219/files#diff-155a8c1574aa241af17a394ce55d6ff3fdc41c01cdb4e7affd54f0c4e45bf71f); the template is JSON-escaped once at construction and used for the `message` field across Simple, Complex, and VeryComplex profiles.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bfa8ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->