### PR TITLE
fix(docs): correct wasm-pack output path so Config Builder loads

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -43,6 +43,13 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.9
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack@0.13.1
 
       - uses: actions/setup-node@v6
         with:

--- a/book/package.json
+++ b/book/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:wasm": "wasm-pack build ../crates/logfwd-config-wasm --target web --out-dir ../book/public/wasm/logfwd-config --release",
+    "build:wasm": "wasm-pack build ../crates/logfwd-config-wasm --target web --out-dir \"$PWD/public/wasm/logfwd-config\" --release",
     "prebuild": "npm run build:wasm",
     "predev": "npm run build:wasm",
     "dev": "astro dev",


### PR DESCRIPTION
## Summary

The Config Builder page deploys but shows **"Failed to load config builder: Importing a module script failed"** because the WASM files are missing from the deployed site (404).

## Root cause

`wasm-pack` resolves `--out-dir` **relative to the crate directory**, not the working directory. The npm script in `book/package.json` used:

```
--out-dir ../book/public/wasm/logfwd-config
```

This resolved from `crates/logfwd-config-wasm/` to `crates/book/public/wasm/logfwd-config/` — a phantom directory that doesn't end up in `dist/`. The CI log confirmed:

```
[INFO]: 📦 Your wasm pkg is ready to publish at ../crates/book/public/wasm/logfwd-config.
```

Meanwhile `book/public/wasm/logfwd-config/` only contained a `.gitignore`, so Astro copied an empty directory to `dist/wasm/logfwd-config/`.

## Fix

Use `\$PWD/public/wasm/logfwd-config` which resolves correctly since npm scripts run with CWD = `book/`.

## Test plan

- CI docs workflow builds successfully
- The upload artifact step should now list `.js` and `.wasm` files under `./wasm/logfwd-config/`
- After merge + deploy, `/memagent/wasm/logfwd-config/logfwd_config_wasm.js` should return 200

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix wasm-pack output path so Config Builder assets load correctly in docs
> - Fixes the `build:wasm` script in [package.json](https://github.com/strawgate/memagent/pull/2231/files#diff-5fe43b2c2e07753b3f6f7e30b346fd3de27f45529537e2ec164f7bbcdacef5a4) to write artifacts to `$PWD/public/wasm/logfwd-config` instead of `../book/public/wasm/logfwd-config`, which was resolving to the wrong directory.
> - Adds `wasm32-unknown-unknown` Rust target and `wasm-pack@0.13.1` installation steps to the [docs.yml](https://github.com/strawgate/memagent/pull/2231/files#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2c) CI workflow so the wasm build can run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e6e48f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->