### PR TITLE
test: add Kani proofs and proptests for escape decoding and number classification

### DIFF
--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -1211,6 +1211,116 @@ mod tests {
                 "padded JSON with array value must produce exactly 1 row"
             );
         }
+
+        /// Escape sequences in string values survive SIMD block boundaries.
+        ///
+        /// Padding `[0, 90)` bytes of whitespace before the JSON object probes
+        /// positions near 64-byte SIMD block edges. Invariants checked:
+        ///  - Exactly 1 row is produced
+        ///  - The `val` field is present and its decoded value equals the
+        ///    original (unescaped) ASCII character
+        #[test]
+        fn escape_sequences_survive_simd_boundaries(
+            padding in 0usize..90,
+        ) {
+            // Test the 8 standard RFC 8259 single-char escapes that round-trip
+            // to a known single byte.
+            let escapes: &[(&str, u8)] = &[
+                ("\\\"", b'"'),
+                ("\\\\", b'\\'),
+                ("\\/", b'/'),
+                ("\\b", 0x08),
+                ("\\f", 0x0C),
+                ("\\n", b'\n'),
+                ("\\r", b'\r'),
+                ("\\t", b'\t'),
+            ];
+            for (esc, expected_byte) in escapes {
+                let spaces = " ".repeat(padding);
+                // Build JSON with the escape inside the string value
+                let json = alloc::format!("{spaces}{{\"v\":\"{esc}\"}}\n");
+                let config = ScanConfig::default();
+                let mut builder = TestBuilder::new();
+                scan_streaming(json.as_bytes(), &config, &mut builder);
+                prop_assert_eq!(
+                    builder.rows.len(), 1,
+                    "JSON with escape must produce 1 row"
+                );
+                let row = &builder.rows[0];
+                let val = row.iter().find(|(k, _)| k == "v").map(|(_, v)| v.as_bytes());
+                prop_assert!(
+                    val.is_some(),
+                    "escape sequence {esc:?} must produce field 'v'"
+                );
+                prop_assert_eq!(
+                    val.unwrap(), &[*expected_byte],
+                    "escape must decode correctly"
+                );
+            }
+        }
+
+        /// Integer vs float classification is consistent across scan_streaming.
+        ///
+        /// An integer JSON value must produce a value prefixed with "int:" and
+        /// a floating-point JSON value must produce a value prefixed with "float:".
+        #[test]
+        fn numeric_classification_is_consistent(
+            int_val in -1_000_000i64..=1_000_000,
+            frac in 1u32..999,
+        ) {
+            let config = ScanConfig::default();
+
+            // Integer path
+            let int_json = alloc::format!("{{\"n\":{int_val}}}\n");
+            let mut int_builder = TestBuilder::new();
+            scan_streaming(int_json.as_bytes(), &config, &mut int_builder);
+            prop_assert_eq!(int_builder.rows.len(), 1, "integer JSON must produce 1 row");
+            let int_row = &int_builder.rows[0];
+            let int_stored = int_row.iter().find(|(k, _)| k == "n").map(|(_, v)| v.as_str());
+            prop_assert!(int_stored.is_some(), "integer JSON must have field 'n'");
+            prop_assert!(
+                int_stored.unwrap().starts_with("int:"),
+                "integer value must be stored with 'int:' prefix, got {:?}", int_stored
+            );
+
+            // Float path
+            let float_json = alloc::format!("{{\"n\":{int_val}.{frac:03}}}\n");
+            let mut float_builder = TestBuilder::new();
+            scan_streaming(float_json.as_bytes(), &config, &mut float_builder);
+            prop_assert_eq!(float_builder.rows.len(), 1, "float JSON must produce 1 row");
+            let float_row = &float_builder.rows[0];
+            let float_stored = float_row.iter().find(|(k, _)| k == "n").map(|(_, v)| v.as_str());
+            prop_assert!(float_stored.is_some(), "float JSON must have field 'n'");
+            prop_assert!(
+                float_stored.unwrap().starts_with("float:"),
+                "float value must be stored with 'float:' prefix, got {:?}", float_stored
+            );
+        }
+
+        /// Duplicate keys: scanner produces the first writer's value (first-writer-wins).
+        ///
+        /// When a JSON object contains the same key twice, the scanner must
+        /// produce exactly 1 row and that row must contain field "k" with one
+        /// of the two values (we don't over-specify which — first or last write).
+        #[test]
+        fn duplicate_keys_produce_consistent_row(
+            v1 in "[a-z]{1,10}",
+            v2 in "[a-z]{1,10}",
+        ) {
+            let json = alloc::format!("{{\"k\":\"{v1}\",\"k\":\"{v2}\"}}\n");
+            let config = ScanConfig::default();
+            let mut builder = TestBuilder::new();
+            scan_streaming(json.as_bytes(), &config, &mut builder);
+            prop_assert_eq!(builder.rows.len(), 1, "duplicate-key JSON must produce 1 row");
+            let row = &builder.rows[0];
+            let val = row.iter().find(|(k, _)| k == "k").map(|(_, v)| v.as_str());
+            prop_assert!(val.is_some(), "duplicate-key JSON must have field 'k'");
+            // The stored value must be one of the two original values.
+            prop_assert!(
+                val.unwrap() == v1.as_str() || val.unwrap() == v2.as_str(),
+                "duplicate-key value must be one of the originals, got {:?}", val
+            );
+        }
     }
 
     /// CRLF line endings must not leak \r into extracted field values or captured line fields.
@@ -1562,5 +1672,167 @@ mod verification {
         }
         kani::cover!(result.is_some(), "quote found in range");
         kani::cover!(result.is_none(), "no quote in range");
+    }
+
+    /// `parse_hex4` correctness: exhaustive oracle check over all valid 4-hex-digit inputs.
+    ///
+    /// For every input that consists of exactly 4 ASCII hex characters, the
+    /// output must equal the value obtained by parsing each hex nibble manually.
+    /// For any byte that is not a hex digit, `parse_hex4` must return `None`.
+    #[kani::proof]
+    fn verify_parse_hex4_correctness() {
+        let bytes: [u8; 4] = kani::any();
+
+        /// True iff `b` is a valid ASCII hex digit.
+        fn is_hex(b: u8) -> bool {
+            matches!(b, b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F')
+        }
+
+        fn hex_val(b: u8) -> u16 {
+            match b {
+                b'0'..=b'9' => (b - b'0') as u16,
+                b'a'..=b'f' => (b - b'a' + 10) as u16,
+                b'A'..=b'F' => (b - b'A' + 10) as u16,
+                _ => unreachable!(),
+            }
+        }
+
+        let result = parse_hex4(&bytes);
+
+        if bytes.iter().all(|&b| is_hex(b)) {
+            // All four bytes are hex digits → must return Some with the correct value
+            let expected = (hex_val(bytes[0]) << 12)
+                | (hex_val(bytes[1]) << 8)
+                | (hex_val(bytes[2]) << 4)
+                | hex_val(bytes[3]);
+            assert_eq!(
+                result,
+                Some(expected),
+                "parse_hex4 must return correct value for valid input"
+            );
+        } else {
+            // At least one non-hex byte → must return None
+            assert_eq!(
+                result, None,
+                "parse_hex4 must return None for invalid input"
+            );
+        }
+
+        kani::cover!(result.is_some(), "valid hex input");
+        kani::cover!(result.is_none(), "invalid hex input");
+    }
+
+    /// `decode_json_escapes` RFC 8259 correctness for all 8 standard single-char escapes.
+    ///
+    /// For each recognized escape byte (`"`, `\`, `/`, `b`, `f`, `n`, `r`, `t`),
+    /// the function must decode `\X` to exactly the correct output byte.
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn verify_decode_json_escapes_rfc8259_correctness() {
+        let escape_char: u8 = kani::any();
+        // Constrain to the 8 standard RFC 8259 single-char escapes (excludes `u`)
+        kani::assume(matches!(
+            escape_char,
+            b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't'
+        ));
+
+        let input = [b'\\', escape_char];
+        let mut out = alloc::vec::Vec::new();
+        decode_json_escapes(&input, &mut out);
+
+        let expected: u8 = match escape_char {
+            b'"' => b'"',
+            b'\\' => b'\\',
+            b'/' => b'/',
+            b'b' => 0x08,
+            b'f' => 0x0C,
+            b'n' => b'\n',
+            b'r' => b'\r',
+            b't' => b'\t',
+            _ => unreachable!(),
+        };
+
+        assert_eq!(
+            out.len(),
+            1,
+            "standard escape must decode to exactly 1 byte"
+        );
+        assert_eq!(
+            out[0], expected,
+            "standard escape must decode to correct byte"
+        );
+    }
+
+    /// `decode_json_escapes` passes through unknown escapes unchanged.
+    ///
+    /// For any byte that is not a recognized RFC 8259 escape, `\X` must be
+    /// passed through literally as `\X` (two bytes).
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn verify_decode_json_escapes_unknown_passthrough() {
+        let escape_char: u8 = kani::any();
+        // Exclude all recognized escapes (standard single-char + u for unicode)
+        kani::assume(!matches!(
+            escape_char,
+            b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' | b'u'
+        ));
+
+        let input = [b'\\', escape_char];
+        let mut out = alloc::vec::Vec::new();
+        decode_json_escapes(&input, &mut out);
+
+        // Unknown escape: pass through the backslash, then continue.
+        // The escape_char byte is processed in the next iteration as a literal.
+        // So output is [b'\\', escape_char].
+        assert_eq!(out.len(), 2, "unknown escape must pass through 2 bytes");
+        assert_eq!(out[0], b'\\', "first byte must be backslash");
+        assert_eq!(
+            out[1], escape_char,
+            "second byte must be the original escape char"
+        );
+    }
+
+    /// `decode_json_escapes` never panics on arbitrary short inputs.
+    ///
+    /// Crash-freedom proof: for any 8-byte input, the function must return
+    /// normally (no panic, no OOB access, no infinite loop).
+    #[kani::proof]
+    #[kani::unwind(16)]
+    fn verify_decode_json_escapes_no_panic() {
+        let input: [u8; 8] = kani::any();
+        let mut out = alloc::vec::Vec::new();
+        decode_json_escapes(&input, &mut out);
+        // The function must not panic. Output length ≤ input length × 3
+        // (worst case: all bytes are literal, each emitted once; \uXXXX can
+        // expand to at most 4 UTF-8 bytes from 6 input bytes).
+        assert!(out.len() <= input.len() * 4 + 4);
+    }
+
+    /// `decode_unicode_escape` always advances past its input position.
+    ///
+    /// Whatever the input, the returned position must be strictly greater
+    /// than `pos` (no infinite loop / stuck cursor), and the output must be
+    /// non-empty.
+    #[kani::proof]
+    #[kani::unwind(16)]
+    fn verify_decode_unicode_escape_advance() {
+        let input: [u8; 14] = kani::any();
+        let pos: usize = kani::any_where(|&p: &usize| p < 14);
+
+        let mut out = alloc::vec::Vec::new();
+        let new_pos = decode_unicode_escape(&input, pos, &mut out);
+
+        // Must always advance (never return pos itself)
+        assert!(new_pos > pos, "decode_unicode_escape must advance past pos");
+
+        // Must always produce at least 1 output byte
+        assert!(
+            !out.is_empty(),
+            "decode_unicode_escape must write at least 1 byte"
+        );
+
+        kani::cover!(new_pos == pos + 1, "short/invalid: advance by 1");
+        kani::cover!(new_pos == pos + 6, "BMP or lone surrogate: advance by 6");
+        kani::cover!(new_pos == pos + 12, "surrogate pair: advance by 12");
     }
 }

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -1217,7 +1217,7 @@ mod tests {
         /// Padding `[0, 90)` bytes of whitespace before the JSON object probes
         /// positions near 64-byte SIMD block edges. Invariants checked:
         ///  - Exactly 1 row is produced
-        ///  - The `val` field is present and its decoded value equals the
+        ///  - The `v` field is present and its decoded value equals the
         ///    original (unescaped) ASCII character
         #[test]
         fn escape_sequences_survive_simd_boundaries(
@@ -1297,11 +1297,12 @@ mod tests {
             );
         }
 
-        /// Duplicate keys: scanner produces the first writer's value (first-writer-wins).
+        /// Duplicate keys: scanner emits values in source order (first-writer-wins).
         ///
         /// When a JSON object contains the same key twice, the scanner must
-        /// produce exactly 1 row and that row must contain field "k" with one
-        /// of the two values (we don't over-specify which — first or last write).
+        /// produce exactly 1 row. The first emitted value for "k" must be v1
+        /// (first-writer-wins), matching the dedup behavior of production
+        /// builders like `StreamingBuilder::check_dup_bits`.
         #[test]
         fn duplicate_keys_produce_consistent_row(
             v1 in "[a-z]{1,10}",
@@ -1313,12 +1314,17 @@ mod tests {
             scan_streaming(json.as_bytes(), &config, &mut builder);
             prop_assert_eq!(builder.rows.len(), 1, "duplicate-key JSON must produce 1 row");
             let row = &builder.rows[0];
-            let val = row.iter().find(|(k, _)| k == "k").map(|(_, v)| v.as_str());
-            prop_assert!(val.is_some(), "duplicate-key JSON must have field 'k'");
-            // The stored value must be one of the two original values.
+            let k_entries: Vec<&str> = row.iter()
+                .filter(|(k, _)| k == "k")
+                .map(|(_, v)| v.as_str())
+                .collect();
             prop_assert!(
-                val.unwrap() == v1.as_str() || val.unwrap() == v2.as_str(),
-                "duplicate-key value must be one of the originals, got {:?}", val
+                !k_entries.is_empty(),
+                "duplicate-key JSON must have at least one 'k' entry"
+            );
+            prop_assert_eq!(
+                k_entries[0], v1.as_str(),
+                "first-writer-wins: first emitted value must be v1 {:?}, got {:?}", v1, k_entries[0]
             );
         }
     }
@@ -1737,7 +1743,7 @@ mod verification {
         ));
 
         let input = [b'\\', escape_char];
-        let mut out = alloc::vec::Vec::new();
+        let mut out = alloc::vec::Vec::with_capacity(2);
         decode_json_escapes(&input, &mut out);
 
         let expected: u8 = match escape_char {
@@ -1761,6 +1767,9 @@ mod verification {
             out[0], expected,
             "standard escape must decode to correct byte"
         );
+
+        kani::cover!(escape_char == b'"', "double-quote escape");
+        kani::cover!(escape_char == b'n', "newline escape");
     }
 
     /// `decode_json_escapes` passes through unknown escapes unchanged.
@@ -1778,7 +1787,7 @@ mod verification {
         ));
 
         let input = [b'\\', escape_char];
-        let mut out = alloc::vec::Vec::new();
+        let mut out = alloc::vec::Vec::with_capacity(2);
         decode_json_escapes(&input, &mut out);
 
         // Unknown escape: pass through the backslash, then continue.
@@ -1790,6 +1799,9 @@ mod verification {
             out[1], escape_char,
             "second byte must be the original escape char"
         );
+
+        kani::cover!(escape_char == b'x', "non-standard \\x passthrough");
+        kani::cover!(escape_char == b' ', "whitespace passthrough");
     }
 
     /// `decode_json_escapes` never panics on arbitrary short inputs.
@@ -1800,11 +1812,11 @@ mod verification {
     #[kani::unwind(16)]
     fn verify_decode_json_escapes_no_panic() {
         let input: [u8; 8] = kani::any();
-        let mut out = alloc::vec::Vec::new();
+        let mut out = alloc::vec::Vec::with_capacity(36);
         decode_json_escapes(&input, &mut out);
-        // The function must not panic. Output length ≤ input length × 3
-        // (worst case: all bytes are literal, each emitted once; \uXXXX can
-        // expand to at most 4 UTF-8 bytes from 6 input bytes).
+        // The function must not panic. Output length ≤ input length × 4 + 4
+        // (worst case: \uXXXX can expand to 4 UTF-8 bytes from 6 input bytes,
+        // plus trailing partial escapes can add a few extra bytes).
         assert!(out.len() <= input.len() * 4 + 4);
     }
 
@@ -1819,7 +1831,7 @@ mod verification {
         let input: [u8; 14] = kani::any();
         let pos: usize = kani::any_where(|&p: &usize| p < 14);
 
-        let mut out = alloc::vec::Vec::new();
+        let mut out = alloc::vec::Vec::with_capacity(14);
         let new_pos = decode_unicode_escape(&input, pos, &mut out);
 
         // Must always advance (never return pos itself)


### PR DESCRIPTION
## Summary

Closes the verification gaps identified in an audit of `json_scanner.rs`. This complements #2238 (delimiter drift fix) by adding formal proofs and property tests for the functions that are most likely to silently misbehave.

## Changes

### 5 new Kani proofs (`#[cfg(kani)] mod verification`):
- `verify_parse_hex4_correctness` — exhaustive oracle over all 256^4 byte inputs; verified locally in 0.7s
- `verify_decode_json_escapes_rfc8259_correctness` — all 8 standard RFC 8259 escapes decode to correct bytes
- `verify_decode_json_escapes_unknown_passthrough` — unknown escapes pass through as `\\X` (2 bytes verbatim)
- `verify_decode_json_escapes_no_panic` — crash-freedom on 8-byte arbitrary input
- `verify_decode_unicode_escape_advance` — returned position is always `> pos`, output always non-empty

### 3 new proptests (inside existing `proptest! {}` block):
- `escape_sequences_survive_simd_boundaries` — all 8 RFC escapes produce correct field values at padding `[0, 90)` (stresses 64-byte SIMD block edges)
- `numeric_classification_is_consistent` — integers get `int:` prefix, floats get `float:` prefix
- `duplicate_keys_produce_consistent_row` — duplicate keys produce 1 row, value is one of the two originals

## Verification

- `verify_parse_hex4_correctness`: SUCCESSFUL locally (189 checks, 0.7s)
- `verify_decode_json_escapes_unknown_passthrough`: SUCCESSFUL locally (691 checks, 2.5s)
- All 38 json_scanner tests pass (`cargo test -p logfwd-core json_scanner`)
- `just fmt && just clippy`: clean

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Kani proofs and proptests for escape decoding and number classification in `json_scanner`
> Adds formal verification and property-based tests to [json_scanner.rs](https://github.com/strawgate/memagent/pull/2255/files#diff-f842a445752f7ba8d2712a1cab0b428512dda1a4324d1c1a408435633f32b582) covering correctness and panic-safety of JSON parsing primitives.
>
> - Kani proofs exhaustively verify `parse_hex4` correctness, RFC 8259 escape decoding, unknown-escape passthrough, no-panic guarantees, and `decode_unicode_escape` position advancement.
> - Proptests check that RFC 8259 single-character escapes round-trip correctly across SIMD boundaries, that integers and floats are classified with the correct `int:`/`float:` prefix, and that duplicate keys follow first-writer-wins behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45a411a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->