### PR TITLE
fix(ci): disable wasm-opt to avoid flaky binaryen download

### DIFF
--- a/crates/logfwd-config-wasm/Cargo.toml
+++ b/crates/logfwd-config-wasm/Cargo.toml
@@ -16,5 +16,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 js-sys = { workspace = true }
 
+[package.metadata.wasm-pack.profile.release]
+# Disable wasm-opt to avoid downloading binaryen at build time.
+# The config-validator WASM module is small and does not benefit
+# meaningfully from wasm-opt, and the download is a flaky CI dep.
+wasm-opt = false
+
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

The Deploy Docs workflow fails intermittently when `wasm-pack` tries to download binaryen (wasm-opt) from GitHub Releases:

```
Error: failed to download from https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-x86_64-linux.tar.gz
```

### Fix

Add `wasm-opt = false` to the config-wasm crate's `[package.metadata.wasm-pack.profile.release]`. The config-validator WASM module is small (~50KB) and doesn't benefit meaningfully from wasm-opt optimization. This eliminates a flaky external dependency from the docs build.

### Test plan

Verified TOML passes `taplo check`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable `wasm-opt` in `logfwd-config-wasm` release builds to avoid flaky binaryen downloads
> Sets `wasm-opt = false` in [Cargo.toml](https://github.com/strawgate/memagent/pull/2248/files#diff-234dbd37474f7b21ba768143c24f6989d1f328635dc1e3d6112e355faba037cb) under `[package.metadata.wasm-pack.profile.release]` to skip the wasm-opt step during CI builds. This prevents build failures caused by unreliable binaryen downloads.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02e9d26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->