### PR TITLE
bench: add otlp projection decision gates

### DIFF
--- a/crates/logfwd-bench/README.md
+++ b/crates/logfwd-bench/README.md
@@ -67,7 +67,7 @@ just bench-report
 |------|-------|-----------------|
 | `pipeline.rs` | `scanner`, `cri`, `transform`, `compress`, `output`, `end_to_end`, `elasticsearch` | Original pipeline stage benchmarks |
 | `output_encode.rs` | `output_encode` | OTLP protobuf, JSON lines, JSON+zstd encoding cost (narrow vs wide, 1K/10K rows) |
-| `otlp_io.rs` | `otlp_input_parser_only`, `otlp_input_decode_materialize`, `otlp_output_encode_only`, `otlp_output_compression`, `otlp_e2e_in_process` | OTLP fixture matrix with stage-separated decode, materialize, encode, compression, and in-process E2E measurements. |
+| `otlp_io.rs` | `otlp_input_parser_only`, `otlp_input_decode_materialize`, `otlp_input_decompress_decode`, `otlp_output_encode_only`, `otlp_output_compression`, `otlp_e2e_in_process`, `otlp_projected_fallback_mix` | OTLP fixture matrix with stage-separated decode, materialize, decompression, encode, compression, fallback mix, and in-process E2E measurements. |
 | `full_chain.rs` | `full_chain_json`, `full_chain_cri`, `full_chain_grok` | Composed pipeline chains — reveals hidden handoff overhead |
 | `file_io.rs` | `file_io_framing`, `file_io_cri` | Disk read + newline framing + CRI parse throughput |
 | `batch_formation.rs` | `batch_scan`, `batch_transform`, `batch_pipeline` | Batch size scaling (100–100K rows) — amortization curve |
@@ -79,13 +79,18 @@ validation in setup only. The timed regions measure just the named stage:
 
 - `otlp_input_parser_only` times protobuf decode only.
 - `otlp_input_decode_materialize` times decode plus Arrow batch materialization.
+- `otlp_input_decompress_decode` times zstd request decompression plus decode and Arrow materialization.
 - `otlp_output_encode_only` times OTLP serialization from a prebuilt batch.
 - `otlp_output_compression` times zstd compression of an already encoded payload.
 - `otlp_e2e_in_process` times decode plus encode in one process, without transport or network effects.
+- `otlp_projected_fallback_mix` times four projected-success payloads plus one unsupported-but-valid fallback payload.
 
 The suite includes the experimental projected wire-to-Arrow decoder for
 primitive fixtures; it is validated against the prost path before benchmark
-timing starts. Mode names are aligned between Criterion and the profile binary:
+timing starts. `projected_fallback_*` modes run the candidate production wrapper:
+primitive shapes use the projected path, while unsupported-but-valid OTLP shapes
+fall back to prost. Mode names are aligned between Criterion and the profile
+binary:
 
 | Decode path | Criterion (decode_materialize) | Criterion (e2e) | Profile binary |
 |-------------|-------------------------------|-----------------|----------------|
@@ -93,14 +98,24 @@ timing starts. Mode names are aligned between Criterion and the profile binary:
 | production current | `production_current_to_batch` | `production_current_to_*_encode` | `production_current_to_batch` |
 | projected detached | `projected_detached_to_batch` | `projected_detached_to_*_encode` | `projected_detached_to_batch` |
 | projected view | `projected_view_to_batch` | `projected_view_to_*_encode` | `projected_view_to_batch` |
+| projected fallback | `projected_fallback_to_batch` | `projected_fallback_to_handwritten_encode` | `projected_fallback_to_batch`, `e2e_projected_fallback` |
+| zstd + production current | `zstd_production_current_to_batch` | n/a | `zstd_production_current_to_batch` |
+| zstd + projected fallback | `zstd_projected_fallback_to_batch` | n/a | `zstd_projected_fallback_to_batch` |
+| projected fallback mix | `projected_success_4x_plus_fallback_1x` | n/a | `projected_fallback_mix` |
 
 **Timing boundaries:**
 
 - `otlp_input_parser_only` — protobuf decode only (no Arrow materialization).
 - `otlp_input_decode_materialize` — protobuf decode + Arrow batch construction.
+- `otlp_input_decompress_decode` — zstd request decompression + protobuf decode + Arrow batch construction.
 - `otlp_output_encode_only` — OTLP serialization from a prebuilt batch.
 - `otlp_output_compression` — zstd compression of an already-encoded payload.
 - `otlp_e2e_in_process` — decode + encode in one pass, no transport or network.
+- `otlp_projected_fallback_mix` — repeated in-process projected fallback decode with a 4:1 projected-success-to-fallback payload mix.
+
+HTTP parsing, request body collection, and receiver channel handoff are covered
+by `bin/http_receiver_apples.rs`; `otlp_io.rs` keeps those transport costs out
+of the Criterion groups so decode-path comparisons stay stable.
 
 All fixture synthesis, prost/reference parity checks, and encode-path assertions
 run in setup before any Criterion timer starts. In the profile binary, warmup
@@ -116,7 +131,7 @@ allocation counting begins after warmup completes.
 | `bin/cloudtrail_profile.rs` | `cloudtrail_profile` | CloudTrail-like generator profile (NDJSON vs direct RecordBatch generation, cardinality, compression) |
 | `es_throughput.rs` | `es-throughput` | Elasticsearch output throughput with worker scaling |
 | `bin/framed_input_profile.rs` | `framed_input_profile` | FramedInput stage timings, RSS, optional flamegraph, optional dhat allocation report |
-| `bin/otlp_io_profile.rs` | `otlp_io_profile` | Focused OTLP decode and decode→encode CPU flamegraphs and allocation counts. Mode names match Criterion (`prost_reference_to_batch`, `production_current_to_batch`, `projected_detached_to_batch`, `projected_view_to_batch`, `e2e_*`). |
+| `bin/otlp_io_profile.rs` | `otlp_io_profile` | Focused OTLP decode and decode→encode CPU flamegraphs and allocation counts. Mode names match Criterion (`prost_reference_to_batch`, `production_current_to_batch`, `projected_detached_to_batch`, `projected_view_to_batch`, `projected_fallback_to_batch`, `zstd_*`, `projected_fallback_mix`, `e2e_*`). |
 | `explore.rs` | *(lib)* | Multi-dimensional exploratory benchmark (CSV output) |
 | `rss.rs` | *(lib)* | Resident set size at each pipeline stage |
 | `sizes.rs` | *(lib)* | Data size analysis: raw → Arrow → IPC → Parquet |

--- a/crates/logfwd-bench/benches/otlp_io.rs
+++ b/crates/logfwd-bench/benches/otlp_io.rs
@@ -5,6 +5,7 @@
 //! stage:
 //! - parser-only protobuf decode (`prost`)
 //! - receiver decode + Arrow materialization
+//! - request decompression + receiver decode + Arrow materialization
 //! - sink encode-only (handwritten vs generated-fast)
 //! - encoded-payload compression
 //! - in-process decode -> encode.
@@ -20,7 +21,8 @@ use logfwd_bench::{generators, make_otlp_sink};
 use logfwd_io::compress::ChunkCompressor;
 use logfwd_io::otlp_receiver::{
     ProjectedOtlpDecoder, decode_protobuf_bytes_to_batch_projected_experimental,
-    decode_protobuf_to_batch, decode_protobuf_to_batch_projected_detached_experimental,
+    decode_protobuf_bytes_to_batch_projected_only_experimental, decode_protobuf_to_batch,
+    decode_protobuf_to_batch_projected_detached_experimental,
     decode_protobuf_to_batch_prost_reference,
 };
 use logfwd_output::Compression;
@@ -31,9 +33,11 @@ struct FixtureData {
     profile: OtlpFixtureProfile,
     payload: Vec<u8>,
     payload_bytes: bytes::Bytes,
+    zstd_payload: Vec<u8>,
     production_batch: arrow::record_batch::RecordBatch,
     projected_batch: Option<arrow::record_batch::RecordBatch>,
     projected_view_batch: Option<arrow::record_batch::RecordBatch>,
+    projected_fallback_batch: arrow::record_batch::RecordBatch,
 }
 
 fn fixtures() -> Vec<FixtureData> {
@@ -55,6 +59,18 @@ fn build_fixture(profile: OtlpFixtureProfile) -> FixtureData {
         decode_protobuf_to_batch(&otlp_data.payload).expect("production fixture should decode");
     assert_batch_matches(&prost_reference_batch, &production_batch, profile.name);
     assert_encode_paths_match(&production_batch, profile.name);
+    let projected_fallback_batch =
+        decode_protobuf_bytes_to_batch_projected_experimental(otlp_data.payload_bytes.clone())
+            .expect("experimental projected fallback decoder should decode fixture");
+    let detached_projected_fallback = logfwd_arrow::materialize::detach(&projected_fallback_batch);
+    assert_batch_matches(
+        &prost_reference_batch,
+        &detached_projected_fallback,
+        profile.name,
+    );
+    assert_encode_paths_match(&projected_fallback_batch, profile.name);
+    let zstd_payload =
+        zstd::encode_all(otlp_data.payload.as_slice(), 1).expect("fixture should zstd compress");
     let mut projected_batch = None;
     let mut projected_view_batch = None;
     if !profile.has_complex_any {
@@ -63,9 +79,10 @@ fn build_fixture(profile: OtlpFixtureProfile) -> FixtureData {
                 .expect("experimental wire decoder should decode primitive fixture");
         assert_batch_matches(&prost_reference_batch, &wire_batch, profile.name);
         assert_encode_paths_match(&wire_batch, profile.name);
-        let view_batch =
-            decode_protobuf_bytes_to_batch_projected_experimental(otlp_data.payload_bytes.clone())
-                .expect("experimental wire view decoder should decode primitive fixture");
+        let view_batch = decode_protobuf_bytes_to_batch_projected_only_experimental(
+            otlp_data.payload_bytes.clone(),
+        )
+        .expect("experimental wire view decoder should decode primitive fixture");
         let detached_view_batch = logfwd_arrow::materialize::detach(&view_batch);
         assert_batch_matches(&prost_reference_batch, &detached_view_batch, profile.name);
         assert_encode_paths_match(&view_batch, profile.name);
@@ -76,9 +93,11 @@ fn build_fixture(profile: OtlpFixtureProfile) -> FixtureData {
         profile,
         payload: otlp_data.payload,
         payload_bytes: otlp_data.payload_bytes,
+        zstd_payload,
         production_batch,
         projected_batch,
         projected_view_batch,
+        projected_fallback_batch,
     }
 }
 
@@ -252,6 +271,21 @@ fn bench_decode_materialize(c: &mut Criterion) {
             },
         );
 
+        group.bench_with_input(
+            BenchmarkId::new("projected_fallback_to_batch", fixture.profile.name),
+            &fixture.payload_bytes,
+            |b, payload| {
+                b.iter(|| {
+                    let batch =
+                        decode_protobuf_bytes_to_batch_projected_experimental(payload.clone())
+                            .expect(
+                                "projected fallback decode + materialize should decode fixture",
+                            );
+                    std::hint::black_box(batch.num_rows());
+                });
+            },
+        );
+
         if !fixture.profile.has_complex_any {
             group.bench_with_input(
                 BenchmarkId::new("projected_detached_to_batch", fixture.profile.name),
@@ -271,9 +305,10 @@ fn bench_decode_materialize(c: &mut Criterion) {
                 &fixture.payload_bytes,
                 |b, payload| {
                     b.iter(|| {
-                        let batch =
-                            decode_protobuf_bytes_to_batch_projected_experimental(payload.clone())
-                                .expect("experimental wire view decoder should decode fixture");
+                        let batch = decode_protobuf_bytes_to_batch_projected_only_experimental(
+                            payload.clone(),
+                        )
+                        .expect("experimental wire view decoder should decode fixture");
                         std::hint::black_box(batch.num_rows());
                     });
                 },
@@ -282,6 +317,61 @@ fn bench_decode_materialize(c: &mut Criterion) {
     }
 
     group.finish();
+}
+
+fn bench_decompress_decode(c: &mut Criterion) {
+    let fixtures = fixtures();
+    let mut group = c.benchmark_group("otlp_input_decompress_decode");
+    group.sample_size(10);
+
+    for fixture in fixtures
+        .iter()
+        .filter(|f| is_decompress_gate_profile(f.profile))
+    {
+        // Timed work: zstd request decompression plus decode into Arrow. HTTP
+        // header parsing, body collection, and receiver channel handoff are
+        // covered by `src/bin/http_receiver_apples.rs`; this group isolates the
+        // decompression+decode cost with the same payload shapes.
+        group.throughput(Throughput::Elements(fixture.profile.total_rows() as u64));
+        group.bench_with_input(
+            BenchmarkId::new("zstd_production_current_to_batch", fixture.profile.name),
+            &fixture.zstd_payload,
+            |b, compressed| {
+                b.iter(|| {
+                    let decompressed =
+                        zstd::decode_all(compressed.as_slice()).expect("zstd fixture decodes");
+                    let batch = decode_protobuf_to_batch(&decompressed)
+                        .expect("production decode + materialize should decode fixture");
+                    std::hint::black_box(batch.num_rows());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("zstd_projected_fallback_to_batch", fixture.profile.name),
+            &fixture.zstd_payload,
+            |b, compressed| {
+                b.iter(|| {
+                    let decompressed =
+                        zstd::decode_all(compressed.as_slice()).expect("zstd fixture decodes");
+                    let batch = decode_protobuf_bytes_to_batch_projected_experimental(
+                        bytes::Bytes::from(decompressed),
+                    )
+                    .expect("projected fallback decode + materialize should decode fixture");
+                    std::hint::black_box(batch.num_rows());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn is_decompress_gate_profile(profile: OtlpFixtureProfile) -> bool {
+    matches!(
+        profile.name,
+        "narrow-1k" | "compression-relevant" | "complex-anyvalue"
+    )
 }
 
 fn bench_output_encode_only(c: &mut Criterion) {
@@ -314,6 +404,18 @@ fn bench_output_encode_only(c: &mut Criterion) {
                 let mut sink = make_otlp_sink(Compression::None);
                 b.iter(|| {
                     sink.encode_batch_generated_fast(&fixture.production_batch, &metadata);
+                    std::hint::black_box(sink.encoded_payload().len());
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("projected_fallback_handwritten", fixture.profile.name),
+            &fixture.projected_fallback_batch,
+            |b, batch| {
+                let mut sink = make_otlp_sink(Compression::None);
+                b.iter(|| {
+                    sink.encode_batch(batch, &metadata);
                     std::hint::black_box(sink.encoded_payload().len());
                 });
             },
@@ -463,6 +565,26 @@ fn bench_end_to_end(c: &mut Criterion) {
             },
         );
 
+        group.bench_with_input(
+            BenchmarkId::new(
+                "projected_fallback_to_handwritten_encode",
+                fixture.profile.name,
+            ),
+            &fixture.payload_bytes,
+            |b, payload| {
+                let mut sink = make_otlp_sink(Compression::None);
+                b.iter(|| {
+                    let batch =
+                        decode_protobuf_bytes_to_batch_projected_experimental(payload.clone())
+                            .expect(
+                                "projected fallback decode + materialize should decode fixture",
+                            );
+                    sink.encode_batch(&batch, &metadata);
+                    std::hint::black_box(sink.encoded_payload().len());
+                });
+            },
+        );
+
         if !fixture.profile.has_complex_any {
             group.bench_with_input(
                 BenchmarkId::new(
@@ -488,9 +610,10 @@ fn bench_end_to_end(c: &mut Criterion) {
                 |b, payload| {
                     let mut sink = make_otlp_sink(Compression::None);
                     b.iter(|| {
-                        let batch =
-                            decode_protobuf_bytes_to_batch_projected_experimental(payload.clone())
-                                .expect("experimental wire view decoder should decode fixture");
+                        let batch = decode_protobuf_bytes_to_batch_projected_only_experimental(
+                            payload.clone(),
+                        )
+                        .expect("experimental wire view decoder should decode fixture");
                         sink.encode_batch(&batch, &metadata);
                         std::hint::black_box(sink.encoded_payload().len());
                     });
@@ -499,6 +622,35 @@ fn bench_end_to_end(c: &mut Criterion) {
         }
     }
 
+    group.finish();
+}
+
+fn bench_projected_fallback_mix(c: &mut Criterion) {
+    let projected = build_fixture(otlp::NARROW_1K);
+    let fallback = build_fixture(otlp::COMPLEX_ANYVALUE);
+    let payloads = [
+        projected.payload_bytes.clone(),
+        projected.payload_bytes.clone(),
+        projected.payload_bytes.clone(),
+        projected.payload_bytes.clone(),
+        fallback.payload_bytes.clone(),
+    ];
+    let rows_per_iter = projected.profile.total_rows() * 4 + fallback.profile.total_rows();
+
+    let mut group = c.benchmark_group("otlp_projected_fallback_mix");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(rows_per_iter as u64));
+    group.bench_function("projected_success_4x_plus_fallback_1x", |b| {
+        b.iter(|| {
+            let mut rows = 0usize;
+            for payload in &payloads {
+                let batch = decode_protobuf_bytes_to_batch_projected_experimental(payload.clone())
+                    .expect("projected fallback mix should decode each fixture");
+                rows += batch.num_rows();
+            }
+            std::hint::black_box(rows);
+        });
+    });
     group.finish();
 }
 
@@ -628,9 +780,11 @@ criterion_group!(
     benches,
     bench_parser_only,
     bench_decode_materialize,
+    bench_decompress_decode,
     bench_output_encode_only,
     bench_output_compression,
     bench_end_to_end,
+    bench_projected_fallback_mix,
     bench_multi_batch_reuse
 );
 criterion_main!(benches);

--- a/crates/logfwd-bench/src/bin/otlp_io_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_io_profile.rs
@@ -12,8 +12,9 @@ use bytes::Bytes;
 use logfwd_bench::generators::otlp::{self, OtlpFixtureProfile};
 use logfwd_bench::{generators, make_otlp_sink};
 use logfwd_io::otlp_receiver::{
-    ProjectedOtlpDecoder, decode_protobuf_bytes_to_batch_projected_only_experimental,
-    decode_protobuf_to_batch, decode_protobuf_to_batch_projected_detached_experimental,
+    ProjectedOtlpDecoder, decode_protobuf_bytes_to_batch_projected_experimental,
+    decode_protobuf_bytes_to_batch_projected_only_experimental, decode_protobuf_to_batch,
+    decode_protobuf_to_batch_projected_detached_experimental,
     decode_protobuf_to_batch_prost_reference,
 };
 use logfwd_output::Compression;
@@ -34,23 +35,33 @@ enum Mode {
     ProjectedDetachedToBatch,
     ProjectedViewToBatch,
     ProjectedViewReuseToBatch,
+    ProjectedFallbackToBatch,
+    ZstdProductionCurrentToBatch,
+    ZstdProjectedFallbackToBatch,
+    ProjectedFallbackMix,
     E2eProstReference,
     E2eProductionCurrent,
     E2eProjectedDetached,
     E2eProjectedView,
+    E2eProjectedFallback,
 }
 
 impl Mode {
-    const ALL: [Mode; 9] = [
+    const ALL: [Mode; 14] = [
         Mode::ProstReferenceToBatch,
         Mode::ProductionCurrentToBatch,
         Mode::ProjectedDetachedToBatch,
         Mode::ProjectedViewToBatch,
         Mode::ProjectedViewReuseToBatch,
+        Mode::ProjectedFallbackToBatch,
+        Mode::ZstdProductionCurrentToBatch,
+        Mode::ZstdProjectedFallbackToBatch,
+        Mode::ProjectedFallbackMix,
         Mode::E2eProstReference,
         Mode::E2eProductionCurrent,
         Mode::E2eProjectedDetached,
         Mode::E2eProjectedView,
+        Mode::E2eProjectedFallback,
     ];
 
     fn name(self) -> &'static str {
@@ -60,10 +71,15 @@ impl Mode {
             Mode::ProjectedDetachedToBatch => "projected_detached_to_batch",
             Mode::ProjectedViewToBatch => "projected_view_to_batch",
             Mode::ProjectedViewReuseToBatch => "projected_view_reuse_to_batch",
+            Mode::ProjectedFallbackToBatch => "projected_fallback_to_batch",
+            Mode::ZstdProductionCurrentToBatch => "zstd_production_current_to_batch",
+            Mode::ZstdProjectedFallbackToBatch => "zstd_projected_fallback_to_batch",
+            Mode::ProjectedFallbackMix => "projected_fallback_mix",
             Mode::E2eProstReference => "e2e_prost_reference",
             Mode::E2eProductionCurrent => "e2e_production_current",
             Mode::E2eProjectedDetached => "e2e_projected_detached",
             Mode::E2eProjectedView => "e2e_projected_view",
+            Mode::E2eProjectedFallback => "e2e_projected_fallback",
         }
     }
 
@@ -75,10 +91,15 @@ impl Mode {
             "projected_detached_to_batch" => Mode::ProjectedDetachedToBatch,
             "projected_view_to_batch" => Mode::ProjectedViewToBatch,
             "projected_view_reuse_to_batch" => Mode::ProjectedViewReuseToBatch,
+            "projected_fallback_to_batch" => Mode::ProjectedFallbackToBatch,
+            "zstd_production_current_to_batch" => Mode::ZstdProductionCurrentToBatch,
+            "zstd_projected_fallback_to_batch" => Mode::ZstdProjectedFallbackToBatch,
+            "projected_fallback_mix" => Mode::ProjectedFallbackMix,
             "e2e_prost_reference" => Mode::E2eProstReference,
             "e2e_production_current" => Mode::E2eProductionCurrent,
             "e2e_projected_detached" => Mode::E2eProjectedDetached,
             "e2e_projected_view" => Mode::E2eProjectedView,
+            "e2e_projected_fallback" => Mode::E2eProjectedFallback,
             // deprecated aliases from earlier naming
             "prost_decode" => Mode::ProstReferenceToBatch,
             "production_to_batch" => Mode::ProductionCurrentToBatch,
@@ -101,7 +122,13 @@ struct Cli {
 struct FixtureData {
     payload: Vec<u8>,
     payload_bytes: Bytes,
+    zstd_payload: Vec<u8>,
     rows: usize,
+}
+
+struct FallbackMixFixture {
+    payloads: [Bytes; 5],
+    rows_per_iteration: usize,
 }
 
 struct ProfileResult {
@@ -253,6 +280,7 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
             | Mode::E2eProductionCurrent
             | Mode::E2eProjectedDetached
             | Mode::E2eProjectedView
+            | Mode::E2eProjectedFallback
     ) {
         let batch = match mode {
             Mode::E2eProstReference => decode_protobuf_to_batch_prost_reference(&fixture.payload)
@@ -268,11 +296,19 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
                 fixture.payload_bytes.clone(),
             )
             .expect("warmup projected view decode"),
+            Mode::E2eProjectedFallback => {
+                decode_protobuf_bytes_to_batch_projected_experimental(fixture.payload_bytes.clone())
+                    .expect("warmup projected fallback decode")
+            }
             Mode::ProstReferenceToBatch
             | Mode::ProductionCurrentToBatch
             | Mode::ProjectedDetachedToBatch
             | Mode::ProjectedViewToBatch
-            | Mode::ProjectedViewReuseToBatch => {
+            | Mode::ProjectedViewReuseToBatch
+            | Mode::ProjectedFallbackToBatch
+            | Mode::ZstdProductionCurrentToBatch
+            | Mode::ZstdProjectedFallbackToBatch
+            | Mode::ProjectedFallbackMix => {
                 unreachable!("decode-only modes are not warmed here")
             }
         };
@@ -286,6 +322,11 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
             .decode_view_bytes(fixture.payload_bytes.clone())
             .expect("warmup reuse decoder");
         Some(dec)
+    } else {
+        None
+    };
+    let fallback_mix = if matches!(mode, Mode::ProjectedFallbackMix) {
+        Some(build_fallback_mix_fixture())
     } else {
         None
     };
@@ -324,6 +365,39 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
                     .expect("projected view reuse");
                 black_box(batch.num_rows());
             }
+            Mode::ProjectedFallbackToBatch => {
+                let batch = decode_protobuf_bytes_to_batch_projected_experimental(
+                    fixture.payload_bytes.clone(),
+                )
+                .expect("projected fallback");
+                black_box(batch.num_rows());
+            }
+            Mode::ZstdProductionCurrentToBatch => {
+                let decompressed =
+                    zstd::decode_all(fixture.zstd_payload.as_slice()).expect("zstd decode");
+                let batch = decode_protobuf_to_batch(&decompressed).expect("production");
+                black_box(batch.num_rows());
+            }
+            Mode::ZstdProjectedFallbackToBatch => {
+                let decompressed =
+                    zstd::decode_all(fixture.zstd_payload.as_slice()).expect("zstd decode");
+                let batch = decode_protobuf_bytes_to_batch_projected_experimental(Bytes::from(
+                    decompressed,
+                ))
+                .expect("projected fallback");
+                black_box(batch.num_rows());
+            }
+            Mode::ProjectedFallbackMix => {
+                let mix = fallback_mix.as_ref().expect("fallback mix initialized");
+                let mut rows = 0usize;
+                for payload in &mix.payloads {
+                    let batch =
+                        decode_protobuf_bytes_to_batch_projected_experimental(payload.clone())
+                            .expect("projected fallback mix");
+                    rows += batch.num_rows();
+                }
+                black_box(rows);
+            }
             Mode::E2eProstReference => {
                 let batch =
                     decode_protobuf_to_batch_prost_reference(&fixture.payload).expect("prost");
@@ -350,6 +424,14 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
                 sink.encode_batch(&batch, &metadata);
                 black_box(sink.encoded_payload().len());
             }
+            Mode::E2eProjectedFallback => {
+                let batch = decode_protobuf_bytes_to_batch_projected_experimental(
+                    fixture.payload_bytes.clone(),
+                )
+                .expect("projected fallback");
+                sink.encode_batch(&batch, &metadata);
+                black_box(sink.encoded_payload().len());
+            }
         }
     }
     let elapsed = started.elapsed();
@@ -365,10 +447,14 @@ fn run_profile(fixture: &FixtureData, mode: Mode, iterations: usize) -> ProfileR
     #[cfg(not(feature = "otlp-profile-alloc"))]
     let stats = AllocStats::default();
 
+    let rows_per_iteration = fallback_mix
+        .as_ref()
+        .map_or(fixture.rows, |mix| mix.rows_per_iteration);
+
     ProfileResult {
         mode: mode.name(),
         iterations,
-        rows: fixture.rows.saturating_mul(iterations),
+        rows: rows_per_iteration.saturating_mul(iterations),
         elapsed,
         bytes_allocated: stats.bytes_allocated,
         allocations: stats.allocations,
@@ -404,6 +490,12 @@ fn build_fixture(profile: OtlpFixtureProfile) -> FixtureData {
         decode_protobuf_to_batch(&otlp_data.payload).expect("production fixture decodes");
     assert_batch_matches(&batch, &production, profile.name);
     assert_encode_paths_match(&production, profile.name);
+    let projected_fallback =
+        decode_protobuf_bytes_to_batch_projected_experimental(otlp_data.payload_bytes.clone())
+            .expect("projected fallback fixture decodes");
+    let detached_projected_fallback = logfwd_arrow::materialize::detach(&projected_fallback);
+    assert_batch_matches(&batch, &detached_projected_fallback, profile.name);
+    assert_encode_paths_match(&projected_fallback, profile.name);
     if !profile.has_complex_any {
         let projected =
             decode_protobuf_to_batch_projected_detached_experimental(&otlp_data.payload)
@@ -419,10 +511,29 @@ fn build_fixture(profile: OtlpFixtureProfile) -> FixtureData {
         assert_encode_paths_match(&view, profile.name);
     }
 
+    let zstd_payload =
+        zstd::encode_all(otlp_data.payload.as_slice(), 1).expect("fixture zstd compresses");
+
     FixtureData {
         payload: otlp_data.payload,
         payload_bytes: otlp_data.payload_bytes,
+        zstd_payload,
         rows: profile.total_rows(),
+    }
+}
+
+fn build_fallback_mix_fixture() -> FallbackMixFixture {
+    let projected = build_fixture(otlp::NARROW_1K);
+    let fallback = build_fixture(otlp::COMPLEX_ANYVALUE);
+    FallbackMixFixture {
+        payloads: [
+            projected.payload_bytes.clone(),
+            projected.payload_bytes.clone(),
+            projected.payload_bytes.clone(),
+            projected.payload_bytes.clone(),
+            fallback.payload_bytes.clone(),
+        ],
+        rows_per_iteration: projected.rows * 4 + fallback.rows,
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #2253.

Adds production-path OTLP benchmark gates around the projected decoder candidate without changing the receiver default:

- adds explicit `projected_fallback_*` Criterion and profile modes so the candidate wrapper is measured separately from projection-only controls
- changes `projected_view_*` controls to use projection-only decoding on supported primitive fixtures
- adds zstd request decompression + decode measurements for representative primitive, compressed, and unsupported-fallback payloads
- adds a 4:1 projected-success-to-prost-fallback mix workload
- documents timing boundaries and the relationship to `http_receiver_apples` for HTTP/channel handoff coverage

## Draft Decision Gates

These are gates for deciding whether projected fallback can become a production default candidate. This PR only adds the measurement surface.

- Correctness: projected fallback parity must stay covered by prost differential tests, and malformed protobuf must remain an error rather than falling back silently.
- Primitive success path: release Criterion/profile runs should not regress production-current decode by more than 5% on representative primitive fixtures (`narrow-1k`, `attrs-heavy`, `trace-heavy`, `resource-heavy`, `compression-relevant`).
- Unsupported fallback path: valid unsupported shapes such as `complex-anyvalue` must stay functionally identical to prost and should not add more than 10% overhead versus production-current prost decode.
- Decompression path: zstd decompress + projected fallback should be within 5% of zstd decompress + production-current on primitive fixtures, with complex fallback reported separately.
- E2E path: decode -> handwritten encode should not regress production-current by more than 5% on primitive fixtures before any default flip.
- Operational scope: HTTP parsing, body collection, and channel handoff remain covered by `http_receiver_apples`; `otlp_io` intentionally isolates decode-path costs.

## Release Profile Output

Release command for baseline/current/projected comparison:

```bash
cargo run -p logfwd-bench --release --bin otlp_io_profile -- --case narrow-1k --iterations 100
```

Release-profile output on this branch:

| Mode | ns/row |
| --- | ---: |
| `prost_reference_to_batch` | 793.5 |
| `production_current_to_batch` | 769.5 |
| `projected_detached_to_batch` | 407.8 |
| `projected_view_to_batch` | 355.9 |
| `projected_view_reuse_to_batch` | 353.1 |
| `projected_fallback_to_batch` | 371.0 |
| `zstd_production_current_to_batch` | 1050.1 |
| `zstd_projected_fallback_to_batch` | 548.9 |
| `projected_fallback_mix` | 1371.5 |
| `e2e_prost_reference` | 1076.4 |
| `e2e_production_current` | 1140.6 |
| `e2e_projected_detached` | 802.9 |
| `e2e_projected_view` | 717.4 |
| `e2e_projected_fallback` | 728.4 |

Additional debug smoke commands run:

```bash
cargo run -p logfwd-bench --bin otlp_io_profile -- --case tiny --mode projected_fallback_to_batch --iterations 10
cargo run -p logfwd-bench --bin otlp_io_profile -- --case complex-anyvalue --mode projected_fallback_to_batch --iterations 10
cargo run -p logfwd-bench --bin otlp_io_profile -- --case compression-relevant --mode zstd_projected_fallback_to_batch --iterations 10
cargo run -p logfwd-bench --bin otlp_io_profile -- --case narrow-1k --mode projected_fallback_mix --iterations 10
cargo run -p logfwd-bench --bin otlp_io_profile -- --case narrow-1k --mode e2e_projected_fallback --iterations 10
```

## Verification

```bash
cargo fmt --check
git diff --check
cargo clippy -p logfwd-bench --bench otlp_io -- -D warnings
cargo clippy -p logfwd-bench --bin otlp_io_profile -- -D warnings
```

Note: allocation columns are zero unless the profile binary is built with `--features otlp-profile-alloc`.