### PR TITLE
fix: bound transform udf pattern caches

### DIFF
--- a/crates/logfwd-transform/src/udf/bounded_lru.rs
+++ b/crates/logfwd-transform/src/udf/bounded_lru.rs
@@ -1,0 +1,64 @@
+use std::borrow::Borrow;
+use std::collections::{HashMap, VecDeque};
+use std::hash::Hash;
+
+#[derive(Debug)]
+pub(crate) struct BoundedLruCache<K, V> {
+    pub(crate) entries: HashMap<K, V>,
+    lru: VecDeque<K>,
+    capacity: usize,
+}
+
+impl<K, V> BoundedLruCache<K, V>
+where
+    K: Clone + Eq + Hash,
+{
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            lru: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    pub(crate) fn get_cloned<Q>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized,
+        V: Clone,
+    {
+        let value = self.entries.get(key).cloned()?;
+        self.touch(key);
+        Some(value)
+    }
+
+    pub(crate) fn insert(&mut self, key: K, value: V) {
+        if self.entries.contains_key(&key) {
+            self.entries.insert(key.clone(), value);
+            self.touch(&key);
+            return;
+        }
+
+        self.entries.insert(key.clone(), value);
+        self.lru.push_back(key);
+
+        while self.entries.len() > self.capacity {
+            if let Some(evicted) = self.lru.pop_front() {
+                self.entries.remove(&evicted);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn touch<Q>(&mut self, key: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Eq + ?Sized,
+    {
+        if let Some(idx) = self.lru.iter().position(|entry| entry.borrow() == key) {
+            let key = self.lru.remove(idx).expect("lru index must be valid");
+            self.lru.push_back(key);
+        }
+    }
+}

--- a/crates/logfwd-transform/src/udf/bounded_lru.rs
+++ b/crates/logfwd-transform/src/udf/bounded_lru.rs
@@ -2,8 +2,15 @@ use std::borrow::Borrow;
 use std::collections::{HashMap, VecDeque};
 use std::hash::Hash;
 
+/// Capacity-limited least-recently-used cache for UDF pattern objects.
+///
+/// The cache stores values in `entries` and tracks access order in `lru`.
+/// Insertions and successful lookups mark a key as most recently used; when
+/// the capacity is exceeded, the least recently used key is evicted. Callers
+/// must provide synchronization if the cache is shared across threads.
 #[derive(Debug)]
 pub(crate) struct BoundedLruCache<K, V> {
+    /// Stored cache entries keyed by pattern text.
     pub(crate) entries: HashMap<K, V>,
     lru: VecDeque<K>,
     capacity: usize,
@@ -13,14 +20,16 @@ impl<K, V> BoundedLruCache<K, V>
 where
     K: Clone + Eq + Hash,
 {
+    /// Create a cache with room for at least one entry.
     pub(crate) fn new(capacity: usize) -> Self {
         Self {
             entries: HashMap::new(),
             lru: VecDeque::new(),
-            capacity,
+            capacity: capacity.max(1),
         }
     }
 
+    /// Return a cloned value and mark the key as recently used.
     pub(crate) fn get_cloned<Q>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -32,6 +41,7 @@ where
         Some(value)
     }
 
+    /// Insert or replace a value and evict least-recently-used entries.
     pub(crate) fn insert(&mut self, key: K, value: V) {
         if self.entries.contains_key(&key) {
             self.entries.insert(key.clone(), value);
@@ -60,5 +70,22 @@ where
             let key = self.lru.remove(idx).expect("lru index must be valid");
             self.lru.push_back(key);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BoundedLruCache;
+
+    #[test]
+    fn zero_capacity_keeps_one_entry() {
+        let mut cache = BoundedLruCache::new(0);
+
+        cache.insert("first", 1);
+        cache.insert("second", 2);
+
+        assert_eq!(cache.entries.len(), 1);
+        assert_eq!(cache.get_cloned("second"), Some(2));
+        assert_eq!(cache.get_cloned("first"), None);
     }
 }

--- a/crates/logfwd-transform/src/udf/grok.rs
+++ b/crates/logfwd-transform/src/udf/grok.rs
@@ -23,7 +23,7 @@
 //! URI, TIMESTAMP_ISO8601, DATE, TIME, LOGLEVEL, HOSTNAME, EMAILADDRESS.
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use arrow::array::{Array, ArrayRef, AsArray, StringBuilder, StructArray};
@@ -44,6 +44,57 @@ use datafusion::logical_expr::{
 struct CompiledGrok {
     pattern: grok::Pattern,
     field_names: Vec<String>,
+}
+
+const GROK_CACHE_CAPACITY: usize = 128;
+
+#[derive(Debug)]
+struct BoundedGrokCache {
+    entries: HashMap<String, Arc<CompiledGrok>>,
+    lru: VecDeque<String>,
+    capacity: usize,
+}
+
+impl BoundedGrokCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            lru: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    fn get_cloned(&mut self, pattern: &str) -> Option<Arc<CompiledGrok>> {
+        let value = self.entries.get(pattern).cloned()?;
+        self.touch(pattern);
+        Some(value)
+    }
+
+    fn insert(&mut self, pattern: String, compiled: Arc<CompiledGrok>) {
+        if self.entries.contains_key(&pattern) {
+            self.entries.insert(pattern.clone(), compiled);
+            self.touch(&pattern);
+            return;
+        }
+
+        self.entries.insert(pattern.clone(), compiled);
+        self.lru.push_back(pattern);
+
+        while self.entries.len() > self.capacity {
+            if let Some(evicted) = self.lru.pop_front() {
+                self.entries.remove(&evicted);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn touch(&mut self, pattern: &str) {
+        if let Some(idx) = self.lru.iter().position(|key| key == pattern) {
+            let key = self.lru.remove(idx).expect("lru index must be valid");
+            self.lru.push_back(key);
+        }
+    }
 }
 
 /// Compile a grok pattern using the `grok` crate's built-in pattern library.
@@ -81,7 +132,7 @@ pub struct GrokUdf {
     /// `OnceLock` would cache the first pattern and silently apply it to all
     /// calls with different patterns.  Keying by pattern string handles multiple
     /// patterns correctly while still avoiding recompilation across batches.
-    grok_cache: Mutex<HashMap<String, Arc<CompiledGrok>>>,
+    grok_cache: Mutex<BoundedGrokCache>,
 }
 
 impl std::fmt::Debug for GrokUdf {
@@ -124,8 +175,37 @@ impl GrokUdf {
                 ]),
                 Volatility::Immutable,
             ),
-            grok_cache: Mutex::new(HashMap::new()),
+            grok_cache: Mutex::new(BoundedGrokCache::new(GROK_CACHE_CAPACITY)),
         }
+    }
+
+    fn get_or_compile_grok(&self, pattern: &str) -> DfResult<Arc<CompiledGrok>> {
+        {
+            let mut cache = self.grok_cache.lock().map_err(|_| {
+                datafusion::error::DataFusionError::Execution(
+                    "grok() internal cache lock poisoned".to_string(),
+                )
+            })?;
+            if let Some(cached) = cache.get_cloned(pattern) {
+                return Ok(cached);
+            }
+        }
+
+        let compiled =
+            Arc::new(compile_grok(pattern).map_err(|e| {
+                datafusion::error::DataFusionError::Execution(format!("grok: {e}"))
+            })?);
+
+        let mut cache = self.grok_cache.lock().map_err(|_| {
+            datafusion::error::DataFusionError::Execution(
+                "grok() internal cache lock poisoned".to_string(),
+            )
+        })?;
+        if let Some(cached) = cache.get_cloned(pattern) {
+            return Ok(cached);
+        }
+        cache.insert(pattern.to_owned(), Arc::clone(&compiled));
+        Ok(compiled)
     }
 }
 
@@ -224,23 +304,7 @@ impl ScalarUDFImpl for GrokUdf {
         // distinct pattern gets its own cache entry so that multiple grok(...)
         // calls with different patterns in the same SQL query each use the
         // correct compiled pattern.
-        let compiled: Arc<CompiledGrok> = {
-            let mut cache = self.grok_cache.lock().map_err(|_| {
-                datafusion::error::DataFusionError::Execution(
-                    "grok() internal cache lock poisoned".to_string(),
-                )
-            })?;
-            if let Some(cached) = cache.get(&pattern_str) {
-                Arc::clone(cached)
-            } else {
-                let new_compiled = compile_grok(&pattern_str).map_err(|e| {
-                    datafusion::error::DataFusionError::Execution(format!("grok: {e}"))
-                })?;
-                let arc = Arc::new(new_compiled);
-                cache.insert(pattern_str, Arc::clone(&arc));
-                arc
-            }
-        };
+        let compiled = self.get_or_compile_grok(&pattern_str)?;
 
         match input {
             ColumnarValue::Array(array) => {
@@ -263,6 +327,10 @@ impl ScalarUDFImpl for GrokUdf {
                                 }
                                 continue;
                             }
+                            // NOTE: the grok crate uses fancy-regex internally.
+                            // If matching exceeds fancy-regex backtracking limits,
+                            // `match_against` currently reports None. We treat this
+                            // exactly like a non-match and return NULL captures.
                             match compiled.pattern.match_against(strings.value(row)) {
                                 Some(matches) => {
                                     for (i, name) in compiled.field_names.iter().enumerate() {
@@ -721,5 +789,76 @@ mod tests {
                 "row {row}: NULL pattern must propagate NULL"
             );
         }
+    }
+
+    #[test]
+    fn test_grok_cache_reuses_compiled_pattern() {
+        let udf = GrokUdf::new();
+        let first = udf
+            .get_or_compile_grok("%{WORD:method} %{NUMBER:status}")
+            .expect("pattern should compile");
+        let second = udf
+            .get_or_compile_grok("%{WORD:method} %{NUMBER:status}")
+            .expect("pattern should be cached");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "same pattern must reuse compiled grok program"
+        );
+    }
+
+    #[test]
+    fn test_grok_cache_evicts_lru_entry() {
+        let udf = GrokUdf::new();
+        for idx in 0..GROK_CACHE_CAPACITY {
+            let pattern = format!("%{{WORD:word{idx}}}");
+            udf.get_or_compile_grok(&pattern)
+                .expect("pattern should compile");
+        }
+
+        // Touch word0 so word1 becomes LRU.
+        udf.get_or_compile_grok("%{WORD:word0}")
+            .expect("pattern should remain cached");
+        udf.get_or_compile_grok("%{WORD:overflow}")
+            .expect("overflow pattern should compile");
+
+        let cache = udf.grok_cache.lock().expect("cache lock");
+        assert_eq!(
+            cache.entries.len(),
+            GROK_CACHE_CAPACITY,
+            "cache should remain bounded"
+        );
+        assert!(
+            cache.entries.contains_key("%{WORD:word0}"),
+            "most recently used entry should stay in cache"
+        );
+        assert!(
+            !cache.entries.contains_key("%{WORD:word1}"),
+            "least recently used entry should be evicted"
+        );
+    }
+
+    #[test]
+    fn test_grok_pathological_regex_returns_null_quickly() {
+        use std::time::{Duration, Instant};
+
+        let udf = GrokUdf::new();
+        let compiled = udf
+            .get_or_compile_grok("(?<cat>(a+)+)b")
+            .expect("pattern should compile");
+
+        let input = "a".repeat(4096);
+        let started = Instant::now();
+        let matched = compiled.pattern.match_against(&input);
+        let elapsed = started.elapsed();
+
+        // Current contract: catastrophic/backtrack-limit paths are treated as no-match.
+        assert!(
+            matched.is_none(),
+            "pathological regex should not produce captures on non-matching input"
+        );
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "pathological regex match took too long: {elapsed:?}"
+        );
     }
 }

--- a/crates/logfwd-transform/src/udf/grok.rs
+++ b/crates/logfwd-transform/src/udf/grok.rs
@@ -23,7 +23,6 @@
 //! URI, TIMESTAMP_ISO8601, DATE, TIME, LOGLEVEL, HOSTNAME, EMAILADDRESS.
 
 use std::any::Any;
-use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use arrow::array::{Array, ArrayRef, AsArray, StringBuilder, StructArray};
@@ -33,6 +32,8 @@ use datafusion::common::Result as DfResult;
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
 };
+
+use crate::udf::bounded_lru::BoundedLruCache;
 
 // ---------------------------------------------------------------------------
 // Grok pattern compilation (via grok crate)
@@ -48,54 +49,7 @@ struct CompiledGrok {
 
 const GROK_CACHE_CAPACITY: usize = 128;
 
-#[derive(Debug)]
-struct BoundedGrokCache {
-    entries: HashMap<String, Arc<CompiledGrok>>,
-    lru: VecDeque<String>,
-    capacity: usize,
-}
-
-impl BoundedGrokCache {
-    fn new(capacity: usize) -> Self {
-        Self {
-            entries: HashMap::new(),
-            lru: VecDeque::new(),
-            capacity,
-        }
-    }
-
-    fn get_cloned(&mut self, pattern: &str) -> Option<Arc<CompiledGrok>> {
-        let value = self.entries.get(pattern).cloned()?;
-        self.touch(pattern);
-        Some(value)
-    }
-
-    fn insert(&mut self, pattern: String, compiled: Arc<CompiledGrok>) {
-        if self.entries.contains_key(&pattern) {
-            self.entries.insert(pattern.clone(), compiled);
-            self.touch(&pattern);
-            return;
-        }
-
-        self.entries.insert(pattern.clone(), compiled);
-        self.lru.push_back(pattern);
-
-        while self.entries.len() > self.capacity {
-            if let Some(evicted) = self.lru.pop_front() {
-                self.entries.remove(&evicted);
-            } else {
-                break;
-            }
-        }
-    }
-
-    fn touch(&mut self, pattern: &str) {
-        if let Some(idx) = self.lru.iter().position(|key| key == pattern) {
-            let key = self.lru.remove(idx).expect("lru index must be valid");
-            self.lru.push_back(key);
-        }
-    }
-}
+type BoundedGrokCache = BoundedLruCache<String, Arc<CompiledGrok>>;
 
 /// Compile a grok pattern using the `grok` crate's built-in pattern library.
 fn compile_grok(pattern: &str) -> Result<CompiledGrok, crate::TransformError> {
@@ -841,24 +795,44 @@ mod tests {
     fn test_grok_pathological_regex_returns_null_quickly() {
         use std::time::{Duration, Instant};
 
-        let udf = GrokUdf::new();
-        let compiled = udf
-            .get_or_compile_grok("(?<cat>(a+)+)b")
-            .expect("pattern should compile");
-
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "message",
+            DataType::Utf8,
+            true,
+        )]));
         let input = "a".repeat(4096);
+        let messages: ArrayRef = Arc::new(StringArray::from(vec![Some(input)]));
+        let batch = RecordBatch::try_new(schema, vec![messages]).expect("batch should build");
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
         let started = Instant::now();
-        let matched = compiled.pattern.match_against(&input);
+        let result = rt.block_on(run_sql(
+            batch,
+            "SELECT grok(message, '(?<cat>(a+)+)b') AS captures FROM logs",
+        ));
         let elapsed = started.elapsed();
 
-        // Current contract: catastrophic/backtrack-limit paths are treated as no-match.
-        assert!(
-            matched.is_none(),
-            "pathological regex should not produce captures on non-matching input"
-        );
         assert!(
             elapsed < Duration::from_secs(2),
             "pathological regex match took too long: {elapsed:?}"
+        );
+        assert_eq!(result.num_rows(), 1, "query should return one row");
+
+        let captures = result
+            .column_by_name("captures")
+            .expect("query should produce captures column")
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("grok(...) should return a struct array");
+        let cat = captures
+            .column_by_name("cat")
+            .expect("struct should contain cat capture");
+        assert!(
+            cat.is_null(0),
+            "pathological regex should surface as a NULL capture"
         );
     }
 }

--- a/crates/logfwd-transform/src/udf/mod.rs
+++ b/crates/logfwd-transform/src/udf/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! These are registered in `SqlTransform::execute()` and available in user SQL.
 
+mod bounded_lru;
+
 /// CSV-backed IP-range geo database implementation and helpers.
 pub mod csv_range_geo;
 pub mod geo_lookup;

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -11,7 +11,7 @@
 //! ```
 
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use arrow::array::{Array, AsArray, StringBuilder};
@@ -23,6 +23,57 @@ use datafusion::logical_expr::{
 };
 
 use regex::Regex;
+
+const REGEXP_CACHE_CAPACITY: usize = 128;
+
+#[derive(Debug)]
+struct BoundedRegexCache {
+    entries: HashMap<String, Arc<Regex>>,
+    lru: VecDeque<String>,
+    capacity: usize,
+}
+
+impl BoundedRegexCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            lru: VecDeque::new(),
+            capacity,
+        }
+    }
+
+    fn get_cloned(&mut self, pattern: &str) -> Option<Arc<Regex>> {
+        let value = self.entries.get(pattern).cloned()?;
+        self.touch(pattern);
+        Some(value)
+    }
+
+    fn insert(&mut self, pattern: String, regex: Arc<Regex>) {
+        if self.entries.contains_key(&pattern) {
+            self.entries.insert(pattern.clone(), regex);
+            self.touch(&pattern);
+            return;
+        }
+
+        self.entries.insert(pattern.clone(), regex);
+        self.lru.push_back(pattern);
+
+        while self.entries.len() > self.capacity {
+            if let Some(evicted) = self.lru.pop_front() {
+                self.entries.remove(&evicted);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn touch(&mut self, pattern: &str) {
+        if let Some(idx) = self.lru.iter().position(|key| key == pattern) {
+            let key = self.lru.remove(idx).expect("lru index must be valid");
+            self.lru.push_back(key);
+        }
+    }
+}
 
 /// UDF: regexp_extract(string, pattern, group_index) -> Utf8
 ///
@@ -37,7 +88,7 @@ pub struct RegexpExtractUdf {
     /// single-slot `OnceLock` would permanently cache the first pattern seen and
     /// silently apply it to all subsequent calls with different patterns.
     /// Keying the cache by pattern string correctly handles multiple patterns.
-    regex_cache: Mutex<HashMap<String, Arc<Regex>>>,
+    regex_cache: Mutex<BoundedRegexCache>,
 }
 
 impl std::fmt::Debug for RegexpExtractUdf {
@@ -107,8 +158,39 @@ impl RegexpExtractUdf {
                 ]),
                 Volatility::Immutable,
             ),
-            regex_cache: Mutex::new(HashMap::new()),
+            regex_cache: Mutex::new(BoundedRegexCache::new(REGEXP_CACHE_CAPACITY)),
         }
+    }
+
+    fn get_or_compile_regex(&self, pattern: &str) -> DfResult<Arc<Regex>> {
+        {
+            let mut cache = self.regex_cache.lock().map_err(|_| {
+                datafusion::error::DataFusionError::Execution(
+                    "regexp_extract() internal cache lock poisoned".to_string(),
+                )
+            })?;
+            if let Some(cached) = cache.get_cloned(pattern) {
+                return Ok(cached);
+            }
+        }
+
+        let compiled = Arc::new(Regex::new(pattern).map_err(|e| {
+            datafusion::error::DataFusionError::Execution(format!(
+                "regexp_extract: invalid pattern '{}': {}",
+                pattern, e
+            ))
+        })?);
+
+        let mut cache = self.regex_cache.lock().map_err(|_| {
+            datafusion::error::DataFusionError::Execution(
+                "regexp_extract() internal cache lock poisoned".to_string(),
+            )
+        })?;
+        if let Some(cached) = cache.get_cloned(pattern) {
+            return Ok(cached);
+        }
+        cache.insert(pattern.to_owned(), Arc::clone(&compiled));
+        Ok(compiled)
     }
 }
 
@@ -169,26 +251,7 @@ impl ScalarUDFImpl for RegexpExtractUdf {
         // pattern gets its own cache entry so that multiple regexp_extract(...)
         // calls with different patterns in the same SQL query each use the
         // correct compiled regex.
-        let re: Arc<Regex> = {
-            let mut cache = self.regex_cache.lock().map_err(|_| {
-                datafusion::error::DataFusionError::Execution(
-                    "regexp_extract() internal cache lock poisoned".to_string(),
-                )
-            })?;
-            if let Some(cached) = cache.get(&pattern_str) {
-                Arc::clone(cached)
-            } else {
-                let compiled = Regex::new(&pattern_str).map_err(|e| {
-                    datafusion::error::DataFusionError::Execution(format!(
-                        "regexp_extract: invalid pattern '{}': {}",
-                        pattern_str, e
-                    ))
-                })?;
-                let arc = Arc::new(compiled);
-                cache.insert(pattern_str, Arc::clone(&arc));
-                arc
-            }
-        };
+        let re = self.get_or_compile_regex(&pattern_str)?;
 
         // Extract group index.
         let idx = match group_idx {
@@ -702,6 +765,52 @@ mod tests {
         assert!(
             msg.contains("group_index argument must be a scalar integer literal"),
             "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_regex_cache_reuses_compiled_pattern() {
+        let udf = RegexpExtractUdf::new();
+        let first = udf
+            .get_or_compile_regex(r"status=(\d+)")
+            .expect("pattern should compile");
+        let second = udf
+            .get_or_compile_regex(r"status=(\d+)")
+            .expect("pattern should be cached");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "same pattern must reuse compiled regex"
+        );
+    }
+
+    #[test]
+    fn test_regex_cache_evicts_lru_entry() {
+        let udf = RegexpExtractUdf::new();
+        for idx in 0..REGEXP_CACHE_CAPACITY {
+            let pattern = format!("field{idx}=(\\d+)");
+            udf.get_or_compile_regex(&pattern)
+                .expect("pattern should compile");
+        }
+
+        // Touch field0 so field1 becomes LRU.
+        udf.get_or_compile_regex("field0=(\\d+)")
+            .expect("pattern should remain cached");
+        udf.get_or_compile_regex("overflow=(\\d+)")
+            .expect("overflow pattern should compile");
+
+        let cache = udf.regex_cache.lock().expect("cache lock");
+        assert_eq!(
+            cache.entries.len(),
+            REGEXP_CACHE_CAPACITY,
+            "cache should remain bounded"
+        );
+        assert!(
+            cache.entries.contains_key("field0=(\\d+)"),
+            "most recently used entry should stay in cache"
+        );
+        assert!(
+            !cache.entries.contains_key("field1=(\\d+)"),
+            "least recently used entry should be evicted"
         );
     }
 }

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -11,7 +11,6 @@
 //! ```
 
 use std::any::Any;
-use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 use arrow::array::{Array, AsArray, StringBuilder};
@@ -22,58 +21,12 @@ use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
 };
 
+use crate::udf::bounded_lru::BoundedLruCache;
 use regex::Regex;
 
 const REGEXP_CACHE_CAPACITY: usize = 128;
 
-#[derive(Debug)]
-struct BoundedRegexCache {
-    entries: HashMap<String, Arc<Regex>>,
-    lru: VecDeque<String>,
-    capacity: usize,
-}
-
-impl BoundedRegexCache {
-    fn new(capacity: usize) -> Self {
-        Self {
-            entries: HashMap::new(),
-            lru: VecDeque::new(),
-            capacity,
-        }
-    }
-
-    fn get_cloned(&mut self, pattern: &str) -> Option<Arc<Regex>> {
-        let value = self.entries.get(pattern).cloned()?;
-        self.touch(pattern);
-        Some(value)
-    }
-
-    fn insert(&mut self, pattern: String, regex: Arc<Regex>) {
-        if self.entries.contains_key(&pattern) {
-            self.entries.insert(pattern.clone(), regex);
-            self.touch(&pattern);
-            return;
-        }
-
-        self.entries.insert(pattern.clone(), regex);
-        self.lru.push_back(pattern);
-
-        while self.entries.len() > self.capacity {
-            if let Some(evicted) = self.lru.pop_front() {
-                self.entries.remove(&evicted);
-            } else {
-                break;
-            }
-        }
-    }
-
-    fn touch(&mut self, pattern: &str) {
-        if let Some(idx) = self.lru.iter().position(|key| key == pattern) {
-            let key = self.lru.remove(idx).expect("lru index must be valid");
-            self.lru.push_back(key);
-        }
-    }
-}
+type BoundedRegexCache = BoundedLruCache<String, Arc<Regex>>;
 
 /// UDF: regexp_extract(string, pattern, group_index) -> Utf8
 ///


### PR DESCRIPTION
## Summary
- replace unbounded regexp_extract and grok pattern caches with bounded LRU caches
- compile patterns outside the cache lock and re-check on insert to keep locking short
- document and test the grok catastrophic/backtracking behavior as a no-match path under the current grok/fancy-regex stack

Fixes #2031.

## Tests
- `cargo test -p logfwd-transform test_regex_cache_reuses_compiled_pattern -- --nocapture`
- `cargo test -p logfwd-transform test_grok_pathological_regex_returns_null_quickly -- --nocapture`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound pattern caches in `grok()` and `regexp_extract()` UDFs to 128 entries with LRU eviction
> - Adds a generic `BoundedLruCache` in [`bounded_lru.rs`](https://github.com/strawgate/memagent/pull/2245/files#diff-258d219647e7fee4f09289d3ffba7e730baaebda56a1aec9be6c4a4cfd02f256) backed by a `HashMap` and `VecDeque`, with a configurable capacity and LRU eviction on overflow.
> - Replaces the unbounded `HashMap` caches in [`grok.rs`](https://github.com/strawgate/memagent/pull/2245/files#diff-b2afb20090fb53f827b886b3db7efac924faa0074a0b78f5ae770f041a8c83a5) and [`regexp_extract.rs`](https://github.com/strawgate/memagent/pull/2245/files#diff-53b1d1b12e649ff264f98f2e6c0509dbf5b22edfb236111cb2a636bc51516d97) with `BoundedLruCache` capped at 128 entries.
> - Pattern compilation now happens outside the mutex lock in both UDFs, reducing lock contention.
> - Behavioral Change: previously the caches grew without bound; now entries beyond 128 are evicted by LRU order.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ba22c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->