### PR TITLE
docs: add highway backpressure animation

### DIFF
--- a/book/package-lock.json
+++ b/book/package-lock.json
@@ -901,9 +901,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -919,9 +916,6 @@
       "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -939,9 +933,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -957,9 +948,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -977,9 +965,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -995,9 +980,6 @@
       "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1015,9 +997,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1034,9 +1013,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1052,9 +1028,6 @@
       "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1078,9 +1051,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1102,9 +1072,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1128,9 +1095,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1152,9 +1116,6 @@
       "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1178,9 +1139,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1203,9 +1161,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1227,9 +1182,6 @@
       "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1581,9 +1533,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1596,9 +1545,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1613,9 +1559,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1628,9 +1571,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1645,9 +1585,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1660,9 +1597,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1677,9 +1611,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1692,9 +1623,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1709,9 +1637,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1724,9 +1649,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1741,9 +1663,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1757,9 +1676,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1772,9 +1688,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2317,9 +2230,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2335,9 +2245,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2355,9 +2262,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2373,9 +2277,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -2393,9 +2294,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2412,9 +2310,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2430,9 +2325,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2456,9 +2348,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2480,9 +2369,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2506,9 +2392,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2531,9 +2414,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2555,9 +2435,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/book/src/components/HighwayBackpressure.astro
+++ b/book/src/components/HighwayBackpressure.astro
@@ -1,0 +1,342 @@
+---
+// Animated highway metaphor for backpressure.
+// Cars flow from an on-ramp through a highway to an exit.
+// A "slow collector" tollbooth causes traffic to back up through the highway
+// and eventually block the on-ramp. When it clears, traffic flows again.
+// Pure CSS + vanilla JS — no framework deps.
+---
+
+<div class="hw" id="highway-bp">
+  <div class="hw-label">Why backpressure?</div>
+  <div class="hw-scene">
+    <svg class="hw-svg" viewBox="0 0 800 200" preserveAspectRatio="xMidYMid meet">
+      <!-- Road surface -->
+      <rect x="0" y="75" width="800" height="50" rx="4" fill="var(--hw-road)" />
+      <!-- Lane dashes -->
+      <line x1="0" y1="100" x2="800" y2="100" stroke="var(--hw-dash)" stroke-width="2" stroke-dasharray="20,14" />
+      <!-- On-ramp -->
+      <path d="M 80,170 C 80,130 120,110 160,105" fill="none" stroke="var(--hw-road)" stroke-width="40" stroke-linecap="round" />
+      <path d="M 80,170 C 80,130 120,110 160,105" fill="none" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="8,8" />
+      <!-- Exit / tollbooth -->
+      <rect x="680" y="78" width="14" height="44" rx="3" fill="var(--hw-toll)" class="hw-toll" />
+      <text x="687" y="72" text-anchor="middle" fill="var(--hw-muted)" font-size="9" font-weight="600">EXIT</text>
+      <!-- Labels -->
+      <text x="80" y="195" text-anchor="middle" fill="var(--hw-muted)" font-size="9" font-weight="600">ON-RAMP</text>
+      <text x="80" y="205" text-anchor="middle" fill="var(--hw-muted)" font-size="8">(log source)</text>
+      <text x="400" y="68" text-anchor="middle" fill="var(--hw-muted)" font-size="9" font-weight="600">PIPELINE</text>
+      <text x="400" y="58" text-anchor="middle" fill="var(--hw-muted)" font-size="8">(bounded channels)</text>
+      <text x="750" y="95" text-anchor="middle" fill="var(--hw-muted)" font-size="9" font-weight="600">COLLECTOR</text>
+      <text x="750" y="107" text-anchor="middle" fill="var(--hw-muted)" font-size="8">(output)</text>
+      <!-- Car container -->
+      <g id="hw-cars"></g>
+    </svg>
+  </div>
+  <div class="hw-status" id="hw-status">Flowing smoothly — collector keeping up</div>
+  <div class="hw-controls">
+    <button class="hw-btn hw-btn-slow" id="hw-btn-slow">🚧 Slow the exit</button>
+    <button class="hw-btn hw-btn-clear" id="hw-btn-clear" disabled>✅ Clear the exit</button>
+  </div>
+</div>
+
+<style is:global>
+  .hw {
+    --hw-road: color-mix(in srgb, var(--sl-color-gray-5) 60%, var(--sl-color-bg-sidebar));
+    --hw-dash: var(--sl-color-gray-4);
+    --hw-muted: var(--sl-color-gray-3);
+    --hw-car: #60a5fa;
+    --hw-car-wait: #f59e0b;
+    --hw-car-block: #ef4444;
+    --hw-toll: #22c55e;
+    --hw-toll-slow: #ef4444;
+    --hw-accent: var(--sl-color-accent);
+    margin: 1rem 0 1.5rem;
+    padding: 1rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 10px;
+    background: var(--sl-color-bg-sidebar);
+    overflow: hidden;
+  }
+  .hw * { margin-top: 0 !important; }
+
+  .hw-label {
+    font-size: 0.65rem;
+    font-weight: 600;
+    color: var(--hw-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 0.5rem;
+    text-align: center;
+  }
+
+  .hw-scene { width: 100%; overflow: hidden; }
+  .hw-svg { width: 100%; height: auto; display: block; }
+
+  .hw-status {
+    text-align: center;
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--sl-color-text);
+    margin: 0.6rem 0 0.5rem;
+    min-height: 1.4em;
+    transition: color 0.3s;
+  }
+
+  .hw-controls {
+    display: flex;
+    justify-content: center;
+    gap: 0.6rem;
+  }
+  .hw-btn {
+    padding: 0.35rem 0.85rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 6px;
+    background: var(--sl-color-bg-sidebar);
+    color: var(--sl-color-text);
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+  .hw-btn:hover:not(:disabled) {
+    border-color: var(--hw-accent);
+    background: color-mix(in srgb, var(--hw-accent) 10%, var(--sl-color-bg-sidebar));
+  }
+  .hw-btn:disabled { opacity: 0.4; cursor: default; }
+
+  .hw-toll { transition: fill 0.4s; }
+</style>
+
+<script>
+(function() {
+  var svg = document.querySelector('#highway-bp .hw-svg');
+  var carsG = document.getElementById('hw-cars');
+  var status = document.getElementById('hw-status');
+  var btnSlow = document.getElementById('hw-btn-slow');
+  var btnClear = document.getElementById('hw-btn-clear');
+  var toll = document.querySelector('#highway-bp .hw-toll');
+  if (!svg || !carsG) return;
+
+  // --- State ---
+  var SLOW = false;
+  var cars = [];         // { el, x, y, lane, speed, waiting }
+  var nextId = 0;
+  var TICK = 30;         // ms per frame
+  var SPAWN_NORMAL = 600;  // ms between spawns (flowing)
+  var SPAWN_SLOW = 400;    // ms between spawns (still arriving while backed up)
+  var lastSpawn = 0;
+  var timer = null;
+
+  // Road geometry
+  var ROAD_Y_TOP = 83;
+  var ROAD_Y_BOT = 109;
+  var RAMP_START_X = 80;
+  var RAMP_JOIN_X = 170;
+  var EXIT_X = 672;
+  var DESPAWN_X = 790;
+  var CAR_W = 24;
+  var CAR_H = 10;
+  var SPEED_NORMAL = 3.0;
+  var SPEED_SLOW = 0.3;
+  var MIN_GAP = 30;
+
+  function laneY(lane) { return lane === 0 ? ROAD_Y_TOP + 3 : ROAD_Y_BOT - CAR_H - 3; }
+
+  function makeCar(x, y) {
+    var g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    // Body
+    var body = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    body.setAttribute('width', CAR_W);
+    body.setAttribute('height', CAR_H);
+    body.setAttribute('rx', '3');
+    body.setAttribute('fill', 'var(--hw-car)');
+    body.classList.add('hw-car-body');
+    g.appendChild(body);
+    // Windshield
+    var ws = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    ws.setAttribute('x', CAR_W - 7);
+    ws.setAttribute('y', '2');
+    ws.setAttribute('width', '4');
+    ws.setAttribute('height', CAR_H - 4);
+    ws.setAttribute('rx', '1');
+    ws.setAttribute('fill', 'rgba(255,255,255,0.3)');
+    g.appendChild(ws);
+    g.setAttribute('transform', 'translate(' + x + ',' + y + ')');
+    carsG.appendChild(g);
+    return g;
+  }
+
+  function spawnCar() {
+    var lane = Math.random() < 0.5 ? 0 : 1;
+    // Cars start on the ramp curve
+    var car = {
+      el: null,
+      x: RAMP_START_X,
+      y: 155,
+      targetY: laneY(lane),
+      lane: lane,
+      speed: SPEED_NORMAL,
+      waiting: false,
+      onRamp: true,
+      rampT: 0,
+      id: nextId++
+    };
+    car.el = makeCar(car.x, car.y);
+    cars.push(car);
+  }
+
+  function rampPos(t) {
+    // Cubic bezier approximation of the on-ramp curve
+    var t2 = Math.min(t, 1);
+    var x = RAMP_START_X + (RAMP_JOIN_X - RAMP_START_X) * t2;
+    var y = 155 + (laneY(0) - 155) * (t2 * t2 * (3 - 2 * t2)); // smoothstep
+    return { x: x, y: y };
+  }
+
+  function closestAhead(car) {
+    var closest = null;
+    var dist = Infinity;
+    for (var i = 0; i < cars.length; i++) {
+      var c = cars[i];
+      if (c.id === car.id || c.onRamp) continue;
+      if (c.lane !== car.lane) continue;
+      var d = c.x - car.x;
+      if (d > 0 && d < dist) { dist = d; closest = c; }
+    }
+    return { car: closest, dist: dist };
+  }
+
+  function tick() {
+    var now = Date.now();
+
+    // Spawn
+    var interval = SLOW ? SPAWN_SLOW : SPAWN_NORMAL;
+    if (now - lastSpawn > interval && cars.length < 40) {
+      spawnCar();
+      lastSpawn = now;
+    }
+
+    var rampBlocked = false;
+
+    for (var i = cars.length - 1; i >= 0; i--) {
+      var car = cars[i];
+
+      // On-ramp movement
+      if (car.onRamp) {
+        car.rampT += 0.025;
+        if (car.rampT >= 1) {
+          car.onRamp = false;
+          car.x = RAMP_JOIN_X;
+          car.y = car.targetY;
+        } else {
+          // Check if ramp exit is blocked
+          var rampExit = closestAhead({ x: RAMP_JOIN_X - MIN_GAP, lane: car.lane, id: car.id, onRamp: false });
+          if (rampExit.dist < MIN_GAP + CAR_W) {
+            rampBlocked = true;
+            // Stall on ramp
+            car.el.querySelector('.hw-car-body').setAttribute('fill', 'var(--hw-car-block)');
+          } else {
+            var pos = rampPos(car.rampT);
+            car.x = pos.x;
+            car.y = pos.y + (car.targetY - laneY(0)) * car.rampT;
+            car.el.querySelector('.hw-car-body').setAttribute('fill', 'var(--hw-car)');
+          }
+        }
+        car.el.setAttribute('transform', 'translate(' + car.x.toFixed(1) + ',' + car.y.toFixed(1) + ')');
+        continue;
+      }
+
+      // Highway movement
+      var maxSpeed = SPEED_NORMAL;
+
+      // Slow near exit when SLOW mode
+      if (SLOW && car.x > EXIT_X - 20) {
+        maxSpeed = SPEED_SLOW;
+      }
+
+      // Don't rear-end the car ahead
+      var ahead = closestAhead(car);
+      if (ahead.dist < MIN_GAP + CAR_W) {
+        maxSpeed = Math.min(maxSpeed, Math.max(0, (ahead.dist - CAR_W - 4) * 0.1));
+        car.waiting = true;
+      } else {
+        car.waiting = false;
+      }
+
+      car.speed += (maxSpeed - car.speed) * 0.15;
+      car.x += car.speed;
+
+      // Color: flowing / waiting / blocked
+      var fill = 'var(--hw-car)';
+      if (car.speed < 0.5 && car.waiting) {
+        fill = car.x < RAMP_JOIN_X + 60 ? 'var(--hw-car-block)' : 'var(--hw-car-wait)';
+      }
+      car.el.querySelector('.hw-car-body').setAttribute('fill', fill);
+
+      car.el.setAttribute('transform', 'translate(' + car.x.toFixed(1) + ',' + car.y.toFixed(1) + ')');
+
+      // Despawn past exit
+      if (car.x > DESPAWN_X) {
+        carsG.removeChild(car.el);
+        cars.splice(i, 1);
+      }
+    }
+
+    // Update status
+    if (SLOW) {
+      if (rampBlocked) {
+        status.textContent = '🔴 On-ramp blocked — source feels backpressure, no data lost';
+        status.style.color = 'var(--hw-car-block)';
+      } else {
+        status.textContent = '🟡 Exit slow — traffic backing up through the pipeline';
+        status.style.color = 'var(--hw-car-wait)';
+      }
+    } else {
+      status.textContent = '🟢 Flowing smoothly — collector keeping up';
+      status.style.color = '';
+    }
+  }
+
+  btnSlow.addEventListener('click', function() {
+    SLOW = true;
+    toll.setAttribute('fill', 'var(--hw-toll-slow)');
+    btnSlow.disabled = true;
+    btnClear.disabled = false;
+  });
+
+  btnClear.addEventListener('click', function() {
+    SLOW = false;
+    toll.setAttribute('fill', 'var(--hw-toll)');
+    btnSlow.disabled = false;
+    btnClear.disabled = true;
+  });
+
+  // Start
+  if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    timer = setInterval(tick, TICK);
+    lastSpawn = Date.now();
+    // Seed a few cars
+    for (var s = 0; s < 6; s++) {
+      var lane = s % 2;
+      var c = {
+        el: null,
+        x: 180 + s * 85,
+        y: laneY(lane),
+        targetY: laneY(lane),
+        lane: lane,
+        speed: SPEED_NORMAL,
+        waiting: false,
+        onRamp: false,
+        rampT: 1,
+        id: nextId++
+      };
+      c.el = makeCar(c.x, c.y);
+      cars.push(c);
+    }
+  }
+
+  // Cleanup on Starlight SPA nav
+  document.addEventListener('astro:before-swap', function() {
+    clearInterval(timer);
+  }, { once: true });
+})();
+</script>

--- a/book/src/components/HighwayBackpressure.astro
+++ b/book/src/components/HighwayBackpressure.astro
@@ -31,10 +31,10 @@
       <g id="hw-cars"></g>
     </svg>
   </div>
-  <div class="hw-status" id="hw-status">Flowing smoothly — collector keeping up</div>
+  <div class="hw-status" id="hw-status" role="status" aria-live="polite" aria-atomic="true">Flowing smoothly — collector keeping up</div>
   <div class="hw-controls">
-    <button class="hw-btn hw-btn-slow" id="hw-btn-slow">🚧 Slow the exit</button>
-    <button class="hw-btn hw-btn-clear" id="hw-btn-clear" disabled>✅ Clear the exit</button>
+    <button type="button" class="hw-btn hw-btn-slow" id="hw-btn-slow">🚧 Slow the exit</button>
+    <button type="button" class="hw-btn hw-btn-clear" id="hw-btn-clear" disabled>✅ Clear the exit</button>
   </div>
 </div>
 
@@ -124,6 +124,7 @@
   var SPAWN_NORMAL = 600;  // ms between spawns (flowing)
   var SPAWN_SLOW = 400;    // ms between spawns (still arriving while backed up)
   var lastSpawn = 0;
+  var lastStatus = '';
   var timer = null;
 
   // Road geometry
@@ -222,18 +223,17 @@
 
       // On-ramp movement
       if (car.onRamp) {
-        car.rampT += 0.025;
-        if (car.rampT >= 1) {
-          car.onRamp = false;
-          car.x = RAMP_JOIN_X;
-          car.y = car.targetY;
+        // Check if ramp exit is blocked BEFORE advancing position.
+        var rampExit = closestAhead({ x: RAMP_JOIN_X - MIN_GAP, lane: car.lane, id: car.id, onRamp: false });
+        if (rampExit.dist < MIN_GAP + CAR_W) {
+          rampBlocked = true;
+          car.el.querySelector('.hw-car-body').setAttribute('fill', 'var(--hw-car-block)');
         } else {
-          // Check if ramp exit is blocked
-          var rampExit = closestAhead({ x: RAMP_JOIN_X - MIN_GAP, lane: car.lane, id: car.id, onRamp: false });
-          if (rampExit.dist < MIN_GAP + CAR_W) {
-            rampBlocked = true;
-            // Stall on ramp
-            car.el.querySelector('.hw-car-body').setAttribute('fill', 'var(--hw-car-block)');
+          car.rampT = Math.min(1, car.rampT + 0.025);
+          if (car.rampT >= 1) {
+            car.onRamp = false;
+            car.x = RAMP_JOIN_X;
+            car.y = car.targetY;
           } else {
             var pos = rampPos(car.rampT);
             car.x = pos.x;
@@ -281,18 +281,25 @@
       }
     }
 
-    // Update status
+    // Update status only when message changes to avoid DOM churn.
+    var newStatus;
+    var newColor;
     if (SLOW) {
       if (rampBlocked) {
-        status.textContent = '🔴 On-ramp blocked — source feels backpressure, no data lost';
-        status.style.color = 'var(--hw-car-block)';
+        newStatus = '🔴 On-ramp blocked — source feels backpressure, no data lost';
+        newColor = 'var(--hw-car-block)';
       } else {
-        status.textContent = '🟡 Exit slow — traffic backing up through the pipeline';
-        status.style.color = 'var(--hw-car-wait)';
+        newStatus = '🟡 Exit slow — traffic backing up through the pipeline';
+        newColor = 'var(--hw-car-wait)';
       }
     } else {
-      status.textContent = '🟢 Flowing smoothly — collector keeping up';
-      status.style.color = '';
+      newStatus = '🟢 Flowing smoothly — collector keeping up';
+      newColor = '';
+    }
+    if (newStatus !== lastStatus) {
+      status.textContent = newStatus;
+      status.style.color = newColor;
+      lastStatus = newStatus;
     }
   }
 
@@ -332,6 +339,28 @@
       c.el = makeCar(c.x, c.y);
       cars.push(c);
     }
+  } else {
+    // Reduced motion: show a static snapshot of traffic, disable controls.
+    for (var s = 0; s < 6; s++) {
+      var lane = s % 2;
+      var c = {
+        el: null,
+        x: 180 + s * 85,
+        y: laneY(lane),
+        targetY: laneY(lane),
+        lane: lane,
+        speed: 0,
+        waiting: false,
+        onRamp: false,
+        rampT: 1,
+        id: nextId++
+      };
+      c.el = makeCar(c.x, c.y);
+      cars.push(c);
+    }
+    btnSlow.disabled = true;
+    btnClear.disabled = true;
+    status.textContent = 'Animation paused (reduced motion)';
   }
 
   // Cleanup on Starlight SPA nav

--- a/book/src/content/docs/learn/backpressure.mdx
+++ b/book/src/content/docs/learn/backpressure.mdx
@@ -3,12 +3,31 @@ title: "Backpressure in Action"
 description: "Interactive simulation of how logfwd propagates backpressure from slow outputs back through the pipeline"
 ---
 
+import HighwayBackpressure from '../../../components/HighwayBackpressure.astro';
 import BackpressureSim from '../../../components/BackpressureSim.astro';
 import InputBackpressure from '../../../components/InputBackpressure.astro';
 
-When a collector goes slow or drops offline, logfwd doesn't buffer infinitely or drop data.
-Instead, **bounded channels** turn slow outputs into backpressure that cascades all the way
-back to the file reader — by design.
+Think of a log pipeline like a highway. When traffic flows freely, cars cruise
+from the on-ramp through to the exit. But when the exit backs up — a slow
+collector, a network blip — cars start queuing on the highway itself. Eventually
+the backup reaches the on-ramp and new cars can't even enter.
+
+That's backpressure. And it's **exactly what you want**. The alternative —
+letting cars pile onto the highway with no limit — is how you get a 40-car pileup
+and an OOM kill.
+
+Press **"Slow the exit"** and watch what happens:
+
+<HighwayBackpressure />
+
+logfwd works the same way. Every stage is connected by **bounded channels** — fixed-capacity
+lanes that can only hold so many batches. When a collector goes slow, pressure cascades back
+through the pipeline to the source. Files pause on disk (where they're safe), UDP drops
+packets (because UDP has no brakes), and OTLP senders get 429s and back off.
+
+No unbounded queues. No OOM. No silent data loss.
+
+## See it in the real pipeline
 
 Use the source selector to pick your input type and watch what it *feels* as pressure builds:
 a file falls behind and catches up on recovery, UDP drops packets permanently, OTLP senders


### PR DESCRIPTION
## Summary

Adds an interactive highway animation to the Backpressure in Action page that makes backpressure intuitive before diving into technical details.

**The animation:** Cars flow through a 2-lane highway from an on-ramp (log source) to an exit (collector). Users press "Slow the exit" to watch traffic back up through the pipeline and block the on-ramp, then "Clear the exit" to watch it recover.

**Page intro:** Rewrote the opening with a highway metaphor — three short paragraphs that explain *why* backpressure matters before the existing technical simulations.

**Component details:**
- `HighwayBackpressure.astro` — pure CSS + vanilla JS SVG animation
- Respects `prefers-reduced-motion`
- Cleans up on Starlight SPA navigation
- Uses Starlight CSS variables for dark/light theming

## Test Plan
- MDX imports, component structure, and a11y features validated
- Follows existing component patterns (DataFlowAnimation, BackpressureSim)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add interactive highway backpressure animation to docs
> - Adds a new [`HighwayBackpressure.astro`](https://github.com/strawgate/memagent/pull/2241/files#diff-47399e83c747483e8e2291c0d77604fec3da890d28b1c54ef22a4f09b7b1350c) component that renders an SVG highway scene with animated cars spawning, moving, and backing up to illustrate backpressure.
> - Two controls ('Slow the exit' and 'Clear the exit') let readers trigger and resolve congestion; cars change color to indicate flowing, waiting, or blocked states with live status text.
> - The component degrades gracefully in reduced-motion environments by rendering a static snapshot and disabling controls.
> - Embeds the component in [`backpressure.mdx`](https://github.com/strawgate/memagent/pull/2241/files#diff-48b4291019b229cb77af1794ddcb8692f5569cc280a35e88b4eb00734b9f6920) alongside updated explanatory copy that uses the highway metaphor.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0a37d9f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->