### PR TITLE
perf(kani): narrow lifecycle proof checkpoints from u64 to u8

### DIFF
--- a/crates/logfwd-types/src/pipeline/lifecycle.rs
+++ b/crates/logfwd-types/src/pipeline/lifecycle.rs
@@ -1134,8 +1134,7 @@ mod verification {
     #[kani::unwind(2)]
     fn verify_is_drained_when_empty() {
         // An empty pipeline (never any batches) must be immediately drained.
-        let running: PipelineMachine<Running, Cp> =
-            PipelineMachine::<Starting, Cp>::new().start();
+        let running: PipelineMachine<Running, Cp> = PipelineMachine::<Starting, Cp>::new().start();
         let draining = running.begin_drain();
         assert!(draining.is_drained());
         assert_eq!(draining.in_flight_count(), 0);

--- a/crates/logfwd-types/src/pipeline/lifecycle.rs
+++ b/crates/logfwd-types/src/pipeline/lifecycle.rs
@@ -761,6 +761,11 @@ mod verification {
     // for coverage — while avoiding the SAT explosion that u64 causes in
     // BTreeMap reasoning (verify_dropped_ticket_does_not_block took 54 min
     // with u64 vs <1s with u8).
+    //
+    // TLA+ no-impact: PipelineMachine.tla models checkpoints as opaque
+    // values. This cfg(kani)-only alias narrows only the Rust proof input
+    // domain; it does not change lifecycle transitions for batch sequencing,
+    // ACK/reject advance, drain, or checkpoint ordering.
     type Cp = u8;
 
     /// Ordered ACK: after all batches acked, committed checkpoint equals the last batch's.
@@ -774,6 +779,12 @@ mod verification {
         let cp1: Cp = kani::any();
         let cp2: Cp = kani::any();
         let cp3: Cp = kani::any();
+        kani::assume(cp1 <= cp2);
+        kani::assume(cp2 <= cp3);
+        kani::cover!(
+            cp1 < cp2 && cp2 < cp3,
+            "strictly increasing checkpoints covered"
+        );
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);

--- a/crates/logfwd-types/src/pipeline/lifecycle.rs
+++ b/crates/logfwd-types/src/pipeline/lifecycle.rs
@@ -782,6 +782,10 @@ mod verification {
         kani::assume(cp1 <= cp2);
         kani::assume(cp2 <= cp3);
         kani::cover!(
+            cp1 == cp2 || cp2 == cp3,
+            "non-strict checkpoint ordering boundary covered"
+        );
+        kani::cover!(
             cp1 < cp2 && cp2 < cp3,
             "strictly increasing checkpoints covered"
         );

--- a/crates/logfwd-types/src/pipeline/lifecycle.rs
+++ b/crates/logfwd-types/src/pipeline/lifecycle.rs
@@ -755,17 +755,25 @@ mod tests {
 mod verification {
     use super::*;
 
+    // Use u8 instead of u64 for symbolic checkpoint values in Kani proofs.
+    // The proofs verify state-machine behavior (ordering, drain, advance),
+    // not checkpoint arithmetic. u8 gives 256 symbolic values — sufficient
+    // for coverage — while avoiding the SAT explosion that u64 causes in
+    // BTreeMap reasoning (verify_dropped_ticket_does_not_block took 54 min
+    // with u64 vs <1s with u8).
+    type Cp = u8;
+
     /// Ordered ACK: after all batches acked, committed checkpoint equals the last batch's.
     #[kani::proof]
     #[kani::unwind(4)]
     fn verify_ordered_ack() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp1: u64 = kani::any();
-        let cp2: u64 = kani::any();
-        let cp3: u64 = kani::any();
+        let cp1: Cp = kani::any();
+        let cp2: Cp = kani::any();
+        let cp3: Cp = kani::any();
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);
@@ -799,12 +807,12 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(3)]
     fn verify_all_acked_final_checkpoint() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp1: u64 = kani::any();
-        let cp2: u64 = kani::any();
+        let cp1: Cp = kani::any();
+        let cp2: Cp = kani::any();
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);
@@ -823,11 +831,11 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(3)]
     fn verify_drain_to_stop() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp: u64 = kani::any();
+        let cp: Cp = kani::any();
         let t1 = running.create_batch(src, cp);
         let s1 = running.begin_send(t1);
 
@@ -843,13 +851,13 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(3)]
     fn verify_multi_source_independence() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src_a = SourceId(0);
         let src_b = SourceId(1);
 
-        let cp_a: u64 = kani::any();
-        let cp_b: u64 = kani::any();
+        let cp_a: Cp = kani::any();
+        let cp_b: Cp = kani::any();
 
         let ta = running.create_batch(src_a, cp_a);
         let tb = running.create_batch(src_b, cp_b);
@@ -870,11 +878,11 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(3)]
     fn verify_duplicate_ack_harmless() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp: u64 = kani::any();
+        let cp: Cp = kani::any();
         let t1 = running.create_batch(src, cp);
         let s1 = running.begin_send(t1);
         let receipt = s1.ack();
@@ -906,14 +914,14 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(5)]
     fn verify_symbolic_order_ack_4_batches() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp1: u64 = kani::any();
-        let cp2: u64 = kani::any();
-        let cp3: u64 = kani::any();
-        let cp4: u64 = kani::any();
+        let cp1: Cp = kani::any();
+        let cp2: Cp = kani::any();
+        let cp3: Cp = kani::any();
+        let cp4: Cp = kani::any();
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);
@@ -991,13 +999,13 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(4)]
     fn verify_committed_monotonic() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp1: u64 = kani::any();
-        let cp2: u64 = kani::any();
-        let cp3: u64 = kani::any();
+        let cp1: Cp = kani::any();
+        let cp2: Cp = kani::any();
+        let cp3: Cp = kani::any();
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);
@@ -1045,11 +1053,11 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(3)]
     fn verify_stop_blocks_when_in_flight() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp: u64 = kani::any();
+        let cp: Cp = kani::any();
         let t1 = running.create_batch(src, cp);
         let _s1 = running.begin_send(t1); // leave it in-flight
 
@@ -1074,11 +1082,11 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(3)]
     fn verify_reject_advances_checkpoint() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp: u64 = kani::any();
+        let cp: Cp = kani::any();
         let t1 = running.create_batch(src, cp);
         let s1 = running.begin_send(t1);
 
@@ -1105,13 +1113,13 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(4)]
     fn verify_batch_id_strictly_monotonic() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let t1 = running.create_batch(src, 0u64);
-        let t2 = running.create_batch(src, 0u64);
-        let t3 = running.create_batch(src, 0u64);
+        let t1 = running.create_batch(src, 0);
+        let t2 = running.create_batch(src, 0);
+        let t3 = running.create_batch(src, 0);
 
         assert!(t1.id() < t2.id(), "batch IDs must be strictly increasing");
         assert!(t2.id() < t3.id(), "batch IDs must be strictly increasing");
@@ -1126,8 +1134,8 @@ mod verification {
     #[kani::unwind(2)]
     fn verify_is_drained_when_empty() {
         // An empty pipeline (never any batches) must be immediately drained.
-        let running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let draining = running.begin_drain();
         assert!(draining.is_drained());
         assert_eq!(draining.in_flight_count(), 0);
@@ -1138,10 +1146,10 @@ mod verification {
     #[kani::unwind(3)]
     fn verify_not_drained_with_in_flight() {
         // A pipeline with exactly one unsent-to-acked batch must NOT be drained.
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(kani::any());
-        let cp: u64 = kani::any();
+        let cp: Cp = kani::any();
         let t1 = running.create_batch(src, cp);
         let _s1 = running.begin_send(t1); // in-flight, not acked
 
@@ -1161,13 +1169,13 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(4)]
     fn verify_mixed_ack_reject_advances() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp1: u64 = kani::any();
-        let cp2: u64 = kani::any();
-        let cp3: u64 = kani::any();
+        let cp1: Cp = kani::any();
+        let cp2: Cp = kani::any();
+        let cp3: Cp = kani::any();
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);
@@ -1203,11 +1211,11 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(3)]
     fn verify_force_stop_always_succeeds() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp: u64 = kani::any();
+        let cp: Cp = kani::any();
         let t1 = running.create_batch(src, cp);
         let _s1 = running.begin_send(t1); // leave in-flight
 
@@ -1235,12 +1243,12 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(3)]
     fn verify_force_stop_preserves_committed() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp1: u64 = kani::any();
-        let cp2: u64 = kani::any();
+        let cp1: Cp = kani::any();
+        let cp2: Cp = kani::any();
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);
@@ -1271,12 +1279,12 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(4)]
     fn verify_dropped_ticket_does_not_block() {
-        let mut running: PipelineMachine<Running, u64> =
-            PipelineMachine::<Starting, u64>::new().start();
+        let mut running: PipelineMachine<Running, Cp> =
+            PipelineMachine::<Starting, Cp>::new().start();
         let src = SourceId(0);
 
-        let cp1: u64 = kani::any();
-        let cp2: u64 = kani::any();
+        let cp1: Cp = kani::any();
+        let cp2: Cp = kani::any();
 
         // Create batch 1 — then DROP the Queued ticket (simulates scan error)
         let _dropped = running.create_batch(src, cp1);

--- a/dev-docs/DESIGN.md
+++ b/dev-docs/DESIGN.md
@@ -138,6 +138,16 @@ work for file inputs.
 `CheckpointAdvance<C>`.  
 **Research:** `dev-docs/research/offset-checkpoint-research.md`. **Related:** #270.
 
+### Kani checkpoint proof domain
+
+The `pipeline/lifecycle.rs` Kani harnesses may narrow symbolic checkpoint values
+to a small integer domain when the proof only checks lifecycle behavior. This is
+valid because `PipelineMachine<S, C>` stores, orders, and returns checkpoints
+without interpreting their arithmetic meaning. TLA+ coverage is unchanged: the
+`PipelineMachine.tla` model already treats checkpoint values as opaque tokens
+while checking batch sequencing, ACK/reject advance, drain, and ordering
+invariants.
+
 ### Rejected batches advance the checkpoint
 
 `RejectBatch` has the same state transition as `AckBatch` — permanently-undeliverable data

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -341,7 +341,7 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 | `scan_config.rs` | `parse_int_fast`, `parse_float_fast`, `ScanConfig` | Kani exhaustive (2 proofs) |
 | `cri.rs` | CRI log parsing + partial line reassembly | Kani exhaustive (8 proofs) |
 | `otlp.rs` | Protobuf wire format + OTLP encoding + timestamp parsing | Kani mixed exhaustive + bounded (30 proofs incl. 3 contract verifications) |
-| `pipeline/lifecycle.rs` | Pipeline state machine (ordered ACK, drain, shutdown) | Kani exhaustive (6 proofs) + proptest + **TLA+** |
+| `pipeline/lifecycle.rs` | Pipeline state machine (ordered ACK, drain, shutdown) | Kani exhaustive (16 proofs) + proptest + **TLA+** |
 | `logfwd-runtime/pipeline/health.rs` | Pipeline component-health transition reducer (`observed`, bounded startup poll failure escalation, shutdown) | Kani exhaustive (6 proofs) + unit tests + proptest sequence checks |
 | `pipeline/batch.rs` | BatchTicket typestate (ack/nack/fail/reject) | Kani exhaustive (5 proofs) + compile-time |
 | `logfwd-types/diagnostics/health.rs` | `ComponentHealth` lattice (`combine`, readiness, storage repr) | Kani exhaustive (4 proofs) + unit tests |


### PR DESCRIPTION
## Summary

- Narrows symbolic checkpoint type in all 16 lifecycle Kani proofs from `u64` to `u8`
- Proofs verify state-machine behavior (ordering, drain, advance), not checkpoint arithmetic
- `u8` gives 256 symbolic values — sufficient for coverage
- `verify_dropped_ticket_does_not_block` was taking 54+ minutes with `u64`, blocking the entire periphery shard

## Root cause

BTreeMap operations with symbolic `u64` values create exponential SAT state space. The checkpoint values are stored (not compared/branched on), but `Clone` impls and BTreeMap node management still force the solver to track all 2^64 possibilities.

## Test plan

- [ ] All 60 `logfwd-types` tests pass
- [ ] Kani periphery shard completes without timeout
- [ ] `just lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Narrow Kani lifecycle proof checkpoint type from `u64` to `u8` for tractability
> - Introduces a `#[cfg(kani)]`-scoped `Cp = u8` type alias in [lifecycle.rs](https://github.com/strawgate/memagent/pull/2270/files#diff-6b7c6c696a750b6bb18ab803e28ae0a281a298519c9fa4415b2ed4ea362292da) to replace `u64` across all 16 Kani proof harnesses, reducing the symbolic domain size.
> - Adds `kani::assume` constraints in `verify_ordered_ack` to enforce non-decreasing checkpoint order, and `kani::cover` calls to exercise boundary cases.
> - Documents the rationale in [DESIGN.md](https://github.com/strawgate/memagent/pull/2270/files#diff-6ebf3e5da68624f7a21d08428def9c331bb576b8c5139ef9dec46c076ac1387d): checkpoints are treated as opaque ordered values, so narrowing to `u8` preserves proof validity while keeping verification tractable.
> - Updates [VERIFICATION.md](https://github.com/strawgate/memagent/pull/2270/files#diff-9ee6083bcef7ba7a04169944b164331c00618ea836614229e2ad1b240b70eb77) to reflect 16 proofs (up from 6).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 903fb03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->