### PR TITLE
feat: wire otlp projected decode opt-in metrics

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -27,8 +27,6 @@ use decode::*;
 use projection::ProjectionError;
 
 use std::io;
-#[cfg(any(feature = "otlp-research", test))]
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, mpsc};
 
@@ -36,6 +34,8 @@ use arrow::record_batch::RecordBatch;
 use axum::routing::post;
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 use logfwd_types::field_names;
+#[cfg(any(feature = "otlp-research", test))]
+use tokio::sync::Mutex;
 use tokio::sync::oneshot;
 
 use crate::InputError;

--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -27,6 +27,8 @@ use decode::*;
 use projection::ProjectionError;
 
 use std::io;
+#[cfg(any(feature = "otlp-research", test))]
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, mpsc};
 
@@ -92,6 +94,8 @@ struct OtlpServerState {
     health: Arc<AtomicU8>,
     resource_prefix: String,
     protobuf_decode_mode: OtlpProtobufDecodeMode,
+    #[cfg(any(feature = "otlp-research", test))]
+    projected_decoder: Option<Mutex<ProjectedOtlpDecoder>>,
     stats: Option<Arc<ComponentStats>>,
     /// Maximum request body size. Defaults to `MAX_REQUEST_BODY_SIZE` (10 MiB).
     max_message_size_bytes: usize,
@@ -226,6 +230,7 @@ impl OtlpReceiverInput {
         stats: Option<Arc<ComponentStats>>,
         resource_prefix: impl Into<String>,
         protobuf_decode_mode: OtlpProtobufDecodeMode,
+        max_message_size_bytes: Option<usize>,
     ) -> io::Result<Self> {
         Self::new_with_capacity_stats_prefix_and_decode_mode(
             name,
@@ -234,7 +239,7 @@ impl OtlpReceiverInput {
             stats,
             resource_prefix.into(),
             protobuf_decode_mode,
-            None,
+            max_message_size_bytes,
         )
     }
 
@@ -259,12 +264,20 @@ impl OtlpReceiverInput {
         let (tx, rx) = mpsc::sync_channel(capacity);
         let is_running = Arc::new(AtomicBool::new(true));
         let health = Arc::new(AtomicU8::new(ComponentHealth::Healthy.as_repr()));
+        #[cfg(any(feature = "otlp-research", test))]
+        let projected_decoder = if protobuf_decode_mode == OtlpProtobufDecodeMode::Prost {
+            None
+        } else {
+            Some(Mutex::new(ProjectedOtlpDecoder::new(&resource_prefix)))
+        };
         let state = Arc::new(OtlpServerState {
             tx,
             is_running: Arc::clone(&is_running),
             health: Arc::clone(&health),
             resource_prefix,
             protobuf_decode_mode,
+            #[cfg(any(feature = "otlp-research", test))]
+            projected_decoder,
             stats,
             max_message_size_bytes,
         });

--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -14,6 +14,7 @@ use prost::Message;
 
 use crate::InputError;
 
+#[cfg(any(feature = "otlp-research", test))]
 use super::OtlpProtobufDecodeMode;
 use super::convert::{
     convert_request_to_batch, decode_protojson_bytes, hex, parse_protojson_f64,
@@ -73,6 +74,7 @@ pub(super) fn decode_otlp_protobuf(
     decode_otlp_protobuf_with_prost(body, resource_prefix)
 }
 
+#[cfg(any(feature = "otlp-research", test))]
 pub(super) fn decode_otlp_protobuf_bytes_with_mode(
     body: Bytes,
     resource_prefix: &str,

--- a/crates/logfwd-io/src/otlp_receiver/projection.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection.rs
@@ -153,6 +153,14 @@ impl ProjectedOtlpDecoder {
 
     /// Decode an OTLP payload using the view-bytes path, reusing builder capacity.
     pub fn decode_view_bytes(&mut self, body: Bytes) -> Result<RecordBatch, InputError> {
+        self.try_decode_view_bytes(body)
+            .map_err(ProjectionError::into_input_error)
+    }
+
+    pub(super) fn try_decode_view_bytes(
+        &mut self,
+        body: Bytes,
+    ) -> Result<RecordBatch, ProjectionError> {
         let backing = body.clone();
         self.builder.begin_batch();
         if !backing.is_empty() {
@@ -192,12 +200,12 @@ impl ProjectedOtlpDecoder {
             // Reset builder to idle so the next begin_batch succeeds even
             // if we were mid-row when the error occurred.
             self.builder.discard_batch();
-            return Err(e.into_input_error());
+            return Err(e);
         }
 
         self.builder
             .finish_batch()
-            .map_err(|e| InputError::Receiver(format!("batch build error: {e}")))
+            .map_err(|e| ProjectionError::Batch(format!("batch build error: {e}")))
     }
 }
 

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -120,7 +120,7 @@ pub(super) async fn handle_otlp_request(
     let batch = if is_json {
         decode_otlp_json(&body, &state.resource_prefix)
     } else {
-        decode_otlp_protobuf_request(body, &state)
+        decode_otlp_protobuf_request(body, &state).await
     };
     let batch = match batch {
         Ok(batch) => batch,
@@ -177,7 +177,7 @@ pub(super) async fn handle_otlp_request(
     }
 }
 
-fn decode_otlp_protobuf_request(
+async fn decode_otlp_protobuf_request(
     body: Vec<u8>,
     state: &OtlpServerState,
 ) -> Result<arrow::record_batch::RecordBatch, InputError> {
@@ -185,21 +185,21 @@ fn decode_otlp_protobuf_request(
         OtlpProtobufDecodeMode::Prost => decode_otlp_protobuf(&body, &state.resource_prefix),
         #[cfg(any(feature = "otlp-research", test))]
         OtlpProtobufDecodeMode::ProjectedFallback => {
-            decode_otlp_protobuf_projected_fallback(Bytes::from(body), state)
+            decode_otlp_protobuf_projected_fallback(Bytes::from(body), state).await
         }
         #[cfg(any(feature = "otlp-research", test))]
         OtlpProtobufDecodeMode::ProjectedOnly => {
-            decode_otlp_protobuf_projected_only(Bytes::from(body), state)
+            decode_otlp_protobuf_projected_only(Bytes::from(body), state).await
         }
     }
 }
 
 #[cfg(any(feature = "otlp-research", test))]
-fn decode_otlp_protobuf_projected_fallback(
+async fn decode_otlp_protobuf_projected_fallback(
     body: Bytes,
     state: &OtlpServerState,
 ) -> Result<arrow::record_batch::RecordBatch, InputError> {
-    match decode_with_reusable_projected_decoder(body.clone(), state) {
+    match decode_with_reusable_projected_decoder(body.clone(), state).await {
         Ok(batch) => {
             record_projected_success(state.stats.as_ref());
             Ok(batch)
@@ -216,11 +216,11 @@ fn decode_otlp_protobuf_projected_fallback(
 }
 
 #[cfg(any(feature = "otlp-research", test))]
-fn decode_otlp_protobuf_projected_only(
+async fn decode_otlp_protobuf_projected_only(
     body: Bytes,
     state: &OtlpServerState,
 ) -> Result<arrow::record_batch::RecordBatch, InputError> {
-    match decode_with_reusable_projected_decoder(body, state) {
+    match decode_with_reusable_projected_decoder(body, state).await {
         Ok(batch) => {
             record_projected_success(state.stats.as_ref());
             Ok(batch)
@@ -236,7 +236,7 @@ fn decode_otlp_protobuf_projected_only(
 }
 
 #[cfg(any(feature = "otlp-research", test))]
-fn decode_with_reusable_projected_decoder(
+async fn decode_with_reusable_projected_decoder(
     body: Bytes,
     state: &OtlpServerState,
 ) -> Result<arrow::record_batch::RecordBatch, ProjectionError> {
@@ -244,9 +244,7 @@ fn decode_with_reusable_projected_decoder(
         .projected_decoder
         .as_ref()
         .ok_or_else(|| ProjectionError::Batch("projected decoder not initialized".to_string()))?;
-    let mut decoder = decoder
-        .lock()
-        .map_err(|_| ProjectionError::Batch("projected decoder lock poisoned".to_string()))?;
+    let mut decoder = decoder.lock().await;
     decoder.try_decode_view_bytes(body)
 }
 

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -8,16 +8,16 @@ use axum::extract::State;
 use axum::http::header::{CONTENT_ENCODING, CONTENT_TYPE};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
+#[cfg(any(feature = "otlp-research", test))]
 use bytes::Bytes;
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 
 use crate::InputError;
 use crate::receiver_http::{parse_content_length, parse_content_type, read_limited_body};
 
-use super::decode::{
-    decode_otlp_json, decode_otlp_protobuf, decode_otlp_protobuf_bytes_with_mode, decompress_gzip,
-    decompress_zstd,
-};
+use super::decode::{decode_otlp_json, decode_otlp_protobuf, decompress_gzip, decompress_zstd};
+#[cfg(any(feature = "otlp-research", test))]
+use super::projection::ProjectionError;
 use super::{OtlpProtobufDecodeMode, OtlpServerState, ReceiverPayload};
 
 pub(super) fn record_error(stats: Option<&Arc<ComponentStats>>) {
@@ -119,14 +119,8 @@ pub(super) async fn handle_otlp_request(
 
     let batch = if is_json {
         decode_otlp_json(&body, &state.resource_prefix)
-    } else if state.protobuf_decode_mode == OtlpProtobufDecodeMode::Prost {
-        decode_otlp_protobuf(&body, &state.resource_prefix)
     } else {
-        decode_otlp_protobuf_bytes_with_mode(
-            Bytes::from(body),
-            &state.resource_prefix,
-            state.protobuf_decode_mode,
-        )
+        decode_otlp_protobuf_request(body, &state)
     };
     let batch = match batch {
         Ok(batch) => batch,
@@ -180,6 +174,100 @@ pub(super) async fn handle_otlp_request(
             )
                 .into_response()
         }
+    }
+}
+
+fn decode_otlp_protobuf_request(
+    body: Vec<u8>,
+    state: &OtlpServerState,
+) -> Result<arrow::record_batch::RecordBatch, InputError> {
+    match state.protobuf_decode_mode {
+        OtlpProtobufDecodeMode::Prost => decode_otlp_protobuf(&body, &state.resource_prefix),
+        #[cfg(any(feature = "otlp-research", test))]
+        OtlpProtobufDecodeMode::ProjectedFallback => {
+            decode_otlp_protobuf_projected_fallback(Bytes::from(body), state)
+        }
+        #[cfg(any(feature = "otlp-research", test))]
+        OtlpProtobufDecodeMode::ProjectedOnly => {
+            decode_otlp_protobuf_projected_only(Bytes::from(body), state)
+        }
+    }
+}
+
+#[cfg(any(feature = "otlp-research", test))]
+fn decode_otlp_protobuf_projected_fallback(
+    body: Bytes,
+    state: &OtlpServerState,
+) -> Result<arrow::record_batch::RecordBatch, InputError> {
+    match decode_with_reusable_projected_decoder(body.clone(), state) {
+        Ok(batch) => {
+            record_projected_success(state.stats.as_ref());
+            Ok(batch)
+        }
+        Err(ProjectionError::Unsupported(_)) => {
+            record_projected_fallback(state.stats.as_ref());
+            decode_otlp_protobuf(&body, &state.resource_prefix)
+        }
+        Err(err) => {
+            record_projection_invalid(state.stats.as_ref());
+            Err(err.into_input_error())
+        }
+    }
+}
+
+#[cfg(any(feature = "otlp-research", test))]
+fn decode_otlp_protobuf_projected_only(
+    body: Bytes,
+    state: &OtlpServerState,
+) -> Result<arrow::record_batch::RecordBatch, InputError> {
+    match decode_with_reusable_projected_decoder(body, state) {
+        Ok(batch) => {
+            record_projected_success(state.stats.as_ref());
+            Ok(batch)
+        }
+        Err(ProjectionError::Unsupported(err)) => {
+            Err(ProjectionError::Unsupported(err).into_input_error())
+        }
+        Err(err) => {
+            record_projection_invalid(state.stats.as_ref());
+            Err(err.into_input_error())
+        }
+    }
+}
+
+#[cfg(any(feature = "otlp-research", test))]
+fn decode_with_reusable_projected_decoder(
+    body: Bytes,
+    state: &OtlpServerState,
+) -> Result<arrow::record_batch::RecordBatch, ProjectionError> {
+    let decoder = state
+        .projected_decoder
+        .as_ref()
+        .ok_or_else(|| ProjectionError::Batch("projected decoder not initialized".to_string()))?;
+    let mut decoder = decoder
+        .lock()
+        .map_err(|_| ProjectionError::Batch("projected decoder lock poisoned".to_string()))?;
+    decoder.try_decode_view_bytes(body)
+}
+
+#[cfg(any(feature = "otlp-research", test))]
+fn record_projected_success(stats: Option<&Arc<ComponentStats>>) {
+    if let Some(stats) = stats {
+        stats.inc_otlp_projected_success();
+    }
+}
+
+#[cfg(any(feature = "otlp-research", test))]
+fn record_projected_fallback(stats: Option<&Arc<ComponentStats>>) {
+    if let Some(stats) = stats {
+        stats.inc_otlp_projected_fallback();
+    }
+}
+
+#[cfg(any(feature = "otlp-research", test))]
+fn record_projection_invalid(stats: Option<&Arc<ComponentStats>>) {
+    if let Some(stats) = stats {
+        stats.inc_otlp_projection_invalid();
     }
 }
 

--- a/crates/logfwd-io/src/otlp_receiver/tests.rs
+++ b/crates/logfwd-io/src/otlp_receiver/tests.rs
@@ -1076,7 +1076,22 @@ fn invalid_protobuf_increments_parse_errors_when_stats_hooked() {
 
 #[test]
 fn experimental_projection_decode_mode_controls_http_protobuf_path() {
-    let request = ExportLogsServiceRequest {
+    let primitive_request = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            scope_logs: vec![ScopeLogs {
+                log_records: vec![LogRecord {
+                    body: Some(AnyValue {
+                        value: Some(Value::StringValue("primitive".into())),
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+    let primitive_body = primitive_request.encode_to_vec();
+    let unsupported_request = ExportLogsServiceRequest {
         resource_logs: vec![ResourceLogs {
             scope_logs: vec![ScopeLogs {
                 log_records: vec![LogRecord {
@@ -1094,7 +1109,7 @@ fn experimental_projection_decode_mode_controls_http_protobuf_path() {
             ..Default::default()
         }],
     };
-    let body = request.encode_to_vec();
+    let unsupported_body = unsupported_request.encode_to_vec();
 
     let projected_only = OtlpReceiverInput::new_with_protobuf_decode_mode_experimental(
         "projected-only",
@@ -1102,13 +1117,14 @@ fn experimental_projection_decode_mode_controls_http_protobuf_path() {
         None,
         field_names::DEFAULT_RESOURCE_PREFIX,
         OtlpProtobufDecodeMode::ProjectedOnly,
+        None,
     )
     .expect("projected-only receiver should bind");
     let projected_only_url = format!("http://{}/v1/logs", projected_only.local_addr());
     let projected_only_status = match loopback_http_client()
         .post(&projected_only_url)
         .header("content-type", "application/x-protobuf")
-        .send(body.as_slice())
+        .send(unsupported_body.as_slice())
     {
         Ok(resp) => resp.status().as_u16(),
         Err(ureq::Error::StatusCode(code)) => code,
@@ -1119,19 +1135,38 @@ fn experimental_projection_decode_mode_controls_http_protobuf_path() {
         "ProjectedOnly must reject unsupported but valid OTLP shapes"
     );
 
+    let stats = Arc::new(ComponentStats::new());
     let mut fallback = OtlpReceiverInput::new_with_protobuf_decode_mode_experimental(
         "projected-fallback",
         "127.0.0.1:0",
-        None,
+        Some(Arc::clone(&stats)),
         field_names::DEFAULT_RESOURCE_PREFIX,
         OtlpProtobufDecodeMode::ProjectedFallback,
+        None,
     )
     .expect("fallback receiver should bind");
     let fallback_url = format!("http://{}/v1/logs", fallback.local_addr());
+    let projected_status = match loopback_http_client()
+        .post(&fallback_url)
+        .header("content-type", "application/x-protobuf")
+        .send(primitive_body.as_slice())
+    {
+        Ok(resp) => resp.status().as_u16(),
+        Err(ureq::Error::StatusCode(code)) => code,
+        Err(e) => panic!("unexpected transport error: {e}"),
+    };
+    assert_eq!(
+        projected_status, 200,
+        "ProjectedFallback must use the projected path for primitive OTLP shapes"
+    );
+    assert_eq!(stats.otlp_projected_success(), 1);
+    assert_eq!(stats.otlp_projected_fallback(), 0);
+    assert_eq!(stats.otlp_projection_invalid(), 0);
+
     let fallback_status = match loopback_http_client()
         .post(&fallback_url)
         .header("content-type", "application/x-protobuf")
-        .send(body.as_slice())
+        .send(unsupported_body.as_slice())
     {
         Ok(resp) => resp.status().as_u16(),
         Err(ureq::Error::StatusCode(code)) => code,
@@ -1141,18 +1176,43 @@ fn experimental_projection_decode_mode_controls_http_protobuf_path() {
         fallback_status, 200,
         "ProjectedFallback must use prost for supported-by-prost complex values"
     );
+    assert_eq!(stats.otlp_projected_success(), 1);
+    assert_eq!(stats.otlp_projected_fallback(), 1);
+    assert_eq!(stats.otlp_projection_invalid(), 0);
+
+    let malformed_status = match loopback_http_client()
+        .post(&fallback_url)
+        .header("content-type", "application/x-protobuf")
+        .send(b"not valid protobuf".as_slice())
+    {
+        Ok(resp) => resp.status().as_u16(),
+        Err(ureq::Error::StatusCode(code)) => code,
+        Err(e) => panic!("unexpected transport error: {e}"),
+    };
+    assert_eq!(
+        malformed_status, 400,
+        "ProjectedFallback must reject malformed protobuf instead of falling back"
+    );
+    assert_eq!(stats.otlp_projected_success(), 1);
+    assert_eq!(stats.otlp_projected_fallback(), 1);
+    assert_eq!(stats.otlp_projection_invalid(), 1);
+    assert_eq!(stats.parse_errors(), 1);
 
     let events = poll_receiver_until(
         &mut fallback,
         Duration::from_secs(2),
         |events| {
-            events.iter().any(
-                |event| matches!(event, InputEvent::Batch { batch, .. } if batch.num_rows() == 1),
-            )
+            events
+                .iter()
+                .filter(|event| {
+                    matches!(event, InputEvent::Batch { batch, .. } if batch.num_rows() == 1)
+                })
+                .count()
+                == 2
         },
         "fallback receiver should emit decoded batch",
     );
-    assert_eq!(events.len(), 1);
+    assert_eq!(events.len(), 2);
 }
 
 #[test]

--- a/crates/logfwd-io/src/otlp_receiver/tests.rs
+++ b/crates/logfwd-io/src/otlp_receiver/tests.rs
@@ -1212,7 +1212,15 @@ fn experimental_projection_decode_mode_controls_http_protobuf_path() {
         },
         "fallback receiver should emit decoded batch",
     );
-    assert_eq!(events.len(), 2);
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| {
+                matches!(event, InputEvent::Batch { batch, .. } if batch.num_rows() == 1)
+            })
+            .count(),
+        2
+    );
 }
 
 #[test]

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -289,6 +289,7 @@ pub(super) fn build_input_state(
                 Some(Arc::clone(&stats)),
                 resource_prefix,
                 protobuf_decode_mode,
+                o.max_recv_message_size_bytes,
             )
             .map_err(|e| format!("input '{name}': failed to start OTLP receiver: {e}"))?;
             #[cfg(not(feature = "otlp-research"))]

--- a/crates/logfwd-types/src/diagnostics.rs
+++ b/crates/logfwd-types/src/diagnostics.rs
@@ -22,6 +22,12 @@ pub struct ComponentStats {
     pub rotations_total: AtomicU64,
     /// Lines that failed format parsing (e.g. malformed CRI lines).
     pub parse_errors_total: AtomicU64,
+    /// OTLP protobuf requests decoded through the projected fast path.
+    pub otlp_projected_success_total: AtomicU64,
+    /// OTLP protobuf requests that used prost fallback after unsupported projection.
+    pub otlp_projected_fallback_total: AtomicU64,
+    /// OTLP protobuf requests rejected after projection reported malformed input.
+    pub otlp_projection_invalid_total: AtomicU64,
     /// Coarse lifecycle and health snapshot for readiness/diagnostics.
     health: AtomicU8,
     // Transport specific
@@ -41,6 +47,9 @@ pub struct ComponentStats {
     otel_errors: Counter<u64>,
     otel_rotations: Counter<u64>,
     otel_parse_errors: Counter<u64>,
+    otel_otlp_projected_success: Counter<u64>,
+    otel_otlp_projected_fallback: Counter<u64>,
+    otel_otlp_projection_invalid: Counter<u64>,
     otel_attrs: Vec<KeyValue>,
 }
 
@@ -58,6 +67,9 @@ impl ComponentStats {
             errors_total: AtomicU64::new(0),
             rotations_total: AtomicU64::new(0),
             parse_errors_total: AtomicU64::new(0),
+            otlp_projected_success_total: AtomicU64::new(0),
+            otlp_projected_fallback_total: AtomicU64::new(0),
+            otlp_projection_invalid_total: AtomicU64::new(0),
             health: AtomicU8::new(initial_health.as_repr()),
             file_error_polls: AtomicU32::new(0),
             tcp_accepted: AtomicU64::new(0),
@@ -69,6 +81,15 @@ impl ComponentStats {
             otel_errors: meter.u64_counter(format!("{prefix}_errors")).build(),
             otel_rotations: meter.u64_counter(format!("{prefix}_rotations")).build(),
             otel_parse_errors: meter.u64_counter(format!("{prefix}_parse_errors")).build(),
+            otel_otlp_projected_success: meter
+                .u64_counter(format!("{prefix}_otlp_projected_success"))
+                .build(),
+            otel_otlp_projected_fallback: meter
+                .u64_counter(format!("{prefix}_otlp_projected_fallback"))
+                .build(),
+            otel_otlp_projection_invalid: meter
+                .u64_counter(format!("{prefix}_otlp_projection_invalid"))
+                .build(),
             otel_attrs: attrs,
         }
     }
@@ -118,6 +139,27 @@ impl ComponentStats {
         self.otel_parse_errors.add(n, &self.otel_attrs);
     }
 
+    /// Increment OTLP projected fast-path success count.
+    pub fn inc_otlp_projected_success(&self) {
+        self.otlp_projected_success_total
+            .fetch_add(1, Ordering::Relaxed);
+        self.otel_otlp_projected_success.add(1, &self.otel_attrs);
+    }
+
+    /// Increment OTLP projected fallback-to-prost count.
+    pub fn inc_otlp_projected_fallback(&self) {
+        self.otlp_projected_fallback_total
+            .fetch_add(1, Ordering::Relaxed);
+        self.otel_otlp_projected_fallback.add(1, &self.otel_attrs);
+    }
+
+    /// Increment OTLP malformed projection rejection count.
+    pub fn inc_otlp_projection_invalid(&self) {
+        self.otlp_projection_invalid_total
+            .fetch_add(1, Ordering::Relaxed);
+        self.otel_otlp_projection_invalid.add(1, &self.otel_attrs);
+    }
+
     /// Current line count (relaxed load).
     pub fn lines(&self) -> u64 {
         self.lines_total.load(Ordering::Relaxed)
@@ -141,6 +183,21 @@ impl ComponentStats {
     /// Current parse-error count (relaxed load).
     pub fn parse_errors(&self) -> u64 {
         self.parse_errors_total.load(Ordering::Relaxed)
+    }
+
+    /// Current OTLP projected success count.
+    pub fn otlp_projected_success(&self) -> u64 {
+        self.otlp_projected_success_total.load(Ordering::Relaxed)
+    }
+
+    /// Current OTLP projected fallback count.
+    pub fn otlp_projected_fallback(&self) -> u64 {
+        self.otlp_projected_fallback_total.load(Ordering::Relaxed)
+    }
+
+    /// Current OTLP malformed projection rejection count.
+    pub fn otlp_projection_invalid(&self) -> u64 {
+        self.otlp_projection_invalid_total.load(Ordering::Relaxed)
     }
 
     /// Update the component's coarse health snapshot.


### PR DESCRIPTION
## Summary

Closes #2252.

Wires the existing explicit OTLP `protobuf_decode_mode: projected_fallback` opt-in into the production receiver path without changing the default prost decoder.

- keeps `prost` as the default and keeps projected modes behind `otlp-research`
- adds reusable `ProjectedOtlpDecoder` state to the OTLP HTTP receiver for projected modes
- records counters for projected success, unsupported fallback to prost, and malformed projection rejection
- preserves the existing contract: only `Unsupported` falls back; malformed projection errors return 400
- passes `max_recv_message_size_bytes` through the feature-enabled projected constructor path
- expands HTTP receiver tests to cover projected success, unsupported fallback, malformed rejection, and counter accounting

## Notes

The reusable decoder is protected by a mutex in the receiver state. That keeps ownership explicit and lets the builder/scratch capacity be reused safely across HTTP requests without introducing cross-request unsynchronized state. Prost remains the fallback and default path.

## Verification

```bash
git diff --check
cargo fmt --check
cargo test -p logfwd-io otlp_receiver --features otlp-research -- --nocapture
cargo clippy -p logfwd-io --lib --features otlp-research -- -D warnings
cargo clippy -p logfwd-runtime --lib --features otlp-research -- -D warnings
just ci
```

`just ci` completed with 1637 tests passed and 42 skipped.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add projected OTLP decode mode routing and outcome metrics to the OTLP receiver
> - Adds `ProjectedFallback` and `ProjectedOnly` decode modes to the OTLP receiver's protobuf path, gated behind the `otlp-research` feature flag. A new `decode_otlp_protobuf_request` helper in [server.rs](https://github.com/strawgate/memagent/pull/2264/files#diff-79c2aa47d4a6663c41f6d4600ae976eb353c7067c59848773f702daddf493d40) dispatches requests to the appropriate decode path.
> - In `ProjectedFallback` mode, unsupported-but-valid requests fall back to Prost decoding; in `ProjectedOnly` mode, unsupported requests return HTTP 400.
> - A reusable `ProjectedOtlpDecoder` is pre-initialized in `OtlpServerState` and shared across requests via a `Mutex`.
> - Adds three new counters to `ComponentStats` (`otlp_projected_success_total`, `otlp_projected_fallback_total`, `otlp_projection_invalid_total`) with corresponding OTel metrics and increment methods.
> - `ProjectedOtlpDecoder::try_decode_view_bytes` is introduced to return structured `ProjectionError` instead of `InputError`, enabling fallback vs. invalid distinction in the server layer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a25f4e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->