### PR TITLE
fix: recursive normalize_utf8view and UTF-8 validation in validated path

### DIFF
--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -872,8 +872,10 @@ fn build_string_array_validated(
     let final_off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
     offsets.push(final_off);
 
-    // Validate UTF-8 for external bytes.
-    if !original_buf.is_empty() && std::str::from_utf8(&values).is_err() {
+    // Validate UTF-8 for all string bytes (covers both original_buf and
+    // write_str_bytes sources). This runs only in the validated path
+    // (utf8_trusted=false), so the cost is acceptable.
+    if std::str::from_utf8(&values).is_err() {
         // Identify which row contains the invalid UTF-8.
         for row in 0..num_rows {
             let start = offsets[row] as usize;
@@ -895,15 +897,11 @@ fn build_string_array_validated(
     let offset_buf = OffsetBuffer::new(ScalarBuffer::from(offsets));
     let values_buf = Buffer::from_vec(values);
 
-    if original_buf.is_empty() {
-        // All data from write_str(&str) — valid UTF-8 by Rust's type system.
-        // SAFETY: offsets built sequentially, source is &str.
-        let array = unsafe { StringArray::new_unchecked(offset_buf, values_buf, nulls) };
-        Ok((Arc::new(array), DataType::Utf8))
-    } else {
-        let array = StringArray::new(offset_buf, values_buf, nulls);
-        Ok((Arc::new(array), DataType::Utf8))
-    }
+    // All bytes validated above — use checked constructor uniformly.
+    // (The prior unsafe shortcut for original_buf.is_empty() was unsound when
+    // write_str_bytes was used with non-&str sources.)
+    let array = StringArray::new(offset_buf, values_buf, nulls);
+    Ok((Arc::new(array), DataType::Utf8))
 }
 
 /// Read string bytes from the 2-buffer system without UTF-8 validation.
@@ -1242,6 +1240,34 @@ mod tests {
         };
         let result = acc.materialize("x", 1, mode, true);
         assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, MaterializeError::InvalidUtf8 { .. }),
+            "expected InvalidUtf8, got {err:?}"
+        );
+    }
+
+    /// Regression test: invalid UTF-8 in generated buffer (write_str_bytes path)
+    /// must be caught even when original_buf is empty. Previously, the validated
+    /// path skipped checking when original_buf was empty, assuming all generated
+    /// data came from write_str(&str).
+    #[test]
+    fn invalid_utf8_in_generated_buffer_returns_error() {
+        let bad_bytes: &[u8] = &[0xFF, 0xFE, 0x80, 0x81];
+        let mut acc = ColumnAccumulator::for_planned(FieldKind::Utf8View);
+        // Offset 0 with empty original_buf → references generated_buf at index 0.
+        acc.push_str(0, StringRef { offset: 0, len: 4 });
+
+        let mode = FinalizationMode {
+            original_buf: Buffer::from(&[] as &[u8]),
+            generated_buf: Buffer::from(bad_bytes),
+            utf8_trusted: false,
+        };
+        let result = acc.materialize("x", 1, mode, true);
+        assert!(
+            result.is_err(),
+            "invalid UTF-8 in generated buffer must be caught"
+        );
         let err = result.unwrap_err();
         assert!(
             matches!(err, MaterializeError::InvalidUtf8 { .. }),

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -1111,6 +1111,27 @@ mod tests {
         );
     }
 
+    /// Regression: write_str_bytes with invalid UTF-8 must fail when
+    /// utf8_trusted is false, even when no original buffer is set.
+    #[test]
+    fn write_str_bytes_invalid_utf8_untrusted_fails() {
+        let mut plan = BatchPlan::new();
+        let msg = plan.declare_planned("msg", FieldKind::Utf8View).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+        b.set_utf8_trusted(false);
+
+        b.begin_batch();
+        b.begin_row();
+        b.write_str_bytes(msg, &[0xFF, 0xFE]).unwrap();
+        b.end_row();
+
+        let result = b.finish_batch();
+        assert!(
+            result.is_err(),
+            "invalid UTF-8 via write_str_bytes must be caught when utf8_trusted=false"
+        );
+    }
+
     #[test]
     fn zero_copy_original_buffer_round_trip() {
         let input = b"helloworld";

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -1122,14 +1122,19 @@ mod tests {
 
         b.begin_batch();
         b.begin_row();
-        b.write_str_bytes(msg, &[0xFF, 0xFE]).unwrap();
-        b.end_row();
+        // Accept error from either write_str_bytes or finish_batch — the
+        // invariant is that invalid bytes cannot materialize successfully.
+        let write_result = b.write_str_bytes(msg, &[0xFF, 0xFE]);
 
-        let result = b.finish_batch();
-        assert!(
-            result.is_err(),
-            "invalid UTF-8 via write_str_bytes must be caught when utf8_trusted=false"
-        );
+        if write_result.is_ok() {
+            b.end_row();
+
+            let result = b.finish_batch();
+            assert!(
+                result.is_err(),
+                "invalid UTF-8 via write_str_bytes must be caught when utf8_trusted=false"
+            );
+        }
     }
 
     #[test]

--- a/crates/logfwd-bench/benches/otlp_io.rs
+++ b/crates/logfwd-bench/benches/otlp_io.rs
@@ -11,6 +11,7 @@
 
 use std::sync::Arc;
 
+use arrow::array::{Array, StructArray, make_array};
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Field, Schema};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
@@ -99,7 +100,40 @@ fn assert_encode_paths_match(batch: &arrow::record_batch::RecordBatch, fixture_n
     );
 }
 
-/// Normalize a batch by casting Utf8View columns to Utf8 for comparison.
+/// Recursively cast Utf8View → Utf8 in an array, including Struct children.
+fn normalize_utf8view_array(arr: &dyn Array) -> Arc<dyn Array> {
+    match arr.data_type() {
+        DataType::Utf8View => cast(arr, &DataType::Utf8).expect("cast Utf8View→Utf8"),
+        DataType::Struct(fields) => {
+            let struct_arr = arr
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .expect("struct downcast");
+            let new_fields: Vec<_> = fields
+                .iter()
+                .enumerate()
+                .map(|(i, f)| {
+                    let child = normalize_utf8view_array(struct_arr.column(i).as_ref());
+                    let new_dt = child.data_type().clone();
+                    let new_field = Arc::new(Field::new(f.name(), new_dt, f.is_nullable()));
+                    (new_field, child)
+                })
+                .collect();
+            let (new_field_refs, new_arrays): (Vec<_>, Vec<_>) = new_fields.into_iter().unzip();
+            Arc::new(
+                StructArray::try_new(
+                    new_field_refs.into(),
+                    new_arrays,
+                    struct_arr.nulls().cloned(),
+                )
+                .expect("struct rebuild"),
+            )
+        }
+        _ => make_array(arr.to_data()),
+    }
+}
+
+/// Normalize a batch by recursively casting Utf8View columns to Utf8.
 /// ColumnarBatchBuilder produces Utf8View; prost/StreamingBuilder produces Utf8.
 fn normalize_utf8view(
     batch: &arrow::record_batch::RecordBatch,
@@ -109,17 +143,14 @@ fn normalize_utf8view(
     let mut new_columns = Vec::with_capacity(batch.num_columns());
     for (i, field) in schema.fields().iter().enumerate() {
         let col = batch.column(i);
-        if *field.data_type() == DataType::Utf8View {
-            new_fields.push(Arc::new(Field::new(
-                field.name(),
-                DataType::Utf8,
-                field.is_nullable(),
-            )));
-            new_columns.push(cast(col, &DataType::Utf8).expect("Utf8View→Utf8 cast"));
-        } else {
-            new_fields.push(Arc::clone(field));
-            new_columns.push(Arc::clone(col));
-        }
+        let normalized = normalize_utf8view_array(col.as_ref());
+        let new_dt = normalized.data_type().clone();
+        new_fields.push(Arc::new(Field::new(
+            field.name(),
+            new_dt,
+            field.is_nullable(),
+        )));
+        new_columns.push(normalized);
     }
     let new_schema = Arc::new(Schema::new(new_fields));
     arrow::record_batch::RecordBatch::try_new(new_schema, new_columns).expect("normalized batch")

--- a/crates/logfwd-bench/benches/otlp_io.rs
+++ b/crates/logfwd-bench/benches/otlp_io.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use arrow::array::{Array, StructArray, make_array};
 use arrow::compute::cast;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Schema};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use logfwd_bench::generators::otlp::{self, OtlpFixtureProfile};
 use logfwd_bench::{generators, make_otlp_sink};
@@ -115,7 +115,11 @@ fn normalize_utf8view_array(arr: &dyn Array) -> Arc<dyn Array> {
                 .map(|(i, f)| {
                     let child = normalize_utf8view_array(struct_arr.column(i).as_ref());
                     let new_dt = child.data_type().clone();
-                    let new_field = Arc::new(Field::new(f.name(), new_dt, f.is_nullable()));
+                    let new_field = if &new_dt == f.data_type() {
+                        Arc::clone(f)
+                    } else {
+                        Arc::new(f.as_ref().clone().with_data_type(new_dt))
+                    };
                     (new_field, child)
                 })
                 .collect();
@@ -145,11 +149,13 @@ fn normalize_utf8view(
         let col = batch.column(i);
         let normalized = normalize_utf8view_array(col.as_ref());
         let new_dt = normalized.data_type().clone();
-        new_fields.push(Arc::new(Field::new(
-            field.name(),
-            new_dt,
-            field.is_nullable(),
-        )));
+        // Preserve field metadata — only change data_type when it differs.
+        let new_field = if &new_dt == field.data_type() {
+            Arc::clone(field)
+        } else {
+            Arc::new(field.as_ref().clone().with_data_type(new_dt))
+        };
+        new_fields.push(new_field);
         new_columns.push(normalized);
     }
     let new_schema = Arc::new(Schema::new(new_fields));

--- a/crates/logfwd-bench/src/bin/otlp_io_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_io_profile.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use arrow::array::{Array, StructArray, make_array};
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Field, Schema};
 
@@ -443,7 +444,40 @@ fn assert_encode_paths_match(batch: &arrow::record_batch::RecordBatch, fixture_n
     );
 }
 
-/// Normalize a batch by casting Utf8View columns to Utf8 for comparison.
+/// Recursively cast Utf8View → Utf8 in an array, including Struct children.
+fn normalize_utf8view_array(arr: &dyn Array) -> Arc<dyn Array> {
+    match arr.data_type() {
+        DataType::Utf8View => cast(arr, &DataType::Utf8).expect("cast Utf8View→Utf8"),
+        DataType::Struct(fields) => {
+            let struct_arr = arr
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .expect("struct downcast");
+            let new_fields: Vec<_> = fields
+                .iter()
+                .enumerate()
+                .map(|(i, f)| {
+                    let child = normalize_utf8view_array(struct_arr.column(i).as_ref());
+                    let new_dt = child.data_type().clone();
+                    let new_field = Arc::new(Field::new(f.name(), new_dt, f.is_nullable()));
+                    (new_field, child)
+                })
+                .collect();
+            let (new_field_refs, new_arrays): (Vec<_>, Vec<_>) = new_fields.into_iter().unzip();
+            Arc::new(
+                StructArray::try_new(
+                    new_field_refs.into(),
+                    new_arrays,
+                    struct_arr.nulls().cloned(),
+                )
+                .expect("struct rebuild"),
+            )
+        }
+        _ => make_array(arr.to_data()),
+    }
+}
+
+/// Normalize a batch by recursively casting Utf8View columns to Utf8.
 /// ColumnarBatchBuilder produces Utf8View; prost/StreamingBuilder produces Utf8.
 fn normalize_utf8view(
     batch: &arrow::record_batch::RecordBatch,
@@ -453,17 +487,14 @@ fn normalize_utf8view(
     let mut new_columns = Vec::with_capacity(batch.num_columns());
     for (i, field) in schema.fields().iter().enumerate() {
         let col = batch.column(i);
-        if *field.data_type() == DataType::Utf8View {
-            new_fields.push(Arc::new(Field::new(
-                field.name(),
-                DataType::Utf8,
-                field.is_nullable(),
-            )));
-            new_columns.push(cast(col, &DataType::Utf8).expect("Utf8View→Utf8 cast"));
-        } else {
-            new_fields.push(Arc::clone(field));
-            new_columns.push(Arc::clone(col));
-        }
+        let normalized = normalize_utf8view_array(col.as_ref());
+        let new_dt = normalized.data_type().clone();
+        new_fields.push(Arc::new(Field::new(
+            field.name(),
+            new_dt,
+            field.is_nullable(),
+        )));
+        new_columns.push(normalized);
     }
     let new_schema = Arc::new(Schema::new(new_fields));
     arrow::record_batch::RecordBatch::try_new(new_schema, new_columns).expect("normalized batch")

--- a/crates/logfwd-bench/src/bin/otlp_io_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_io_profile.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use arrow::array::{Array, StructArray, make_array};
 use arrow::compute::cast;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Schema};
 
 use bytes::Bytes;
 use logfwd_bench::generators::otlp::{self, OtlpFixtureProfile};
@@ -459,7 +459,11 @@ fn normalize_utf8view_array(arr: &dyn Array) -> Arc<dyn Array> {
                 .map(|(i, f)| {
                     let child = normalize_utf8view_array(struct_arr.column(i).as_ref());
                     let new_dt = child.data_type().clone();
-                    let new_field = Arc::new(Field::new(f.name(), new_dt, f.is_nullable()));
+                    let new_field = if &new_dt == f.data_type() {
+                        Arc::clone(f)
+                    } else {
+                        Arc::new(f.as_ref().clone().with_data_type(new_dt))
+                    };
                     (new_field, child)
                 })
                 .collect();
@@ -489,11 +493,13 @@ fn normalize_utf8view(
         let col = batch.column(i);
         let normalized = normalize_utf8view_array(col.as_ref());
         let new_dt = normalized.data_type().clone();
-        new_fields.push(Arc::new(Field::new(
-            field.name(),
-            new_dt,
-            field.is_nullable(),
-        )));
+        // Preserve field metadata — only change data_type when it differs.
+        let new_field = if &new_dt == field.data_type() {
+            Arc::clone(field)
+        } else {
+            Arc::new(field.as_ref().clone().with_data_type(new_dt))
+        };
+        new_fields.push(new_field);
         new_columns.push(normalized);
     }
     let new_schema = Arc::new(Schema::new(new_fields));


### PR DESCRIPTION
## Summary

Follow-up to #2215 addressing review feedback that was identified after merge.

### Changes

**1. Recursive normalize_utf8view** (bench + profile test helpers)

`normalize_utf8view` in `otlp_io.rs` (bench) and `otlp_io_profile.rs` previously only cast top-level `Utf8View` columns to `Utf8` for comparison. If a conflict `Struct` column contained `Utf8View` children, the comparison would silently pass with mismatched data. Now recursively normalizes nested Struct children, matching the version in `projection.rs` tests.

**2. UTF-8 validation in `build_string_array_validated`** (safety fix)

When `utf8_trusted=false`, the validated materialization path skipped UTF-8 validation when `original_buf` was empty, assuming all generated data came from `write_str(&str)`. But `write_str_bytes(&[u8])` also writes to the generated buffer, so invalid bytes could bypass validation and reach `StringArray::new_unchecked`. Now the validated path always checks UTF-8 regardless of buffer origin, and uses the checked `StringArray::new` constructor.

**3. Regression tests** for both issues.

### Files changed

- `crates/logfwd-arrow/src/columnar/accumulator.rs` — fix validation guard + regression test  
- `crates/logfwd-arrow/src/columnar/builder.rs` — builder-level regression test
- `crates/logfwd-bench/benches/otlp_io.rs` — recursive normalize_utf8view
- `crates/logfwd-bench/src/bin/otlp_io_profile.rs` — recursive normalize_utf8view

Relates to #1845


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix recursive `normalize_utf8view` and UTF-8 validation in the validated accumulator path
> - Fixes a bug in `build_string_array_validated` where invalid UTF-8 from the `write_str_bytes` path was silently accepted when `original_buf` was empty; now always validates the concatenated buffer and constructs `StringArray` via the checked constructor.
> - Adds recursive `normalize_utf8view_array` helpers in the benchmark and profile binaries that cast `Utf8View→Utf8` within nested `StructArray` children, replacing the previous top-level-only cast in `normalize_utf8view`.
> - Adds regression tests covering invalid UTF-8 in the generated buffer with `utf8_trusted=false`.
> - Behavioral Change: `build_string_array_validated` no longer uses `StringArray::new_unchecked` for any input; previously, an empty `original_buf` bypassed validation entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 062a1ce.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->