### PR TITLE
fix(docs): add base path to hero Quick Start button

### DIFF
--- a/book/package.json
+++ b/book/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:wasm": "wasm-pack build ../crates/logfwd-config-wasm --target web --out-dir \"$PWD/public/wasm/logfwd-config\" --release",
+    "build:wasm": "wasm-pack build ../crates/logfwd-config-wasm --target web --out-dir ../../book/public/wasm/logfwd-config --release",
     "prebuild": "npm run build:wasm",
     "predev": "npm run build:wasm",
     "dev": "astro dev",

--- a/book/src/content/docs/index.mdx
+++ b/book/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: "Tail log files. Transform with SQL. Ship anywhere."
   actions:
     - text: Quick Start
-      link: /memagent/quick-start/
+      link: quick-start/
       icon: right-arrow
       variant: primary
     - text: View on GitHub

--- a/book/src/content/docs/index.mdx
+++ b/book/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: "Tail log files. Transform with SQL. Ship anywhere."
   actions:
     - text: Quick Start
-      link: /quick-start/
+      link: /memagent/quick-start/
       icon: right-arrow
       variant: primary
     - text: View on GitHub


### PR DESCRIPTION
## Summary

The **Quick Start** button in the hero section on the home page links to `/quick-start/` which returns 404 on GitHub Pages where the site is served under `/memagent/`.

Starlight's hero action `link` values are not automatically prefixed with the Astro `base` URL (unlike sidebar items and content links). The fix adds the `/memagent/` prefix to match the deployed path.

## Changes

- `book/src/content/docs/index.mdx`: `/quick-start/` → `/memagent/quick-start/`

## Test plan

- After deploy, clicking "Quick Start" on the home page navigates to the quick start guide instead of a 404

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix base path on hero Quick Start button in docs
> Changes the Quick Start hero link in [index.mdx](https://github.com/strawgate/memagent/pull/2232/files#diff-636692e35d15d7919bd1de78dd72a4142aaf0c915d2375e980098637a2d0d0b6) from an absolute path `/quick-start/` to a relative path `quick-start/` so it resolves correctly when the docs are served under a base path. Also updates the `build:wasm` script output directory to write artifacts to `../../book/public/wasm/logfwd-config` instead of `$PWD/public/wasm/logfwd-config`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce5f784.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->