### PR TITLE
ci: reduce CI waste — gate expensive jobs on lint, fix nightly, cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,10 @@ jobs:
   # -------------------------------------------------------------------------
   lint:
     name: Lint
-    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
         run: cargo nextest run --workspace --profile ci
 
   # macOS: push + ci:full only (expensive runner, no path filter or draft check).
+  # Exclude Linux-only eBPF crates (aya does not compile on macOS).
   test-macos:
     name: Test (macOS)
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci:full')
@@ -277,7 +278,10 @@ jobs:
       - uses: taiki-e/install-action@nextest
 
       - name: Tests
-        run: cargo nextest run --workspace --profile ci
+        run: >-
+          cargo nextest run --workspace --profile ci
+          --exclude sensor-ebpf
+          --exclude sensor-ebpf-common
 
   # -------------------------------------------------------------------------
   # Network integration tests — #[ignore] tests that bind ports / make
@@ -348,7 +352,7 @@ jobs:
   # -------------------------------------------------------------------------
   kani-core:
     name: Kani proofs (core)
-    needs: [changes]
+    needs: [changes, lint]
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -374,12 +378,10 @@ jobs:
             -Z mem-predicates
             -Z stubbing
             -p logfwd-core
-        env:
-          RUSTC_WRAPPER: ""
 
   kani-arrow:
     name: Kani proofs (arrow)
-    needs: [changes]
+    needs: [changes, lint]
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -408,12 +410,10 @@ jobs:
             -Z stubbing
             -p logfwd-arrow
             --lib
-        env:
-          RUSTC_WRAPPER: ""
 
   kani-periphery:
     name: Kani proofs (periphery)
-    needs: [changes]
+    needs: [changes, lint]
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -444,8 +444,6 @@ jobs:
             -p logfwd-runtime
             -p logfwd-diagnostics
             -p logfwd
-        env:
-          RUSTC_WRAPPER: ""
 
   # -------------------------------------------------------------------------
   # Miri — UB-oriented execution, split into two parallel shards.
@@ -454,7 +452,7 @@ jobs:
   # -------------------------------------------------------------------------
   miri-core:
     name: Miri (core)
-    needs: [changes]
+    needs: [changes, lint]
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -481,7 +479,7 @@ jobs:
 
   miri-types:
     name: Miri (types)
-    needs: [changes]
+    needs: [changes, lint]
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
@@ -532,7 +530,7 @@ jobs:
   # -------------------------------------------------------------------------
   tlc:
     name: "TLA+ model checking"
-    needs: [changes]
+    needs: [changes, lint]
     if: |
       github.event_name == 'push' ||
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||

--- a/.github/workflows/nightly-testing.yml
+++ b/.github/workflows/nightly-testing.yml
@@ -238,3 +238,5 @@ jobs:
             echo "=== Fuzzing $target for ${{ matrix.duration }}s ==="
             cargo +nightly fuzz run "$target" -- -max_total_time=${{ matrix.duration }}
           done
+        env:
+          RUSTUP_TOOLCHAIN: nightly

--- a/.github/workflows/ready-for-human.yml
+++ b/.github/workflows/ready-for-human.yml
@@ -3,10 +3,6 @@ name: "Auto: ready-for-human label"
 on:
   workflow_dispatch: {}  # disabled — re-enable triggers when needed
 
-concurrency:
-  group: ready-for-human-${{ github.run_id }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/ready-for-human.yml
+++ b/.github/workflows/ready-for-human.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}  # disabled — re-enable triggers when needed
 
 concurrency:
-  group: ready-for-human-${{ github.event.pull_request.number || github.event.workflow_run.id || 'schedule' }}
+  group: ready-for-human-${{ github.run_id }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/ready-for-human.yml
+++ b/.github/workflows/ready-for-human.yml
@@ -1,16 +1,7 @@
 name: "Auto: ready-for-human label"
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
-  pull_request_review:
-    types: [submitted, dismissed]
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-  schedule:
-    - cron: "*/30 * * * *"
-  workflow_dispatch:
+  workflow_dispatch: {}  # disabled — re-enable triggers when needed
 
 concurrency:
   group: ready-for-human-${{ github.event.pull_request.number || github.event.workflow_run.id || 'schedule' }}


### PR DESCRIPTION
## Summary

Reduces CI runner waste and fixes three broken nightly tests.

### Changes

**Gate expensive jobs on lint** — Kani (3 shards), Miri (2 shards), and TLC now `needs: [changes, lint]` instead of just `needs: [changes]`. Previously these started immediately and could run to their 90-minute timeouts even when lint failed in ~80 seconds. Saves ~180+ runner-minutes per failed lint run.

**Fix macOS test compilation** — Exclude `sensor-ebpf` and `sensor-ebpf-common` from the macOS test job. The `aya` crate uses Linux-only libc symbols (`CLOCK_BOOTTIME`, netlink structs) that don't exist on macOS, causing consistent compile failures.

**Fix nightly fuzz toolchain** — Add `RUSTUP_TOOLCHAIN=nightly` env to the fuzz run step. `cargo-fuzz` internally invokes `rustc` without `+nightly`, so `-Z` flags fail with "only accepted on the nightly compiler".

**Remove stale `RUSTC_WRAPPER`** — Clean up `RUSTC_WRAPPER: ""` from all 3 Kani jobs (sccache was removed in #2256).

**Disable ready-for-human workflow** — Fired 177 times in last 500 runs, switched to `workflow_dispatch` only.

### Impact

| Before | After |
|--------|-------|
| Lint failure → 6 expensive jobs run to timeout (~256 min wasted) | Lint failure → 6 expensive jobs skip instantly |
| macOS test always fails (aya compile error) | macOS test compiles and runs |
| Nightly fuzz fails (`-Z` on stable rustc) | Nightly fuzz uses nightly toolchain |
| `ready-for-human` fires on every PR event | Disabled (manual dispatch only) |

Relates to CI audit from #2256.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate expensive CI jobs on lint passing and fix nightly fuzzing toolchain
> - Kani, Miri, and TLC jobs now depend on both `changes` and `lint` jobs, so they only run after lint passes.
> - The `lint` job also runs on PRs labeled `ci:full`.
> - macOS tests exclude `sensor-ebpf` and `sensor-ebpf-common` targets.
> - Nightly fuzzing step sets `RUSTUP_TOOLCHAIN=nightly` to fix toolchain selection.
> - The `ready-for-human` workflow is switched to manual dispatch only, removing all automatic triggers and concurrency config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83e8f03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->