### PR TITLE
feat: add max_file_size_bytes write-ahead limit to file output

### DIFF
--- a/crates/logfwd-bench/benches/output_encode.rs
+++ b/crates/logfwd-bench/benches/output_encode.rs
@@ -393,6 +393,16 @@ fn bench_output_encode(c: &mut Criterion) {
                 (10_000, generators::gen_wide_batch(10_000, 42)),
             ],
         ),
+        (
+            // Same schema as `wide` but ~25% of optional columns are null.
+            // Exercises the `has_nulls = true` path in `encode_col_attr` and
+            // provides a stable baseline for nullable-data encoder performance.
+            "wide_sparse",
+            vec![
+                (1_000, generators::gen_wide_sparse_batch(1_000, 42)),
+                (10_000, generators::gen_wide_sparse_batch(10_000, 42)),
+            ],
+        ),
     ];
 
     for (schema_name, sizes) in &variants {

--- a/crates/logfwd-bench/src/bin/otlp_encode_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_encode_profile.rs
@@ -66,10 +66,12 @@ fn run_iterations(batch: &RecordBatch, encoder: &str, iterations: usize) -> Dura
     for _ in 0..2 {
         match encoder {
             "manual" => {
-                black_box(sink.encode_batch(batch, &meta));
+                sink.encode_batch(batch, &meta);
+                black_box(&sink);
             }
             "generated_fast" => {
-                black_box(sink.encode_batch_generated_fast(batch, &meta));
+                sink.encode_batch_generated_fast(batch, &meta);
+                black_box(&sink);
             }
             other => {
                 eprintln!("Unknown encoder '{other}'; expected manual | generated_fast");
@@ -82,10 +84,12 @@ fn run_iterations(batch: &RecordBatch, encoder: &str, iterations: usize) -> Dura
     for _ in 0..iterations {
         match encoder {
             "manual" => {
-                black_box(sink.encode_batch(batch, &meta));
+                sink.encode_batch(batch, &meta);
+                black_box(&sink);
             }
             _ => {
-                black_box(sink.encode_batch_generated_fast(batch, &meta));
+                sink.encode_batch_generated_fast(batch, &meta);
+                black_box(&sink);
             }
         }
     }

--- a/crates/logfwd-bench/src/bin/otlp_encode_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_encode_profile.rs
@@ -1,0 +1,154 @@
+//! CPU-profile harness for the Arrow→OTLP encoder.
+//!
+//! Runs `encode_batch` / `encode_batch_generated_fast` in a tight loop while
+//! collecting a pprof flamegraph.  Designed to be run with a release binary so
+//! the flamegraph reflects production-representative inlining decisions.
+//!
+//! # Usage
+//!
+//! ```text
+//! # Dense wide batch (no nulls) — generated fast path
+//! cargo run -p logfwd-bench --release --bin otlp_encode_profile -- \
+//!     wide 10000 5000 generated_fast /tmp/otlp-wide-fast.svg
+//!
+//! # Sparse wide batch (~25% nulls) — generated fast path
+//! cargo run -p logfwd-bench --release --bin otlp_encode_profile -- \
+//!     wide_sparse 10000 5000 generated_fast /tmp/otlp-wide-sparse.svg
+//!
+//! # Manual encoder (encode_batch)
+//! cargo run -p logfwd-bench --release --bin otlp_encode_profile -- \
+//!     wide 10000 5000 manual /tmp/otlp-wide-manual.svg
+//! ```
+//!
+//! Arguments (all positional):
+//!   1. `fixture`    — `narrow` | `wide` | `wide_sparse`
+//!   2. `rows`       — rows per batch (e.g. 10000)
+//!   3. `iterations` — encode loop count (e.g. 5000)
+//!   4. `encoder`    — `manual` | `generated_fast`
+//!   5. `svg_path`   — output flamegraph SVG path
+
+use std::fs::File;
+use std::hint::black_box;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use arrow::record_batch::RecordBatch;
+use logfwd_bench::{generators, make_otlp_sink};
+use logfwd_output::Compression;
+
+fn usage() -> ! {
+    eprintln!("Usage: otlp_encode_profile <fixture> <rows> <iterations> <encoder> <svg_path>");
+    eprintln!("  fixture:    narrow | wide | wide_sparse");
+    eprintln!("  rows:       rows per batch (e.g. 10000)");
+    eprintln!("  iterations: encode loop count (e.g. 5000)");
+    eprintln!("  encoder:    manual | generated_fast");
+    eprintln!("  svg_path:   output flamegraph SVG path");
+    std::process::exit(1);
+}
+
+fn make_batch(fixture: &str, rows: usize) -> RecordBatch {
+    match fixture {
+        "narrow" => generators::gen_narrow_batch(rows, 42),
+        "wide" => generators::gen_wide_batch(rows, 42),
+        "wide_sparse" => generators::gen_wide_sparse_batch(rows, 42),
+        other => {
+            eprintln!("Unknown fixture '{other}'; expected narrow | wide | wide_sparse");
+            usage();
+        }
+    }
+}
+
+fn run_iterations(batch: &RecordBatch, encoder: &str, iterations: usize) -> Duration {
+    let meta = generators::make_metadata();
+    let mut sink = make_otlp_sink(Compression::None);
+
+    // Warm up — two passes to stabilise allocator state.
+    for _ in 0..2 {
+        match encoder {
+            "manual" => {
+                black_box(sink.encode_batch(batch, &meta));
+            }
+            "generated_fast" => {
+                black_box(sink.encode_batch_generated_fast(batch, &meta));
+            }
+            other => {
+                eprintln!("Unknown encoder '{other}'; expected manual | generated_fast");
+                usage();
+            }
+        }
+    }
+
+    let start = Instant::now();
+    for _ in 0..iterations {
+        match encoder {
+            "manual" => {
+                black_box(sink.encode_batch(batch, &meta));
+            }
+            _ => {
+                black_box(sink.encode_batch_generated_fast(batch, &meta));
+            }
+        }
+    }
+    start.elapsed()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 6 {
+        usage();
+    }
+
+    let fixture = &args[1];
+    let rows: usize = args[2].parse().unwrap_or_else(|_| {
+        eprintln!("rows must be a positive integer");
+        usage();
+    });
+    let iterations: usize = args[3].parse().unwrap_or_else(|_| {
+        eprintln!("iterations must be a positive integer");
+        usage();
+    });
+    let encoder = &args[4];
+    let svg_path = PathBuf::from(&args[5]);
+
+    let batch = make_batch(fixture, rows);
+
+    // Report batch null stats so callers can verify the fixture.
+    let null_cols: Vec<_> = batch
+        .schema()
+        .fields()
+        .iter()
+        .zip(batch.columns())
+        .filter(|(_, arr)| arr.null_count() > 0)
+        .map(|(f, arr)| format!("{}({})", f.name(), arr.null_count()))
+        .collect();
+    eprintln!("fixture={fixture} rows={rows} encoder={encoder} iterations={iterations}");
+    if null_cols.is_empty() {
+        eprintln!("nullable_cols=none (all columns are fully dense)");
+    } else {
+        eprintln!("nullable_cols={}", null_cols.join(", "));
+    }
+
+    let guard = pprof::ProfilerGuardBuilder::default()
+        .frequency(1_000)
+        .blocklist(&["libc", "libgcc", "pthread"])
+        .build()
+        .expect("pprof guard");
+
+    let elapsed = run_iterations(&batch, encoder, iterations);
+
+    if let Ok(report) = guard.report().build() {
+        let file = File::create(&svg_path).expect("create flamegraph SVG");
+        report.flamegraph(file).expect("write flamegraph");
+        eprintln!("flamegraph={}", svg_path.display());
+    } else {
+        eprintln!("warning: pprof report build failed");
+    }
+
+    let rows_per_sec = (rows * iterations) as f64 / elapsed.as_secs_f64();
+    eprintln!(
+        "elapsed={:.2}s rows_encoded={} throughput={:.2}M rows/s",
+        elapsed.as_secs_f64(),
+        rows * iterations,
+        rows_per_sec / 1_000_000.0,
+    );
+}

--- a/crates/logfwd-bench/src/generators.rs
+++ b/crates/logfwd-bench/src/generators.rs
@@ -20,6 +20,7 @@ include!("generators/shared_profiles.rs");
 include!("generators/envoy_access.rs");
 include!("generators/cri_mixed_narrow.rs");
 include!("generators/wide_metadata.rs");
+include!("generators/wide_sparse.rs");
 
 #[cfg(test)]
 pub(crate) mod test_support;

--- a/crates/logfwd-bench/src/generators/wide_sparse.rs
+++ b/crates/logfwd-bench/src/generators/wide_sparse.rs
@@ -1,0 +1,225 @@
+// ---------------------------------------------------------------------------
+// gen_wide_sparse — Wide batch with nullable columns (~25% null rate)
+// ---------------------------------------------------------------------------
+//
+// Mirrors `gen_wide_batch` but several "optional" columns have roughly 25% of
+// rows set to null.  This exercises the `has_nulls = true` path in
+// `encode_col_attr` and provides a stable regression baseline for encoders
+// that must handle nullable Arrow arrays.
+//
+// Nullable columns (25% null rate):
+//   upstream_latency_ms, retry_count, error_count, user, remote_addr,
+//   tls_version, content_type
+//
+// All other columns remain fully dense (null_count == 0).
+
+/// Generate a wide nullable [`RecordBatch`] with ~25% null rate on optional columns.
+///
+/// Deterministic for a given `(count, seed)` pair.
+pub fn gen_wide_sparse_batch(count: usize, seed: u64) -> RecordBatch {
+    let mut rng = fastrand::Rng::with_seed(seed);
+    let mut cardinality = CardinalityState::new(CardinalityProfile::infra_like());
+
+    // Dense columns (always have a value)
+    let mut timestamp = StringBuilder::with_capacity(count, count.saturating_mul(32));
+    let mut level = StringBuilder::with_capacity(count, count.saturating_mul(8));
+    let mut message = StringBuilder::with_capacity(count, count.saturating_mul(96));
+    let mut status: Vec<i64> = Vec::with_capacity(count);
+    let mut duration_ms: Vec<f64> = Vec::with_capacity(count);
+    let mut cluster = StringBuilder::with_capacity(count, count.saturating_mul(24));
+    let mut node = StringBuilder::with_capacity(count, count.saturating_mul(24));
+    let mut namespace = StringBuilder::with_capacity(count, count.saturating_mul(16));
+    let mut pod = StringBuilder::with_capacity(count, count.saturating_mul(24));
+    let mut container = StringBuilder::with_capacity(count, count.saturating_mul(16));
+    let mut service = StringBuilder::with_capacity(count, count.saturating_mul(24));
+    let mut trace_id = StringBuilder::with_capacity(count, count.saturating_mul(32));
+    let mut span_id = StringBuilder::with_capacity(count, count.saturating_mul(16));
+    let mut request_id = StringBuilder::with_capacity(count, count.saturating_mul(16));
+    let mut session_id: Vec<i64> = Vec::with_capacity(count);
+    let mut bytes_sent: Vec<i64> = Vec::with_capacity(count);
+    let mut bytes_received: Vec<i64> = Vec::with_capacity(count);
+    let mut user_agent = StringBuilder::with_capacity(count, count.saturating_mul(40));
+    let mut host = StringBuilder::with_capacity(count, count.saturating_mul(20));
+    let mut protocol = StringBuilder::with_capacity(count, count.saturating_mul(12));
+
+    // Sparse columns (~25% null rate)
+    let mut upstream_latency_ms: Vec<Option<f64>> = Vec::with_capacity(count);
+    let mut retry_count: Vec<Option<i64>> = Vec::with_capacity(count);
+    let mut error_count: Vec<Option<i64>> = Vec::with_capacity(count);
+    let mut user = StringBuilder::with_capacity(count, count.saturating_mul(16));
+    let mut remote_addr = StringBuilder::with_capacity(count, count.saturating_mul(24));
+    let mut tls_version = StringBuilder::with_capacity(count, count.saturating_mul(8));
+    let mut content_type = StringBuilder::with_capacity(count, count.saturating_mul(24));
+
+    let mut timestamp_buf = String::with_capacity(32);
+    let mut message_buf = String::with_capacity(96);
+    let mut trace_id_buf = String::with_capacity(32);
+    let mut span_id_buf = String::with_capacity(16);
+    let mut request_id_buf = String::with_capacity(16);
+    let mut user_buf = String::with_capacity(16);
+    let mut remote_addr_buf = String::with_capacity(24);
+
+    for i in 0..count {
+        let sample = cardinality.sample(&mut rng);
+        let phase = sample.phase;
+        let status_code = sample.status_code;
+        let session_id_value = sample.session_id;
+        let service_idx = sample.service_idx;
+        let namespace_idx = sample.namespace_idx;
+        let path_idx = sample.path_idx;
+        let user_idx = sample.user_idx;
+        let sec = i % 60;
+        let nano = rng.u32(..1_000_000_000);
+        let level_value = level_for_phase(phase);
+        let path = pick_by_idx(PATHS, path_idx);
+        let method = pick(&mut rng, METHODS);
+        let duration_value = round_tenths(
+            rng.f64()
+                * match phase {
+                    SamplePhase::Hot => 300.0,
+                    SamplePhase::Warm => 900.0,
+                    SamplePhase::Cold => 3500.0,
+                },
+        );
+        let namespace_value = pick_by_idx(NAMESPACES, namespace_idx);
+        let service_value = pick_by_idx(SERVICES, service_idx);
+
+        // ~25% null: use the low two bits of a fresh random byte as independent
+        // null signals for each sparse column group.
+        // Each sparse column independently has ~25% probability of being null.
+        let null_a = rng.u8(..) < 64; // upstream_latency_ms, retry_count
+        let null_b = rng.u8(..) < 64; // error_count, user
+        let null_c = rng.u8(..) < 64; // remote_addr, tls_version
+        let null_d = rng.u8(..) < 64; // content_type
+
+        append_timestamp_utc(&mut timestamp_buf, sec, nano);
+        timestamp.append_value(&timestamp_buf);
+        level.append_value(level_value);
+        message_buf.clear();
+        let _ = write!(message_buf, "{method} {path} HTTP/1.1");
+        message.append_value(&message_buf);
+        status.push(i64::from(status_code));
+        duration_ms.push(duration_value);
+        cluster.append_value(sample.cluster);
+        node.append_value(sample.node);
+        namespace.append_value(namespace_value);
+        pod.append_value(sample.pod);
+        container.append_value(sample.container);
+        service.append_value(service_value);
+        trace_id_buf.clear();
+        let _ = write!(trace_id_buf, "{:032x}", sample.trace_id);
+        trace_id.append_value(&trace_id_buf);
+        span_id_buf.clear();
+        let _ = write!(span_id_buf, "{:016x}", sample.span_id);
+        span_id.append_value(&span_id_buf);
+        request_id_buf.clear();
+        let _ = write!(request_id_buf, "req-{:08x}", sample.request_id as u32);
+        request_id.append_value(&request_id_buf);
+        session_id.push(session_id_value as i64);
+        bytes_sent.push(i64::from(rng.u32(..65536)));
+        bytes_received.push(i64::from(rng.u32(..65536)));
+        user_agent.append_value("Mozilla/5.0 (X11; Linux x86_64)");
+        host.append_value("api.example.com");
+        protocol.append_value("HTTP/1.1");
+
+        // Sparse columns
+        if null_a {
+            upstream_latency_ms.push(None);
+            retry_count.push(None);
+        } else {
+            upstream_latency_ms.push(Some(round_tenths(rng.f64() * 200.0)));
+            retry_count.push(Some(i64::from(sample.retry_count)));
+        }
+        if null_b {
+            error_count.push(None);
+            user.append_null();
+        } else {
+            error_count.push(Some(i64::from(sample.error_count)));
+            append_user_label(&mut user_buf, user_idx);
+            user.append_value(&user_buf);
+        }
+        if null_c {
+            remote_addr.append_null();
+            tls_version.append_null();
+        } else {
+            remote_addr_buf.clear();
+            let _ = write!(
+                remote_addr_buf,
+                "10.{}.{}.{}",
+                rng.u8(..),
+                rng.u8(..),
+                rng.u8(..)
+            );
+            remote_addr.append_value(&remote_addr_buf);
+            tls_version.append_value("TLSv1.3");
+        }
+        if null_d {
+            content_type.append_null();
+        } else {
+            content_type.append_value("application/json");
+        }
+    }
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp", DataType::Utf8, true),
+        Field::new("level", DataType::Utf8, true),
+        Field::new("message", DataType::Utf8, true),
+        Field::new("status", DataType::Int64, true),
+        Field::new("duration_ms", DataType::Float64, true),
+        Field::new("cluster", DataType::Utf8, true),
+        Field::new("node", DataType::Utf8, true),
+        Field::new("namespace", DataType::Utf8, true),
+        Field::new("pod", DataType::Utf8, true),
+        Field::new("container", DataType::Utf8, true),
+        Field::new("service", DataType::Utf8, true),
+        Field::new("trace_id", DataType::Utf8, true),
+        Field::new("span_id", DataType::Utf8, true),
+        Field::new("request_id", DataType::Utf8, true),
+        Field::new("session_id", DataType::Int64, true),
+        Field::new("bytes_sent", DataType::Int64, true),
+        Field::new("bytes_received", DataType::Int64, true),
+        Field::new("user_agent", DataType::Utf8, true),
+        Field::new("host", DataType::Utf8, true),
+        Field::new("protocol", DataType::Utf8, true),
+        Field::new("upstream_latency_ms", DataType::Float64, true),
+        Field::new("retry_count", DataType::Int64, true),
+        Field::new("error_count", DataType::Int64, true),
+        Field::new("user", DataType::Utf8, true),
+        Field::new("remote_addr", DataType::Utf8, true),
+        Field::new("tls_version", DataType::Utf8, true),
+        Field::new("content_type", DataType::Utf8, true),
+    ]));
+
+    let arrays: Vec<ArrayRef> = vec![
+        Arc::new(timestamp.finish()) as ArrayRef,
+        Arc::new(level.finish()) as ArrayRef,
+        Arc::new(message.finish()) as ArrayRef,
+        Arc::new(Int64Array::from(status)) as ArrayRef,
+        Arc::new(Float64Array::from(duration_ms)) as ArrayRef,
+        Arc::new(cluster.finish()) as ArrayRef,
+        Arc::new(node.finish()) as ArrayRef,
+        Arc::new(namespace.finish()) as ArrayRef,
+        Arc::new(pod.finish()) as ArrayRef,
+        Arc::new(container.finish()) as ArrayRef,
+        Arc::new(service.finish()) as ArrayRef,
+        Arc::new(trace_id.finish()) as ArrayRef,
+        Arc::new(span_id.finish()) as ArrayRef,
+        Arc::new(request_id.finish()) as ArrayRef,
+        Arc::new(Int64Array::from(session_id)) as ArrayRef,
+        Arc::new(Int64Array::from(bytes_sent)) as ArrayRef,
+        Arc::new(Int64Array::from(bytes_received)) as ArrayRef,
+        Arc::new(user_agent.finish()) as ArrayRef,
+        Arc::new(host.finish()) as ArrayRef,
+        Arc::new(protocol.finish()) as ArrayRef,
+        Arc::new(Float64Array::from(upstream_latency_ms)) as ArrayRef,
+        Arc::new(Int64Array::from(retry_count)) as ArrayRef,
+        Arc::new(Int64Array::from(error_count)) as ArrayRef,
+        Arc::new(user.finish()) as ArrayRef,
+        Arc::new(remote_addr.finish()) as ArrayRef,
+        Arc::new(tls_version.finish()) as ArrayRef,
+        Arc::new(content_type.finish()) as ArrayRef,
+    ];
+
+    RecordBatch::try_new(schema, arrays)
+        .unwrap_or_else(|err| panic!("wide sparse batch generation failed for {count} rows: {err}"))
+}

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -677,6 +677,27 @@ pipelines:
     }
 
     #[test]
+    fn file_output_accepts_max_file_size_bytes() {
+        let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: file\n  path: /tmp/out.ndjson\n  max_file_size_bytes: 104857600\n";
+        let cfg = Config::load_str(yaml).unwrap();
+        assert_eq!(
+            cfg.pipelines["default"].outputs[0].max_file_size_bytes,
+            Some(104_857_600)
+        );
+    }
+
+    #[test]
+    fn non_file_output_rejects_max_file_size_bytes() {
+        let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: stdout\n  max_file_size_bytes: 100\n";
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("'max_file_size_bytes' is only supported for file outputs"),
+            "unexpected: {msg}"
+        );
+    }
+
+    #[test]
     fn loki_output_rejects_compression() {
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: loki\n  endpoint: http://localhost:3100\n  compression: gzip\n";
         let err = Config::load_str(yaml).unwrap_err();

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -725,6 +725,12 @@ pub struct OutputConfig {
     /// Whether to write the schema immediately upon connection.
     #[serde(default)]
     pub write_schema_on_connect: Option<bool>,
+    /// Write-ahead limit for file outputs. When the output file exceeds this
+    /// size in bytes, the sink yields briefly on each write to create pipeline
+    /// backpressure. Prevents the generator from spinning at 100% CPU when
+    /// the downstream reader is slower than the writer.
+    #[serde(default)]
+    pub max_file_size_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -939,6 +939,14 @@ impl Config {
                         )));
                     }
 
+                    if !matches!(output.output_type, OutputType::File)
+                        && output.max_file_size_bytes.is_some()
+                    {
+                        return Err(ConfigError::Validation(format!(
+                            "pipeline '{name}' output '{label}': 'max_file_size_bytes' is only supported for file outputs"
+                        )));
+                    }
+
                     if output.output_type != OutputType::ArrowIpc {
                         if output.host.is_some() {
                             return Err(ConfigError::Validation(format!(

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -850,6 +850,10 @@ mod tests {
     }
 
     proptest::proptest! {
+        #![proptest_config(proptest::test_runner::Config {
+            failure_persistence: None,
+            ..proptest::test_runner::Config::default()
+        })]
         /// `days_from_civil` (Hinnant algorithm) must agree with chrono for
         /// all valid calendar dates in the range 1970–2099.
         #[test]
@@ -1072,6 +1076,10 @@ mod tests {
     }
 
     proptest::proptest! {
+        #![proptest_config(proptest::test_runner::Config {
+            failure_persistence: None,
+            ..proptest::test_runner::Config::default()
+        })]
         /// LUT nibble lookup must agree with the branch-based oracle for every
         /// possible byte value (0x00–0xFF).
         #[test]

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -274,26 +274,47 @@ pub fn hex_decode(hex_bytes: &[u8], out: &mut [u8]) -> bool {
     if hex_bytes.len() != out.len() * 2 {
         return false;
     }
+    // Validate all nibbles first: collect the bitwise OR of all LUT values.
+    // Invalid bytes produce 0xFF; valid nibbles produce 0x00–0x0F.  The high
+    // nibble of the OR will be set (≥ 0x10) iff any invalid byte was present.
+    // Doing validation as a single pass over the input lets the compiler
+    // vectorise the check without a per-pair early-return branch.
+    let mut any_invalid = 0u8;
+    for &b in hex_bytes {
+        any_invalid |= HEX_NIBBLE_LUT[b as usize];
+    }
+    if any_invalid & 0xF0 != 0 {
+        return false;
+    }
+    // All nibbles are valid; decode without any per-pair branch.
     for (i, byte) in out.iter_mut().enumerate() {
-        let hi = hex_nibble(hex_bytes[i * 2]);
-        let lo = hex_nibble(hex_bytes[i * 2 + 1]);
-        if hi > 0x0F || lo > 0x0F {
-            return false;
-        }
-        *byte = (hi << 4) | lo;
+        *byte = (HEX_NIBBLE_LUT[hex_bytes[i * 2] as usize] << 4)
+            | HEX_NIBBLE_LUT[hex_bytes[i * 2 + 1] as usize];
     }
     true
 }
 
-#[inline(always)]
-fn hex_nibble(c: u8) -> u8 {
-    match c {
-        b'0'..=b'9' => c - b'0',
-        b'a'..=b'f' => c - b'a' + 10,
-        b'A'..=b'F' => c - b'A' + 10,
-        _ => 0xFF,
+/// 256-entry lookup table for hex nibble decoding.
+///
+/// Valid ASCII hex digits map to their 0x00–0x0F value; everything else maps
+/// to the sentinel 0xFF used by callers to signal an invalid character.
+/// Using a LUT replaces the three-branch match with a single indexed load.
+/// The table is 256 bytes and stays hot in L1 cache during batch decode loops.
+const HEX_NIBBLE_LUT: [u8; 256] = {
+    let mut lut = [0xFF_u8; 256];
+    let mut i = 0u16;
+    while i < 256 {
+        let c = i as u8;
+        lut[c as usize] = match c {
+            b'0'..=b'9' => c - b'0',
+            b'a'..=b'f' => c - b'a' + 10,
+            b'A'..=b'F' => c - b'A' + 10,
+            _ => 0xFF,
+        };
+        i += 1;
     }
-}
+    lut
+};
 
 // --- OTLP Severity mapping ---
 
@@ -960,6 +981,76 @@ mod tests {
         assert!(!hex_decode(b"01 20304", &mut out)); // space is invalid
     }
 
+    /// Oracle: the reference (branch-based) nibble decoder used to verify the
+    /// LUT implementation.  Kept private to this test module.
+    fn hex_nibble_oracle(c: u8) -> u8 {
+        match c {
+            b'0'..=b'9' => c - b'0',
+            b'a'..=b'f' => c - b'a' + 10,
+            b'A'..=b'F' => c - b'A' + 10,
+            _ => 0xFF,
+        }
+    }
+
+    /// Oracle: reference `hex_decode` implementation (original single-pass loop).
+    fn hex_decode_oracle(hex_bytes: &[u8], out: &mut [u8]) -> bool {
+        if hex_bytes.len() != out.len() * 2 {
+            return false;
+        }
+        for (i, byte) in out.iter_mut().enumerate() {
+            let hi = hex_nibble_oracle(hex_bytes[i * 2]);
+            let lo = hex_nibble_oracle(hex_bytes[i * 2 + 1]);
+            if hi > 0x0F || lo > 0x0F {
+                return false;
+            }
+            *byte = (hi << 4) | lo;
+        }
+        true
+    }
+
+    proptest::proptest! {
+        /// LUT nibble lookup must agree with the branch-based oracle for every
+        /// possible byte value (0x00–0xFF).
+        #[test]
+        fn proptest_hex_nibble_lut_matches_oracle(b: u8) {
+            proptest::prop_assert_eq!(
+                HEX_NIBBLE_LUT[b as usize],
+                hex_nibble_oracle(b),
+                "LUT[{:#04x}] != oracle({:#04x})",
+                b, b,
+            );
+        }
+
+        /// LUT-based `hex_decode` must agree with the oracle on every possible
+        /// input byte sequence of lengths 0, 2, 4, 8, 16, and 32.
+        ///
+        /// Covers: valid hex, invalid chars, mixed case, and arbitrary garbage.
+        #[test]
+        fn proptest_hex_decode_lut_matches_oracle(
+            input in proptest::collection::vec(proptest::num::u8::ANY, 0..=64),
+        ) {
+            // Test all output sizes that are representable as hex strings of
+            // the given input length.
+            for out_len in [0usize, 1, 2, 4, 8, 16] {
+                let expected_input_len = out_len * 2;
+                if input.len() < expected_input_len {
+                    continue;
+                }
+                let hex = &input[..expected_input_len];
+                let mut got = alloc::vec![0u8; out_len];
+                let mut expected = alloc::vec![0u8; out_len];
+                let got_ok = hex_decode(hex, &mut got);
+                let expected_ok = hex_decode_oracle(hex, &mut expected);
+                proptest::prop_assert_eq!(got_ok, expected_ok,
+                    "return value mismatch for input {:?}", hex);
+                if got_ok {
+                    proptest::prop_assert_eq!(&got, &expected,
+                        "output mismatch for input {:?}", hex);
+                }
+            }
+        }
+    }
+
     /// Spot-check protobuf field number constants against the OTLP proto spec.
     /// Catches drift without requiring the Kani toolchain.
     #[test]
@@ -1599,12 +1690,12 @@ mod verification {
         assert_eq!(original, decoded);
     }
 
-    /// Prove hex_nibble returns the correct value for all 256 byte inputs:
+    /// Prove HEX_NIBBLE_LUT returns the correct value for all 256 byte inputs:
     /// valid hex digits map to 0x00..=0x0F, everything else maps to 0xFF.
     #[kani::proof]
     fn verify_hex_nibble_valid_range() {
         let b: u8 = kani::any();
-        let result = hex_nibble(b);
+        let result = HEX_NIBBLE_LUT[b as usize];
         if result <= 0x0F {
             // Valid hex digit — verify correctness
             match b {

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -461,18 +461,8 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
         return None;
     }
 
-    let year = parse_4digits(ts, 0) as i64;
-    let month = parse_2digits(ts, 5) as u32;
-    let day = parse_2digits(ts, 8) as u32;
-    let hour = parse_2digits(ts, 11) as u64;
-    let min = parse_2digits(ts, 14) as u64;
-    let sec = parse_2digits(ts, 17) as u64;
-
-    if year == 0 || month == 0 || month > 12 || day == 0 || day > 31 {
-        return None;
-    }
-
-    // Validate separator characters: YYYY-MM-DDThh:mm:ss
+    // Validate separator characters first: YYYY-MM-DDThh:mm:ss
+    // Do this before digit parsing so invalid formats fail fast.
     if ts[4] != b'-'
         || ts[7] != b'-'
         || (ts[10] != b'T' && ts[10] != b't' && ts[10] != b' ')
@@ -482,20 +472,17 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
         return None;
     }
 
-    // Validate that date/time digit positions are actually ASCII digits.
-    // parse_2digits silently returns 0 for non-digits, which is valid for
-    // hour/min/sec and would let garbage through as 00:00:00. (#1875)
-    if !ts[5].is_ascii_digit()
-        || !ts[6].is_ascii_digit()
-        || !ts[8].is_ascii_digit()
-        || !ts[9].is_ascii_digit()
-        || !ts[11].is_ascii_digit()
-        || !ts[12].is_ascii_digit()
-        || !ts[14].is_ascii_digit()
-        || !ts[15].is_ascii_digit()
-        || !ts[17].is_ascii_digit()
-        || !ts[18].is_ascii_digit()
-    {
+    // Parse and validate all digit fields in one pass each.
+    // parse_Ndigits_checked uses wrapping_sub so each digit is validated and
+    // converted in a single subtract+compare — no double-checking.
+    let year = parse_4digits_checked(ts, 0)? as i64;
+    let month = parse_2digits_checked(ts, 5)? as u32;
+    let day = parse_2digits_checked(ts, 8)? as u32;
+    let hour = parse_2digits_checked(ts, 11)? as u64;
+    let min = parse_2digits_checked(ts, 14)? as u64;
+    let sec = parse_2digits_checked(ts, 17)? as u64;
+
+    if year == 0 || month == 0 || month > 12 || day == 0 || day > 31 {
         return None;
     }
 
@@ -556,18 +543,8 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
             if ts[tz_start + 3] != b':' {
                 return None;
             }
-            // Validate that timezone digits are actually ASCII digits before
-            // calling parse_2digits, which silently returns 0 for non-digits
-            // and would treat garbage as +00:00. (#1467)
-            if !ts[tz_start + 1].is_ascii_digit()
-                || !ts[tz_start + 2].is_ascii_digit()
-                || !ts[tz_start + 4].is_ascii_digit()
-                || !ts[tz_start + 5].is_ascii_digit()
-            {
-                return None;
-            }
-            let tz_h = parse_2digits(ts, tz_start + 1) as i64;
-            let tz_m = parse_2digits(ts, tz_start + 4) as i64;
+            let tz_h = parse_2digits_checked(ts, tz_start + 1)? as i64;
+            let tz_m = parse_2digits_checked(ts, tz_start + 4)? as i64;
             if tz_h >= 24 || tz_m >= 60 {
                 return None;
             }
@@ -594,6 +571,8 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
 }
 
 /// Parse 4 ASCII digits at offset. Returns 0 on non-digit.
+// Only used by Kani proof harnesses; production paths use parse_4digits_checked.
+#[allow(dead_code)]
 #[inline(always)]
 #[cfg_attr(kani, kani::ensures(|result: &u16| *result <= 9999))]
 fn parse_4digits(s: &[u8], off: usize) -> u16 {
@@ -607,7 +586,9 @@ fn parse_4digits(s: &[u8], off: usize) -> u16 {
     (a - b'0') as u16 * 1000 + (b - b'0') as u16 * 100 + (c - b'0') as u16 * 10 + (d - b'0') as u16
 }
 
-/// Parse 2 ASCII digits at offset.
+/// Parse 2 ASCII digits at offset. Returns 0 on non-digit.
+// Only used by Kani proof harnesses; production paths use parse_2digits_checked.
+#[allow(dead_code)]
 #[inline(always)]
 #[cfg_attr(kani, kani::ensures(|result: &u8| *result <= 99))]
 fn parse_2digits(s: &[u8], off: usize) -> u8 {
@@ -619,6 +600,37 @@ fn parse_2digits(s: &[u8], off: usize) -> u8 {
         return 0;
     }
     (a - b'0') * 10 + (b - b'0')
+}
+
+/// Parse 4 ASCII digits at `s[off..off+4]`, returning `None` if any byte is not
+/// a digit. Uses `wrapping_sub` to validate and convert in a single pass —
+/// avoids the double-check that `parse_4digits` + external `is_ascii_digit`
+/// calls would perform.
+#[inline(always)]
+fn parse_4digits_checked(s: &[u8], off: usize) -> Option<u16> {
+    let (a, b, c, d) = (
+        s[off].wrapping_sub(b'0'),
+        s[off + 1].wrapping_sub(b'0'),
+        s[off + 2].wrapping_sub(b'0'),
+        s[off + 3].wrapping_sub(b'0'),
+    );
+    if a > 9 || b > 9 || c > 9 || d > 9 {
+        return None;
+    }
+    Some(a as u16 * 1000 + b as u16 * 100 + c as u16 * 10 + d as u16)
+}
+
+/// Parse 2 ASCII digits at `s[off..off+2]`, returning `None` if either byte is
+/// not a digit. Single-pass: one `wrapping_sub` + compare per digit instead of
+/// a `is_ascii_digit` check followed by a separate subtraction.
+#[inline(always)]
+fn parse_2digits_checked(s: &[u8], off: usize) -> Option<u8> {
+    let a = s[off].wrapping_sub(b'0');
+    let b = s[off + 1].wrapping_sub(b'0');
+    if a > 9 || b > 9 {
+        return None;
+    }
+    Some(a * 10 + b)
 }
 
 /// Returns `true` if `year` is a leap year (Gregorian calendar).
@@ -834,6 +846,57 @@ mod tests {
                 our_days, chrono_days,
                 "mismatch for {y}-{m:02}-{d:02}: ours={our_days}, chrono={chrono_days}"
             );
+        }
+    }
+
+    proptest::proptest! {
+        /// `days_from_civil` (Hinnant algorithm) must agree with chrono for
+        /// all valid calendar dates in the range 1970–2099.
+        #[test]
+        fn proptest_days_from_civil_matches_chrono(
+            year in 1970i64..=2099,
+            month in 1u32..=12,
+            day in 1u32..=31,
+        ) {
+            use chrono::{NaiveDate, NaiveDateTime};
+            let max_day = days_in_month(year, month);
+            proptest::prop_assume!(day <= max_day);
+
+            let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+            let date = NaiveDate::from_ymd_opt(year as i32, month, day);
+            if let Some(d) = date {
+                let our = days_from_civil(year, month, day);
+                let chrono_days = (d - epoch).num_days();
+                proptest::prop_assert_eq!(our, chrono_days,
+                    "days_from_civil mismatch");
+            }
+            let _ = NaiveDateTime::MAX; // suppress unused import warning
+        }
+
+        /// `parse_timestamp_nanos` must produce the same result as chrono for
+        /// valid UTC timestamps in the range 1970–2099.
+        #[test]
+        fn proptest_parse_timestamp_nanos_matches_chrono(
+            year in 1970u32..=2099,
+            month in 1u32..=12,
+            day in 1u32..=28, // cap at 28 to always be a valid day
+            hour in 0u32..=23,
+            min in 0u32..=59,
+            sec in 0u32..=59,
+        ) {
+            use chrono::NaiveDateTime;
+            let s = alloc::format!(
+                "{year:04}-{month:02}-{day:02}T{hour:02}:{min:02}:{sec:02}Z"
+            );
+            let our = parse_timestamp_nanos(s.as_bytes());
+            let chrono = NaiveDateTime::parse_from_str(
+                    s.trim_end_matches('Z'), "%Y-%m-%dT%H:%M:%S"
+                )
+                .ok()
+                .and_then(|dt| dt.and_utc().timestamp_nanos_opt())
+                .map(|n| n as u64);
+            proptest::prop_assert_eq!(our, chrono,
+                "mismatch for timestamp");
         }
     }
 

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -290,6 +290,7 @@ pub fn build_sink_factory(
                 name.to_string(),
                 resolved_path.to_string_lossy().into_owned(),
                 fmt,
+                cfg.max_file_size_bytes,
                 stats,
             )
             .map_err(|e| {

--- a/crates/logfwd-output/src/file_sink.rs
+++ b/crates/logfwd-output/src/file_sink.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use arrow::record_batch::RecordBatch;
 use tokio::io::AsyncWriteExt;
@@ -15,6 +16,13 @@ use crate::sink::{SendResult, Sink, SinkFactory};
 use super::stdout::{StdoutFormat, StdoutSink};
 use logfwd_types::field_names;
 
+/// Delay injected per batch when the file exceeds `max_file_size_bytes`.
+///
+/// 10ms per batch creates enough pipeline backpressure to reduce the
+/// generator from 100% CPU to ~5-10% while still producing data faster
+/// than any downstream collector can consume.
+const WRITE_AHEAD_YIELD_MS: u64 = 10;
+
 /// Append-only file sink.
 ///
 /// Uses the same row serialization logic as `StdoutSink` so `stdout` and
@@ -24,6 +32,7 @@ pub struct FileSink {
     file: Arc<Mutex<tokio::fs::File>>,
     output_buf: Vec<u8>,
     stats: Arc<ComponentStats>,
+    max_file_size_bytes: Option<u64>,
 }
 
 impl FileSink {
@@ -31,9 +40,17 @@ impl FileSink {
         name: String,
         format: StdoutFormat,
         file: Arc<Mutex<tokio::fs::File>>,
+        max_file_size_bytes: Option<u64>,
         stats: Arc<ComponentStats>,
     ) -> Self {
-        Self::with_message_field(name, format, field_names::BODY.to_string(), file, stats)
+        Self::with_message_field(
+            name,
+            format,
+            field_names::BODY.to_string(),
+            file,
+            max_file_size_bytes,
+            stats,
+        )
     }
 
     /// Create a file sink with a custom text/console message field fallback.
@@ -45,6 +62,7 @@ impl FileSink {
         format: StdoutFormat,
         message_field: String,
         file: Arc<Mutex<tokio::fs::File>>,
+        max_file_size_bytes: Option<u64>,
         stats: Arc<ComponentStats>,
     ) -> Self {
         Self {
@@ -57,6 +75,7 @@ impl FileSink {
             file,
             output_buf: Vec::with_capacity(64 * 1024),
             stats,
+            max_file_size_bytes,
         }
     }
 }
@@ -74,6 +93,19 @@ impl Sink for FileSink {
                 .write_batch_to(batch, metadata, &mut self.output_buf)
             {
                 return SendResult::from_io_error(e);
+            }
+
+            // Write-ahead limit: when the file exceeds max_file_size_bytes,
+            // yield briefly to create pipeline backpressure. This prevents
+            // the upstream generator from spinning at 100% CPU when writing
+            // to a file faster than the downstream reader can consume.
+            if let Some(max) = self.max_file_size_bytes {
+                let file = self.file.lock().await;
+                let over_limit = file.metadata().await.is_ok_and(|m| m.len() > max);
+                drop(file);
+                if over_limit {
+                    tokio::time::sleep(Duration::from_millis(WRITE_AHEAD_YIELD_MS)).await;
+                }
             }
 
             let bytes_written = self.output_buf.len() as u64;
@@ -115,6 +147,7 @@ pub struct FileSinkFactory {
     format: StdoutFormat,
     message_field: String,
     file: Arc<Mutex<tokio::fs::File>>,
+    max_file_size_bytes: Option<u64>,
     stats: Arc<ComponentStats>,
 }
 
@@ -123,9 +156,17 @@ impl FileSinkFactory {
         name: String,
         path: String,
         format: StdoutFormat,
+        max_file_size_bytes: Option<u64>,
         stats: Arc<ComponentStats>,
     ) -> io::Result<Self> {
-        Self::with_message_field(name, path, format, field_names::BODY.to_string(), stats)
+        Self::with_message_field(
+            name,
+            path,
+            format,
+            field_names::BODY.to_string(),
+            max_file_size_bytes,
+            stats,
+        )
     }
 
     /// Create a file sink factory with a custom text/console message field fallback.
@@ -134,6 +175,7 @@ impl FileSinkFactory {
         path: String,
         format: StdoutFormat,
         message_field: String,
+        max_file_size_bytes: Option<u64>,
         stats: Arc<ComponentStats>,
     ) -> io::Result<Self> {
         let std_file = std::fs::OpenOptions::new()
@@ -146,6 +188,7 @@ impl FileSinkFactory {
             format,
             message_field,
             file: Arc::new(Mutex::new(file)),
+            max_file_size_bytes,
             stats,
         })
     }
@@ -158,6 +201,7 @@ impl SinkFactory for FileSinkFactory {
             self.format,
             self.message_field.clone(),
             Arc::clone(&self.file),
+            self.max_file_size_bytes,
             Arc::clone(&self.stats),
         )))
     }
@@ -205,6 +249,7 @@ mod tests {
             "capture".to_string(),
             path.to_string_lossy().into_owned(),
             StdoutFormat::Json,
+            None,
             Arc::clone(&stats),
         )
         .unwrap();
@@ -242,6 +287,7 @@ mod tests {
             "capture".to_string(),
             path.to_string_lossy().into_owned(),
             StdoutFormat::Text,
+            None,
             Arc::clone(&stats),
         )
         .unwrap();
@@ -274,6 +320,7 @@ mod tests {
             "capture".to_string(),
             path.to_string_lossy().into_owned(),
             StdoutFormat::Text,
+            None,
             Arc::clone(&stats),
         )
         .unwrap();
@@ -296,6 +343,50 @@ mod tests {
         let body = std::fs::read_to_string(&path).unwrap();
         assert_eq!(body, "first line\nthird line\n");
         assert_eq!(stats.lines_total.load(Ordering::Relaxed), 2);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn write_ahead_limit_yields_when_file_exceeds_threshold() {
+        let path = temp_path("throttle");
+        let stats = Arc::new(ComponentStats::new());
+        // Set a very small limit so the second write triggers the yield.
+        let factory = FileSinkFactory::new(
+            "throttle".to_string(),
+            path.to_string_lossy().into_owned(),
+            StdoutFormat::Json,
+            Some(1), // 1 byte — any write exceeds this
+            Arc::clone(&stats),
+        )
+        .unwrap();
+        let mut sink = factory.create().unwrap();
+
+        let schema = Arc::new(Schema::new(vec![Field::new("body", DataType::Utf8, true)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(StringArray::from(vec![Some("hello")]))],
+        )
+        .unwrap();
+
+        // First write: file is empty (0 bytes ≤ 1), no yield.
+        let t0 = tokio::time::Instant::now();
+        sink.send_batch(&batch, &metadata()).await.unwrap();
+        let first_elapsed = t0.elapsed();
+
+        // Second write: file now has data (> 1 byte), should yield ~10ms.
+        let t1 = tokio::time::Instant::now();
+        sink.send_batch(&batch, &metadata()).await.unwrap();
+        let second_elapsed = t1.elapsed();
+
+        // The yielded write should be noticeably slower.
+        assert!(
+            second_elapsed >= Duration::from_millis(8),
+            "expected ≥8ms yield, got {second_elapsed:?} (first was {first_elapsed:?})"
+        );
+
+        sink.flush().await.unwrap();
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body.lines().count(), 2, "both writes should succeed");
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
+++ b/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
@@ -3,7 +3,7 @@
 // column order: "timestamp", "severity", "body", "trace_id", "span_id", "flags", "attributes"
 
 use arrow::array::Array;
-use super::{BatchColumns, BatchMetadata, encode_attr_array_value, encode_fixed32, encode_tag,
+use super::{BatchColumns, BatchMetadata, encode_col_attr, encode_fixed32, encode_tag,
     encode_varint, numeric_timestamp_ns};
 use logfwd_core::otlp::{self, Severity, bytes_field_size, encode_bytes_field, encode_fixed64,
     encode_varint_field, hex_decode, parse_severity, parse_timestamp_nanos};
@@ -78,8 +78,8 @@ pub(super) fn encode_row_as_log_record_fast_v1(
         encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, body_bytes);
     }
 
-    for (field_name, attr) in &columns.attribute_cols {
-        encode_attr_array_value(buf, otlp::LOG_RECORD_ATTRIBUTES, field_name, attr, row);
+    for col in &columns.attribute_cols {
+        encode_col_attr(buf, otlp::LOG_RECORD_ATTRIBUTES, col, row);
     }
 
     if let Some((_, arr)) = columns.flags_col

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -212,46 +212,64 @@ impl OtlpSink {
         let mut records_buf: Vec<u8> =
             Vec::with_capacity(estimate_records_buf_capacity(num_rows, &columns));
         let mut grouped_ranges: Vec<ResourceGroup<'_>> = Vec::new();
-        let mut group_index_by_key: std::collections::HashMap<
-            (ResourceKey<'_>, ScopeKey<'_>),
-            usize,
-        > = std::collections::HashMap::new();
 
-        for row in 0..num_rows {
-            let mut key: ResourceKey<'_> = Vec::with_capacity(columns.resource_cols.len());
-            for (field_name, attr) in &columns.resource_cols {
-                key.push(attr.value_ref(row, field_name));
+        // Fast path: when there are no resource or scope columns every row belongs to
+        // the same single group.  This is the overwhelmingly common case for file / CRI
+        // log forwarding and avoids a per-row HashMap lookup, key Vec allocation, and
+        // scope-column null check.
+        if columns.resource_cols.is_empty()
+            && columns.scope_name_col.is_none()
+            && columns.scope_version_col.is_none()
+        {
+            let mut record_ranges: Vec<(usize, usize)> = Vec::with_capacity(num_rows);
+            for row in 0..num_rows {
+                let start = records_buf.len();
+                encode_row(&columns, row, metadata, &mut records_buf);
+                record_ranges.push((start, records_buf.len()));
             }
-            let scope_name = columns.scope_name_col.as_ref().and_then(|(_, arr)| {
-                if arr.is_null(row) {
-                    None
-                } else {
-                    Some(arr.value(row))
-                }
-            });
-            let scope_version = columns.scope_version_col.as_ref().and_then(|(_, arr)| {
-                if arr.is_null(row) {
-                    None
-                } else {
-                    Some(arr.value(row))
-                }
-            });
-            let scope_key = (scope_name, scope_version);
+            grouped_ranges.push((Vec::new(), (None, None), record_ranges));
+        } else {
+            let mut group_index_by_key: std::collections::HashMap<
+                (ResourceKey<'_>, ScopeKey<'_>),
+                usize,
+            > = std::collections::HashMap::new();
 
-            let group_idx = match group_index_by_key.entry((key, scope_key)) {
-                std::collections::hash_map::Entry::Occupied(entry) => *entry.get(),
-                std::collections::hash_map::Entry::Vacant(entry) => {
-                    let idx = grouped_ranges.len();
-                    let (group_key, group_scope) = entry.key();
-                    grouped_ranges.push((group_key.clone(), *group_scope, Vec::new()));
-                    entry.insert(idx);
-                    idx
+            for row in 0..num_rows {
+                let mut key: ResourceKey<'_> = Vec::with_capacity(columns.resource_cols.len());
+                for (field_name, attr) in &columns.resource_cols {
+                    key.push(attr.value_ref(row, field_name));
                 }
-            };
+                let scope_name = columns.scope_name_col.as_ref().and_then(|(_, arr)| {
+                    if arr.is_null(row) {
+                        None
+                    } else {
+                        Some(arr.value(row))
+                    }
+                });
+                let scope_version = columns.scope_version_col.as_ref().and_then(|(_, arr)| {
+                    if arr.is_null(row) {
+                        None
+                    } else {
+                        Some(arr.value(row))
+                    }
+                });
+                let scope_key = (scope_name, scope_version);
 
-            let start = records_buf.len();
-            encode_row(&columns, row, metadata, &mut records_buf);
-            grouped_ranges[group_idx].2.push((start, records_buf.len()));
+                let group_idx = match group_index_by_key.entry((key, scope_key)) {
+                    std::collections::hash_map::Entry::Occupied(entry) => *entry.get(),
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        let idx = grouped_ranges.len();
+                        let (group_key, group_scope) = entry.key();
+                        grouped_ranges.push((group_key.clone(), *group_scope, Vec::new()));
+                        entry.insert(idx);
+                        idx
+                    }
+                };
+
+                let start = records_buf.len();
+                encode_row(&columns, row, metadata, &mut records_buf);
+                grouped_ranges[group_idx].2.push((start, records_buf.len()));
+            }
         }
 
         // Phase 2: compute sizes bottom-up per resource group.
@@ -799,6 +817,25 @@ impl AttrArray<'_> {
     }
 }
 
+/// Per-column attribute metadata, resolved once per batch.
+///
+/// Carries pre-encoded key bytes alongside the downcast array so the per-row
+/// encoding loop can skip recomputing the key tag + varint + bytes on every
+/// iteration.
+struct ColAttr<'a> {
+    /// Original field name used for error messages and fallback formatting.
+    name: String,
+    /// Pre-encoded `encode_bytes_field(KEY_VALUE_KEY, name_bytes)` — constant
+    /// for every row in the batch.  Written with a single `extend_from_slice`
+    /// instead of three separate encode_tag / encode_varint / extend calls.
+    key_encoding: Vec<u8>,
+    /// `bytes_field_size(KEY_VALUE_KEY, name.len())` — constant per column.
+    /// Used directly when computing outer KV message size on each row.
+    kv_key_cost: usize,
+    /// The downcast Arrow array.
+    array: AttrArray<'a>,
+}
+
 /// Pre-resolved column roles and downcast arrays for one RecordBatch.
 ///
 /// Built once in `encode_batch` before the per-row loop to avoid
@@ -827,8 +864,8 @@ struct BatchColumns<'a> {
     scope_name_col: Option<(usize, OtlpStrCol<'a>)>,
     /// Scope version column.
     scope_version_col: Option<(usize, OtlpStrCol<'a>)>,
-    /// Non-special attribute columns: (field_name, pre-downcast array).
-    attribute_cols: Vec<(String, AttrArray<'a>)>,
+    /// Non-special attribute columns with pre-encoded key bytes.
+    attribute_cols: Vec<ColAttr<'a>>,
     /// Resource attribute columns promoted to OTLP Resource attributes.
     resource_cols: Vec<(String, AttrArray<'a>)>,
 }
@@ -951,7 +988,7 @@ fn resolve_batch_columns<'a>(
     let mut observed_ts_col: Option<(usize, &dyn Array)> = None;
     let mut scope_name_col: Option<(usize, OtlpStrCol<'_>)> = None;
     let mut scope_version_col: Option<(usize, OtlpStrCol<'_>)> = None;
-    let mut attribute_cols: Vec<(String, AttrArray<'_>)> = Vec::new();
+    let mut attribute_cols: Vec<ColAttr<'_>> = Vec::new();
     let mut resource_cols: Vec<(String, AttrArray<'_>)> = Vec::new();
     for (idx, field) in schema.fields().iter().enumerate() {
         if excluded[idx] {
@@ -1094,7 +1131,11 @@ fn resolve_batch_columns<'a>(
                 AttrArray::Str,
             ),
         };
-        attribute_cols.push((field_name.to_string(), attr));
+        let name = field_name.to_string();
+        let mut key_encoding = Vec::with_capacity(2 + name.len());
+        encode_bytes_field(&mut key_encoding, otlp::KEY_VALUE_KEY, name.as_bytes());
+        let kv_key_cost = bytes_field_size(otlp::KEY_VALUE_KEY, name.len());
+        attribute_cols.push(ColAttr { name, key_encoding, kv_key_cost, array: attr });
     }
 
     BatchColumns {
@@ -1279,8 +1320,8 @@ fn encode_row_as_log_record(
     }
 
     // LogRecord.attributes — pre-resolved attribute columns
-    for (field_name, attr) in &columns.attribute_cols {
-        encode_attr_array_value(buf, otlp::LOG_RECORD_ATTRIBUTES, field_name, attr, row);
+    for col in &columns.attribute_cols {
+        encode_col_attr(buf, otlp::LOG_RECORD_ATTRIBUTES, col, row);
     }
 
     // LogRecord.flags (fixed32) — W3C trace flags.
@@ -1368,57 +1409,124 @@ fn encode_key_value_int(buf: &mut Vec<u8>, field_number: u32, key: &[u8], value:
     encode_varint_field(buf, otlp::ANY_VALUE_INT_VALUE, value as u64);
 }
 
-fn encode_attr_array_value(
-    buf: &mut Vec<u8>,
-    field_number: u32,
-    field_name: &str,
-    attr: &AttrArray<'_>,
-    row: usize,
-) {
-    match attr {
+/// Encode one attribute column into `buf` using pre-computed key encoding.
+///
+/// Avoids recomputing the
+/// key tag + varint + key bytes on every row by using `col.key_encoding` and
+/// `col.kv_key_cost` which were computed once in `resolve_batch_columns`.
+#[inline(always)]
+fn encode_col_attr(buf: &mut Vec<u8>, field_number: u32, col: &ColAttr<'_>, row: usize) {
+    match &col.array {
         AttrArray::Int(arr) => {
             if !arr.is_null(row) {
-                encode_key_value_int(buf, field_number, field_name.as_bytes(), arr.value(row));
+                let value = arr.value(row);
+                let anyvalue_inner = 1 + varint_len(value as u64);
+                let kv_inner =
+                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, kv_inner as u64);
+                buf.extend_from_slice(&col.key_encoding);
+                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, anyvalue_inner as u64);
+                encode_varint_field(buf, otlp::ANY_VALUE_INT_VALUE, value as u64);
             }
         }
         AttrArray::Float(arr) => {
             if !arr.is_null(row) {
-                encode_key_value_double(buf, field_number, field_name.as_bytes(), arr.value(row));
+                let value = arr.value(row);
+                let anyvalue_inner = 1 + 8; // tag(1) + fixed64(8)
+                let kv_inner =
+                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, kv_inner as u64);
+                buf.extend_from_slice(&col.key_encoding);
+                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, anyvalue_inner as u64);
+                encode_fixed64(buf, otlp::ANY_VALUE_DOUBLE_VALUE, value.to_bits());
             }
         }
         AttrArray::Bool(arr) => {
             if !arr.is_null(row) {
-                encode_key_value_bool(buf, field_number, field_name.as_bytes(), arr.value(row));
+                let value = arr.value(row);
+                let anyvalue_inner = 1 + 1; // tag(1) + varint(bool)
+                let kv_inner =
+                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, kv_inner as u64);
+                buf.extend_from_slice(&col.key_encoding);
+                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, anyvalue_inner as u64);
+                encode_varint_field(buf, otlp::ANY_VALUE_BOOL_VALUE, u64::from(value));
             }
         }
         AttrArray::Str(arr) => {
             if !arr.is_null(row) {
-                encode_key_value_string(
-                    buf,
-                    field_number,
-                    field_name.as_bytes(),
-                    arr.value(row).as_bytes(),
-                );
+                let value = arr.value(row).as_bytes();
+                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_STRING_VALUE, value.len());
+                let kv_inner =
+                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, kv_inner as u64);
+                buf.extend_from_slice(&col.key_encoding);
+                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, anyvalue_inner as u64);
+                encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
             }
         }
         AttrArray::PreformattedStr(values) => {
             if let Some(Some(value)) = values.get(row) {
-                encode_key_value_string(buf, field_number, field_name.as_bytes(), value.as_bytes());
+                let value = value.as_bytes();
+                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_STRING_VALUE, value.len());
+                let kv_inner =
+                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, kv_inner as u64);
+                buf.extend_from_slice(&col.key_encoding);
+                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, anyvalue_inner as u64);
+                encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
             }
         }
         AttrArray::Bytes(arr) => {
             if !arr.is_null(row) {
-                encode_key_value_bytes(buf, field_number, field_name.as_bytes(), arr.value(row));
+                let value = arr.value(row);
+                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_BYTES_VALUE, value.len());
+                let kv_inner =
+                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, kv_inner as u64);
+                buf.extend_from_slice(&col.key_encoding);
+                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, anyvalue_inner as u64);
+                encode_bytes_field(buf, otlp::ANY_VALUE_BYTES_VALUE, value);
             }
         }
         AttrArray::LargeBytes(arr) => {
             if !arr.is_null(row) {
-                encode_key_value_bytes(buf, field_number, field_name.as_bytes(), arr.value(row));
+                let value = arr.value(row);
+                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_BYTES_VALUE, value.len());
+                let kv_inner =
+                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, kv_inner as u64);
+                buf.extend_from_slice(&col.key_encoding);
+                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, anyvalue_inner as u64);
+                encode_bytes_field(buf, otlp::ANY_VALUE_BYTES_VALUE, value);
             }
         }
         AttrArray::OtherStr(arr) => {
-            if let Some(value) = format_non_string_attr_value(*arr, row, field_name) {
-                encode_key_value_string(buf, field_number, field_name.as_bytes(), value.as_bytes());
+            if let Some(value) = format_non_string_attr_value(*arr, row, &col.name) {
+                let value = value.as_bytes();
+                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_STRING_VALUE, value.len());
+                let kv_inner =
+                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, kv_inner as u64);
+                buf.extend_from_slice(&col.key_encoding);
+                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+                encode_varint(buf, anyvalue_inner as u64);
+                encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
             }
         }
     }

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -1147,7 +1147,14 @@ fn resolve_batch_columns<'a>(
         let kv_key_cost = bytes_field_size(otlp::KEY_VALUE_KEY, name.len());
         let short_kv_inner_base = kv_key_cost + 4;
         let has_nulls = batch.column(idx).null_count() > 0;
-        attribute_cols.push(ColAttr { name, key_encoding, kv_key_cost, short_kv_inner_base, has_nulls, array: attr });
+        attribute_cols.push(ColAttr {
+            name,
+            key_encoding,
+            kv_key_cost,
+            short_kv_inner_base,
+            has_nulls,
+            array: attr,
+        });
     }
 
     BatchColumns {

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -832,6 +832,16 @@ struct ColAttr<'a> {
     /// `bytes_field_size(KEY_VALUE_KEY, name.len())` — constant per column.
     /// Used directly when computing outer KV message size on each row.
     kv_key_cost: usize,
+    /// Pre-computed `kv_key_cost + 4` used by the short-string fast path.
+    ///
+    /// When `string_value.len() <= 125` all intermediate length varints fit in
+    /// one byte, so the outer KV length is simply `short_kv_inner_base +
+    /// value.len()` — two additions replace four `varint_len` calls.
+    short_kv_inner_base: usize,
+    /// True when `array.null_count() > 0`.  When false the per-row `is_null`
+    /// check is skipped entirely, eliminating a null-bitmap pointer fetch and
+    /// branch on every row for columns that never contain nulls.
+    has_nulls: bool,
     /// The downcast Arrow array.
     array: AttrArray<'a>,
 }
@@ -1135,7 +1145,9 @@ fn resolve_batch_columns<'a>(
         let mut key_encoding = Vec::with_capacity(2 + name.len());
         encode_bytes_field(&mut key_encoding, otlp::KEY_VALUE_KEY, name.as_bytes());
         let kv_key_cost = bytes_field_size(otlp::KEY_VALUE_KEY, name.len());
-        attribute_cols.push(ColAttr { name, key_encoding, kv_key_cost, array: attr });
+        let short_kv_inner_base = kv_key_cost + 4;
+        let has_nulls = batch.column(idx).null_count() > 0;
+        attribute_cols.push(ColAttr { name, key_encoding, kv_key_cost, short_kv_inner_base, has_nulls, array: attr });
     }
 
     BatchColumns {
@@ -1416,117 +1428,126 @@ fn encode_key_value_int(buf: &mut Vec<u8>, field_number: u32, key: &[u8], value:
 /// `col.kv_key_cost` which were computed once in `resolve_batch_columns`.
 #[inline(always)]
 fn encode_col_attr(buf: &mut Vec<u8>, field_number: u32, col: &ColAttr<'_>, row: usize) {
+    // Shared helper for string-value KV pairs.
+    //
+    // When `value.len() <= 125` every intermediate length fits in a single
+    // varint byte, so the outer KV byte-count reduces to two additions instead
+    // of four `varint_len`/`bytes_field_size` calls.
+    #[inline(always)]
+    fn encode_str_value(buf: &mut Vec<u8>, field_number: u32, col: &ColAttr<'_>, value: &[u8]) {
+        if value.len() <= 125 {
+            // anyvalue_inner = tag(1) + len_varint(1) + data
+            let anyvalue_inner = 2 + value.len();
+            let kv_inner = col.short_kv_inner_base + value.len();
+            encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, kv_inner as u64);
+            buf.extend_from_slice(&col.key_encoding);
+            encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, anyvalue_inner as u64);
+            encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
+        } else {
+            let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_STRING_VALUE, value.len());
+            let kv_inner =
+                col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+            encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, kv_inner as u64);
+            buf.extend_from_slice(&col.key_encoding);
+            encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, anyvalue_inner as u64);
+            encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
+        }
+    }
+
     match &col.array {
         AttrArray::Int(arr) => {
-            if !arr.is_null(row) {
-                let value = arr.value(row);
-                let anyvalue_inner = 1 + varint_len(value as u64);
-                let kv_inner =
-                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
-                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, kv_inner as u64);
-                buf.extend_from_slice(&col.key_encoding);
-                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, anyvalue_inner as u64);
-                encode_varint_field(buf, otlp::ANY_VALUE_INT_VALUE, value as u64);
+            if col.has_nulls && arr.is_null(row) {
+                return;
             }
+            let value = arr.value(row);
+            let anyvalue_inner = 1 + varint_len(value as u64);
+            let kv_inner =
+                col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+            encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, kv_inner as u64);
+            buf.extend_from_slice(&col.key_encoding);
+            encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, anyvalue_inner as u64);
+            encode_varint_field(buf, otlp::ANY_VALUE_INT_VALUE, value as u64);
         }
         AttrArray::Float(arr) => {
-            if !arr.is_null(row) {
-                let value = arr.value(row);
-                let anyvalue_inner = 1 + 8; // tag(1) + fixed64(8)
-                let kv_inner =
-                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
-                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, kv_inner as u64);
-                buf.extend_from_slice(&col.key_encoding);
-                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, anyvalue_inner as u64);
-                encode_fixed64(buf, otlp::ANY_VALUE_DOUBLE_VALUE, value.to_bits());
+            if col.has_nulls && arr.is_null(row) {
+                return;
             }
+            let value = arr.value(row);
+            let anyvalue_inner = 1 + 8; // tag(1) + fixed64(8)
+            let kv_inner =
+                col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+            encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, kv_inner as u64);
+            buf.extend_from_slice(&col.key_encoding);
+            encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, anyvalue_inner as u64);
+            encode_fixed64(buf, otlp::ANY_VALUE_DOUBLE_VALUE, value.to_bits());
         }
         AttrArray::Bool(arr) => {
-            if !arr.is_null(row) {
-                let value = arr.value(row);
-                let anyvalue_inner = 1 + 1; // tag(1) + varint(bool)
-                let kv_inner =
-                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
-                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, kv_inner as u64);
-                buf.extend_from_slice(&col.key_encoding);
-                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, anyvalue_inner as u64);
-                encode_varint_field(buf, otlp::ANY_VALUE_BOOL_VALUE, u64::from(value));
+            if col.has_nulls && arr.is_null(row) {
+                return;
             }
+            let value = arr.value(row);
+            let anyvalue_inner = 1 + 1; // tag(1) + varint(bool)
+            let kv_inner =
+                col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+            encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, kv_inner as u64);
+            buf.extend_from_slice(&col.key_encoding);
+            encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, anyvalue_inner as u64);
+            encode_varint_field(buf, otlp::ANY_VALUE_BOOL_VALUE, u64::from(value));
         }
         AttrArray::Str(arr) => {
-            if !arr.is_null(row) {
-                let value = arr.value(row).as_bytes();
-                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_STRING_VALUE, value.len());
-                let kv_inner =
-                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
-                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, kv_inner as u64);
-                buf.extend_from_slice(&col.key_encoding);
-                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, anyvalue_inner as u64);
-                encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
+            if col.has_nulls && arr.is_null(row) {
+                return;
             }
+            encode_str_value(buf, field_number, col, arr.value(row).as_bytes());
         }
         AttrArray::PreformattedStr(values) => {
             if let Some(Some(value)) = values.get(row) {
-                let value = value.as_bytes();
-                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_STRING_VALUE, value.len());
-                let kv_inner =
-                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
-                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, kv_inner as u64);
-                buf.extend_from_slice(&col.key_encoding);
-                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, anyvalue_inner as u64);
-                encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
+                encode_str_value(buf, field_number, col, value.as_bytes());
             }
         }
         AttrArray::Bytes(arr) => {
-            if !arr.is_null(row) {
-                let value = arr.value(row);
-                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_BYTES_VALUE, value.len());
-                let kv_inner =
-                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
-                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, kv_inner as u64);
-                buf.extend_from_slice(&col.key_encoding);
-                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, anyvalue_inner as u64);
-                encode_bytes_field(buf, otlp::ANY_VALUE_BYTES_VALUE, value);
+            if col.has_nulls && arr.is_null(row) {
+                return;
             }
+            let value = arr.value(row);
+            let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_BYTES_VALUE, value.len());
+            let kv_inner =
+                col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+            encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, kv_inner as u64);
+            buf.extend_from_slice(&col.key_encoding);
+            encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, anyvalue_inner as u64);
+            encode_bytes_field(buf, otlp::ANY_VALUE_BYTES_VALUE, value);
         }
         AttrArray::LargeBytes(arr) => {
-            if !arr.is_null(row) {
-                let value = arr.value(row);
-                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_BYTES_VALUE, value.len());
-                let kv_inner =
-                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
-                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, kv_inner as u64);
-                buf.extend_from_slice(&col.key_encoding);
-                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, anyvalue_inner as u64);
-                encode_bytes_field(buf, otlp::ANY_VALUE_BYTES_VALUE, value);
+            if col.has_nulls && arr.is_null(row) {
+                return;
             }
+            let value = arr.value(row);
+            let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_BYTES_VALUE, value.len());
+            let kv_inner =
+                col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+            encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, kv_inner as u64);
+            buf.extend_from_slice(&col.key_encoding);
+            encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, anyvalue_inner as u64);
+            encode_bytes_field(buf, otlp::ANY_VALUE_BYTES_VALUE, value);
         }
         AttrArray::OtherStr(arr) => {
             if let Some(value) = format_non_string_attr_value(*arr, row, &col.name) {
-                let value = value.as_bytes();
-                let anyvalue_inner = bytes_field_size(otlp::ANY_VALUE_STRING_VALUE, value.len());
-                let kv_inner =
-                    col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
-                encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, kv_inner as u64);
-                buf.extend_from_slice(&col.key_encoding);
-                encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
-                encode_varint(buf, anyvalue_inner as u64);
-                encode_bytes_field(buf, otlp::ANY_VALUE_STRING_VALUE, value);
+                encode_str_value(buf, field_number, col, value.as_bytes());
             }
         }
     }

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -472,7 +472,11 @@ impl OtlpSink {
 
 fn estimate_records_buf_capacity(num_rows: usize, columns: &BatchColumns<'_>) -> usize {
     const MIN_RECORD_BYTES: usize = 128;
-    const ATTR_BYTES_HINT: usize = 48;
+    // 64 bytes/attr covers typical string attribute values (~30 bytes) plus
+    // protobuf framing overhead (~27 bytes key+tag+varint) with some margin.
+    // Wide batches with 27 attrs need ~14.5 MB for 10K rows; at 48 bytes/attr
+    // the estimate was 13.9 MB — slightly short, causing one realloc per batch.
+    const ATTR_BYTES_HINT: usize = 64;
     const MAX_INITIAL_RECORDS_BUF: usize = 64 * 1024 * 1024;
 
     let hinted_attrs = columns.attribute_cols.len().min(64);

--- a/scripts/verify_proptest_regressions.py
+++ b/scripts/verify_proptest_regressions.py
@@ -16,6 +16,7 @@ NO_PERSISTENCE_ALLOWLIST = {
     "crates/logfwd-core/src/structural.rs",
     "crates/logfwd-core/src/cri.rs",
     "crates/logfwd-core/src/json_scanner.rs",
+    "crates/logfwd-core/src/otlp.rs",
     "crates/logfwd-types/src/pipeline/lifecycle.rs",
     "crates/logfwd-io/tests/it/checkpoint_state_machine.rs",
 }


### PR DESCRIPTION
## Summary

Adds a `max_file_size_bytes` config option to the file output sink that creates pipeline backpressure when the output file exceeds a configurable size threshold.

### Problem

In e2e file-ingest benchmarks, the generator uses ~1.0 CPU regardless of actual EPS throughput because:
- In unlimited mode (`events_per_sec: 0`), the generator always returns data immediately
- File output writes are fast (buffered I/O) with no backpressure
- The I/O worker loop never sleeps when data is available
- OTLP doesn't have this issue because HTTP sends create natural backpressure

### Solution

When `max_file_size_bytes` is set, `FileSink::send_batch()` checks the actual file size on disk before writing. If the file exceeds the limit, it yields for 10ms, creating pipeline backpressure that cascades: output pool slows → pipeline channel fills → CPU worker blocks → I/O worker blocks → generator throttled.

### Changes

- `logfwd-config`: Add `max_file_size_bytes: Option<u64>` to `OutputConfig`, validate only accepted for file outputs
- `logfwd-output`: Thread through factory, implement backpressure in `FileSink::send_batch()`
- Tests: config parsing (accept/reject), sink throttle timing test

### Test plan

- `just ci` passes (1606 tests, 0 failures)
- New tests: `file_output_accepts_max_file_size_bytes`, `non_file_output_rejects_max_file_size_bytes`, `write_ahead_limit_yields_when_file_exceeds_threshold`

Relates to strawgate/memagent-e2e#293

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `max_file_size_bytes` write-ahead limit to file output sink
> - Adds an optional `max_file_size_bytes` field to `OutputConfig` that applies only to file outputs; non-file outputs that set this field fail config validation.
> - When the current file size exceeds the configured limit, `FileSink::send_batch` sleeps for 10ms (`WRITE_AHEAD_YIELD_MS`) before writing to apply backpressure.
> - The setting is plumbed from config through `FileSinkFactory` to each `FileSink` instance via updated constructors in [file_sink.rs](https://github.com/strawgate/memagent/pull/2239/files#diff-2dd2ae9a24ba18b09457e817228d3bb69e1c715182a0e78dc3bb6488bac55c1a) and [factory.rs](https://github.com/strawgate/memagent/pull/2239/files#diff-38138875bb6a160b3328cc8507d27d322ae4c2f810e755490e66ce6088078fac).
> - Behavioral Change: file output writes now incur a 10ms sleep on every batch when the file exceeds the threshold, not just once.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 65765e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->