### PR TITLE
fix(ci): install wasm-pack in docs workflow so Config Builder deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,13 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

The Config Builder (added in #2127) has **never successfully deployed** to the live site. The docs workflow fails at the Astro prebuild step because `wasm-pack` is not installed:

```
> prebuild
> npm run build:wasm
> wasm-pack build ../crates/logfwd-config-wasm ...
sh: 1: wasm-pack: not found
```

This is why the Config Builder page returns 404 on the live site despite being present on `main`.

## Changes

- Add `wasm32-unknown-unknown` target to the `dtolnay/rust-toolchain` step
- Add `Install wasm-pack` step using the official installer script

## Context

This also explains the recurring "Config Builder disappeared" reports — the page was never actually live, and the repeated deletions/restorations by merge conflicts (#2144, #2151, #2211) were a separate issue that has since been fixed.

Closes the deploy blocker. Once merged, the next push to `main` will trigger a successful docs deploy including the Config Builder page.

## Test plan

- CI runs the docs workflow on this PR — the build step should pass (previously failed with exit code 127)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install wasm-pack in docs workflow so Config Builder deploys correctly
> The [docs.yml](https://github.com/strawgate/memagent/pull/2228/files#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2c) workflow was missing the `wasm32-unknown-unknown` Rust target and `wasm-pack`, which are required to build the Config Builder WASM component. Adds the target to the `dtolnay/rust-toolchain@stable` step and inserts a new step to install `wasm-pack@0.13.1` via `taiki-e/install-action@v2`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 47a6075.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->