### PR TITLE
refactor: extract scatter_values/null_bitmap_bits for Kani testability

### DIFF
--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -1488,6 +1488,7 @@ mod verification {
 
     /// Valid original-buffer reference returns correct bytes.
     #[kani::proof]
+    #[kani::unwind(10)]
     fn verify_read_str_bytes_original() {
         let original = [0xAAu8; 8];
         let generated = [0xBBu8; 8];
@@ -1504,10 +1505,14 @@ mod verification {
         for &b in bytes {
             assert_eq!(b, 0xAA);
         }
+
+        kani::cover!(len == 1, "single-byte original ref");
+        kani::cover!(offset == 0, "ref from start of original");
     }
 
     /// Valid generated-buffer reference returns correct bytes.
     #[kani::proof]
+    #[kani::unwind(10)]
     fn verify_read_str_bytes_generated() {
         let original = [0xAAu8; 8];
         let generated = [0xBBu8; 8];
@@ -1527,6 +1532,9 @@ mod verification {
         for &b in bytes {
             assert_eq!(b, 0xBB);
         }
+
+        kani::cover!(len == 1, "single-byte generated ref");
+        kani::cover!(gen_offset == 0, "ref from start of generated");
     }
 
     /// Out-of-bounds StringRef returns error for both buffers.
@@ -1555,6 +1563,9 @@ mod verification {
                 assert!(result.is_err());
             }
         }
+
+        kani::cover!(offset < original.len() as u32, "OOB in original range");
+        kani::cover!(offset >= original.len() as u32, "OOB in generated range");
     }
 
     /// No StringRef can span across the original/generated boundary.
@@ -1572,6 +1583,9 @@ mod verification {
         let sref = StringRef { offset, len };
         let result = read_str_bytes(&original, &generated, original.len(), sref);
         assert!(result.is_err(), "spanning ref must be rejected");
+
+        kani::cover!(len >= 2, "multi-byte spanning ref");
+        kani::cover!(offset == 0, "spanning from start of original");
     }
 
     // ── scatter_values — dense/sparse placement ────────────────────────────
@@ -1595,6 +1609,9 @@ mod verification {
         for (i, &(_, v)) in facts.iter().enumerate() {
             assert_eq!(values[i], v, "dense value must match fact");
         }
+
+        kani::cover!(num_rows == 1, "single row dense");
+        kani::cover!(num_rows == 4, "max rows dense");
     }
 
     /// Sparse scatter: fact rows get their value, gap rows stay default.
@@ -1627,6 +1644,7 @@ mod verification {
         }
 
         kani::cover!(facts.len() == 1, "single fact");
+        kani::cover!(num_rows == 4 && facts.len() == 2, "half-populated");
     }
 
     /// Last-write-wins: when dedup=false (sparse path), later facts overwrite.
@@ -1640,6 +1658,9 @@ mod verification {
         let (values, dense) = scatter_values(&facts, 1, false);
         assert!(!dense, "dedup=false must not be dense");
         assert_eq!(values[0], second, "last write must win");
+
+        kani::cover!(first < second, "increasing overwrite");
+        kani::cover!(first > second, "decreasing overwrite");
     }
 
     // ── validity_bitmap_bits — bit-packed correctness ──────────────────────
@@ -1676,6 +1697,7 @@ mod verification {
 
     /// Out-of-bounds row indices are silently ignored.
     #[kani::proof]
+    #[kani::unwind(6)]
     fn verify_validity_bitmap_bits_oob_ignored() {
         let num_rows: usize = 4;
         let oob_row: u32 = kani::any();
@@ -1689,6 +1711,9 @@ mod verification {
             let bit_set = bits[row >> 3] & (1 << (row & 7)) != 0;
             assert!(!bit_set, "non-fact row must be clear");
         }
+
+        kani::cover!(oob_row == 4, "minimal OOB");
+        kani::cover!(oob_row > 100, "large OOB");
     }
 
     // ── is_dense — classification ──────────────────────────────────────────
@@ -1712,6 +1737,9 @@ mod verification {
             let partial = facts[..num_rows - 1].to_vec();
             assert!(!is_dense(&partial, num_rows, true));
         }
+
+        kani::cover!(num_rows == 1, "single row");
+        kani::cover!(num_rows == 4, "max test rows");
     }
 }
 

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -505,13 +505,14 @@ fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
 // Pure scatter / bitmap — Arrow-free, Kani-provable
 // ---------------------------------------------------------------------------
 
-/// Scatter fact values into a pre-zeroed vec indexed by row.
+/// Scatter fact values into a default-initialized vec indexed by row.
 ///
 /// Dense path: facts\[i\] → values\[i\] (sequential, no bounds check needed).
 /// Sparse path: facts\[i\].0 → row index (last-write-wins for duplicates).
+/// Rows without a fact retain `T::default()`.
 ///
-/// Returns `(values, dense)`. Callers use `dense` to decide whether a null
-/// bitmap is needed.
+/// Returns `(values, dense)`. Callers use `dense` to decide whether a
+/// validity bitmap is needed.
 fn scatter_values<T: Default + Copy>(
     facts: &[(u32, T)],
     num_rows: usize,
@@ -538,11 +539,12 @@ fn scatter_values<T: Default + Copy>(
     (values, dense)
 }
 
-/// Build a bit-packed null bitmap from sparse fact row indices.
+/// Build a bit-packed validity bitmap from sparse fact row indices.
 ///
-/// Returns raw bytes where bit `i` is set iff row `i` has at least one fact.
+/// Returns raw bytes where bit `i` is **set** (1) iff row `i` is valid
+/// (has at least one fact). This follows Arrow convention: 1 = valid, 0 = null.
 /// Arrow-free — just a `Vec<u8>` that callers wrap in `NullBuffer`.
-fn null_bitmap_bits<T>(facts: &[(u32, T)], num_rows: usize) -> Vec<u8> {
+fn validity_bitmap_bits<T>(facts: &[(u32, T)], num_rows: usize) -> Vec<u8> {
     let byte_len = num_rows.div_ceil(8);
     let mut bits = vec![0u8; byte_len];
     for &(row, _) in facts {
@@ -560,7 +562,7 @@ fn null_bitmap_bits<T>(facts: &[(u32, T)], num_rows: usize) -> Vec<u8> {
 
 /// Build a `NullBuffer` from sparse row indices.
 fn sparse_null_buffer<T>(facts: &[(u32, T)], num_rows: usize) -> NullBuffer {
-    let bits = null_bitmap_bits(facts, num_rows);
+    let bits = validity_bitmap_bits(facts, num_rows);
     let buf = Buffer::from_vec(bits);
     NullBuffer::new(arrow::buffer::BooleanBuffer::new(buf, 0, num_rows))
 }
@@ -1640,12 +1642,12 @@ mod verification {
         assert_eq!(values[0], second, "last write must win");
     }
 
-    // ── null_bitmap_bits — bit-packed correctness ──────────────────────────
+    // ── validity_bitmap_bits — bit-packed correctness ──────────────────────
 
-    /// Every fact row has its bit set, every gap row has bit clear.
+    /// Every fact row has its bit set (valid), every gap row has bit clear (null).
     #[kani::proof]
     #[kani::unwind(10)]
-    fn verify_null_bitmap_bits_correctness() {
+    fn verify_validity_bitmap_bits_correctness() {
         let num_rows: usize = kani::any();
         kani::assume(num_rows > 0 && num_rows <= 8);
 
@@ -1658,7 +1660,7 @@ mod verification {
         }
         kani::assume(!facts.is_empty());
 
-        let bits = null_bitmap_bits(&facts, num_rows);
+        let bits = validity_bitmap_bits(&facts, num_rows);
         assert_eq!(bits.len(), num_rows.div_ceil(8));
 
         for row in 0..num_rows {
@@ -1674,13 +1676,13 @@ mod verification {
 
     /// Out-of-bounds row indices are silently ignored.
     #[kani::proof]
-    fn verify_null_bitmap_bits_oob_ignored() {
+    fn verify_validity_bitmap_bits_oob_ignored() {
         let num_rows: usize = 4;
         let oob_row: u32 = kani::any();
         kani::assume(oob_row >= num_rows as u32 && oob_row <= 255);
 
         let facts = vec![(0u32, 0i64), (oob_row, 0i64)];
-        let bits = null_bitmap_bits(&facts, num_rows);
+        let bits = validity_bitmap_bits(&facts, num_rows);
 
         assert!(bits[0] & 1 != 0, "row 0 must be set");
         for row in 1..num_rows {

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -501,27 +501,24 @@ fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
         && (num_rows == 0 || facts[num_rows - 1].0 as usize == num_rows - 1)
 }
 
-/// Build a bit-packed NullBuffer from sparse row indices.
-///
-/// Directly produces a bit-packed buffer (1 bit/row) instead of the default
-/// `vec![false; num_rows]` → `NullBuffer::from(Vec<bool>)` path which
-/// allocates 1 byte/row before packing.
-fn sparse_null_buffer<T>(facts: &[(u32, T)], num_rows: usize) -> NullBuffer {
-    let byte_len = num_rows.div_ceil(8);
-    let mut bits = vec![0u8; byte_len];
-    for &(row, _) in facts {
-        let r = row as usize;
-        if r < num_rows {
-            bits[r >> 3] |= 1 << (r & 7);
-        }
-    }
-    let buf = Buffer::from_vec(bits);
-    NullBuffer::new(arrow::buffer::BooleanBuffer::new(buf, 0, num_rows))
-}
+// ---------------------------------------------------------------------------
+// Pure scatter / bitmap — Arrow-free, Kani-provable
+// ---------------------------------------------------------------------------
 
-fn build_int64(facts: &[(u32, i64)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
+/// Scatter fact values into a pre-zeroed vec indexed by row.
+///
+/// Dense path: facts\[i\] → values\[i\] (sequential, no bounds check needed).
+/// Sparse path: facts\[i\].0 → row index (last-write-wins for duplicates).
+///
+/// Returns `(values, dense)`. Callers use `dense` to decide whether a null
+/// bitmap is needed.
+fn scatter_values<T: Default + Copy>(
+    facts: &[(u32, T)],
+    num_rows: usize,
+    dedup: bool,
+) -> (Vec<T>, bool) {
     let dense = is_dense(facts, num_rows, dedup);
-    let mut values = vec![0i64; num_rows];
+    let mut values = vec![T::default(); num_rows];
     if dense {
         debug_assert!(
             facts.is_empty() || facts[0].0 == 0,
@@ -538,6 +535,38 @@ fn build_int64(facts: &[(u32, i64)], num_rows: usize, dedup: bool) -> (ArrayRef,
             }
         }
     }
+    (values, dense)
+}
+
+/// Build a bit-packed null bitmap from sparse fact row indices.
+///
+/// Returns raw bytes where bit `i` is set iff row `i` has at least one fact.
+/// Arrow-free — just a `Vec<u8>` that callers wrap in `NullBuffer`.
+fn null_bitmap_bits<T>(facts: &[(u32, T)], num_rows: usize) -> Vec<u8> {
+    let byte_len = num_rows.div_ceil(8);
+    let mut bits = vec![0u8; byte_len];
+    for &(row, _) in facts {
+        let r = row as usize;
+        if r < num_rows {
+            bits[r >> 3] |= 1 << (r & 7);
+        }
+    }
+    bits
+}
+
+// ---------------------------------------------------------------------------
+// Arrow wrappers — thin constructors over scatter/bitmap results
+// ---------------------------------------------------------------------------
+
+/// Build a `NullBuffer` from sparse row indices.
+fn sparse_null_buffer<T>(facts: &[(u32, T)], num_rows: usize) -> NullBuffer {
+    let bits = null_bitmap_bits(facts, num_rows);
+    let buf = Buffer::from_vec(bits);
+    NullBuffer::new(arrow::buffer::BooleanBuffer::new(buf, 0, num_rows))
+}
+
+fn build_int64(facts: &[(u32, i64)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
+    let (values, dense) = scatter_values(facts, num_rows, dedup);
     let nulls = if dense {
         None
     } else {
@@ -550,24 +579,7 @@ fn build_int64(facts: &[(u32, i64)], num_rows: usize, dedup: bool) -> (ArrayRef,
 }
 
 fn build_float64(facts: &[(u32, f64)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
-    let dense = is_dense(facts, num_rows, dedup);
-    let mut values = vec![0.0f64; num_rows];
-    if dense {
-        debug_assert!(
-            facts.is_empty() || facts[0].0 == 0,
-            "dense path requires consecutive rows starting at 0"
-        );
-        for (i, &(_, v)) in facts.iter().enumerate() {
-            values[i] = v;
-        }
-    } else {
-        for &(row, v) in facts {
-            let r = row as usize;
-            if r < num_rows {
-                values[r] = v;
-            }
-        }
-    }
+    let (values, dense) = scatter_values(facts, num_rows, dedup);
     let nulls = if dense {
         None
     } else {
@@ -580,24 +592,7 @@ fn build_float64(facts: &[(u32, f64)], num_rows: usize, dedup: bool) -> (ArrayRe
 }
 
 fn build_bool(facts: &[(u32, bool)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
-    let dense = is_dense(facts, num_rows, dedup);
-    let mut values = vec![false; num_rows];
-    if dense {
-        debug_assert!(
-            facts.is_empty() || facts[0].0 == 0,
-            "dense path requires consecutive rows starting at 0"
-        );
-        for (i, &(_, v)) in facts.iter().enumerate() {
-            values[i] = v;
-        }
-    } else {
-        for &(row, v) in facts {
-            let r = row as usize;
-            if r < num_rows {
-                values[r] = v;
-            }
-        }
-    }
+    let (values, dense) = scatter_values(facts, num_rows, dedup);
     let nulls = if dense {
         None
     } else {
@@ -1485,6 +1480,236 @@ mod verification {
 
         kani::cover!(orig_offset == 0, "start of original");
         kani::cover!(gen_offset == 0, "start of generated");
+    }
+
+    // ── read_str_bytes — 2-buffer dispatch ─────────────────────────────────
+
+    /// Valid original-buffer reference returns correct bytes.
+    #[kani::proof]
+    fn verify_read_str_bytes_original() {
+        let original = [0xAAu8; 8];
+        let generated = [0xBBu8; 8];
+        let offset: u32 = kani::any();
+        let len: u32 = kani::any();
+        kani::assume(len > 0 && len <= 8);
+        kani::assume(offset <= 8 - len);
+
+        let sref = StringRef { offset, len };
+        let result = read_str_bytes(&original, &generated, original.len(), sref);
+        assert!(result.is_ok());
+        let bytes = result.unwrap();
+        assert_eq!(bytes.len(), len as usize);
+        for &b in bytes {
+            assert_eq!(b, 0xAA);
+        }
+    }
+
+    /// Valid generated-buffer reference returns correct bytes.
+    #[kani::proof]
+    fn verify_read_str_bytes_generated() {
+        let original = [0xAAu8; 8];
+        let generated = [0xBBu8; 8];
+        let gen_offset: u32 = kani::any();
+        let len: u32 = kani::any();
+        kani::assume(len > 0 && len <= 8);
+        kani::assume(gen_offset <= 8 - len);
+
+        let sref = StringRef {
+            offset: original.len() as u32 + gen_offset,
+            len,
+        };
+        let result = read_str_bytes(&original, &generated, original.len(), sref);
+        assert!(result.is_ok());
+        let bytes = result.unwrap();
+        assert_eq!(bytes.len(), len as usize);
+        for &b in bytes {
+            assert_eq!(b, 0xBB);
+        }
+    }
+
+    /// Out-of-bounds StringRef returns error for both buffers.
+    #[kani::proof]
+    fn verify_read_str_bytes_oob() {
+        let original = [0u8; 4];
+        let generated = [0u8; 4];
+        let offset: u32 = kani::any();
+        let len: u32 = kani::any();
+        kani::assume(len > 0 && len <= 16);
+        kani::assume(offset <= 16);
+
+        let sref = StringRef { offset, len };
+
+        let end = (offset as usize).saturating_add(len as usize);
+        if offset < original.len() as u32 {
+            if end > original.len() {
+                let result = read_str_bytes(&original, &generated, original.len(), sref);
+                assert!(result.is_err());
+            }
+        } else {
+            let adj_start = offset as usize - original.len();
+            let adj_end = adj_start + len as usize;
+            if adj_end > generated.len() {
+                let result = read_str_bytes(&original, &generated, original.len(), sref);
+                assert!(result.is_err());
+            }
+        }
+    }
+
+    /// No StringRef can span across the original/generated boundary.
+    #[kani::proof]
+    fn verify_read_str_bytes_no_spanning() {
+        let original = [0xAAu8; 4];
+        let generated = [0xBBu8; 4];
+        let len: u32 = kani::any();
+        kani::assume(len > 0 && len <= 8);
+
+        let offset: u32 = kani::any();
+        kani::assume(offset < original.len() as u32);
+        kani::assume((offset as usize) + (len as usize) > original.len());
+
+        let sref = StringRef { offset, len };
+        let result = read_str_bytes(&original, &generated, original.len(), sref);
+        assert!(result.is_err(), "spanning ref must be rejected");
+    }
+
+    // ── scatter_values — dense/sparse placement ────────────────────────────
+
+    /// Dense scatter: values[i] == facts[i].1 for all i.
+    #[kani::proof]
+    #[kani::unwind(6)]
+    fn verify_scatter_values_dense() {
+        let num_rows: usize = kani::any();
+        kani::assume(num_rows > 0 && num_rows <= 4);
+
+        let mut facts: Vec<(u32, i64)> = Vec::new();
+        for row in 0..num_rows {
+            let val: i64 = kani::any();
+            facts.push((row as u32, val));
+        }
+
+        let (values, dense) = scatter_values(&facts, num_rows, true);
+        assert!(dense, "full-coverage + dedup must be dense");
+        assert_eq!(values.len(), num_rows);
+        for (i, &(_, v)) in facts.iter().enumerate() {
+            assert_eq!(values[i], v, "dense value must match fact");
+        }
+    }
+
+    /// Sparse scatter: fact rows get their value, gap rows stay default.
+    #[kani::proof]
+    #[kani::unwind(6)]
+    fn verify_scatter_values_sparse() {
+        let num_rows: usize = kani::any();
+        kani::assume(num_rows > 0 && num_rows <= 4);
+
+        let presence: u8 = kani::any();
+        let mut facts: Vec<(u32, i64)> = Vec::new();
+        for row in 0..num_rows {
+            if presence & (1 << row) != 0 {
+                facts.push((row as u32, row as i64 + 100));
+            }
+        }
+        kani::assume(!facts.is_empty());
+        kani::assume(facts.len() < num_rows);
+
+        let (values, dense) = scatter_values(&facts, num_rows, true);
+        assert!(!dense, "partial coverage must not be dense");
+        assert_eq!(values.len(), num_rows);
+
+        for row in 0..num_rows {
+            if presence & (1 << row) != 0 {
+                assert_eq!(values[row], row as i64 + 100);
+            } else {
+                assert_eq!(values[row], 0, "gap row must be default");
+            }
+        }
+
+        kani::cover!(facts.len() == 1, "single fact");
+    }
+
+    /// Last-write-wins: when dedup=false (sparse path), later facts overwrite.
+    #[kani::proof]
+    fn verify_scatter_values_last_write_wins() {
+        let first: i64 = kani::any();
+        let second: i64 = kani::any();
+        kani::assume(first != second);
+
+        let facts = vec![(0u32, first), (0u32, second)];
+        let (values, dense) = scatter_values(&facts, 1, false);
+        assert!(!dense, "dedup=false must not be dense");
+        assert_eq!(values[0], second, "last write must win");
+    }
+
+    // ── null_bitmap_bits — bit-packed correctness ──────────────────────────
+
+    /// Every fact row has its bit set, every gap row has bit clear.
+    #[kani::proof]
+    #[kani::unwind(10)]
+    fn verify_null_bitmap_bits_correctness() {
+        let num_rows: usize = kani::any();
+        kani::assume(num_rows > 0 && num_rows <= 8);
+
+        let presence: u8 = kani::any();
+        let mut facts: Vec<(u32, i64)> = Vec::new();
+        for row in 0..num_rows {
+            if presence & (1 << row) != 0 {
+                facts.push((row as u32, 0));
+            }
+        }
+        kani::assume(!facts.is_empty());
+
+        let bits = null_bitmap_bits(&facts, num_rows);
+        assert_eq!(bits.len(), num_rows.div_ceil(8));
+
+        for row in 0..num_rows {
+            let bit_set = bits[row >> 3] & (1 << (row & 7)) != 0;
+            let has_fact = presence & (1 << row) != 0;
+            assert_eq!(bit_set, has_fact, "bit must match fact presence at row");
+        }
+
+        kani::cover!(num_rows == 1, "single row");
+        kani::cover!(num_rows == 8, "full byte boundary");
+        kani::cover!(presence == 0xFF, "all rows present");
+    }
+
+    /// Out-of-bounds row indices are silently ignored.
+    #[kani::proof]
+    fn verify_null_bitmap_bits_oob_ignored() {
+        let num_rows: usize = 4;
+        let oob_row: u32 = kani::any();
+        kani::assume(oob_row >= num_rows as u32 && oob_row <= 255);
+
+        let facts = vec![(0u32, 0i64), (oob_row, 0i64)];
+        let bits = null_bitmap_bits(&facts, num_rows);
+
+        assert!(bits[0] & 1 != 0, "row 0 must be set");
+        for row in 1..num_rows {
+            let bit_set = bits[row >> 3] & (1 << (row & 7)) != 0;
+            assert!(!bit_set, "non-fact row must be clear");
+        }
+    }
+
+    // ── is_dense — classification ──────────────────────────────────────────
+
+    /// is_dense returns true iff facts cover [0, num_rows) exactly with dedup.
+    #[kani::proof]
+    #[kani::unwind(6)]
+    fn verify_is_dense_classification() {
+        let num_rows: usize = kani::any();
+        kani::assume(num_rows > 0 && num_rows <= 4);
+
+        let mut facts: Vec<(u32, i64)> = Vec::new();
+        for row in 0..num_rows {
+            facts.push((row as u32, 0));
+        }
+
+        assert!(is_dense(&facts, num_rows, true));
+        assert!(!is_dense(&facts, num_rows, false));
+
+        if num_rows > 1 {
+            let partial = facts[..num_rows - 1].to_vec();
+            assert!(!is_dense(&partial, num_rows, true));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Split the three `build_*` functions (int64, float64, bool) in `accumulator.rs` into:

- **`scatter_values<T>`**: pure Arrow-free scatter of facts into a pre-zeroed values vec (dense sequential or sparse indexed)
- **`null_bitmap_bits<T>`**: pure Arrow-free bit-packed null bitmap construction  
- **Thin Arrow wrappers** that call scatter + wrap results in typed arrays

This separation lets Kani exhaustively verify the core scatter/bitmap logic without pulling in Arrow's type system, which causes CBMC state-space explosion and CI timeouts.

## Motivation

Kani proofs for `build_int64`, `build_float64`, and `build_bool` were timing out because Arrow array constructors explode the CBMC state space. By extracting the pure logic into Arrow-free functions, we get exhaustive bounded verification of the critical scatter/bitmap paths while the trivial Arrow constructor wrappers remain proptest-covered.

## New Kani proofs (10 total, all Arrow-free)

| Proof | Property |
|-------|----------|
| `verify_scatter_values_dense` | values[i] == facts[i].1 for full coverage |
| `verify_scatter_values_sparse` | gap rows stay default(0), fact rows match |
| `verify_scatter_values_last_write_wins` | dedup=false: later fact overwrites earlier |
| `verify_null_bitmap_bits_correctness` | bit set iff row has fact (all 8-row combos) |
| `verify_null_bitmap_bits_oob_ignored` | out-of-bounds rows silently skipped |
| `verify_is_dense_classification` | dense iff full coverage + dedup=true |
| `verify_read_str_bytes_original` | correct dispatch to original buffer |
| `verify_read_str_bytes_generated` | correct dispatch to generated buffer |
| `verify_read_str_bytes_oob` | OOB references return error |
| `verify_read_str_bytes_no_spanning` | no cross-boundary refs possible |

## Test plan

- `cargo test -p logfwd-arrow` — 234 tests pass (behavior-preserving refactor)
- `cargo clippy -p logfwd-arrow --lib -- -D warnings` — clean
- Kani proof `verify_scatter_values_last_write_wins` verified locally (0.5s, SUCCESSFUL)
- Existing proptests for `build_int64`, `build_float64`, `build_bool` continue to cover the Arrow wrapper layer

Relates to #1838

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `scatter_values` and `validity_bitmap_bits` helpers in accumulator for Kani testability
> - Extracts `scatter_values` and `validity_bitmap_bits` as standalone generic helpers in [accumulator.rs](https://github.com/strawgate/memagent/pull/2237/files#diff-41b79f99ae1f7fd4f98545794a773da1bfeb0b7b6fac100feeac992e956c7e02), replacing inline logic in `build_int64`, `build_float64`, and `build_bool`.
> - `scatter_values` writes fact values into a `Vec<T>` with dense/sparse detection and last-write-wins support; `validity_bitmap_bits` produces a bit-packed validity bitmap independent of Arrow types.
> - `sparse_null_buffer` is refactored to delegate to `validity_bitmap_bits`, keeping Arrow wrapping at the call site.
> - Adds Kani proofs covering dense/sparse classification, last-write-wins behavior, out-of-bounds index handling, and `StringRef` boundary conditions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cf03eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->