### PR TITLE
fix: consume tcp octet delimiter newline

### DIFF
--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -82,7 +82,7 @@ struct Client {
     discard_octet_bytes: usize,
     /// After consuming an octet-counted payload, optionally consume exactly one
     /// delimiter newline if it appears as the immediate next byte.
-    consume_octet_delimiter_newline: bool,
+    should_consume_octet_delimiter_newline: bool,
     /// Whether we are dropping newline-delimited bytes until a newline appears.
     discard_until_newline: bool,
     /// Raw bytes read from the socket that have not yet been charged to an
@@ -169,11 +169,11 @@ fn extract_complete_records(client: &mut Client, out: &mut Vec<u8>) {
             continue;
         }
 
-        if client.consume_octet_delimiter_newline {
+        if client.should_consume_octet_delimiter_newline {
             if pending[0] == b'\n' {
                 consumed += 1;
             }
-            client.consume_octet_delimiter_newline = false;
+            client.should_consume_octet_delimiter_newline = false;
             continue;
         }
 
@@ -203,16 +203,20 @@ fn extract_complete_records(client: &mut Client, out: &mut Vec<u8>) {
 
             if octet_frame_ready && octet_boundary_is_plausible {
                 client.octet_counting_mode = true;
+                let should_consume_octet_delimiter_newline =
+                    pending.len() == needed || matches!(pending.get(needed), Some(b'\n'));
                 if len > MAX_LINE_LENGTH {
                     client.discard_octet_bytes = len;
                     consumed += prefix_len;
-                    client.consume_octet_delimiter_newline = true;
+                    client.should_consume_octet_delimiter_newline =
+                        should_consume_octet_delimiter_newline;
                     continue;
                 }
                 out.extend_from_slice(&pending[prefix_len..needed]);
                 out.push(b'\n');
                 consumed += needed;
-                client.consume_octet_delimiter_newline = true;
+                client.should_consume_octet_delimiter_newline =
+                    should_consume_octet_delimiter_newline;
                 continue;
             }
         }
@@ -408,7 +412,7 @@ impl InputSource for TcpInput {
                         pending: Vec::new(),
                         octet_counting_mode: false,
                         discard_octet_bytes: 0,
-                        consume_octet_delimiter_newline: false,
+                        should_consume_octet_delimiter_newline: false,
                         discard_until_newline: false,
                         unaccounted_bytes: 0,
                     });
@@ -993,17 +997,25 @@ mod tests {
         let mut client = StdTcpStream::connect(addr).unwrap();
         client.write_all(b"5 hello\n").unwrap();
         client.flush().unwrap();
-        std::thread::sleep(Duration::from_millis(50));
 
-        let events = input.poll().unwrap();
-        let joined = events
-            .into_iter()
-            .filter_map(|e| match e {
-                InputEvent::Data { bytes, .. } => Some(bytes),
-                _ => None,
-            })
-            .flatten()
-            .collect::<Vec<u8>>();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut joined = Vec::new();
+        while Instant::now() < deadline {
+            let events = input.poll().unwrap();
+            joined.extend(
+                events
+                    .into_iter()
+                    .filter_map(|e| match e {
+                        InputEvent::Data { bytes, .. } => Some(bytes),
+                        _ => None,
+                    })
+                    .flatten(),
+            );
+            if !joined.is_empty() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
         assert_eq!(joined, b"hello\n");
     }
 

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -204,7 +204,7 @@ fn extract_complete_records(client: &mut Client, out: &mut Vec<u8>) {
             if octet_frame_ready && octet_boundary_is_plausible {
                 client.octet_counting_mode = true;
                 let should_consume_octet_delimiter_newline =
-                    matches!(pending.get(needed), Some(b'\n'));
+                    pending.len() == needed || matches!(pending.get(needed), Some(b'\n'));
                 if len > MAX_LINE_LENGTH {
                     client.discard_octet_bytes = len;
                     consumed += prefix_len;
@@ -684,29 +684,44 @@ mod tests {
     }
 
     #[test]
-    fn octet_frame_consumes_observed_delimiter_only() {
-        let (mut input, mut client) = tcp_input_with_client();
-        client.write_all(b"5 hello\n").unwrap();
-        client.flush().unwrap();
-
-        let got = poll_tcp_bytes_until(&mut input, |bytes| bytes == b"hello\n");
-        assert_eq!(got, b"hello\n");
-    }
-
-    #[test]
-    fn octet_frame_without_observed_delimiter_keeps_later_empty_line() {
+    fn octet_frame_consumes_delimiter_split_across_reads() {
         let (mut input, mut client) = tcp_input_with_client();
         client.write_all(b"5 hello").unwrap();
         client.flush().unwrap();
 
         let first = poll_tcp_bytes_until(&mut input, |bytes| bytes == b"hello\n");
         assert_eq!(first, b"hello\n");
+        assert!(
+            input
+                .clients
+                .first()
+                .is_some_and(|client| client.should_consume_octet_delimiter_newline),
+            "frame ending at a read boundary should wait for an optional delimiter"
+        );
 
         client.write_all(b"\n").unwrap();
         client.flush().unwrap();
 
-        let next = poll_tcp_bytes_until(&mut input, |bytes| bytes == b"\n");
-        assert_eq!(next, b"\n");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut next = Vec::new();
+        let mut consumed_delimiter = false;
+        while Instant::now() < deadline {
+            for event in input.poll().expect("tcp poll should succeed") {
+                if let InputEvent::Data { bytes, .. } = event {
+                    next.extend_from_slice(&bytes);
+                }
+            }
+            if input.clients.first().is_some_and(|client| {
+                !client.should_consume_octet_delimiter_newline && client.pending.is_empty()
+            }) {
+                consumed_delimiter = true;
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert!(consumed_delimiter, "split delimiter should be consumed");
+        assert!(next.is_empty(), "delimiter must not emit an empty record");
     }
 
     #[test]
@@ -1041,40 +1056,6 @@ mod tests {
             .flatten()
             .collect::<Vec<u8>>();
         assert_eq!(joined, b"hello\nworld\n");
-    }
-
-    #[test]
-    fn tcp_octet_counted_frame_consumes_single_delimiter_newline() {
-        let mut input = TcpInput::new(
-            "test",
-            "127.0.0.1:0",
-            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
-        )
-        .unwrap();
-        let addr = input.local_addr().unwrap();
-        let mut client = StdTcpStream::connect(addr).unwrap();
-        client.write_all(b"5 hello\n").unwrap();
-        client.flush().unwrap();
-
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let mut joined = Vec::new();
-        while Instant::now() < deadline {
-            let events = input.poll().unwrap();
-            joined.extend(
-                events
-                    .into_iter()
-                    .filter_map(|e| match e {
-                        InputEvent::Data { bytes, .. } => Some(bytes),
-                        _ => None,
-                    })
-                    .flatten(),
-            );
-            if !joined.is_empty() {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        assert_eq!(joined, b"hello\n");
     }
 
     #[test]

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -204,7 +204,7 @@ fn extract_complete_records(client: &mut Client, out: &mut Vec<u8>) {
             if octet_frame_ready && octet_boundary_is_plausible {
                 client.octet_counting_mode = true;
                 let should_consume_octet_delimiter_newline =
-                    pending.len() == needed || matches!(pending.get(needed), Some(b'\n'));
+                    matches!(pending.get(needed), Some(b'\n'));
                 if len > MAX_LINE_LENGTH {
                     client.discard_octet_bytes = len;
                     consumed += prefix_len;
@@ -650,6 +650,52 @@ mod tests {
     use proptest::prelude::*;
     use std::io::Write;
     use std::net::TcpStream as StdTcpStream;
+
+    fn client_with_pending(pending: Vec<u8>) -> (Client, StdTcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener should bind");
+        let peer =
+            StdTcpStream::connect(listener.local_addr().expect("listener addr")).expect("connect");
+        let (stream, _) = listener.accept().expect("accept test client");
+        let now = Instant::now();
+        (
+            Client {
+                stream,
+                source_id: SourceId(1),
+                last_data: now,
+                last_read: now,
+                pending,
+                octet_counting_mode: false,
+                discard_octet_bytes: 0,
+                should_consume_octet_delimiter_newline: false,
+                discard_until_newline: false,
+                unaccounted_bytes: 0,
+            },
+            peer,
+        )
+    }
+
+    #[test]
+    fn octet_frame_consumes_observed_delimiter_only() {
+        let (mut client, _peer) = client_with_pending(b"5 hello\n".to_vec());
+        let mut out = Vec::new();
+        extract_complete_records(&mut client, &mut out);
+        assert_eq!(out, b"hello\n");
+        assert!(client.pending.is_empty());
+    }
+
+    #[test]
+    fn octet_frame_without_observed_delimiter_keeps_later_empty_line() {
+        let (mut client, _peer) = client_with_pending(b"5 hello".to_vec());
+        let mut out = Vec::new();
+        extract_complete_records(&mut client, &mut out);
+        assert_eq!(out, b"hello\n");
+        assert!(client.pending.is_empty());
+
+        client.pending.extend_from_slice(b"\n");
+        let mut next = Vec::new();
+        extract_complete_records(&mut client, &mut next);
+        assert_eq!(next, b"\n");
+    }
 
     #[test]
     fn receives_tcp_data() {

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -651,49 +651,61 @@ mod tests {
     use std::io::Write;
     use std::net::TcpStream as StdTcpStream;
 
-    fn client_with_pending(pending: Vec<u8>) -> (Client, StdTcpStream) {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener should bind");
-        let peer =
-            StdTcpStream::connect(listener.local_addr().expect("listener addr")).expect("connect");
-        let (stream, _) = listener.accept().expect("accept test client");
-        let now = Instant::now();
-        (
-            Client {
-                stream,
-                source_id: SourceId(1),
-                last_data: now,
-                last_read: now,
-                pending,
-                octet_counting_mode: false,
-                discard_octet_bytes: 0,
-                should_consume_octet_delimiter_newline: false,
-                discard_until_newline: false,
-                unaccounted_bytes: 0,
-            },
-            peer,
+    fn tcp_input_with_client() -> (TcpInput, StdTcpStream) {
+        let input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
         )
+        .expect("test input should bind");
+        let addr = input.local_addr().expect("input should expose local addr");
+        let client = StdTcpStream::connect(addr).expect("client should connect");
+        (input, client)
+    }
+
+    fn poll_tcp_bytes_until(
+        input: &mut TcpInput,
+        mut is_complete: impl FnMut(&[u8]) -> bool,
+    ) -> Vec<u8> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut joined = Vec::new();
+        while Instant::now() < deadline {
+            for event in input.poll().expect("tcp poll should succeed") {
+                if let InputEvent::Data { bytes, .. } = event {
+                    joined.extend_from_slice(&bytes);
+                }
+            }
+            if is_complete(&joined) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        joined
     }
 
     #[test]
     fn octet_frame_consumes_observed_delimiter_only() {
-        let (mut client, _peer) = client_with_pending(b"5 hello\n".to_vec());
-        let mut out = Vec::new();
-        extract_complete_records(&mut client, &mut out);
-        assert_eq!(out, b"hello\n");
-        assert!(client.pending.is_empty());
+        let (mut input, mut client) = tcp_input_with_client();
+        client.write_all(b"5 hello\n").unwrap();
+        client.flush().unwrap();
+
+        let got = poll_tcp_bytes_until(&mut input, |bytes| bytes == b"hello\n");
+        assert_eq!(got, b"hello\n");
     }
 
     #[test]
     fn octet_frame_without_observed_delimiter_keeps_later_empty_line() {
-        let (mut client, _peer) = client_with_pending(b"5 hello".to_vec());
-        let mut out = Vec::new();
-        extract_complete_records(&mut client, &mut out);
-        assert_eq!(out, b"hello\n");
-        assert!(client.pending.is_empty());
+        let (mut input, mut client) = tcp_input_with_client();
+        client.write_all(b"5 hello").unwrap();
+        client.flush().unwrap();
 
-        client.pending.extend_from_slice(b"\n");
-        let mut next = Vec::new();
-        extract_complete_records(&mut client, &mut next);
+        let first = poll_tcp_bytes_until(&mut input, |bytes| bytes == b"hello\n");
+        assert_eq!(first, b"hello\n");
+
+        client.write_all(b"\n").unwrap();
+        client.flush().unwrap();
+
+        let next = poll_tcp_bytes_until(&mut input, |bytes| bytes == b"\n");
         assert_eq!(next, b"\n");
     }
 

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -80,6 +80,9 @@ struct Client {
     octet_counting_mode: bool,
     /// Remaining bytes to drop from an oversized octet-counted frame.
     discard_octet_bytes: usize,
+    /// After consuming an octet-counted payload, optionally consume exactly one
+    /// delimiter newline if it appears as the immediate next byte.
+    consume_octet_delimiter_newline: bool,
     /// Whether we are dropping newline-delimited bytes until a newline appears.
     discard_until_newline: bool,
     /// Raw bytes read from the socket that have not yet been charged to an
@@ -166,6 +169,14 @@ fn extract_complete_records(client: &mut Client, out: &mut Vec<u8>) {
             continue;
         }
 
+        if client.consume_octet_delimiter_newline {
+            if pending[0] == b'\n' {
+                consumed += 1;
+            }
+            client.consume_octet_delimiter_newline = false;
+            continue;
+        }
+
         if client.discard_until_newline {
             if let Some(pos) = memchr::memchr(b'\n', pending) {
                 consumed += pos + 1;
@@ -195,11 +206,13 @@ fn extract_complete_records(client: &mut Client, out: &mut Vec<u8>) {
                 if len > MAX_LINE_LENGTH {
                     client.discard_octet_bytes = len;
                     consumed += prefix_len;
+                    client.consume_octet_delimiter_newline = true;
                     continue;
                 }
                 out.extend_from_slice(&pending[prefix_len..needed]);
                 out.push(b'\n');
                 consumed += needed;
+                client.consume_octet_delimiter_newline = true;
                 continue;
             }
         }
@@ -395,6 +408,7 @@ impl InputSource for TcpInput {
                         pending: Vec::new(),
                         octet_counting_mode: false,
                         discard_octet_bytes: 0,
+                        consume_octet_delimiter_newline: false,
                         discard_until_newline: false,
                         unaccounted_bytes: 0,
                     });
@@ -965,6 +979,32 @@ mod tests {
             .flatten()
             .collect::<Vec<u8>>();
         assert_eq!(joined, b"hello\nworld\n");
+    }
+
+    #[test]
+    fn tcp_octet_counted_frame_consumes_single_delimiter_newline() {
+        let mut input = TcpInput::new(
+            "test",
+            "127.0.0.1:0",
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
+        let addr = input.local_addr().unwrap();
+        let mut client = StdTcpStream::connect(addr).unwrap();
+        client.write_all(b"5 hello\n").unwrap();
+        client.flush().unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        let events = input.poll().unwrap();
+        let joined = events
+            .into_iter()
+            .filter_map(|e| match e {
+                InputEvent::Data { bytes, .. } => Some(bytes),
+                _ => None,
+            })
+            .flatten()
+            .collect::<Vec<u8>>();
+        assert_eq!(joined, b"hello\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- consume a single delimiter newline immediately after an octet-counted TCP frame
- preserve embedded newlines inside the octet-counted payload
- add regression coverage for `5 hello\n` producing one record instead of an extra blank line

Fixes #2226.

## Tests
- `cargo test -p logfwd-io tcp_octet_counted_frame_consumes_single_delimiter_newline -- --nocapture`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix TCP octet-counted frame parser to consume optional delimiter newline
> The octet-counted frame parser in [`tcp_input.rs`](https://github.com/strawgate/memagent/pull/2243/files#diff-fb6ece7048cafbf067d846e591afde225474586202c6ff61a85c0b97ff813be5) was treating a trailing `\n` delimiter after an octet frame as a separate newline-delimited record. The fix tracks a `should_consume_octet_delimiter_newline` flag on each `Client` and, after emitting an octet frame, consumes one leading `\n` if present — including when it arrives in a subsequent read. A new test verifies that a split delimiter does not produce a spurious empty record.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a8d25ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->