### PR TITLE
fix: flush I/O buffer inside event loop to bound batch size

### DIFF
--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -60,6 +60,45 @@ use super::{InputState, InputTransform};
 #[cfg(not(feature = "turmoil"))]
 const IO_CPU_CHANNEL_CAPACITY: usize = 4;
 
+/// Flush `buf` to the channel as an `IoWorkItem::Bytes` chunk.
+///
+/// Returns `false` if the channel is closed (caller should exit the I/O loop).
+/// On backpressure (channel full), logs a warning at most once per 5 s and
+/// blocks until the CPU worker drains.
+#[cfg(not(feature = "turmoil"))]
+fn flush_buf(
+    buf: &mut bytes::BytesMut,
+    source: &dyn logfwd_io::input::InputSource,
+    tx: &mpsc::Sender<IoWorkItem>,
+    metrics: &PipelineMetrics,
+    last_bp_warn: &mut Option<Instant>,
+    input_index: usize,
+) -> bool {
+    if buf.is_empty() {
+        return true;
+    }
+    let data = buf.split().freeze();
+    let checkpoints = source.checkpoint_data();
+    let chunk = IoWorkItem::Bytes(IoChunk {
+        bytes: data,
+        checkpoints,
+        queued_at: tokio::time::Instant::now(),
+        input_index,
+    });
+    match tx.try_send(chunk) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(chunk)) => {
+            if last_bp_warn.is_none_or(|t| t.elapsed() >= Duration::from_secs(5)) {
+                tracing::warn!(input = source.name(), "input.backpressure");
+                *last_bp_warn = Some(Instant::now());
+            }
+            metrics.inc_backpressure_stall();
+            tx.blocking_send(chunk).is_ok()
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => false,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // I/O worker — reads bytes from source, accumulates, sends to CPU worker
 // ---------------------------------------------------------------------------
@@ -105,6 +144,7 @@ fn io_worker_loop(
     let mut consecutive_poll_failures: u32 = 0;
     let mut adaptive_poll =
         AdaptivePollController::new(input.source.get_cadence().adaptive_fast_polls_max);
+    let safe_batch_target_bytes = batch_target_bytes.max(1);
 
     'io_loop: loop {
         if shutdown.is_cancelled() {
@@ -153,38 +193,36 @@ fn io_worker_loop(
                 match event {
                     InputEvent::Data { bytes, .. } => {
                         input.buf.extend_from_slice(&bytes);
-                    }
-                    InputEvent::Batch { batch, .. } => {
-                        if !input.buf.is_empty() {
-                            let data = input.buf.split().freeze();
-                            let checkpoints = input.source.checkpoint_data();
-                            let chunk = IoWorkItem::Bytes(IoChunk {
-                                bytes: data,
-                                checkpoints,
-                                queued_at: tokio::time::Instant::now(),
+                        // Flush eagerly when the buffer reaches the target so
+                        // that a single poll returning many Data events cannot
+                        // accumulate an unbounded buffer.
+                        if input.buf.len() >= safe_batch_target_bytes {
+                            metrics.inc_flush_by_size();
+                            if !flush_buf(
+                                &mut input.buf,
+                                &*input.source,
+                                &tx,
+                                &metrics,
+                                &mut last_bp_warn,
                                 input_index,
-                            });
-                            match tx.try_send(chunk) {
-                                Ok(()) => {}
-                                Err(mpsc::error::TrySendError::Full(chunk)) => {
-                                    if last_bp_warn
-                                        .is_none_or(|t| t.elapsed() >= Duration::from_secs(5))
-                                    {
-                                        tracing::warn!(
-                                            input = input.source.name(),
-                                            "input.backpressure"
-                                        );
-                                        last_bp_warn = Some(Instant::now());
-                                    }
-                                    metrics.inc_backpressure_stall();
-                                    if tx.blocking_send(chunk).is_err() {
-                                        break 'io_loop;
-                                    }
-                                }
-                                Err(mpsc::error::TrySendError::Closed(_)) => break 'io_loop,
+                            ) {
+                                break 'io_loop;
                             }
                             buffered_since = None;
                         }
+                    }
+                    InputEvent::Batch { batch, .. } => {
+                        if !flush_buf(
+                            &mut input.buf,
+                            &*input.source,
+                            &tx,
+                            &metrics,
+                            &mut last_bp_warn,
+                            input_index,
+                        ) {
+                            break 'io_loop;
+                        }
+                        buffered_since = None;
 
                         let item = IoWorkItem::Batch {
                             batch,
@@ -228,7 +266,6 @@ fn io_worker_loop(
             }
         }
 
-        let safe_batch_target_bytes = batch_target_bytes.max(1);
         let timeout_elapsed = buffered_since.is_some_and(|t| t.elapsed() >= batch_timeout);
         let flush_by_size = input.buf.len() >= safe_batch_target_bytes;
         let flush_by_timeout = !input.buf.is_empty() && timeout_elapsed;
@@ -240,31 +277,15 @@ fn io_worker_loop(
                 metrics.inc_flush_by_timeout();
             }
 
-            let data = input.buf.split().freeze();
-            let checkpoints = input.source.checkpoint_data();
-            let chunk = IoWorkItem::Bytes(IoChunk {
-                bytes: data,
-                checkpoints,
-                queued_at: tokio::time::Instant::now(),
+            if !flush_buf(
+                &mut input.buf,
+                &*input.source,
+                &tx,
+                &metrics,
+                &mut last_bp_warn,
                 input_index,
-            });
-
-            // Try non-blocking first; if full, log backpressure and block.
-            // Shutdown awareness comes from the channel-close cascade: when
-            // the CPU worker exits, it drops its rx, so blocking_send returns Err.
-            match tx.try_send(chunk) {
-                Ok(()) => {}
-                Err(mpsc::error::TrySendError::Full(chunk)) => {
-                    if last_bp_warn.is_none_or(|t| t.elapsed() >= Duration::from_secs(5)) {
-                        tracing::warn!(input = input.source.name(), "input.backpressure");
-                        last_bp_warn = Some(Instant::now());
-                    }
-                    metrics.inc_backpressure_stall();
-                    if tx.blocking_send(chunk).is_err() {
-                        break;
-                    }
-                }
-                Err(mpsc::error::TrySendError::Closed(_)) => break,
+            ) {
+                break;
             }
             buffered_since = None;
         }


### PR DESCRIPTION
## Summary

The I/O worker accumulated all `InputEvent::Data` items from a single `poll()` call into `input.buf` before checking `batch_target_bytes`. When an input source (e.g. the generator at high EPS) returned many Data events in one poll, the buffer could grow far beyond the target — producing batches 10–100× larger than intended.

This caused **HTTP 413 rejections** in the competitive OTLP benchmarks (memagent-e2e#283): the collector received oversized batches from the emitter and forwarded them 1:1 to the capture sink, which rejected them at the 10 MB `MAX_REQUEST_BODY_SIZE` limit. 8 batches with ~733K rows were permanently dropped.

## Root Cause

The generator at 200K EPS with `batch_size=1024` returns up to 195 `InputEvent::Data` chunks per `poll()` (line 479-480 in generator.rs: `max_full_batches = burst_cap / batch_size`). The I/O worker event loop appended all of them to `input.buf` before the post-loop size check, accumulating ~46 MB instead of the configured 100 KB `batch_target_bytes`.

## Fix

Check `batch_target_bytes` after every `InputEvent::Data` append and flush eagerly when the threshold is reached. Extract flush logic into a shared `flush_buf()` helper used by:
- The new inline flush (Data arm) — **the fix**
- The existing Batch arm (flush pending bytes before forwarding)
- The post-loop size/timeout flush

This bounds the maximum batch size to roughly `batch_target_bytes + one Data event`, regardless of how many events a single poll returns.

## Testing

- All 181 `logfwd-runtime` tests pass
- Clippy clean (`-D warnings`)
- No behavioral change for normal-rate inputs (flush check only fires when buffer exceeds target)

Relates to https://github.com/strawgate/memagent-e2e/issues/283

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Flush I/O buffer inside event loop to bound batch size in `io_worker_loop`
> - Extracts a `flush_buf` helper in [input_pipeline.rs](https://github.com/strawgate/memagent/pull/2235/files#diff-8d09fe65f044c4f6e39b09d32493e940168bc73ffb42aff651f445fa90a96b9a) that sends accumulated bytes as an `IoWorkItem::Bytes` chunk, handles backpressure with rate-limited warnings, and returns false if the channel is closed.
> - `io_worker_loop` now flushes immediately when buffered bytes reach the size threshold during `InputEvent::Data` handling, rather than waiting for the next periodic flush tick.
> - Pending bytes are also flushed before processing `InputEvent::Batch` events to preserve ordering.
> - `inc_flush_by_size` is now recorded for threshold-triggered flushes during event processing in addition to the periodic flush path.
> - Behavioral Change: a single poll may now emit multiple smaller `IoWorkItem::Bytes` chunks instead of one large one, and the buffer timer resets earlier on size-based flushes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f10eee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->