### PR TITLE
fix: widen cast UDF input coercion

### DIFF
--- a/crates/logfwd-transform/src/cast_udf.rs
+++ b/crates/logfwd-transform/src/cast_udf.rs
@@ -4,10 +4,36 @@ use std::any::Any;
 
 use arrow::datatypes::DataType;
 use datafusion::logical_expr::{
-    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
 };
 
-/// UDF: int(col) — safe cast from Utf8 to Int64, returns NULL on failure.
+fn cast_or_passthrough_array(
+    array: &std::sync::Arc<dyn arrow::array::Array>,
+    target_type: &DataType,
+) -> datafusion::common::Result<ColumnarValue> {
+    if array.data_type() == target_type {
+        return Ok(ColumnarValue::Array(array.clone()));
+    }
+
+    let result = arrow::compute::cast(array, target_type)
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    Ok(ColumnarValue::Array(result))
+}
+
+fn cast_scalar_to(
+    scalar: &datafusion::common::ScalarValue,
+    target_type: &DataType,
+) -> datafusion::common::Result<datafusion::common::ScalarValue> {
+    let array = scalar
+        .to_array()
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    let result = arrow::compute::cast(&array, target_type)
+        .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
+    datafusion::common::ScalarValue::try_from_array(&result, 0)
+}
+
+/// UDF: int(col) — safe cast from strings/numerics to Int64, returns NULL on
+/// parse failure.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct IntCastUdf {
     signature: Signature,
@@ -16,7 +42,15 @@ pub(crate) struct IntCastUdf {
 impl IntCastUdf {
     pub(crate) fn new() -> Self {
         Self {
-            signature: Signature::exact(vec![DataType::Utf8], Volatility::Immutable),
+            signature: Signature::new(
+                TypeSignature::OneOf(vec![
+                    TypeSignature::Exact(vec![DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::Utf8View]),
+                    TypeSignature::Exact(vec![DataType::LargeUtf8]),
+                    TypeSignature::Numeric(1),
+                ]),
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -44,27 +78,20 @@ impl ScalarUDFImpl for IntCastUdf {
     ) -> datafusion::common::Result<ColumnarValue> {
         let arg = &args.args[0];
         match arg {
-            ColumnarValue::Array(array) => {
-                // Safe cast: returns NULL on parse failure.
-                let result = arrow::compute::cast(array, &DataType::Int64)
-                    .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
-                Ok(ColumnarValue::Array(result))
+            ColumnarValue::Array(array) => cast_or_passthrough_array(array, &DataType::Int64),
+            ColumnarValue::Scalar(scalar @ datafusion::common::ScalarValue::Int64(_)) => {
+                Ok(ColumnarValue::Scalar(scalar.clone()))
             }
-            ColumnarValue::Scalar(scalar) => {
-                // Convert scalar to single-element array, cast, convert back.
-                let array = scalar
-                    .to_array()
-                    .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
-                let result = arrow::compute::cast(&array, &DataType::Int64)
-                    .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
-                let scalar_val = datafusion::common::ScalarValue::try_from_array(&result, 0)?;
-                Ok(ColumnarValue::Scalar(scalar_val))
-            }
+            ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(cast_scalar_to(
+                scalar,
+                &DataType::Int64,
+            )?)),
         }
     }
 }
 
-/// UDF: float(col) — safe cast from Utf8 to Float64, returns NULL on failure.
+/// UDF: float(col) — safe cast from strings/numerics to Float64, returns NULL
+/// on parse failure.
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct FloatCastUdf {
     signature: Signature,
@@ -73,7 +100,15 @@ pub(crate) struct FloatCastUdf {
 impl FloatCastUdf {
     pub(crate) fn new() -> Self {
         Self {
-            signature: Signature::exact(vec![DataType::Utf8], Volatility::Immutable),
+            signature: Signature::new(
+                TypeSignature::OneOf(vec![
+                    TypeSignature::Exact(vec![DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::Utf8View]),
+                    TypeSignature::Exact(vec![DataType::LargeUtf8]),
+                    TypeSignature::Numeric(1),
+                ]),
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -101,20 +136,14 @@ impl ScalarUDFImpl for FloatCastUdf {
     ) -> datafusion::common::Result<ColumnarValue> {
         let arg = &args.args[0];
         match arg {
-            ColumnarValue::Array(array) => {
-                let result = arrow::compute::cast(array, &DataType::Float64)
-                    .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
-                Ok(ColumnarValue::Array(result))
+            ColumnarValue::Array(array) => cast_or_passthrough_array(array, &DataType::Float64),
+            ColumnarValue::Scalar(scalar @ datafusion::common::ScalarValue::Float64(_)) => {
+                Ok(ColumnarValue::Scalar(scalar.clone()))
             }
-            ColumnarValue::Scalar(scalar) => {
-                let array = scalar
-                    .to_array()
-                    .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
-                let result = arrow::compute::cast(&array, &DataType::Float64)
-                    .map_err(|e| datafusion::error::DataFusionError::External(Box::new(e)))?;
-                let scalar_val = datafusion::common::ScalarValue::try_from_array(&result, 0)?;
-                Ok(ColumnarValue::Scalar(scalar_val))
-            }
+            ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(cast_scalar_to(
+                scalar,
+                &DataType::Float64,
+            )?)),
         }
     }
 }

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -4,7 +4,7 @@ use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 
 use super::*;
-use arrow::array::{Array, ArrayRef, Float64Array, Int64Array, StringArray};
+use arrow::array::{Array, ArrayRef, Float64Array, Int64Array, StringArray, StringViewArray};
 use arrow::datatypes::{Field, Schema};
 
 /// Helper: build a simple test RecordBatch with bare-name columns matching
@@ -223,6 +223,110 @@ fn test_float_udf() {
     assert!((col.value(0) - 3.25).abs() < 1e-10);
     assert!(col.is_null(1));
     assert!((col.value(2) - 2.125).abs() < 1e-10);
+}
+
+#[test]
+fn test_int_udf_accepts_utf8view_and_preserves_invalid_and_null() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "status",
+        DataType::Utf8View,
+        true,
+    )]));
+    let status: ArrayRef = Arc::new(StringViewArray::from(vec![
+        Some("200"),
+        Some("not_a_number"),
+        None,
+        Some("503"),
+    ]));
+    let batch = RecordBatch::try_new(schema, vec![status]).unwrap();
+
+    let mut transform = SqlTransform::new("SELECT int(status) AS status_int FROM logs").unwrap();
+    let result = transform.execute_blocking(batch).unwrap();
+    let status_int = result
+        .column_by_name("status_int")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(status_int.value(0), 200);
+    assert!(status_int.is_null(1));
+    assert!(status_int.is_null(2));
+    assert_eq!(status_int.value(3), 503);
+}
+
+#[test]
+fn test_int_udf_accepts_int64_without_string_coercion() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "status",
+        DataType::Int64,
+        true,
+    )]));
+    let status: ArrayRef = Arc::new(Int64Array::from(vec![Some(200), Some(500), None]));
+    let batch = RecordBatch::try_new(schema, vec![status]).unwrap();
+
+    let mut transform = SqlTransform::new("SELECT int(status) AS status_int FROM logs").unwrap();
+    let result = transform.execute_blocking(batch).unwrap();
+    let status_int = result
+        .column_by_name("status_int")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap();
+    assert_eq!(status_int.value(0), 200);
+    assert_eq!(status_int.value(1), 500);
+    assert!(status_int.is_null(2));
+}
+
+#[test]
+fn test_float_udf_accepts_utf8view_and_preserves_invalid_and_null() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "val",
+        DataType::Utf8View,
+        true,
+    )]));
+    let val: ArrayRef = Arc::new(StringViewArray::from(vec![
+        Some("3.25"),
+        Some("not_float"),
+        None,
+        Some("2.125"),
+    ]));
+    let batch = RecordBatch::try_new(schema, vec![val]).unwrap();
+
+    let mut transform = SqlTransform::new("SELECT float(val) AS val_f FROM logs").unwrap();
+    let result = transform.execute_blocking(batch).unwrap();
+    let val_f = result
+        .column_by_name("val_f")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    assert!((val_f.value(0) - 3.25).abs() < 1e-10);
+    assert!(val_f.is_null(1));
+    assert!(val_f.is_null(2));
+    assert!((val_f.value(3) - 2.125).abs() < 1e-10);
+}
+
+#[test]
+fn test_float_udf_accepts_float64_without_string_coercion() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "val",
+        DataType::Float64,
+        true,
+    )]));
+    let val: ArrayRef = Arc::new(Float64Array::from(vec![Some(3.25), Some(2.125), None]));
+    let batch = RecordBatch::try_new(schema, vec![val]).unwrap();
+
+    let mut transform = SqlTransform::new("SELECT float(val) AS val_f FROM logs").unwrap();
+    let result = transform.execute_blocking(batch).unwrap();
+    let val_f = result
+        .column_by_name("val_f")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .unwrap();
+    assert!((val_f.value(0) - 3.25).abs() < 1e-10);
+    assert!((val_f.value(1) - 2.125).abs() < 1e-10);
+    assert!(val_f.is_null(2));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow `int()` and `float()` UDFs to accept `Utf8View`, `LargeUtf8`, and numeric inputs instead of only `Utf8`
- avoid unnecessary casts when scalar or array inputs are already at the target type
- add regression tests for string-view, invalid/null, and numeric passthrough inputs

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p logfwd-transform -- --nocapture`

Closes #2179

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Widen input coercion for `int()` and `float()` UDFs to accept numeric and Utf8View types
> - Updates the signatures of `IntCastUdf` and `FloatCastUdf` in [cast_udf.rs](https://github.com/strawgate/memagent/pull/2276/files#diff-d3a54b081384879c64cf8249d498e2c3140be9405e0953e221b712638eeef411) to accept `Utf8`, `Utf8View`, `LargeUtf8`, and any single numeric type, replacing the previous `Utf8`-only restriction.
> - Adds `cast_or_passthrough_array` and `cast_scalar_to` helpers that skip re-casting when the input already matches the target type, and use Arrow's cast semantics (invalid values become NULL) otherwise.
> - Adds tests for `Utf8View` inputs, pass-through of already-typed `Int64`/`Float64` columns, and NULL propagation for invalid values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b95109d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->