### PR TITLE
docs: align runtime configuration references

### DIFF
--- a/book/src/content/docs/configuration/outputs.mdx
+++ b/book/src/content/docs/configuration/outputs.mdx
@@ -115,7 +115,7 @@ would collapse to the same sanitized Loki label key.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `endpoint` | string | Yes | Loki push URL |
+| `endpoint` | string | Yes | Loki base URL |
 | `tenant_id` | string | No | Optional `X-Scope-OrgID` value for multi-tenant Loki |
 | `static_labels` | map[string,string] | No | Static labels attached to every stream |
 | `label_columns` | array[string] | No | Log columns to include as labels |

--- a/book/src/content/docs/configuration/outputs.mdx
+++ b/book/src/content/docs/configuration/outputs.mdx
@@ -90,6 +90,7 @@ Streaming mode is experimental and currently requires `compression: none`. Use `
 | `index` | string | No | `logs` | Target index name |
 | `compression` | string | No | none | `gzip` or `none` |
 | `request_mode` | string | No | `buffered` | `buffered` or experimental `streaming` (streaming currently requires `compression: none`) |
+| `auth` | object | No | — | Bearer token or custom headers |
 
 </TabItem>
 <TabItem label="Loki">
@@ -100,6 +101,11 @@ Push logs to Grafana Loki with automatic label grouping.
 output:
   type: loki
   endpoint: http://loki:3100
+  tenant_id: team-a
+  static_labels:
+    app: logfwd
+    env: prod
+  label_columns: [service, level]
 ```
 
 When `label_columns` or `static_labels` are used, logfwd sanitizes label keys
@@ -110,6 +116,12 @@ would collapse to the same sanitized Loki label key.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `endpoint` | string | Yes | Loki push URL |
+| `tenant_id` | string | No | Optional `X-Scope-OrgID` value for multi-tenant Loki |
+| `static_labels` | map[string,string] | No | Static labels attached to every stream |
+| `label_columns` | array[string] | No | Log columns to include as labels |
+| `auth` | object | No | Bearer token or custom headers |
+
+`compression` is not supported for Loki outputs.
 
 </TabItem>
 <TabItem label="Multiple outputs">

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -450,7 +450,7 @@ Push to Grafana Loki.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `endpoint` | string | Yes | Loki push URL. |
+| `endpoint` | string | Yes | Loki base URL. The `/loki/api/v1/push` path is appended automatically. |
 | `tenant_id` | string | No | Optional value sent as `X-Scope-OrgID` for multi-tenant Loki deployments. |
 | `static_labels` | map[string,string] | No | Static labels applied to every pushed log stream. Keys and values must be non-empty. |
 | `label_columns` | array[string] | No | Additional log columns to promote as Loki labels. |
@@ -914,7 +914,7 @@ When `server.diagnostics` is configured, logfwd exposes an HTTP API for monitori
 | `/ready` | GET | Readiness probe. Returns 200 OK when required components are initialized and in a ready health state; returns 503 while components are still starting, stopping, stopped, failed, or otherwise not ready. |
 | `/admin/v1/status` | GET | Canonical rich status payload with live/ready state, component health, and per-pipeline counters. |
 | `/admin/v1/stats` | GET | Aggregate process stats (uptime, RSS, CPU, aggregate line counts). |
-| `/admin/v1/config` | GET | Currently loaded YAML configuration and its file path (disabled by default; enable with `LOGFWD_UNSAFE_EXPOSE_CONFIG=1`). |
+| `/admin/v1/config` | GET | Currently loaded YAML configuration and its file path (disabled by default; enable with `LOGFWD_UNSAFE_EXPOSE_CONFIG=1`). May expose sensitive values; do not enable in shared or production environments unless strictly required. |
 | `/admin/v1/logs` | GET | Recent log lines from logfwd's own stderr (ring buffer). |
 | `/admin/v1/history` | GET | Time-series data (1-hour window) for dashboard charts. |
 | `/admin/v1/traces` | GET | Recent batch processing spans for detailed latency analysis. |

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -425,9 +425,24 @@ output:
 
 Ship to Elasticsearch via the Bulk API.
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `endpoint` | string | Yes | Elasticsearch base URL. |
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `endpoint` | string | Yes | — | Elasticsearch base URL. |
+| `index` | string | No | `logs` | Target index name. Must not be empty, and must not contain Elasticsearch-reserved characters or prefixes. |
+| `compression` | string | No | `none` | `gzip` or `none`. |
+| `request_mode` | string | No | `buffered` | `buffered` or `streaming`. `streaming` currently requires `compression: none`. |
+| `auth` | object | No | — | Optional bearer token or custom headers for HTTP auth. |
+
+```yaml
+output:
+  type: elasticsearch
+  endpoint: https://es-cluster:9200
+  index: logs
+  compression: gzip
+  request_mode: buffered
+  auth:
+    bearer_token: "${ES_TOKEN}"
+```
 
 ### `loki` output
 
@@ -436,6 +451,25 @@ Push to Grafana Loki.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `endpoint` | string | Yes | Loki push URL. |
+| `tenant_id` | string | No | Optional value sent as `X-Scope-OrgID` for multi-tenant Loki deployments. |
+| `static_labels` | map[string,string] | No | Static labels applied to every pushed log stream. Keys and values must be non-empty. |
+| `label_columns` | array[string] | No | Additional log columns to promote as Loki labels. |
+| `auth` | object | No | Optional bearer token or custom headers for HTTP auth. |
+
+```yaml
+output:
+  type: loki
+  endpoint: http://loki:3100
+  tenant_id: team-a
+  static_labels:
+    app: logfwd
+    env: prod
+  label_columns: [service, level]
+  auth:
+    bearer_token: "${LOKI_TOKEN}"
+```
+
+`compression` is not supported for Loki outputs.
 
 ### `file` output
 
@@ -880,7 +914,7 @@ When `server.diagnostics` is configured, logfwd exposes an HTTP API for monitori
 | `/ready` | GET | Readiness probe. Returns 200 OK when required components are initialized and in a ready health state; returns 503 while components are still starting, stopping, stopped, failed, or otherwise not ready. |
 | `/admin/v1/status` | GET | Canonical rich status payload with live/ready state, component health, and per-pipeline counters. |
 | `/admin/v1/stats` | GET | Aggregate process stats (uptime, RSS, CPU, aggregate line counts). |
-| `/admin/v1/config` | GET | Currently loaded YAML configuration and its file path. |
+| `/admin/v1/config` | GET | Currently loaded YAML configuration and its file path (disabled by default; enable with `LOGFWD_UNSAFE_EXPOSE_CONFIG=1`). |
 | `/admin/v1/logs` | GET | Recent log lines from logfwd's own stderr (ring buffer). |
 | `/admin/v1/history` | GET | Time-series data (1-hour window) for dashboard charts. |
 | `/admin/v1/traces` | GET | Recent batch processing spans for detailed latency analysis. |

--- a/book/src/content/docs/deployment/kubernetes.md
+++ b/book/src/content/docs/deployment/kubernetes.md
@@ -27,9 +27,11 @@ node runs one logfwd pod that reads container logs from `/var/log` on the host.
 A ready-to-use manifest is provided at `deploy/daemonset.yml`.
 
 :::note[CRI field requirement]
-The `_timestamp` and `_stream` columns used in the SQL example below are only
-present when the input is parsed as CRI (`format: cri`). If you switch to a
-different input format, remove those columns or update the query accordingly.
+In the file-input example below, `_stream` is only present when the input is
+parsed as CRI (`format: cri`). The `_timestamp` column is present here because
+CRI parsing injects it for this example, but `_timestamp` may also be provided
+by other inputs or formats. If you switch to a different input format and these
+columns are not available, remove them or update the query accordingly.
 :::
 
 ### Minimal DaemonSet

--- a/book/src/content/docs/deployment/kubernetes.md
+++ b/book/src/content/docs/deployment/kubernetes.md
@@ -26,6 +26,12 @@ node runs one logfwd pod that reads container logs from `/var/log` on the host.
 
 A ready-to-use manifest is provided at `deploy/daemonset.yml`.
 
+:::note[CRI field requirement]
+The `_timestamp` and `_stream` columns used in the SQL example below are only
+present when the input is parsed as CRI (`format: cri`). If you switch to a
+different input format, remove those columns or update the query accordingly.
+:::
+
 ### Minimal DaemonSet
 
 ```yaml

--- a/book/src/content/docs/troubleshooting.md
+++ b/book/src/content/docs/troubleshooting.md
@@ -31,7 +31,7 @@ kubectl -n collectors logs -f daemonset/logfwd
 | No logs arrive at destination | `curl -s http://localhost:9090/admin/v1/status | jq '.pipelines[0].inputs'` | `lines_total` increasing | Fix file path/mount permissions |
 | Logs read, but nothing forwarded | `curl -s http://localhost:9090/admin/v1/status | jq '.pipelines[0].transform'` | `lines_in > 0` and `lines_out > 0` | Transform filter dropping all rows |
 | Frequent OTLP send errors | Check runtime logs for `error sending` | No repeated connection/auth errors | Fix endpoint/protocol/connectivity |
-| Startup/config errors | `logfwd validate --config config.yaml` | `config ok` | Fix required fields / YAML syntax |
+| Startup/config errors | `logfwd validate --config config.yaml` | Output contains `config ok:` | Fix required fields / YAML syntax |
 | Throughput unexpectedly low | `curl -s http://localhost:9090/admin/v1/status | jq '.pipelines[0].stage_seconds'` | `output` not dominating total | Network/collector bottleneck |
 
 ## Scenario 1: No logs arrive at destination
@@ -132,7 +132,7 @@ logfwd validate --config config.yaml
 
 ### Expected
 
-Validation succeeds and prints `config ok`.
+Validation succeeds and prints `config ok: <n> pipeline(s)`.
 
 ### Common causes and fixes
 

--- a/book/src/content/docs/troubleshooting.md
+++ b/book/src/content/docs/troubleshooting.md
@@ -31,7 +31,7 @@ kubectl -n collectors logs -f daemonset/logfwd
 | No logs arrive at destination | `curl -s http://localhost:9090/admin/v1/status | jq '.pipelines[0].inputs'` | `lines_total` increasing | Fix file path/mount permissions |
 | Logs read, but nothing forwarded | `curl -s http://localhost:9090/admin/v1/status | jq '.pipelines[0].transform'` | `lines_in > 0` and `lines_out > 0` | Transform filter dropping all rows |
 | Frequent OTLP send errors | Check runtime logs for `error sending` | No repeated connection/auth errors | Fix endpoint/protocol/connectivity |
-| Startup/config errors | `logfwd validate --config config.yaml` | `configuration valid` (or no error output) | Fix required fields / YAML syntax |
+| Startup/config errors | `logfwd validate --config config.yaml` | `config ok` | Fix required fields / YAML syntax |
 | Throughput unexpectedly low | `curl -s http://localhost:9090/admin/v1/status | jq '.pipelines[0].stage_seconds'` | `output` not dominating total | Network/collector bottleneck |
 
 ## Scenario 1: No logs arrive at destination
@@ -132,7 +132,7 @@ logfwd validate --config config.yaml
 
 ### Expected
 
-No validation errors.
+Validation succeeds and prints `config ok`.
 
 ### Common causes and fixes
 


### PR DESCRIPTION
## Summary
- update validation troubleshooting output to the current `config ok` message
- document Elasticsearch and Loki output fields that are supported by the current config schema
- clarify that Kubernetes examples using `_timestamp` and `_stream` require CRI parsing

Fixes #2029.

## Tests
- `cd book && npm ci`
- `cd book && npm run build`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align runtime configuration references for Elasticsearch, Loki, and Admin API docs
> - Expands the Elasticsearch output docs to include `auth`, `compression`, `request_mode`, and example YAML with `auth.bearer_token` in both [outputs.mdx](https://github.com/strawgate/memagent/pull/2247/files#diff-bd85ca3f70e0d74eec4ebfb4f1e245ecca2c7403be3513292fa9baa8c44e1c49) and [reference.mdx](https://github.com/strawgate/memagent/pull/2247/files#diff-6a69bd5c38c92acca3dd194d75d77551f1b8f6b98890da7e56f2c9cbe564aac4)
> - Expands the Loki output docs to include `tenant_id`, `static_labels`, `label_columns`, and `auth` fields, clarifies that `endpoint` is the base URL, and notes that `compression` is not supported
> - Updates the Admin API `/admin/v1/config` description in [reference.mdx](https://github.com/strawgate/memagent/pull/2247/files#diff-6a69bd5c38c92acca3dd194d75d77551f1b8f6b98890da7e56f2c9cbe564aac4) to note it is disabled by default and requires `LOGFWD_UNSAFE_EXPOSE_CONFIG=1`
> - Adds a note in [kubernetes.md](https://github.com/strawgate/memagent/pull/2247/files#diff-1e32ff9d041f47b03ef9b50d88b1d61d28890c05919c093263ef76899d93d289) that the `_stream` column is only present when using CRI parsing (`format: cri`)
> - Updates [troubleshooting.md](https://github.com/strawgate/memagent/pull/2247/files#diff-3c0ddab98a9fb429c092e4b80f07a103632e3cf87d806da2c416a1f1b022d215) to reference the specific `config ok: <n> pipeline(s)` output string instead of a generic success message
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78a3e64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->