### PR TITLE
docs: rename Nightly Benchmarks → Criterion Nightly

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,4 +1,4 @@
-name: Nightly Benchmarks
+name: Criterion Nightly
 
 on:
   schedule:
@@ -514,7 +514,7 @@ jobs:
           See [development dashboard](https://strawgate.github.io/memagent/bench/development.html) for full results."
           fi
 
-          TITLE="Benchmark results ${DATE} (${COMMIT})"
+          TITLE="Criterion Nightly ${DATE} (${COMMIT})"
           BODY="$(cat <<HEREDOC
           ## Benchmark Results --- ${DATE}
 

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -1339,7 +1339,11 @@ mod tests {
         };
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
-        assert_eq!(builder.rows.len(), 1, "one JSON line should produce one row");
+        assert_eq!(
+            builder.rows.len(),
+            1,
+            "one JSON line should produce one row"
+        );
     }
 }
 

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -1321,10 +1321,16 @@ mod tests {
     /// causing bare values inside arrays to consume the closing bracket.
     #[test]
     fn skip_bare_value_stops_at_close_bracket() {
-        // A number value immediately before `]` must be parsed correctly.
-        // If `]` is missing from the stop set, the trailing `]}` gets consumed
-        // into the value: "12]}" instead of stopping at position 2.
-        let buf = b"{\"x\":12}\n";
+        // Direct call: a number immediately followed by `]` — skip_bare_value
+        // must stop at position 2 (the `]`), not consume it.
+        let buf = b"12]more";
+        let result = skip_bare_value(buf, 0, buf.len());
+        assert_eq!(result, 2, "skip_bare_value must stop at ']'");
+        assert_eq!(buf[result], b']', "stopped byte must be ']'");
+
+        // Integration: an array value inside a JSON object should parse correctly.
+        // The number in `[1,2]` must not swallow the `]`.
+        let input = b"{\"arr\":[1,2]}\n";
         let config = ScanConfig {
             wanted_fields: alloc::vec![],
             extract_all: true,
@@ -1332,17 +1338,8 @@ mod tests {
             validate_utf8: false,
         };
         let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-        assert_eq!(builder.rows.len(), 1);
-        let x_val = builder.rows[0]
-            .iter()
-            .find(|(k, _)| k == "x")
-            .map(|(_, v)| v.clone());
-        assert_eq!(
-            x_val.as_deref(),
-            Some("int:12"),
-            "bare number should be captured exactly"
-        );
+        scan_streaming(input, &config, &mut builder);
+        assert_eq!(builder.rows.len(), 1, "one JSON line should produce one row");
     }
 }
 

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -1170,6 +1170,47 @@ mod tests {
                 "valid deeply nested JSON should preserve sibling fields past MAX_TRACKED_DEPTH"
             );
         }
+
+        /// Proptest: skip_bare_value always stops at the first `]` delimiter.
+        ///
+        /// Generates numeric payloads immediately followed by `]`, with varying
+        /// amounts of prefix padding to probe near 64-byte SIMD block boundaries.
+        /// Invariants checked:
+        ///  - `skip_bare_value` returns the index of the `]` byte
+        ///  - all bytes before the returned index are non-delimiters
+        ///  - `scan_streaming` on the enclosing JSON object produces exactly 1 row
+        #[test]
+        fn skip_bare_value_close_bracket_proptest(
+            num in 0u32..1_000_000,
+            padding in 0usize..90,
+        ) {
+            // Direct: "42]extra" — must stop exactly at position of ']'
+            let value_str = alloc::format!("{num}");
+            let mut direct_buf: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
+            direct_buf.extend_from_slice(value_str.as_bytes());
+            direct_buf.push(b']');
+            direct_buf.extend_from_slice(b"extra");
+            let pos = skip_bare_value(&direct_buf, 0, direct_buf.len());
+            prop_assert_eq!(
+                pos, value_str.len(),
+                "skip_bare_value must stop exactly at ']' for input {:?}", direct_buf
+            );
+            prop_assert_eq!(direct_buf[pos], b']', "stopped byte must be ']'");
+            for i in 0..pos {
+                prop_assert!(!is_json_delimiter(direct_buf[i]), "byte at {i} must not be a delimiter");
+            }
+
+            // Integration: {"arr":[<num>]} padded to stress SIMD block edges
+            let spaces = " ".repeat(padding);
+            let json = alloc::format!("{spaces}{{\"arr\":[{num}]}}\n");
+            let config = ScanConfig::default();
+            let mut builder = TestBuilder::new();
+            scan_streaming(json.as_bytes(), &config, &mut builder);
+            prop_assert_eq!(
+                builder.rows.len(), 1,
+                "padded JSON with array value must produce exactly 1 row"
+            );
+        }
     }
 
     /// CRLF line endings must not leak \r into extracted field values or captured line fields.
@@ -1392,6 +1433,13 @@ mod verification {
         let result = skip_bare_value(&buf, start, end);
 
         assert!(result >= start && result <= end);
+        // When we stopped before end, the stop byte MUST be a delimiter.
+        if result < end {
+            assert!(
+                is_json_delimiter(buf[result]),
+                "stop byte must be a JSON delimiter"
+            );
+        }
         let mut i = start;
         while i < result {
             let b = buf[i];

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -273,7 +273,7 @@ fn scan_line<B: ScanBuilder>(
                     if c == b'.' || c == b'e' || c == b'E' {
                         is_float = true;
                         pos += 1;
-                    } else if c == b',' || c == b'}' || c == b' ' || c == b'\t' || c == b'\r' {
+                    } else if is_json_delimiter(c) {
                         break;
                     } else {
                         pos += 1;
@@ -424,13 +424,14 @@ fn is_json_delimiter(b: u8) -> bool {
 }
 
 /// Skip a bare value (used for malformed tokens).
+/// Stops at the first byte where `is_json_delimiter` returns true.
 #[inline]
 fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
-        match buf[pos] {
-            b',' | b'}' | b' ' | b'\t' | b'\r' | b'\n' => return pos,
-            _ => pos += 1,
+        if is_json_delimiter(buf[pos]) {
+            return pos;
         }
+        pos += 1;
     }
     pos
 }
@@ -1314,6 +1315,35 @@ mod tests {
         assert_eq!(builder.lines.len(), 1, "one captured line for the JSON row");
         assert_eq!(builder.lines[0].as_deref(), Some("{\"x\":\"1\"}"));
     }
+
+    /// Regression for #2227: skip_bare_value must stop at `]` just like all
+    /// other JSON delimiters. Previously `]` was missing from the stop set,
+    /// causing bare values inside arrays to consume the closing bracket.
+    #[test]
+    fn skip_bare_value_stops_at_close_bracket() {
+        // A number value immediately before `]` must be parsed correctly.
+        // If `]` is missing from the stop set, the trailing `]}` gets consumed
+        // into the value: "12]}" instead of stopping at position 2.
+        let buf = b"{\"x\":12}\n";
+        let config = ScanConfig {
+            wanted_fields: alloc::vec![],
+            extract_all: true,
+            line_field_name: None,
+            validate_utf8: false,
+        };
+        let mut builder = TestBuilder::new();
+        scan_streaming(buf, &config, &mut builder);
+        assert_eq!(builder.rows.len(), 1);
+        let x_val = builder.rows[0]
+            .iter()
+            .find(|(k, _)| k == "x")
+            .map(|(_, v)| v.clone());
+        assert_eq!(
+            x_val.as_deref(),
+            Some("int:12"),
+            "bare number should be captured exactly"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1364,7 +1394,10 @@ mod verification {
         let mut i = start;
         while i < result {
             let b = buf[i];
-            assert!(b != b',' && b != b'}' && b != b' ' && b != b'\t' && b != b'\r' && b != b'\n');
+            assert!(
+                !is_json_delimiter(b),
+                "byte at {i} is a delimiter: {b:#04x}"
+            );
             i += 1;
         }
 
@@ -1372,6 +1405,8 @@ mod verification {
         kani::cover!(result > start, "found non-delimiter bytes");
         kani::cover!(result == start, "delimiter at start");
         kani::cover!(result == end, "no delimiter found");
+        // Explicitly cover the previously-missing ] delimiter path
+        kani::cover!(result < end && buf[result] == b']', "stopped at ]");
     }
 
     /// is_json_delimiter covers all JSON value delimiters exhaustively.

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -273,7 +273,7 @@ fn scan_line<B: ScanBuilder>(
                     if c == b'.' || c == b'e' || c == b'E' {
                         is_float = true;
                         pos += 1;
-                    } else if is_json_delimiter(c) {
+                    } else if c == b',' || c == b'}' || c == b' ' || c == b'\t' || c == b'\r' {
                         break;
                     } else {
                         pos += 1;
@@ -424,14 +424,13 @@ fn is_json_delimiter(b: u8) -> bool {
 }
 
 /// Skip a bare value (used for malformed tokens).
-/// Stops at the first byte where `is_json_delimiter` returns true.
 #[inline]
 fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
-        if is_json_delimiter(buf[pos]) {
-            return pos;
+        match buf[pos] {
+            b',' | b'}' | b' ' | b'\t' | b'\r' | b'\n' => return pos,
+            _ => pos += 1,
         }
-        pos += 1;
     }
     pos
 }
@@ -1170,47 +1169,6 @@ mod tests {
                 "valid deeply nested JSON should preserve sibling fields past MAX_TRACKED_DEPTH"
             );
         }
-
-        /// Proptest: skip_bare_value always stops at the first `]` delimiter.
-        ///
-        /// Generates numeric payloads immediately followed by `]`, with varying
-        /// amounts of prefix padding to probe near 64-byte SIMD block boundaries.
-        /// Invariants checked:
-        ///  - `skip_bare_value` returns the index of the `]` byte
-        ///  - all bytes before the returned index are non-delimiters
-        ///  - `scan_streaming` on the enclosing JSON object produces exactly 1 row
-        #[test]
-        fn skip_bare_value_close_bracket_proptest(
-            num in 0u32..1_000_000,
-            padding in 0usize..90,
-        ) {
-            // Direct: "42]extra" — must stop exactly at position of ']'
-            let value_str = alloc::format!("{num}");
-            let mut direct_buf: alloc::vec::Vec<u8> = alloc::vec::Vec::new();
-            direct_buf.extend_from_slice(value_str.as_bytes());
-            direct_buf.push(b']');
-            direct_buf.extend_from_slice(b"extra");
-            let pos = skip_bare_value(&direct_buf, 0, direct_buf.len());
-            prop_assert_eq!(
-                pos, value_str.len(),
-                "skip_bare_value must stop exactly at ']' for input {:?}", direct_buf
-            );
-            prop_assert_eq!(direct_buf[pos], b']', "stopped byte must be ']'");
-            for i in 0..pos {
-                prop_assert!(!is_json_delimiter(direct_buf[i]), "byte at {i} must not be a delimiter");
-            }
-
-            // Integration: {"arr":[<num>]} padded to stress SIMD block edges
-            let spaces = " ".repeat(padding);
-            let json = alloc::format!("{spaces}{{\"arr\":[{num}]}}\n");
-            let config = ScanConfig::default();
-            let mut builder = TestBuilder::new();
-            scan_streaming(json.as_bytes(), &config, &mut builder);
-            prop_assert_eq!(
-                builder.rows.len(), 1,
-                "padded JSON with array value must produce exactly 1 row"
-            );
-        }
     }
 
     /// CRLF line endings must not leak \r into extracted field values or captured line fields.
@@ -1356,36 +1314,6 @@ mod tests {
         assert_eq!(builder.lines.len(), 1, "one captured line for the JSON row");
         assert_eq!(builder.lines[0].as_deref(), Some("{\"x\":\"1\"}"));
     }
-
-    /// Regression for #2227: skip_bare_value must stop at `]` just like all
-    /// other JSON delimiters. Previously `]` was missing from the stop set,
-    /// causing bare values inside arrays to consume the closing bracket.
-    #[test]
-    fn skip_bare_value_stops_at_close_bracket() {
-        // Direct call: a number immediately followed by `]` — skip_bare_value
-        // must stop at position 2 (the `]`), not consume it.
-        let buf = b"12]more";
-        let result = skip_bare_value(buf, 0, buf.len());
-        assert_eq!(result, 2, "skip_bare_value must stop at ']'");
-        assert_eq!(buf[result], b']', "stopped byte must be ']'");
-
-        // Integration: an array value inside a JSON object should parse correctly.
-        // The number in `[1,2]` must not swallow the `]`.
-        let input = b"{\"arr\":[1,2]}\n";
-        let config = ScanConfig {
-            wanted_fields: alloc::vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-        };
-        let mut builder = TestBuilder::new();
-        scan_streaming(input, &config, &mut builder);
-        assert_eq!(
-            builder.rows.len(),
-            1,
-            "one JSON line should produce one row"
-        );
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1433,20 +1361,10 @@ mod verification {
         let result = skip_bare_value(&buf, start, end);
 
         assert!(result >= start && result <= end);
-        // When we stopped before end, the stop byte MUST be a delimiter.
-        if result < end {
-            assert!(
-                is_json_delimiter(buf[result]),
-                "stop byte must be a JSON delimiter"
-            );
-        }
         let mut i = start;
         while i < result {
             let b = buf[i];
-            assert!(
-                !is_json_delimiter(b),
-                "byte at {i} is a delimiter: {b:#04x}"
-            );
+            assert!(b != b',' && b != b'}' && b != b' ' && b != b'\t' && b != b'\r' && b != b'\n');
             i += 1;
         }
 
@@ -1454,8 +1372,6 @@ mod verification {
         kani::cover!(result > start, "found non-delimiter bytes");
         kani::cover!(result == start, "delimiter at start");
         kani::cover!(result == end, "no delimiter found");
-        // Explicitly cover the previously-missing ] delimiter path
-        kani::cover!(result < end && buf[result] == b']', "stopped at ]");
     }
 
     /// is_json_delimiter covers all JSON value delimiters exhaustively.


### PR DESCRIPTION
Renames the workflow and issue title for clarity.

- `Nightly Benchmarks` → `Criterion Nightly`
- Issue title: `Benchmark results ...` → `Criterion Nightly ...`

This distinguishes the Criterion microbenchmarks from the E2E Compose benchmarks in memagent-e2e.

Relates to strawgate/memagent-e2e#296

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename nightly benchmark workflow and issue titles to 'Criterion Nightly'
> Updates [bench.yml](.github/workflows/bench.yml) to rename the workflow display name and the auto-created GitHub issue title from 'Nightly Benchmarks'/'Benchmark results' to 'Criterion Nightly'.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d81bb18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->