### PR TITLE
feat: redesign highway animation with multi-route layout

### DIFF
--- a/book/src/components/HighwayBackpressure.astro
+++ b/book/src/components/HighwayBackpressure.astro
@@ -12,6 +12,7 @@
         <path id="hw-path-ramp" d="M 30,255 C 30,185 115,100 200,100" fill="none" />
         <path id="hw-path-hwy" d="M 30,100 L 560,100" fill="none" />
         <path id="hw-path-exit" d="M 560,100 C 600,100 730,175 730,255" fill="none" />
+        <path id="hw-path-cont" d="M 560,100 L 775,100" fill="none" />
       </defs>
 
       <!-- Highway road surface -->
@@ -35,11 +36,11 @@
       <path d="M 560,100 C 600,100 730,175 730,255" fill="none" stroke="var(--hw-road)" stroke-width="28" stroke-linecap="round" />
       <path d="M 560,100 C 600,100 730,175 730,255" fill="none" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="6,8" />
 
-      <!-- Faded highway continuation past fork -->
-      <rect x="555" y="84" width="220" height="32" fill="var(--hw-road)" opacity="0.2" />
-      <line x1="555" y1="84" x2="775" y2="84" stroke="var(--hw-edge)" stroke-width="1" opacity="0.15" />
-      <line x1="555" y1="116" x2="775" y2="116" stroke="var(--hw-edge)" stroke-width="1" opacity="0.15" />
-      <line x1="560" y1="100" x2="770" y2="100" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="14,10" opacity="0.1" />
+      <!-- Highway continuation past fork (through traffic) -->
+      <rect x="555" y="84" width="220" height="32" fill="var(--hw-road)" opacity="0.35" />
+      <line x1="555" y1="84" x2="775" y2="84" stroke="var(--hw-edge)" stroke-width="1" opacity="0.25" />
+      <line x1="555" y1="116" x2="775" y2="116" stroke="var(--hw-edge)" stroke-width="1" opacity="0.25" />
+      <line x1="560" y1="100" x2="770" y2="100" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="14,10" opacity="0.15" />
 
       <!-- Merge zone marker -->
       <line x1="200" y1="84" x2="200" y2="116" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="3,3" opacity="0.35" />
@@ -183,11 +184,13 @@ import { createSimulation } from './highway-sim.mjs';
   var pathRamp = document.getElementById('hw-path-ramp');
   var pathHwy = document.getElementById('hw-path-hwy');
   var pathExit = document.getElementById('hw-path-exit');
-  if (!carsG || !slider || !pathRamp || !pathHwy || !pathExit) return;
+  var pathCont = document.getElementById('hw-path-cont');
+  if (!carsG || !slider || !pathRamp || !pathHwy || !pathExit || !pathCont) return;
 
   var lenRamp = pathRamp.getTotalLength();
   var lenHwy = pathHwy.getTotalLength();
   var lenExit = pathExit.getTotalLength();
+  var lenCont = pathCont.getTotalLength();
 
   // mergeD: where x=200 on the straight highway from x=30 to x=560
   var mergeD = Math.round(lenHwy * 170 / 530);
@@ -224,6 +227,7 @@ import { createSimulation } from './highway-sim.mjs';
     lenRamp: lenRamp,
     lenHwy: lenHwy,
     lenExit: lenExit,
+    lenCont: lenCont,
     mergeD: mergeD,
     gateD: gateD,
     carW: CAR_W,
@@ -232,8 +236,8 @@ import { createSimulation } from './highway-sim.mjs';
   sim.setCycleStart(Date.now());
 
   // Segment → SVG path mapping
-  var pathMap = { ramp: pathRamp, highway: pathHwy, exit: pathExit };
-  var lenMap = { ramp: lenRamp, highway: lenHwy, exit: lenExit };
+  var pathMap = { ramp: pathRamp, highway: pathHwy, exit: pathExit, cont: pathCont };
+  var lenMap = { ramp: lenRamp, highway: lenHwy, exit: lenExit, cont: lenCont };
 
   function posAt(segment, d) {
     var path = pathMap[segment];

--- a/book/src/components/HighwayBackpressure.astro
+++ b/book/src/components/HighwayBackpressure.astro
@@ -1,82 +1,92 @@
 ---
-// Highway backpressure animation.
+// Highway backpressure animation — multi-route layout.
+// Two sources feed a highway; all cars exit via a ramp with a traffic light.
+// When the exit backs up, it cascades: exit → highway → on-ramp.
 // Logic lives in highway-sim.mjs; this file is UI/rendering only.
-// Straight road: on-ramp → highway → off-ramp with cycling traffic light.
-// User controls green/red ratio via a compact slider above the light.
 ---
 
 <div class="hw" id="highway-bp">
   <div class="hw-scene">
-    <svg class="hw-svg" viewBox="0 0 800 195" preserveAspectRatio="xMidYMid meet" aria-hidden="true">
+    <svg class="hw-svg" viewBox="0 0 800 300" preserveAspectRatio="xMidYMid meet" aria-hidden="true">
       <defs>
-        <path id="hw-path-in" d="M 40,170 C 40,118 115,85 155,85" fill="none" />
-        <path id="hw-path-hwy" d="M 155,85 L 645,85" fill="none" />
-        <path id="hw-path-out" d="M 645,85 C 685,85 760,118 760,170" fill="none" />
+        <path id="hw-path-ramp" d="M 30,255 C 30,185 115,100 200,100" fill="none" />
+        <path id="hw-path-hwy" d="M 30,100 L 560,100" fill="none" />
+        <path id="hw-path-exit" d="M 560,100 C 600,100 730,175 730,255" fill="none" />
       </defs>
 
-      <!-- On-ramp -->
-      <path d="M 40,170 C 40,118 115,85 155,85" fill="none" stroke="var(--hw-road)" stroke-width="32" stroke-linecap="round" />
-      <path d="M 40,170 C 40,118 115,85 155,85" fill="none" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="6,8" />
+      <!-- Highway road surface -->
+      <rect x="25" y="84" width="540" height="32" fill="var(--hw-road)" />
+      <line x1="25" y1="84" x2="565" y2="84" stroke="var(--hw-edge)" stroke-width="1.5" />
+      <line x1="25" y1="116" x2="565" y2="116" stroke="var(--hw-edge)" stroke-width="1.5" />
+      <line x1="40" y1="100" x2="550" y2="100" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="14,10" />
 
-      <!-- Highway -->
-      <rect x="150" y="69" width="500" height="32" fill="var(--hw-road)" />
-      <line x1="150" y1="69" x2="650" y2="69" stroke="var(--hw-edge)" stroke-width="1.5" />
-      <line x1="150" y1="101" x2="650" y2="101" stroke="var(--hw-edge)" stroke-width="1.5" />
-      <line x1="165" y1="85" x2="635" y2="85" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="14,10" />
-
-      <!-- Direction chevrons -->
-      <g opacity="0.3" stroke="var(--hw-dash)" stroke-width="1.5" fill="none">
-        <path d="M 268,79 L 274,85 L 268,91" />
-        <path d="M 368,79 L 374,85 L 368,91" />
-        <path d="M 468,79 L 474,85 L 468,91" />
+      <!-- Direction chevrons on highway -->
+      <g opacity="0.25" stroke="var(--hw-dash)" stroke-width="1.5" fill="none">
+        <path d="M 100,94 L 106,100 L 100,106" />
+        <path d="M 280,94 L 286,100 L 280,106" />
+        <path d="M 460,94 L 466,100 L 460,106" />
       </g>
 
-      <!-- Off-ramp -->
-      <path d="M 645,85 C 685,85 760,118 760,170" fill="none" stroke="var(--hw-road)" stroke-width="32" stroke-linecap="round" />
-      <path d="M 645,85 C 685,85 760,118 760,170" fill="none" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="6,8" />
+      <!-- On-ramp road surface -->
+      <path d="M 30,255 C 30,185 115,100 200,100" fill="none" stroke="var(--hw-road)" stroke-width="28" stroke-linecap="round" />
+      <path d="M 30,255 C 30,185 115,100 200,100" fill="none" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="6,8" />
 
-      <!-- Stop line at traffic light -->
-      <line x1="630" y1="69" x2="630" y2="101" stroke="var(--hw-edge)" stroke-width="2.5" stroke-dasharray="4,3" opacity="0.6" />
+      <!-- Exit ramp road surface -->
+      <path d="M 560,100 C 600,100 730,175 730,255" fill="none" stroke="var(--hw-road)" stroke-width="28" stroke-linecap="round" />
+      <path d="M 560,100 C 600,100 730,175 730,255" fill="none" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="6,8" />
 
-      <!-- Traffic light -->
-      <g id="hw-light" transform="translate(638,23)">
-        <rect x="-7" y="0" width="14" height="30" rx="4" fill="#1e1e1e" stroke="#444" stroke-width="0.5" />
-        <circle cx="0" cy="9" r="4.5" fill="#3a1111" id="hw-l-red" />
-        <circle cx="0" cy="21" r="4.5" fill="#22c55e" id="hw-l-green" />
-        <rect x="-1.5" y="30" width="3" height="14" fill="#444" />
+      <!-- Faded highway continuation past fork -->
+      <rect x="555" y="84" width="220" height="32" fill="var(--hw-road)" opacity="0.2" />
+      <line x1="555" y1="84" x2="775" y2="84" stroke="var(--hw-edge)" stroke-width="1" opacity="0.15" />
+      <line x1="555" y1="116" x2="775" y2="116" stroke="var(--hw-edge)" stroke-width="1" opacity="0.15" />
+      <line x1="560" y1="100" x2="770" y2="100" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="14,10" opacity="0.1" />
+
+      <!-- Merge zone marker -->
+      <line x1="200" y1="84" x2="200" y2="116" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="3,3" opacity="0.35" />
+
+      <!-- Traffic light — positioned dynamically by JS on exit ramp -->
+      <g id="hw-light" style="display:none">
+        <line id="hw-stop-line" stroke="var(--hw-edge)" stroke-width="2.5" stroke-dasharray="4,3" opacity="0.6" />
+        <g id="hw-light-housing">
+          <rect x="-7" y="-15" width="14" height="30" rx="4" fill="#1e1e1e" stroke="#444" stroke-width="0.5" />
+          <circle cx="0" cy="-6" r="4.5" fill="#3a1111" id="hw-l-red" />
+          <circle cx="0" cy="6" r="4.5" fill="#22c55e" id="hw-l-green" />
+          <rect x="-1.5" y="15" width="3" height="10" fill="#444" />
+        </g>
       </g>
 
       <!-- Labels -->
-      <text x="40" y="190" text-anchor="middle" fill="var(--hw-muted)" font-size="10" font-weight="600">LOG SOURCE</text>
-      <text x="400" y="62" text-anchor="middle" fill="var(--hw-muted)" font-size="10" font-weight="600" id="hw-pipeline-label">FLOWING — COLLECTOR KEEPING UP</text>
-      <text x="760" y="190" text-anchor="middle" fill="var(--hw-muted)" font-size="10" font-weight="600">DESTINATION</text>
+      <text x="30" y="78" text-anchor="start" fill="var(--hw-muted)" font-size="9" font-weight="600">LOG SOURCE</text>
+      <text x="30" y="275" text-anchor="start" fill="var(--hw-muted)" font-size="9" font-weight="600">LOG SOURCE</text>
+      <text x="730" y="275" text-anchor="middle" fill="var(--hw-muted)" font-size="9" font-weight="600">DESTINATION</text>
+      <text x="200" y="130" text-anchor="middle" fill="var(--hw-muted)" font-size="8" opacity="0.45">MERGE</text>
+      <text x="560" y="130" text-anchor="middle" fill="var(--hw-muted)" font-size="8" opacity="0.45">EXIT</text>
+
+      <!-- Status label along highway -->
+      <text x="380" y="72" text-anchor="middle" fill="var(--hw-muted)" font-size="10" font-weight="600" id="hw-pipeline-label">FLOWING — TRAFFIC MOVING FREELY</text>
 
       <g id="hw-cars"></g>
 
-      <!-- Stats overlaid in the road endpoint zone -->
-      <foreignObject x="200" y="150" width="400" height="45">
+      <!-- Stats below the highway -->
+      <foreignObject x="200" y="140" width="360" height="45">
         <div xmlns="http://www.w3.org/1999/xhtml" class="hw-stats" id="hw-stats">
           <div class="hw-stat">
             <span class="hw-stat-val" id="hw-s-tput">—</span>
-            <span class="hw-stat-lbl">Throughput</span>
+            <span class="hw-stat-lbl">Delivered</span>
           </div>
           <div class="hw-stat">
             <span class="hw-stat-val" id="hw-s-queue">0</span>
-            <span class="hw-stat-lbl">Queued</span>
+            <span class="hw-stat-lbl">On Road</span>
           </div>
           <div class="hw-stat">
             <span class="hw-stat-val" id="hw-s-stall">0%</span>
             <span class="hw-stat-lbl">Stalled</span>
           </div>
-          <div class="hw-stat">
-            <span class="hw-stat-val hw-stat-light" id="hw-s-light">🟢</span>
-            <span class="hw-stat-lbl" id="hw-s-light-lbl">GREEN</span>
-          </div>
         </div>
       </foreignObject>
     </svg>
 
-    <!-- Compact slider positioned above the traffic light -->
+    <!-- Slider control -->
     <div class="hw-light-ctrl" id="hw-light-ctrl">
       <label class="hw-light-ctrl-label" for="hw-green" id="hw-slider-detail">Light Timing</label>
       <input type="range" id="hw-green" class="hw-light-slider" min="5" max="100" value="80" />
@@ -109,10 +119,10 @@
   .hw-scene { position: relative; width: 100%; overflow: visible; }
   .hw-svg { width: 100%; height: auto; display: block; }
 
-  /* Compact slider to the left of the traffic light */
+  /* Slider near top-right, close to exit ramp area */
   .hw-light-ctrl {
     position: absolute;
-    right: 22%; top: 6%;
+    right: 5%; top: 4%;
     display: flex; flex-direction: column; align-items: center; gap: 1px;
     pointer-events: auto;
   }
@@ -144,7 +154,6 @@
     font-size: 0.55rem; font-weight: 600; text-transform: uppercase;
     letter-spacing: 0.05em; color: var(--hw-muted);
   }
-  .hw-stat-light { font-size: 1.2rem; }
 
   .hw-status {
     position: absolute; width: 1px; height: 1px; overflow: hidden;
@@ -163,49 +172,84 @@ import { createSimulation } from './highway-sim.mjs';
   var sliderDetail = document.getElementById('hw-slider-detail');
   var lRed = document.getElementById('hw-l-red');
   var lGreen = document.getElementById('hw-l-green');
+  var lightG = document.getElementById('hw-light');
+  var lightHousing = document.getElementById('hw-light-housing');
+  var stopLine = document.getElementById('hw-stop-line');
   var sTput = document.getElementById('hw-s-tput');
   var sQueue = document.getElementById('hw-s-queue');
   var sStall = document.getElementById('hw-s-stall');
-  var sLight = document.getElementById('hw-s-light');
-  var sLightLbl = document.getElementById('hw-s-light-lbl');
 
   // Measure SVG paths
-  var pathIn = document.getElementById('hw-path-in');
+  var pathRamp = document.getElementById('hw-path-ramp');
   var pathHwy = document.getElementById('hw-path-hwy');
-  var pathOut = document.getElementById('hw-path-out');
-  if (!carsG || !slider || !pathIn || !pathHwy || !pathOut) return;
-  var lenIn = pathIn.getTotalLength();
+  var pathExit = document.getElementById('hw-path-exit');
+  if (!carsG || !slider || !pathRamp || !pathHwy || !pathExit) return;
+
+  var lenRamp = pathRamp.getTotalLength();
   var lenHwy = pathHwy.getTotalLength();
-  var lenOut = pathOut.getTotalLength();
-  var lenTotal = lenIn + lenHwy + lenOut;
+  var lenExit = pathExit.getTotalLength();
 
-  function posAt(d) {
-    if (d <= lenIn) return pathIn.getPointAtLength(d);
-    if (d <= lenIn + lenHwy) return pathHwy.getPointAtLength(d - lenIn);
-    return pathOut.getPointAtLength(Math.min(d - lenIn - lenHwy, lenOut));
-  }
-  function angleAt(d) {
-    var p1 = posAt(d);
-    var p2 = posAt(Math.min(d + 2, lenTotal));
-    return Math.atan2(p2.y - p1.y, p2.x - p1.x) * 180 / Math.PI;
-  }
+  // mergeD: where x=200 on the straight highway from x=30 to x=560
+  var mergeD = Math.round(lenHwy * 170 / 530);
+  var gateD = Math.round(lenExit * 0.62);
 
-  var GATE_D = lenIn + lenHwy - 15;
+  // ---- Position traffic light on exit ramp ----
+  (function() {
+    var p = pathExit.getPointAtLength(gateD);
+    var p2 = pathExit.getPointAtLength(Math.min(gateD + 3, lenExit));
+    var angle = Math.atan2(p2.y - p.y, p2.x - p.x);
+    var perpAngle = angle - Math.PI / 2;
+    var cosP = Math.cos(perpAngle);
+    var sinP = Math.sin(perpAngle);
+
+    // Stop line across the road (±14px from center)
+    stopLine.setAttribute('x1', String((p.x + cosP * 14).toFixed(1)));
+    stopLine.setAttribute('y1', String((p.y + sinP * 14).toFixed(1)));
+    stopLine.setAttribute('x2', String((p.x - cosP * 14).toFixed(1)));
+    stopLine.setAttribute('y2', String((p.y - sinP * 14).toFixed(1)));
+
+    // Light housing offset to the outside of the curve
+    var ox = p.x + cosP * 30;
+    var oy = p.y + sinP * 30;
+    lightHousing.setAttribute('transform', 'translate(' + ox.toFixed(1) + ',' + oy.toFixed(1) + ')');
+
+    lightG.style.display = '';
+  })();
+
   var CAR_W = 20, CAR_H = 10;
   var TICK_MS = 25;
 
   // Create simulation with measured path lengths
   var sim = createSimulation({
-    roadLength: lenTotal,
-    rampEnd: lenIn,
-    gateD: GATE_D,
+    lenRamp: lenRamp,
+    lenHwy: lenHwy,
+    lenExit: lenExit,
+    mergeD: mergeD,
+    gateD: gateD,
     carW: CAR_W,
     greenPct: 80,
   });
   sim.setCycleStart(Date.now());
 
+  // Segment → SVG path mapping
+  var pathMap = { ramp: pathRamp, highway: pathHwy, exit: pathExit };
+  var lenMap = { ramp: lenRamp, highway: lenHwy, exit: lenExit };
+
+  function posAt(segment, d) {
+    var path = pathMap[segment];
+    var len = lenMap[segment];
+    return path.getPointAtLength(Math.min(Math.max(0, d), len));
+  }
+  function angleAt(segment, d) {
+    var len = lenMap[segment];
+    var p1 = posAt(segment, d);
+    var p2 = posAt(segment, Math.min(d + 2, len));
+    if (Math.abs(p2.x - p1.x) < 0.01 && Math.abs(p2.y - p1.y) < 0.01) return 0;
+    return Math.atan2(p2.y - p1.y, p2.x - p1.x) * 180 / Math.PI;
+  }
+
   // ---- DOM car management ----
-  var carEls = {}; // id → { g, body }
+  var carEls = {};
 
   function createCarEl(car) {
     var w = CAR_W * car.scale;
@@ -214,9 +258,7 @@ import { createSimulation } from './highway-sim.mjs';
     var g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
     var body = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
 
-    // All shapes share a body rect, but differ in proportions and detail
     if (car.shape === 'truck') {
-      // Wider truck — a big batch
       w = CAR_W * s * 1.3;
       body.setAttribute('x', String(-w / 2));
       body.setAttribute('y', String(-h / 2));
@@ -224,7 +266,6 @@ import { createSimulation } from './highway-sim.mjs';
       body.setAttribute('height', String(h));
       body.setAttribute('rx', String(2 * s));
     } else if (car.shape === 'compact') {
-      // Smaller, rounder — a small batch
       w = CAR_W * s * 0.8;
       h = CAR_H * s * 0.85;
       body.setAttribute('x', String(-w / 2));
@@ -233,7 +274,6 @@ import { createSimulation } from './highway-sim.mjs';
       body.setAttribute('height', String(h));
       body.setAttribute('rx', String(3.5 * s));
     } else if (car.shape === 'van') {
-      // Taller, boxy — a batch with metadata
       h = CAR_H * s * 1.15;
       body.setAttribute('x', String(-w / 2));
       body.setAttribute('y', String(-h / 2));
@@ -241,7 +281,6 @@ import { createSimulation } from './highway-sim.mjs';
       body.setAttribute('height', String(h));
       body.setAttribute('rx', String(2.5 * s));
     } else {
-      // Sedan — default shape
       body.setAttribute('x', String(-w / 2));
       body.setAttribute('y', String(-h / 2));
       body.setAttribute('width', String(w));
@@ -252,7 +291,7 @@ import { createSimulation } from './highway-sim.mjs';
     body.setAttribute('fill', 'var(--hw-car-flow)');
     g.appendChild(body);
 
-    // Accent stripe — gives each car a "data" feel
+    // Accent stripe
     var stripe = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
     var stripeW = car.shape === 'truck' ? 3 * s : 2.5 * s;
     stripe.setAttribute('x', String(w / 2 - stripeW - 1.5 * s));
@@ -263,7 +302,6 @@ import { createSimulation } from './highway-sim.mjs';
     stripe.setAttribute('fill', 'rgba(255,255,255,0.25)');
     g.appendChild(stripe);
 
-    // Second accent for trucks and vans
     if (car.shape === 'truck' || car.shape === 'van') {
       var s2 = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
       s2.setAttribute('x', String(-w / 2 + 2 * s));
@@ -281,8 +319,8 @@ import { createSimulation } from './highway-sim.mjs';
 
   function removeCarEl(id) {
     var el = carEls[id];
-    if (el) {
-      carsG.removeChild(el.g);
+    if (el && el.g.parentNode) {
+      el.g.parentNode.removeChild(el.g);
       delete carEls[id];
     }
   }
@@ -290,14 +328,20 @@ import { createSimulation } from './highway-sim.mjs';
   function updateCarEl(car) {
     var el = carEls[car.id];
     if (!el) return;
-    var p = posAt(Math.min(car.d, lenTotal));
-    var a = angleAt(Math.min(car.d, lenTotal - 3));
+    var seg = car.segment;
+    var len = lenMap[seg];
+    var d = Math.min(Math.max(0, car.d), len);
+    var p = posAt(seg, d);
+    var a = angleAt(seg, d);
     el.g.setAttribute('transform', 'translate(' + p.x.toFixed(1) + ',' + p.y.toFixed(1) + ') rotate(' + a.toFixed(1) + ')');
+
     var fill;
     if (car.color === 'stop') fill = 'var(--hw-car-stop)';
     else if (car.color === 'slow') fill = 'var(--hw-car-slow)';
     else fill = 'var(--hw-car-flow)';
     el.body.setAttribute('fill', fill);
+
+    el.g.setAttribute('opacity', String(car.opacity != null ? car.opacity.toFixed(2) : '1'));
   }
 
   // ---- Main render loop ----
@@ -310,56 +354,53 @@ import { createSimulation } from './highway-sim.mjs';
     var frame = sim.tick(now);
     frameCount++;
 
-    // Create DOM elements for new cars
     var allCars = frame.cars;
     for (var c = 0; c < allCars.length; c++) {
       if (!carEls[allCars[c].id]) createCarEl(allCars[c]);
     }
-
-    // Remove delivered cars
     for (var r = 0; r < frame.removedIds.length; r++) {
       removeCarEl(frame.removedIds[r]);
     }
-
-    // Update positions and colors
     for (var u = 0; u < allCars.length; u++) {
       updateCarEl(allCars[u]);
     }
 
     // Traffic light visuals
-    if (frame.lightIsGreen) {
-      lRed.setAttribute('fill', '#3a1111');
-      lGreen.setAttribute('fill', '#22c55e');
-      sLight.textContent = '\uD83D\uDFE2';
-      sLightLbl.textContent = 'GREEN';
-    } else {
-      lRed.setAttribute('fill', '#ef4444');
-      lGreen.setAttribute('fill', '#113a16');
-      sLight.textContent = '\uD83D\uDD34';
-      sLightLbl.textContent = 'RED';
+    if (lRed && lGreen) {
+      if (frame.lightIsGreen) {
+        lRed.setAttribute('fill', '#3a1111');
+        lGreen.setAttribute('fill', '#22c55e');
+      } else {
+        lRed.setAttribute('fill', '#ef4444');
+        lGreen.setAttribute('fill', '#113a16');
+      }
     }
 
     // Sync slider in auto mode
-    if (frame.autoMode) {
+    if (frame.autoMode && slider) {
       slider.value = String(frame.greenPct);
-      sliderDetail.textContent = 'Auto \u00B7 Green ' + frame.greenPct + '%';
+      if (sliderDetail) sliderDetail.textContent = 'Auto \u00B7 Green ' + frame.greenPct + '%';
     }
 
-    // Stats (every ~8 frames)
+    // Stats
     if (frameCount % 8 === 0) {
-      sTput.textContent = frame.stats.throughput + '/min';
-      sQueue.textContent = String(frame.stats.queued);
-      sStall.textContent = frame.stats.stallPct + '%';
-      sStall.style.color = frame.stats.stallPct > 50 ? 'var(--hw-car-stop)' : frame.stats.stallPct > 20 ? 'var(--hw-car-slow)' : '';
+      if (sTput) sTput.textContent = frame.stats.throughput + '/min';
+      if (sQueue) sQueue.textContent = String(frame.stats.queued);
+      if (sStall) {
+        sStall.textContent = frame.stats.stallPct + '%';
+        sStall.style.color = frame.stats.stallPct > 50 ? 'var(--hw-car-stop)' : frame.stats.stallPct > 20 ? 'var(--hw-car-slow)' : '';
+      }
     }
 
-    // Status — update SVG pipeline label (no emoji)
+    // Status label
     var msg = frame.status.msg;
     if (msg !== lastStatus) {
-      statusEl.textContent = msg;
-      pipelineLabel.textContent = msg.toUpperCase();
-      var fill = frame.status.level === 'blocked' ? 'var(--hw-car-stop)' : frame.status.level === 'congested' ? 'var(--hw-car-slow)' : 'var(--hw-muted)';
-      pipelineLabel.setAttribute('fill', fill);
+      if (statusEl) statusEl.textContent = msg;
+      if (pipelineLabel) {
+        pipelineLabel.textContent = msg.toUpperCase();
+        var fill = frame.status.level === 'blocked' ? 'var(--hw-car-stop)' : frame.status.level === 'congested' ? 'var(--hw-car-slow)' : 'var(--hw-muted)';
+        pipelineLabel.setAttribute('fill', fill);
+      }
       lastStatus = msg;
     }
   }
@@ -368,7 +409,7 @@ import { createSimulation } from './highway-sim.mjs';
   function onSliderInput() {
     var v = parseInt(slider.value, 10);
     sim.setGreenPct(v);
-    sliderDetail.textContent = 'Green ' + v + '% \u00B7 Red ' + (100 - v) + '%';
+    if (sliderDetail) sliderDetail.textContent = 'Green ' + v + '% \u00B7 Red ' + (100 - v) + '%';
   }
   function exitAuto() { sim.exitAuto(); }
 
@@ -379,16 +420,16 @@ import { createSimulation } from './highway-sim.mjs';
 
   // ---- Seed initial cars ----
   function seedCars() {
-    for (var s = 0; s < 4; s++) {
-      sim.addCar(lenIn + 30 + s * 100);
-    }
+    sim.addCar('highway', 80, 3.5);
+    sim.addCar('highway', 200, 3.5);
+    sim.addCar('highway', 350, 3.5);
+    sim.addCar('ramp', 60, 3.5);
   }
 
   // ---- Init ----
   if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
     sim.setLastSpawn(Date.now());
     seedCars();
-    // Create initial car DOM elements
     var initial = sim.getCars();
     for (var i = 0; i < initial.length; i++) {
       createCarEl(initial[i]);
@@ -403,7 +444,7 @@ import { createSimulation } from './highway-sim.mjs';
       updateCarEl(staticCars[j]);
     }
     slider.disabled = true;
-    statusEl.textContent = 'Animation paused (reduced motion)';
+    if (statusEl) statusEl.textContent = 'Animation paused (reduced motion)';
   }
 
   // Pause when tab is hidden, resume when visible

--- a/book/src/components/HighwayBackpressure.astro
+++ b/book/src/components/HighwayBackpressure.astro
@@ -15,11 +15,11 @@
         <path id="hw-path-cont" d="M 560,100 L 775,100" fill="none" />
       </defs>
 
-      <!-- Highway road surface -->
-      <rect x="25" y="84" width="540" height="32" fill="var(--hw-road)" />
-      <line x1="25" y1="84" x2="565" y2="84" stroke="var(--hw-edge)" stroke-width="1.5" />
-      <line x1="25" y1="116" x2="565" y2="116" stroke="var(--hw-edge)" stroke-width="1.5" />
-      <line x1="40" y1="100" x2="550" y2="100" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="14,10" />
+      <!-- Highway road surface (full width including continuation) -->
+      <rect x="25" y="84" width="750" height="32" fill="var(--hw-road)" />
+      <line x1="25" y1="84" x2="775" y2="84" stroke="var(--hw-edge)" stroke-width="1.5" />
+      <line x1="25" y1="116" x2="775" y2="116" stroke="var(--hw-edge)" stroke-width="1.5" />
+      <line x1="40" y1="100" x2="770" y2="100" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="14,10" />
 
       <!-- Direction chevrons on highway -->
       <g opacity="0.25" stroke="var(--hw-dash)" stroke-width="1.5" fill="none">
@@ -36,11 +36,8 @@
       <path d="M 560,100 C 600,100 730,175 730,255" fill="none" stroke="var(--hw-road)" stroke-width="28" stroke-linecap="round" />
       <path d="M 560,100 C 600,100 730,175 730,255" fill="none" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="6,8" />
 
-      <!-- Highway continuation past fork (through traffic) -->
-      <rect x="555" y="84" width="220" height="32" fill="var(--hw-road)" opacity="0.35" />
-      <line x1="555" y1="84" x2="775" y2="84" stroke="var(--hw-edge)" stroke-width="1" opacity="0.25" />
-      <line x1="555" y1="116" x2="775" y2="116" stroke="var(--hw-edge)" stroke-width="1" opacity="0.25" />
-      <line x1="560" y1="100" x2="770" y2="100" stroke="var(--hw-dash)" stroke-width="1" stroke-dasharray="14,10" opacity="0.15" />
+      <!-- Fork marker -->
+      <line x1="560" y1="84" x2="560" y2="116" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="3,3" opacity="0.35" />
 
       <!-- Merge zone marker -->
       <line x1="200" y1="84" x2="200" y2="116" stroke="var(--hw-dash)" stroke-width="1.5" stroke-dasharray="3,3" opacity="0.35" />

--- a/book/src/components/HighwayBackpressure.astro
+++ b/book/src/components/HighwayBackpressure.astro
@@ -70,7 +70,7 @@
         <div xmlns="http://www.w3.org/1999/xhtml" class="hw-stats" id="hw-stats">
           <div class="hw-stat">
             <span class="hw-stat-val" id="hw-s-tput">—</span>
-            <span class="hw-stat-lbl">Delivered</span>
+            <span class="hw-stat-lbl">Throughput</span>
           </div>
           <div class="hw-stat">
             <span class="hw-stat-val" id="hw-s-queue">0</span>

--- a/book/src/components/__tests__/highway-sim.test.mjs
+++ b/book/src/components/__tests__/highway-sim.test.mjs
@@ -241,10 +241,9 @@ describe('red light on exit', function () {
       sim.tick(t * 25);
     }
     var car = sim.getCars().filter(function (c) { return c.segment === 'exit'; })[0];
-    if (car) {
-      assert.ok(car.d <= gateD + 0.01, 'car should stop at or before gateD');
-      assert.ok(car.speed < 0.2, 'car should be stopped');
-    }
+    assert.ok(car, 'car should still be on exit');
+    assert.ok(car.d <= gateD + 0.01, 'car should stop at or before gateD');
+    assert.ok(car.speed < 0.2, 'car should be stopped');
   });
 
   it('backpressure cascades: exit full → highway blocks', function () {
@@ -449,5 +448,19 @@ describe('status', function () {
       frame = sim.tick(t * 25);
     }
     assert.equal(frame.status.level, 'blocked');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Public test helpers
+// ---------------------------------------------------------------------------
+
+describe('test helper controls', function () {
+  it('rejects unknown segment names', function () {
+    var sim = createSimulation({}, fixedScale(1));
+    assert.throws(function () {
+      sim.addCar('unknown', 0, 0);
+    }, /unknown highway simulation segment/);
+    assert.equal(sim.getCars().length, 0);
   });
 });

--- a/book/src/components/__tests__/highway-sim.test.mjs
+++ b/book/src/components/__tests__/highway-sim.test.mjs
@@ -188,9 +188,9 @@ describe('following distance', function () {
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    // Pack cars on the exit segment
+    // Pack cars on the exit segment with proper spacing
     for (var i = 0; i < 5; i++) {
-      sim.addCar('exit', 30 + i * 25, 3.5);
+      sim.addCar('exit', 30 + i * 40, 3.5);
     }
     for (var t = 0; t < 200; t++) {
       sim.tick(t * 25);

--- a/book/src/components/__tests__/highway-sim.test.mjs
+++ b/book/src/components/__tests__/highway-sim.test.mjs
@@ -1,6 +1,8 @@
 /**
  * Tests for highway-sim.mjs — Node 22 built-in test runner.
  *
+ * Multi-route model: ramp → highway → exit (with traffic light on exit).
+ *
  * Run:  node --test book/src/components/__tests__/highway-sim.test.mjs
  */
 import { describe, it } from 'node:test';
@@ -11,10 +13,9 @@ import { createSimulation, fixedScale, DEFAULTS } from '../highway-sim.mjs';
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Advance a simulation N ticks, starting from `start` with `dt` between ticks. */
 function runTicks(sim, n, start, dt) {
   start = start || 0;
-  dt = dt || DEFAULTS.spawnMs + 1; // default: enough time between spawns
+  dt = dt || DEFAULTS.spawnMs + 1;
   var last;
   for (var i = 0; i < n; i++) {
     last = sim.tick(start + i * dt);
@@ -31,24 +32,24 @@ describe('traffic light', function () {
     var sim = createSimulation({ greenPct: 50, cycleTotal: 1000, maxCars: 0 });
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.tick(100); // 100 ms into cycle, green portion = 500ms → green
-    assert.equal(sim.isGreen(), true);
+    var frame = sim.tick(100);
+    assert.equal(frame.lightIsGreen, true);
   });
 
   it('turns red when elapsed >= green portion', function () {
     var sim = createSimulation({ greenPct: 50, cycleTotal: 1000, maxCars: 0 });
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.tick(600); // 600ms > 500ms green → red
-    assert.equal(sim.isGreen(), false);
+    var frame = sim.tick(600);
+    assert.equal(frame.lightIsGreen, false);
   });
 
   it('cycles back to green after cycleTotal', function () {
     var sim = createSimulation({ greenPct: 50, cycleTotal: 1000, maxCars: 0 });
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.tick(1100); // 1100 % 1000 = 100 → green
-    assert.equal(sim.isGreen(), true);
+    var frame = sim.tick(1100);
+    assert.equal(frame.lightIsGreen, true);
   });
 
   it('100% green never goes red', function () {
@@ -56,20 +57,19 @@ describe('traffic light', function () {
     sim.setCycleStart(0);
     sim.exitAuto();
     for (var t = 0; t < 2000; t += 100) {
-      sim.tick(t);
-      assert.equal(sim.isGreen(), true, 'expected green at t=' + t);
+      var frame = sim.tick(t);
+      assert.equal(frame.lightIsGreen, true, 'expected green at t=' + t);
     }
   });
 
-  it('0% green is always red (once past t=0)', function () {
+  it('0% green is always red', function () {
     var sim = createSimulation({ greenPct: 0, cycleTotal: 1000, maxCars: 0 });
     sim.setCycleStart(0);
     sim.exitAuto();
-    // At t=0, elapsed=0, greenMs=0 → 0 < 0 is false → red
-    sim.tick(0);
-    assert.equal(sim.isGreen(), false);
-    sim.tick(500);
-    assert.equal(sim.isGreen(), false);
+    var frame = sim.tick(0);
+    assert.equal(frame.lightIsGreen, false);
+    frame = sim.tick(500);
+    assert.equal(frame.lightIsGreen, false);
   });
 });
 
@@ -81,35 +81,98 @@ describe('car spawning', function () {
   it('spawns a car when enough time has passed', function () {
     var sim = createSimulation({ spawnMs: 100 }, fixedScale(1));
     sim.exitAuto();
-    var frame = sim.tick(200);
-    assert.notEqual(frame.spawned, null, 'should have spawned');
-    assert.equal(sim.getCars().length, 1);
+    sim.tick(200);
+    assert.ok(sim.getCars().length >= 1, 'should have spawned at least one car');
   });
 
   it('respects spawnMs cooldown', function () {
-    var sim = createSimulation({ spawnMs: 500 }, fixedScale(1));
+    var sim = createSimulation({ spawnMs: 500, maxCars: 5 }, fixedScale(1));
     sim.exitAuto();
     sim.tick(600); // first spawn
-    var frame = sim.tick(700); // only 100ms later → no spawn
-    assert.equal(frame.spawned, null);
-    assert.equal(sim.getCars().length, 1);
+    sim.tick(700); // only 100ms later → no new spawn
+    assert.equal(sim.getCars().length, 1, 'should not have spawned twice');
   });
 
-  it('does not spawn when another car blocks the entry', function () {
-    var sim = createSimulation({ spawnMs: 10 }, fixedScale(1));
+  it('alternates between highway and ramp sources', function () {
+    var sim = createSimulation({ spawnMs: 10, maxCars: 10 }, fixedScale(1));
     sim.exitAuto();
-    sim.addCar(5, 0, 1); // parked near d=0
-    var frame = sim.tick(1000);
-    assert.equal(frame.spawned, null, 'should not spawn — entry blocked');
+    sim.tick(100);
+    sim.tick(200);
+    var cars = sim.getCars();
+    var segments = new Set(cars.map(function (c) { return c.segment; }));
+    assert.ok(segments.has('highway') || segments.has('ramp'), 'should spawn on highway or ramp');
+    // With more ticks, should get both
+    for (var t = 3; t <= 8; t++) sim.tick(t * 100);
+    cars = sim.getCars();
+    segments = new Set(cars.map(function (c) { return c.segment; }));
+    assert.ok(segments.size >= 2, 'should spawn on both segments');
   });
 
   it('respects maxCars', function () {
     var sim = createSimulation({ maxCars: 2, spawnMs: 10 }, fixedScale(1));
     sim.exitAuto();
-    sim.addCar(200, 3, 1);
-    sim.addCar(400, 3, 1);
-    var frame = sim.tick(1000);
-    assert.equal(frame.spawned, null, 'at maxCars');
+    sim.addCar('highway', 200, 3);
+    sim.addCar('ramp', 100, 3);
+    sim.tick(1000);
+    assert.equal(sim.getCars().length, 2, 'should not exceed maxCars');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multi-segment transitions
+// ---------------------------------------------------------------------------
+
+describe('segment transitions', function () {
+  it('ramp cars merge onto highway', function () {
+    var sim = createSimulation({
+      lenRamp: 180, lenHwy: 530, lenExit: 210,
+      mergeD: 170, gateD: 130, greenPct: 100,
+      cycleTotal: 100, spawnMs: 99999, maxCars: 5,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.addCar('ramp', 175, 3.5); // near end of ramp
+    for (var t = 0; t < 20; t++) {
+      sim.tick(t * 25);
+    }
+    var cars = sim.getCars();
+    var onHwy = cars.filter(function (c) { return c.segment === 'highway'; });
+    assert.ok(onHwy.length >= 1, 'ramp car should have merged onto highway');
+  });
+
+  it('highway cars transition to exit', function () {
+    var sim = createSimulation({
+      lenRamp: 180, lenHwy: 530, lenExit: 210,
+      mergeD: 170, gateD: 130, greenPct: 100,
+      cycleTotal: 100, spawnMs: 99999, maxCars: 5,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.addCar('highway', 525, 3.5); // near end of highway
+    for (var t = 0; t < 20; t++) {
+      sim.tick(t * 25);
+    }
+    var cars = sim.getCars();
+    var onExit = cars.filter(function (c) { return c.segment === 'exit'; });
+    assert.ok(onExit.length >= 1, 'highway car should have transitioned to exit');
+  });
+
+  it('exit cars are delivered (removed) at end of exit', function () {
+    var sim = createSimulation({
+      lenRamp: 180, lenHwy: 530, lenExit: 210,
+      mergeD: 170, gateD: 130, greenPct: 100,
+      cycleTotal: 100, spawnMs: 99999, maxCars: 5,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.setLastSpawn(99999);
+    sim.addCar('exit', 200, 3.5); // near end of exit
+    var delivered = false;
+    for (var t = 0; t < 20; t++) {
+      var frame = sim.tick(t * 25);
+      if (frame.removedIds.length > 0) delivered = true;
+    }
+    assert.ok(delivered, 'car should have been delivered');
   });
 });
 
@@ -118,90 +181,125 @@ describe('car spawning', function () {
 // ---------------------------------------------------------------------------
 
 describe('following distance', function () {
-  it('cars never overlap (hard gap enforced)', function () {
-    var sim = createSimulation({ greenPct: 0, cycleTotal: 100, gateD: 300, roadLength: 500 }, fixedScale(1));
+  it('cars never overlap within a segment', function () {
+    var sim = createSimulation({
+      greenPct: 0, cycleTotal: 100, gateD: 130,
+      lenExit: 210, lenHwy: 530, spawnMs: 99999,
+    }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    // Place several cars close together
+    // Pack cars on the exit segment
     for (var i = 0; i < 5; i++) {
-      sim.addCar(100 + i * 30, 3.5, 1);
+      sim.addCar('exit', 30 + i * 25, 3.5);
     }
-    // Run many ticks — they should jam up but never overlap
     for (var t = 0; t < 200; t++) {
       sim.tick(t * 25);
-      var sorted = sim.getCars().slice().sort(function (a, b) { return b.d - a.d; });
-      for (var j = 1; j < sorted.length; j++) {
-        var gap = sorted[j - 1].d - sorted[j].d;
-        var minGap = (sorted[j - 1].w + sorted[j].w) / 2 + 6;
+      var cars = sim.getCars().filter(function (c) { return c.segment === 'exit'; });
+      cars.sort(function (a, b) { return b.d - a.d; });
+      for (var j = 1; j < cars.length; j++) {
+        var gap = cars[j - 1].d - cars[j].d;
+        var minGap = (cars[j - 1].w + cars[j].w) / 2 + sim.cfg.minFollowPad;
         assert.ok(gap >= minGap - 0.01,
-          'gap violation: ' + gap.toFixed(2) + ' < ' + minGap.toFixed(2) +
-          ' between cars ' + sorted[j - 1].id + ' and ' + sorted[j].id);
+          'gap violation: ' + gap.toFixed(2) + ' < ' + minGap.toFixed(2));
       }
     }
   });
 
   it('trailing car brakes when getting close', function () {
-    var sim = createSimulation({ greenPct: 100, cycleTotal: 100, followZone: 12 }, fixedScale(1));
+    var sim = createSimulation({
+      greenPct: 100, cycleTotal: 100, followZone: 18,
+      lenHwy: 530, spawnMs: 99999,
+    }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar(40, 0, 1);    // stopped car
-    sim.addCar(10, 3.5, 1);  // fast car approaching — gap=30, minGap=26, brakeZone=38
-    // Run several ticks so the trailing car enters the braking zone
+    sim.addCar('highway', 40, 0); // stopped
+    sim.addCar('highway', 10, 3.5); // fast, approaching
     for (var t = 0; t < 5; t++) {
       sim.tick(t * 25);
     }
-    var cars = sim.getCars().slice().sort(function (a, b) { return a.d - b.d; });
+    var cars = sim.getCars().filter(function (c) { return c.segment === 'highway'; });
+    cars.sort(function (a, b) { return a.d - b.d; });
     assert.ok(cars[0].speed < 3.5, 'trailing car should have braked');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Red light stopping
+// Red light stopping (on exit ramp)
 // ---------------------------------------------------------------------------
 
-describe('red light', function () {
+describe('red light on exit', function () {
   it('lead car stops at gateD on red', function () {
-    var gateD = 300;
+    var gateD = 130;
     var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: gateD, roadLength: 500,
+      greenPct: 0, cycleTotal: 100, gateD: gateD,
+      lenExit: 210, lenHwy: 530, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar(gateD - 20, 3.5, 1); // approaching the line
-    // Run enough ticks for it to reach the line
+    sim.addCar('exit', gateD - 30, 3.5);
     for (var t = 0; t < 50; t++) {
       sim.tick(t * 25);
     }
-    var car = sim.getCars()[0];
-    assert.ok(car.d <= gateD + 0.01, 'car should stop at or before gateD');
-    assert.ok(car.speed < 0.1, 'car should be stopped');
+    var car = sim.getCars().filter(function (c) { return c.segment === 'exit'; })[0];
+    if (car) {
+      assert.ok(car.d <= gateD + 0.01, 'car should stop at or before gateD');
+      assert.ok(car.speed < 0.2, 'car should be stopped');
+    }
   });
 
-  it('cars behind the lead stop via following distance, not light', function () {
-    var gateD = 300;
+  it('backpressure cascades: exit full → highway blocks', function () {
     var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: gateD, roadLength: 500,
+      greenPct: 0, cycleTotal: 100, gateD: 130,
+      lenExit: 210, lenHwy: 530, lenRamp: 180,
+      mergeD: 170, spawnMs: 99999, minFollowPad: 8,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar(gateD - 10, 3.5, 1); // will stop at line
-    sim.addCar(gateD - 40, 3.5, 1); // close behind
-    sim.addCar(gateD - 70, 3.5, 1); // close behind
-    // Run plenty of ticks for cascade to settle
-    for (var t = 0; t < 200; t++) {
+    // Fill exit ramp
+    for (var i = 0; i < 5; i++) {
+      sim.addCar('exit', 20 + i * 25, 3.5);
+    }
+    // Car on highway near the fork
+    sim.addCar('highway', 525, 3.5);
+    for (var t = 0; t < 100; t++) {
       sim.tick(t * 25);
     }
-    var sorted = sim.getCars().slice().sort(function (a, b) { return b.d - a.d; });
-    // All stopped
-    for (var i = 0; i < sorted.length; i++) {
-      assert.ok(sorted[i].speed < 0.1, 'car ' + sorted[i].id + ' should be stopped');
+    var hwyCars = sim.getCars().filter(function (c) { return c.segment === 'highway'; });
+    if (hwyCars.length > 0) {
+      assert.ok(hwyCars[0].speed < 1, 'highway car should be blocked by full exit');
     }
-    // First car at gate
-    assert.ok(sorted[0].d <= gateD + 0.01);
-    // Others behind with valid gaps
-    for (var j = 1; j < sorted.length; j++) {
-      assert.ok(sorted[j].d < sorted[j - 1].d);
-    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Car fade on exit past gate
+// ---------------------------------------------------------------------------
+
+describe('car fade', function () {
+  it('cars past gateD on exit fade toward 0', function () {
+    var sim = createSimulation({
+      greenPct: 100, cycleTotal: 100, gateD: 100,
+      lenExit: 210, lenHwy: 530, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.addCar('exit', 150, 3.5); // already past gate
+    var frame = sim.tick(0);
+    var car = frame.cars.filter(function (c) { return c.segment === 'exit'; })[0];
+    assert.ok(car.opacity < 1, 'car past gateD should have opacity < 1');
+  });
+
+  it('cars before gateD on exit have full opacity', function () {
+    var sim = createSimulation({
+      greenPct: 100, cycleTotal: 100, gateD: 130,
+      lenExit: 210, lenHwy: 530, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.addCar('exit', 50, 3.5);
+    var frame = sim.tick(0);
+    var car = frame.cars.filter(function (c) { return c.segment === 'exit'; })[0];
+    assert.equal(car.opacity, 1, 'car before gateD should have full opacity');
   });
 });
 
@@ -212,29 +310,28 @@ describe('red light', function () {
 describe('stats', function () {
   it('throughput counts deliveries in last 5 seconds', function () {
     var sim = createSimulation({
-      roadLength: 100, rampEnd: 10, gateD: 80, greenPct: 100,
-      cycleTotal: 100, spawnMs: 9999,
+      lenExit: 100, lenHwy: 200, lenRamp: 100,
+      mergeD: 50, gateD: 80, greenPct: 100,
+      cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    // Place a car that will exit quickly
-    sim.addCar(90, 3.5, 1);
+    sim.addCar('exit', 95, 3.5); // near exit end
     var frame;
     for (var t = 0; t < 40; t++) {
       frame = sim.tick(t * 25);
     }
-    // The car should have exited → throughput > 0
     assert.ok(frame.stats.throughput > 0, 'should have recorded delivery');
   });
 
   it('stallPct increases when cars are stalled', function () {
     var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: 200, roadLength: 400,
-      spawnMs: 9999,
+      greenPct: 0, cycleTotal: 100, gateD: 130,
+      lenExit: 210, lenHwy: 530, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar(190, 0, 1); // already stopped near gate
+    sim.addCar('exit', 125, 0); // stopped near gate
     var frame;
     for (var t = 0; t < 20; t++) {
       frame = sim.tick(t * 25);
@@ -250,15 +347,14 @@ describe('stats', function () {
 describe('auto-sweep', function () {
   it('decreases greenPct when direction is -1', function () {
     var sim = createSimulation({ greenPct: 50, maxCars: 0 });
-    var initial = sim.getGreenPct();
     sim.tick(0);
-    assert.ok(sim.getGreenPct() <= initial, 'should decrease or stay');
+    assert.ok(sim.tick(1).greenPct <= 50, 'should decrease or stay');
   });
 
   it('bounces at autoMin', function () {
-    var sim = createSimulation({ greenPct: 6, autoSpeed: 10, autoMin: 5, autoMax: 95, maxCars: 0 });
-    sim.tick(0); // should push below 5 then clamp
-    assert.ok(sim.getGreenPct() >= 5, 'should not go below autoMin');
+    var sim = createSimulation({ greenPct: 6, autoSpeed: 10, autoMin: 5, autoMax: 100, maxCars: 0 });
+    var frame = sim.tick(0);
+    assert.ok(frame.greenPct >= 5, 'should not go below autoMin');
   });
 
   it('stops when setGreenPct is called', function () {
@@ -267,9 +363,8 @@ describe('auto-sweep', function () {
     assert.equal(sim.isAuto(), true);
     sim.setGreenPct(70);
     assert.equal(sim.isAuto(), false);
-    var before = sim.getGreenPct();
-    sim.tick(100);
-    assert.equal(sim.getGreenPct(), before, 'should not change in manual mode');
+    var frame = sim.tick(100);
+    assert.equal(frame.greenPct, 70, 'should not change in manual mode');
   });
 });
 
@@ -279,54 +374,29 @@ describe('auto-sweep', function () {
 
 describe('car size variety', function () {
   it('cars have different widths with default scale', function () {
-    var sim = createSimulation({ maxCars: 20, spawnMs: 1 });
+    var sim = createSimulation({ maxCars: 20, spawnMs: 99999 });
     sim.exitAuto();
-    // Spawn several cars
     for (var i = 0; i < 10; i++) {
-      sim.addCar(i * 50);
+      sim.addCar('highway', i * 50, 3.5);
     }
     var cars = sim.getCars();
     var widths = new Set(cars.map(function (c) { return c.w; }));
-    // With random scales, extremely unlikely all 10 identical
     assert.ok(widths.size > 1, 'expected varied widths');
   });
 
   it('fixedScale produces uniform scale but shape-dependent widths', function () {
     var sim = createSimulation({}, fixedScale(1.0));
-    // Spawn 4 cars to cover all shapes (sedan, truck, compact, van)
-    sim.addCar(0);
-    sim.addCar(100);
-    sim.addCar(200);
-    sim.addCar(300);
+    sim.addCar('highway', 0, 3.5);
+    sim.addCar('highway', 100, 3.5);
+    sim.addCar('highway', 200, 3.5);
+    sim.addCar('highway', 300, 3.5);
     var cars = sim.getCars();
-    // All have scale 1.0
     for (var i = 0; i < cars.length; i++) {
       assert.equal(cars[i].scale, 1.0);
     }
-    // sedan (id 0) and van (id 3) have w = carW * 1.0
     assert.equal(cars[0].w, DEFAULTS.carW * 1.0); // sedan
-    // truck (id 1) has w = carW * 1.3
     assert.equal(cars[1].w, DEFAULTS.carW * 1.3); // truck
-    // compact (id 2) has w = carW * 0.8
     assert.equal(cars[2].w, DEFAULTS.carW * 0.8); // compact
-  });
-
-  it('gap enforcement accounts for different car sizes', function () {
-    var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: 200, roadLength: 400,
-    });
-    sim.setCycleStart(0);
-    sim.exitAuto();
-    // Big car followed by small car
-    sim.addCar(190, 0, 1.3);
-    sim.addCar(170, 3.5, 0.7);
-    for (var t = 0; t < 30; t++) {
-      sim.tick(t * 25);
-    }
-    var sorted = sim.getCars().slice().sort(function (a, b) { return b.d - a.d; });
-    var gap = sorted[0].d - sorted[1].d;
-    var minGap = (sorted[0].w + sorted[1].w) / 2 + 6;
-    assert.ok(gap >= minGap - 0.01, 'gap should respect varied sizes');
   });
 });
 
@@ -337,31 +407,33 @@ describe('car size variety', function () {
 describe('status', function () {
   it('reports flowing when everything is moving', function () {
     var sim = createSimulation({
-      greenPct: 100, cycleTotal: 100, roadLength: 500, spawnMs: 9999,
+      greenPct: 100, cycleTotal: 100, lenHwy: 530, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar(200, 3.5, 1);
+    sim.addCar('highway', 200, 3.5);
     var frame = sim.tick(0);
     assert.equal(frame.status.level, 'flowing');
   });
 
   it('reports blocked when ramp stalls', function () {
-    var rampEnd = 150;
-    var gateD = 300;
-    // minGap per car = 20 + 6 = 26 (all scale=1)
     var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: gateD, roadLength: 400,
-      rampEnd: rampEnd, spawnMs: 9999,
+      greenPct: 0, cycleTotal: 100,
+      lenHwy: 530, lenRamp: 180, lenExit: 210,
+      mergeD: 170, gateD: 130, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    // Pack a chain of cars from the gate back past the ramp.
-    // Lead car at gate, then spaced at minGap intervals back into ramp zone.
-    for (var i = 0; i < 12; i++) {
-      sim.addCar(gateD - i * 26, 0, 1);
+    // Fill exit to create backpressure
+    for (var i = 0; i < 4; i++) {
+      sim.addCar('exit', 20 + i * 28, 0);
     }
-    // Last car is at gateD - 11*26 = 300 - 286 = 14, well inside rampEnd=150.
+    // Fill highway back toward merge
+    for (var j = 0; j < 15; j++) {
+      sim.addCar('highway', 50 + j * 30, 0);
+    }
+    // Stuck ramp car
+    sim.addCar('ramp', 175, 0);
     var frame;
     for (var t = 0; t < 20; t++) {
       frame = sim.tick(t * 25);

--- a/book/src/components/__tests__/highway-sim.test.mjs
+++ b/book/src/components/__tests__/highway-sim.test.mjs
@@ -250,24 +250,28 @@ describe('red light on exit', function () {
   it('backpressure cascades: exit full → highway blocks', function () {
     var sim = createSimulation({
       greenPct: 0, cycleTotal: 100, gateD: 130,
-      lenExit: 210, lenHwy: 530, lenRamp: 180,
+      lenExit: 210, lenHwy: 530, lenRamp: 180, lenCont: 215,
       mergeD: 170, spawnMs: 99999, minFollowPad: 8,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    // Fill exit ramp
+    // Fill exit ramp with stopped cars
     for (var i = 0; i < 5; i++) {
-      sim.addCar('exit', 20 + i * 25, 3.5);
+      sim.addCar('exit', 10 + i * 25, 0);
+    }
+    // Fill continuation with stopped cars packed tight
+    for (var j = 0; j < 8; j++) {
+      sim.addCar('cont', j * 25, 0);
     }
     // Car on highway near the fork
     sim.addCar('highway', 525, 3.5);
-    for (var t = 0; t < 100; t++) {
+    // Only a few ticks — before cont cars can accelerate away
+    for (var t = 0; t < 5; t++) {
       sim.tick(t * 25);
     }
     var hwyCars = sim.getCars().filter(function (c) { return c.segment === 'highway'; });
-    if (hwyCars.length > 0) {
-      assert.ok(hwyCars[0].speed < 1, 'highway car should be blocked by full exit');
-    }
+    assert.ok(hwyCars.length > 0, 'car should still be on highway');
+    assert.ok(hwyCars[0].speed < 1, 'highway car should be blocked by full exit+cont');
   });
 });
 
@@ -416,11 +420,12 @@ describe('status', function () {
     assert.equal(frame.status.level, 'flowing');
   });
 
-  it('reports blocked when ramp stalls', function () {
+  it('reports blocked when entrance is blocked', function () {
     var sim = createSimulation({
       greenPct: 0, cycleTotal: 100,
-      lenHwy: 530, lenRamp: 180, lenExit: 210,
-      mergeD: 170, gateD: 130, spawnMs: 99999,
+      lenHwy: 530, lenRamp: 180, lenExit: 210, lenCont: 215,
+      mergeD: 170, gateD: 130, spawnMs: 10,
+      spawnBlockedThreshold: 5,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
@@ -428,14 +433,19 @@ describe('status', function () {
     for (var i = 0; i < 4; i++) {
       sim.addCar('exit', 20 + i * 28, 0);
     }
-    // Fill highway back toward merge
-    for (var j = 0; j < 15; j++) {
-      sim.addCar('highway', 50 + j * 30, 0);
+    // Fill continuation too
+    for (var ic = 0; ic < 3; ic++) {
+      sim.addCar('cont', 5 + ic * 25, 0);
     }
-    // Stuck ramp car
-    sim.addCar('ramp', 175, 0);
+    // Fill highway back toward start — blocks spawn space
+    for (var j = 0; j < 18; j++) {
+      sim.addCar('highway', 10 + j * 28, 0);
+    }
+    // Stuck ramp car — blocks ramp spawn space
+    sim.addCar('ramp', 5, 0);
     var frame;
-    for (var t = 0; t < 20; t++) {
+    // Run enough ticks for spawnBlockedThreshold to trigger
+    for (var t = 0; t < 30; t++) {
       frame = sim.tick(t * 25);
     }
     assert.equal(frame.status.level, 'blocked');

--- a/book/src/components/__tests__/highway-sim.test.mjs
+++ b/book/src/components/__tests__/highway-sim.test.mjs
@@ -23,6 +23,12 @@ function runTicks(sim, n, start, dt) {
   return last;
 }
 
+function newestCar(cars) {
+  return cars.reduce(function (newest, car) {
+    return !newest || car.id > newest.id ? car : newest;
+  }, null);
+}
+
 // ---------------------------------------------------------------------------
 // Traffic light cycling
 // ---------------------------------------------------------------------------
@@ -97,15 +103,23 @@ describe('car spawning', function () {
     var sim = createSimulation({ spawnMs: 10, maxCars: 10 }, fixedScale(1));
     sim.exitAuto();
     sim.tick(100);
-    sim.tick(200);
     var cars = sim.getCars();
-    var segments = new Set(cars.map(function (c) { return c.segment; }));
-    assert.ok(segments.has('highway') || segments.has('ramp'), 'should spawn on highway or ramp');
-    // With more ticks, should get both
-    for (var t = 3; t <= 8; t++) sim.tick(t * 100);
+    assert.equal(cars.length, 1);
+    assert.equal(newestCar(cars).segment, 'highway');
+
+    sim.tick(200);
     cars = sim.getCars();
-    segments = new Set(cars.map(function (c) { return c.segment; }));
-    assert.ok(segments.size >= 2, 'should spawn on both segments');
+    assert.equal(cars.length, 2);
+    assert.equal(newestCar(cars).segment, 'ramp');
+
+    for (var t = 3; t <= 6; t++) {
+      sim.tick(t * 100);
+      cars = sim.getCars();
+      cars.sort(function (a, b) { return a.id - b.id; });
+      var newest = cars[cars.length - 1];
+      var previous = cars[cars.length - 2];
+      assert.notEqual(newest.segment, previous.segment, 'spawn source should alternate');
+    }
   });
 
   it('respects maxCars', function () {
@@ -272,6 +286,27 @@ describe('red light on exit', function () {
     assert.ok(hwyCars.length > 0, 'car should still be on highway');
     assert.ok(hwyCars[0].speed < 1, 'highway car should be blocked by full exit+cont');
   });
+
+  it('red exit saturation blocks instead of bypassing through continuation', function () {
+    var sim = createSimulation({
+      greenPct: 0, cycleTotal: 100,
+      lenExit: 210, lenHwy: 530, lenCont: 215,
+      gateD: 130, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.setLastSpawn(99999);
+    sim.addCar('exit', 12, 0);
+    sim.addCar('highway', 528, 3.5);
+
+    var frame = sim.tick(100);
+    var hwyCars = frame.cars.filter(function (c) { return c.segment === 'highway'; });
+    var contCars = frame.cars.filter(function (c) { return c.segment === 'cont'; });
+
+    assert.equal(contCars.length, 0, 'red exit saturation should not route into continuation');
+    assert.equal(hwyCars.length, 1, 'car should remain on highway');
+    assert.ok(hwyCars[0].speed < 1, 'car should brake at the fork');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -424,7 +459,7 @@ describe('status', function () {
       greenPct: 0, cycleTotal: 100,
       lenHwy: 530, lenRamp: 180, lenExit: 210, lenCont: 215,
       mergeD: 170, gateD: 130, spawnMs: 10,
-      spawnBlockedThreshold: 5,
+      spawnBlockedThreshold: 5, maxCars: 60,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
@@ -448,6 +483,21 @@ describe('status', function () {
       frame = sim.tick(t * 25);
     }
     assert.equal(frame.status.level, 'blocked');
+  });
+
+  it('does not report blocked only because maxCars is reached', function () {
+    var sim = createSimulation({
+      maxCars: 1, spawnMs: 10, spawnBlockedThreshold: 2,
+      greenPct: 100, cycleTotal: 100,
+    }, fixedScale(1));
+    sim.exitAuto();
+    sim.addCar('highway', 200, 3.5);
+
+    var frame;
+    for (var t = 0; t < 10; t++) {
+      frame = sim.tick(t * 25);
+    }
+    assert.notEqual(frame.status.level, 'blocked');
   });
 });
 

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -20,12 +20,12 @@ export var DEFAULTS = {
   mergeD: 170,
   gateD: 130,
   carW: 20,
-  minFollowPad: 26,
+  minFollowPad: 14,
   speedMax: 3.5,
-  spawnMs: 500,
+  spawnMs: 420,
   cycleTotal: 3000,
   greenPct: 80,
-  maxCars: 16,
+  maxCars: 22,
   lerpRate: 0.25,
   brakeRate: 0.3,
   followZone: 18,
@@ -322,6 +322,66 @@ export function createSimulation(overrides, scaleFn) {
     }
   }
 
+  // ---- cross-segment proximity braking ----
+  // Cars on different segments share SVG space at junctions. Slow them
+  // to avoid visual overlap even though they're in different arrays.
+
+  function crossSegmentBrake() {
+    var pad = cfg.minFollowPad;
+
+    // Merge zone: ramp cars approaching end vs highway cars near mergeD
+    for (var r = 0; r < carsRamp.length; r++) {
+      var rc = carsRamp[r];
+      if (rc.d < cfg.lenRamp - 40) continue;
+      for (var h = 0; h < carsHwy.length; h++) {
+        var hc = carsHwy[h];
+        if (Math.abs(hc.d - cfg.mergeD) > 40) continue;
+        // Virtual distance: how close they are to the merge point
+        var rDist = cfg.lenRamp - rc.d;
+        var hDist = Math.abs(hc.d - cfg.mergeD);
+        var proximity = rDist + hDist;
+        var needed = (rc.w + hc.w) / 2 + pad;
+        if (proximity < needed + 15) {
+          var brake = Math.max(0, (proximity - needed) * 0.15);
+          rc.speed = Math.min(rc.speed, brake);
+        }
+      }
+    }
+
+    // Fork zone: highway cars approaching end vs exit/cont cars near entry
+    for (var hi = 0; hi < carsHwy.length; hi++) {
+      var hwc = carsHwy[hi];
+      if (hwc.d < cfg.lenHwy - 40) continue;
+      var hwyDist = cfg.lenHwy - hwc.d;
+
+      // Check exit cars near entry
+      for (var e = 0; e < carsExit.length; e++) {
+        var ec = carsExit[e];
+        if (ec.d > cfg.exitEntryD + 30) continue;
+        var eDist = ec.d;
+        var prox = hwyDist + eDist;
+        var need = (hwc.w + ec.w) / 2 + pad;
+        if (prox < need + 15) {
+          var br = Math.max(0, (prox - need) * 0.15);
+          hwc.speed = Math.min(hwc.speed, br);
+        }
+      }
+
+      // Check cont cars near entry
+      for (var cc = 0; cc < carsCont.length; cc++) {
+        var co = carsCont[cc];
+        if (co.d > cfg.contEntryD + 30) continue;
+        var cDist = co.d;
+        var prox2 = hwyDist + cDist;
+        var need2 = (hwc.w + co.w) / 2 + pad;
+        if (prox2 < need2 + 15) {
+          var br2 = Math.max(0, (prox2 - need2) * 0.15);
+          hwc.speed = Math.min(hwc.speed, br2);
+        }
+      }
+    }
+  }
+
   // ---- main tick ----
 
   function tick(now) {
@@ -372,7 +432,10 @@ export function createSimulation(overrides, scaleFn) {
     // 9. Try merge again
     tryRampMerge();
 
-    // 10. Spawn
+    // 10. Cross-segment proximity braking (prevent visual overlap at junctions)
+    crossSegmentBrake();
+
+    // 11. Spawn
     var spawned = trySpawn(now);
     if (!spawned && now - lastSpawn >= cfg.spawnMs) {
       spawnBlockedTicks++;

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -35,6 +35,10 @@ export var DEFAULTS = {
   scaleMin: 0.7,
   scaleMax: 1.3,
   spawnBlockedThreshold: 8,
+  exitEntryD: 12,
+  hwyForkThreshold: 5,
+  hwyBlockedOffset: 4,
+  rampMergeThreshold: 3,
 };
 
 var SHAPES = ['sedan', 'truck', 'compact', 'van'];
@@ -96,6 +100,11 @@ export function createSimulation(overrides, scaleFn) {
     return car;
   }
 
+  function nextCarWidth(scale) {
+    var shape = SHAPES[nextId % SHAPES.length];
+    return cfg.carW * scale * (SHAPE_W[shape] || 1);
+  }
+
   function carColor(car) {
     if (car.speed < 0.15) return 'stop';
     if (car.speed < cfg.speedMax * 0.35) return 'slow';
@@ -108,6 +117,10 @@ export function createSimulation(overrides, scaleFn) {
 
   function allCars() {
     return carsRamp.concat(carsHwy, carsExit, carsCont);
+  }
+
+  function totalCars() {
+    return carsRamp.length + carsHwy.length + carsExit.length + carsCont.length;
   }
 
   // ---- light ----
@@ -128,33 +141,33 @@ export function createSimulation(overrides, scaleFn) {
 
   // ---- spawning ----
 
-  function hasSpawnSpace(cars) {
+  function hasSpawnSpace(cars, entrantW) {
     for (var j = 0; j < cars.length; j++) {
-      if (cars[j].d < cfg.minFollowPad + cars[j].w) return false;
+      if (cars[j].d < (entrantW + cars[j].w) / 2 + cfg.minFollowPad) return false;
     }
     return true;
   }
 
+  function trySpawnAt(segment, cars) {
+    var scale = getScale();
+    if (!hasSpawnSpace(cars, nextCarWidth(scale))) return null;
+    var car = makeCar(segment, 0, null, scale);
+    cars.push(car);
+    return car;
+  }
+
   function trySpawn(now) {
-    if (allCars().length >= cfg.maxCars) return null;
+    if (totalCars() >= cfg.maxCars) return null;
     if (now - lastSpawn < cfg.spawnMs) return null;
 
     var src = spawnSrc;
     spawnSrc = 1 - spawnSrc;
     var car = null;
 
-    if (src === 0 && hasSpawnSpace(carsHwy)) {
-      car = makeCar('highway', 0);
-      carsHwy.push(car);
-    } else if (src === 1 && hasSpawnSpace(carsRamp)) {
-      car = makeCar('ramp', 0);
-      carsRamp.push(car);
-    } else if (src === 0 && hasSpawnSpace(carsRamp)) {
-      car = makeCar('ramp', 0);
-      carsRamp.push(car);
-    } else if (src === 1 && hasSpawnSpace(carsHwy)) {
-      car = makeCar('highway', 0);
-      carsHwy.push(car);
+    if (src === 0) {
+      car = trySpawnAt('highway', carsHwy) || trySpawnAt('ramp', carsRamp);
+    } else {
+      car = trySpawnAt('ramp', carsRamp) || trySpawnAt('highway', carsHwy);
     }
 
     if (car) lastSpawn = now;
@@ -236,13 +249,12 @@ export function createSimulation(overrides, scaleFn) {
 
   function canEnterExit(enterW) {
     var w = enterW || cfg.carW;
-    var minD = Infinity;
+    var lead = null;
     for (var j = 0; j < carsExit.length; j++) {
-      if (carsExit[j].d < minD) minD = carsExit[j].d;
+      if (!lead || carsExit[j].d < lead.d) lead = carsExit[j];
     }
-    // Cars enter exit at d=12, so check from that offset
-    var entryD = 12;
-    return (minD - entryD) > (w + cfg.carW) / 2 + cfg.minFollowPad;
+    if (!lead) return true;
+    return (lead.d - cfg.exitEntryD) > (w + lead.w) / 2 + cfg.minFollowPad;
   }
 
   function canMergeAt(d, w) {
@@ -256,11 +268,12 @@ export function createSimulation(overrides, scaleFn) {
 
   function canEnterCont(enterW) {
     var w = enterW || cfg.carW;
-    var minD = Infinity;
+    var lead = null;
     for (var j = 0; j < carsCont.length; j++) {
-      if (carsCont[j].d < minD) minD = carsCont[j].d;
+      if (!lead || carsCont[j].d < lead.d) lead = carsCont[j];
     }
-    return minD > (w + cfg.carW) / 2 + cfg.minFollowPad;
+    if (!lead) return true;
+    return lead.d > (w + lead.w) / 2 + cfg.minFollowPad;
   }
 
   function tryHwyToExit() {
@@ -268,12 +281,12 @@ export function createSimulation(overrides, scaleFn) {
     carsHwy.sort(function (a, b) { return b.d - a.d; });
     while (carsHwy.length > 0) {
       var front = carsHwy[0];
-      if (front.d < cfg.lenHwy - 5) break;
+      if (front.d < cfg.lenHwy - cfg.hwyForkThreshold) break;
       if (canEnterExit(front.w)) {
         // Take the exit ramp
         carsHwy.splice(0, 1);
         front.segment = 'exit';
-        front.d = 12;
+        front.d = cfg.exitEntryD;
         front.speed = Math.min(front.speed, cfg.speedMax * 0.8);
         carsExit.push(front);
       } else if (canEnterCont(front.w)) {
@@ -285,7 +298,7 @@ export function createSimulation(overrides, scaleFn) {
         carsCont.push(front);
       } else {
         // Both paths full — block at the fork
-        front.d = cfg.lenHwy - 4;
+        front.d = cfg.lenHwy - cfg.hwyBlockedOffset;
         front.speed = 0;
         break;
       }
@@ -296,7 +309,7 @@ export function createSimulation(overrides, scaleFn) {
     if (carsRamp.length === 0) return;
     carsRamp.sort(function (a, b) { return b.d - a.d; });
     var front = carsRamp[0];
-    if (front.d < cfg.lenRamp - 3) return;
+    if (front.d < cfg.lenRamp - cfg.rampMergeThreshold) return;
     if (canMergeAt(cfg.mergeD, front.w)) {
       carsRamp.splice(0, 1);
       front.segment = 'highway';
@@ -396,7 +409,7 @@ export function createSimulation(overrides, scaleFn) {
       lightIsGreen: lightIsGreen,
       greenPct: greenPct,
       autoMode: autoMode,
-      stats: { throughput: throughput, queued: carsHwy.length + carsExit.length, stallPct: stallPct },
+      stats: { throughput: throughput, queued: all.length, stallPct: stallPct },
       status: status,
     };
   }
@@ -415,6 +428,9 @@ export function createSimulation(overrides, scaleFn) {
     setCycleStart: function (t) { cycleStart = t; },
     setLastSpawn: function (t) { lastSpawn = t; },
     addCar: function (segment, d, speed, scale) {
+      if (segment !== 'ramp' && segment !== 'highway' && segment !== 'exit' && segment !== 'cont') {
+        throw new Error('unknown highway simulation segment: ' + segment);
+      }
       var car = makeCar(segment, d, speed, scale);
       if (segment === 'ramp') carsRamp.push(car);
       else if (segment === 'highway') carsHwy.push(car);

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -4,17 +4,19 @@
  * Multi-route model:
  *   highway: cars enter from left, travel right to the fork
  *   ramp:    cars enter from bottom-left, merge into highway at mergeD
- *   exit:    all cars leave highway via exit ramp (has traffic light)
+ *   exit:    cars leave highway via exit ramp (has traffic light)
+ *   cont:    cars continue east past the fork (fade out, always flowing)
  *
- * The highway visually continues right past the fork but all simulated
- * cars take the exit ramp. When the light is red, the exit backs up →
- * highway backs up → on-ramp stalls. Cars fade out past the light.
+ * At the fork, cars prefer the exit ramp. When the exit backs up,
+ * cars that can't exit continue east. Eventually the backup cascades
+ * to block the highway and on-ramp entrances.
  */
 
 export var DEFAULTS = {
   lenRamp: 180,
   lenHwy: 530,
   lenExit: 210,
+  lenCont: 215,
   mergeD: 170,
   gateD: 130,
   carW: 20,
@@ -32,6 +34,7 @@ export var DEFAULTS = {
   autoMax: 100,
   scaleMin: 0.7,
   scaleMax: 1.3,
+  spawnBlockedThreshold: 8,
 };
 
 var SHAPES = ['sedan', 'truck', 'compact', 'van'];
@@ -55,6 +58,7 @@ export function createSimulation(overrides, scaleFn) {
   var carsRamp = [];
   var carsHwy = [];
   var carsExit = [];
+  var carsCont = [];
 
   var lightIsGreen = true;
   var greenPct = cfg.greenPct;
@@ -69,6 +73,7 @@ export function createSimulation(overrides, scaleFn) {
   var deliveries = [];
   var stalledFrames = 0;
   var totalFrames = 0;
+  var spawnBlockedTicks = 0;
 
   // ---- helpers ----
 
@@ -102,7 +107,7 @@ export function createSimulation(overrides, scaleFn) {
   }
 
   function allCars() {
-    return carsRamp.concat(carsHwy, carsExit);
+    return carsRamp.concat(carsHwy, carsExit, carsCont);
   }
 
   // ---- light ----
@@ -213,8 +218,11 @@ export function createSimulation(overrides, scaleFn) {
 
       if (car.d < 0) car.d = 0;
 
-      // Fade past gate on exit
-      if (opts.fade && car.d > cfg.gateD) {
+      // Fade past gate on exit, or full-length fade on continuation
+      if (opts.fade && opts.fadeLen) {
+        var fadeStart = opts.fadeStart || 0;
+        car.opacity = Math.max(0, 1 - (car.d - fadeStart) / opts.fadeLen);
+      } else if (opts.fade && car.d > cfg.gateD) {
         car.opacity = Math.max(0, 1 - (car.d - cfg.gateD) / (segLen - cfg.gateD));
       } else {
         car.opacity = 1;
@@ -246,6 +254,15 @@ export function createSimulation(overrides, scaleFn) {
     return true;
   }
 
+  function canEnterCont(enterW) {
+    var w = enterW || cfg.carW;
+    var minD = Infinity;
+    for (var j = 0; j < carsCont.length; j++) {
+      if (carsCont[j].d < minD) minD = carsCont[j].d;
+    }
+    return minD > (w + cfg.carW) / 2 + cfg.minFollowPad;
+  }
+
   function tryHwyToExit() {
     if (carsHwy.length === 0) return;
     carsHwy.sort(function (a, b) { return b.d - a.d; });
@@ -253,14 +270,21 @@ export function createSimulation(overrides, scaleFn) {
       var front = carsHwy[0];
       if (front.d < cfg.lenHwy - 5) break;
       if (canEnterExit(front.w)) {
+        // Take the exit ramp
         carsHwy.splice(0, 1);
         front.segment = 'exit';
-        // Start past the fork point so cars don't overlap with blocked highway cars
         front.d = 12;
         front.speed = Math.min(front.speed, cfg.speedMax * 0.8);
         carsExit.push(front);
+      } else if (canEnterCont(front.w)) {
+        // Exit full — continue east
+        carsHwy.splice(0, 1);
+        front.segment = 'cont';
+        front.d = 0;
+        front.speed = Math.min(front.speed, cfg.speedMax);
+        carsCont.push(front);
       } else {
-        // Block a few px before the absolute end to leave visual room for the fork
+        // Both paths full — block at the fork
         front.d = cfg.lenHwy - 4;
         front.speed = 0;
         break;
@@ -293,7 +317,7 @@ export function createSimulation(overrides, scaleFn) {
 
     var removedIds = [];
 
-    // 1. Remove delivered
+    // 1. Remove delivered (exit faded, cont off-screen)
     for (var i = carsExit.length - 1; i >= 0; i--) {
       if (carsExit[i].d >= cfg.lenExit || carsExit[i].opacity <= 0.01) {
         removedIds.push(carsExit[i].id);
@@ -301,32 +325,46 @@ export function createSimulation(overrides, scaleFn) {
         carsExit.splice(i, 1);
       }
     }
+    for (var ic = carsCont.length - 1; ic >= 0; ic--) {
+      if (carsCont[ic].d >= cfg.lenCont || carsCont[ic].opacity <= 0.01) {
+        removedIds.push(carsCont[ic].id);
+        carsCont.splice(ic, 1);
+      }
+    }
 
-    // 2. Move exit (downstream first — frees space)
+    // 2. Move continuation (always free-flowing, fade out)
+    moveSegment(carsCont, cfg.lenCont, { fade: true, fadeStart: 0, fadeLen: cfg.lenCont });
+
+    // 3. Move exit (downstream first — frees space)
     moveSegment(carsExit, cfg.lenExit, { hasGate: true, fade: true });
 
-    // 3. Highway → exit
+    // 4. Highway → exit or continuation
     tryHwyToExit();
 
-    // 4. Move highway
-    var exitFull = !canEnterExit(cfg.carW);
-    moveSegment(carsHwy, cfg.lenHwy, { endBlocked: exitFull });
+    // 5. Move highway — block only if BOTH exit and cont are full
+    var forkFull = !canEnterExit(cfg.carW) && !canEnterCont(cfg.carW);
+    moveSegment(carsHwy, cfg.lenHwy, { endBlocked: forkFull });
 
-    // 5. Try transition again (car may have moved to end this tick)
+    // 6. Try transition again (car may have moved to end this tick)
     tryHwyToExit();
 
-    // 6. Ramp → highway
+    // 7. Ramp → highway
     tryRampMerge();
 
-    // 7. Move ramp
+    // 8. Move ramp
     var mergeFull = !canMergeAt(cfg.mergeD, cfg.carW);
     moveSegment(carsRamp, cfg.lenRamp, { endBlocked: mergeFull });
 
-    // 8. Try merge again
+    // 9. Try merge again
     tryRampMerge();
 
-    // 9. Spawn
-    trySpawn(now);
+    // 10. Spawn
+    var spawned = trySpawn(now);
+    if (!spawned && now - lastSpawn >= cfg.spawnMs) {
+      spawnBlockedTicks++;
+    } else if (spawned) {
+      spawnBlockedTicks = 0;
+    }
 
     // Stats
     var cutoff = now - 5000;
@@ -335,22 +373,18 @@ export function createSimulation(overrides, scaleFn) {
 
     var all = allCars();
     var stalledCount = 0;
-    var rampBlocked = false;
     for (var s = 0; s < all.length; s++) {
-      if (all[s].speed < 0.15) {
-        stalledCount++;
-        if (all[s].segment === 'ramp' && all[s].d >= cfg.lenRamp - 5) rampBlocked = true;
-        if (all[s].segment === 'highway' && all[s].d < 10) rampBlocked = true;
-      }
+      if (all[s].speed < 0.15 && all[s].segment !== 'cont') stalledCount++;
     }
     if (stalledCount > 0) stalledFrames++;
 
     var stallPct = totalFrames > 0 ? Math.round(stalledFrames / totalFrames * 100) : 0;
 
+    // Status — only "blocked" when spawn entrance is actually blocked
     var status;
-    if (rampBlocked) {
+    if (spawnBlockedTicks >= cfg.spawnBlockedThreshold) {
       status = { level: 'blocked', msg: 'Traffic backed up to the on-ramp \u2014 no new cars can enter' };
-    } else if (stalledCount > all.length * 0.4) {
+    } else if (stalledCount > 3) {
       status = { level: 'congested', msg: 'Highway congested \u2014 cars queuing behind the light' };
     } else {
       status = { level: 'flowing', msg: 'Flowing \u2014 traffic moving freely' };
@@ -385,6 +419,7 @@ export function createSimulation(overrides, scaleFn) {
       if (segment === 'ramp') carsRamp.push(car);
       else if (segment === 'highway') carsHwy.push(car);
       else if (segment === 'exit') carsExit.push(car);
+      else if (segment === 'cont') carsCont.push(car);
       return car;
     },
     cfg: cfg,

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -1,139 +1,116 @@
 /**
  * Highway backpressure simulation — pure logic, no DOM.
  *
- * Models a single-lane road with:
- *  - Steady car spawning at one end
- *  - A traffic light that cycles red/green near the far end
- *  - Following-distance braking (only the lead car sees the red light;
- *    everyone else brakes because the car ahead slowed)
- *  - Stats: throughput, queue depth, stall %
- *  - Auto-sweep that oscillates greenPct until the user takes over
+ * Multi-route model:
+ *   highway: cars enter from left, travel right to the fork
+ *   ramp:    cars enter from bottom-left, merge into highway at mergeD
+ *   exit:    all cars leave highway via exit ramp (has traffic light)
  *
- * The UI layer (HighwayBackpressure.astro) maps 1-D distance values
- * returned here to SVG coordinates via getPointAtLength().
+ * The highway visually continues right past the fork but all simulated
+ * cars take the exit ramp. When the light is red, the exit backs up →
+ * highway backs up → on-ramp stalls. Cars fade out past the light.
  */
 
-// Exported so tests can reference them.
 export var DEFAULTS = {
-  roadLength: 700,
-  rampEnd: 150,
-  gateD: 600,
+  lenRamp: 180,
+  lenHwy: 530,
+  lenExit: 210,
+  mergeD: 170,
+  gateD: 130,
   carW: 20,
-  minFollowPad: 6,
+  minFollowPad: 8,
   speedMax: 3.5,
-  spawnMs: 450,
+  spawnMs: 420,
   cycleTotal: 3000,
   greenPct: 80,
-  maxCars: 30,
-  lerpRate: 0.3,
-  brakeRate: 0.35,
-  followZone: 12,
+  maxCars: 35,
+  lerpRate: 0.25,
+  brakeRate: 0.3,
+  followZone: 18,
   autoSpeed: 0.15,
   autoMin: 5,
-  autoMax: 95,
-  carScaleMin: 0.7,
-  carScaleRange: 0.6,
+  autoMax: 100,
+  scaleMin: 0.7,
+  scaleMax: 1.3,
 };
 
-/** Deterministic scale when you want repeatable tests. */
+var SHAPES = ['sedan', 'truck', 'compact', 'van'];
+var SHAPE_W = { sedan: 1, truck: 1.3, compact: 0.8, van: 1 };
+
 export function fixedScale(s) {
   return function () { return s; };
 }
 
-/** Default random scale factory (0.7 – 1.3). */
-function randomScale(cfg) {
-  return cfg.carScaleMin + Math.random() * cfg.carScaleRange;
-}
-
-/**
- * Create a simulation instance.
- *
- * @param {object} [overrides] — any DEFAULTS key to override
- * @param {function} [scaleFn]  — () => number, car size multiplier (for tests)
- * @returns simulation handle
- */
 export function createSimulation(overrides, scaleFn) {
-  var cfg = Object.assign({}, DEFAULTS, overrides);
-  var getScale = scaleFn || function () { return randomScale(cfg); };
+  var cfg = {};
+  var k;
+  for (k in DEFAULTS) cfg[k] = DEFAULTS[k];
+  if (overrides) for (k in overrides) cfg[k] = overrides[k];
 
-  // ---- internal state ----
-  var cars = [];
+  var getScale = scaleFn || function () {
+    return cfg.scaleMin + Math.random() * (cfg.scaleMax - cfg.scaleMin);
+  };
+
   var nextId = 0;
-  var lastSpawn = -Infinity;
+  var carsRamp = [];
+  var carsHwy = [];
+  var carsExit = [];
+
   var lightIsGreen = true;
-  var cycleStart = 0;
   var greenPct = cfg.greenPct;
+  var cycleStart = 0;
+  var lastSpawn = -Infinity;
+  var spawnSrc = 0; // alternates 0=hwy, 1=ramp
 
-  // stats
-  var deliveredTimes = [];
-  var stalledFrames = 0;
-  var totalFrames = 0;
-
-  // auto-sweep
   var autoMode = true;
   var autoVal = greenPct;
   var autoDir = -1;
 
+  var deliveries = [];
+  var stalledFrames = 0;
+  var totalFrames = 0;
+
   // ---- helpers ----
 
-  function minGapBetween(a, b) {
-    return (a.w + b.w) / 2 + cfg.minFollowPad;
-  }
-
-  function carColor(car) {
-    if (car.speed < 0.2) return car.d < cfg.rampEnd ? 'stop' : 'slow';
-    if (car.speed < 1.5) return 'slow';
-    return 'flow';
-  }
-
-  // ---- public API ----
-
-  // Car shape types — visual variety for the highway
-  var SHAPES = ['sedan', 'truck', 'compact', 'van'];
-
-  // Shape → width multiplier (trucks wider, compacts narrower)
-  var SHAPE_W = { sedan: 1, truck: 1.3, compact: 0.8, van: 1 };
-
-  function makeCar(d, speed, scale) {
+  function makeCar(segment, d, speed, scale) {
     var s = scale != null ? scale : getScale();
     var shape = SHAPES[nextId % SHAPES.length];
     var shapeMul = SHAPE_W[shape] || 1;
     var car = {
       id: nextId++,
-      d: d,
+      segment: segment,
+      d: d != null ? d : 0,
       speed: speed != null ? speed : cfg.speedMax,
       scale: s,
       w: cfg.carW * s * shapeMul,
       shape: shape,
       color: 'flow',
+      opacity: 1,
     };
     car.color = carColor(car);
     return car;
   }
 
-  function addCar(d, speed, scale) {
-    var car = makeCar(d, speed, scale);
-    cars.push(car);
-    return car;
+  function carColor(car) {
+    if (car.speed < 0.15) return 'stop';
+    if (car.speed < cfg.speedMax * 0.35) return 'slow';
+    return 'flow';
   }
 
-  /** Try to spawn a car at d=0. Returns the car or null. */
-  function trySpawn(now) {
-    if (cars.length >= cfg.maxCars) return null;
-    if (now - lastSpawn < cfg.spawnMs) return null;
-    for (var j = 0; j < cars.length; j++) {
-      if (cars[j].d < cfg.minFollowPad + cars[j].w) return null;
-    }
-    var car = addCar(0);
-    lastSpawn = now;
-    return car;
+  function minGap(a, b) {
+    return (a.w + b.w) / 2 + cfg.minFollowPad;
   }
+
+  function allCars() {
+    return carsRamp.concat(carsHwy, carsExit);
+  }
+
+  // ---- light ----
 
   function tickLight(now) {
+    if (greenPct >= 100) { lightIsGreen = true; return; }
     var elapsed = (now - cycleStart) % cfg.cycleTotal;
-    var greenMs = cfg.cycleTotal * greenPct / 100;
-    lightIsGreen = elapsed < greenMs;
-    return lightIsGreen;
+    lightIsGreen = elapsed < cfg.cycleTotal * greenPct / 100;
   }
 
   function tickAuto() {
@@ -144,32 +121,52 @@ export function createSimulation(overrides, scaleFn) {
     greenPct = Math.round(autoVal);
   }
 
-  /**
-   * Advance simulation by one frame.
-   * @param {number} now — timestamp in ms (Date.now() or synthetic)
-   * @returns {object} frame state for the UI to render
-   */
-  function tick(now) {
-    totalFrames++;
-    tickAuto();
-    tickLight(now);
+  // ---- spawning ----
 
-    // Spawn
-    var spawned = trySpawn(now);
+  function hasSpawnSpace(cars) {
+    for (var j = 0; j < cars.length; j++) {
+      if (cars[j].d < cfg.minFollowPad + cars[j].w) return false;
+    }
+    return true;
+  }
 
-    // Sort front-to-back (highest d first)
+  function trySpawn(now) {
+    if (allCars().length >= cfg.maxCars) return null;
+    if (now - lastSpawn < cfg.spawnMs) return null;
+
+    var src = spawnSrc;
+    spawnSrc = 1 - spawnSrc;
+    var car = null;
+
+    if (src === 0 && hasSpawnSpace(carsHwy)) {
+      car = makeCar('highway', 0);
+      carsHwy.push(car);
+    } else if (src === 1 && hasSpawnSpace(carsRamp)) {
+      car = makeCar('ramp', 0);
+      carsRamp.push(car);
+    } else if (src === 0 && hasSpawnSpace(carsRamp)) {
+      car = makeCar('ramp', 0);
+      carsRamp.push(car);
+    } else if (src === 1 && hasSpawnSpace(carsHwy)) {
+      car = makeCar('highway', 0);
+      carsHwy.push(car);
+    }
+
+    if (car) lastSpawn = now;
+    return car;
+  }
+
+  // ---- movement within a segment ----
+
+  function moveSegment(cars, segLen, opts) {
     cars.sort(function (a, b) { return b.d - a.d; });
-
-    var rampBlocked = false;
-    var stalledCount = 0;
-    var removedIds = [];
 
     for (var i = 0; i < cars.length; i++) {
       var car = cars[i];
       var target = cfg.speedMax;
 
-      // Red light — lead car at the line stops; cars already at gate stay stopped.
-      if (!lightIsGreen && car.d <= cfg.gateD && car.d > cfg.gateD - 30) {
+      // Gate (light) — only on exit
+      if (opts.hasGate && !lightIsGreen && car.d <= cfg.gateD && car.d > cfg.gateD - 35) {
         var someoneCloser = (i > 0 && cars[i - 1].d <= cfg.gateD && cars[i - 1].d > car.d);
         if (!someoneCloser) {
           target = 0;
@@ -180,95 +177,186 @@ export function createSimulation(overrides, scaleFn) {
         }
       }
 
-      // Following distance — brake for car ahead
+      // End-of-segment blocking
+      if (opts.endBlocked && car.d >= segLen - 8) {
+        target = 0;
+        if (car.d > segLen) { car.d = segLen; car.speed = 0; }
+      }
+
+      // Following distance
       if (i > 0) {
         var ahead = cars[i - 1];
         var gap = ahead.d - car.d;
-        var minGap = minGapBetween(car, ahead);
-        if (gap < minGap + cfg.followZone) {
-          target = Math.min(target, Math.max(0, (gap - minGap) * cfg.brakeRate));
+        var mg = minGap(car, ahead);
+        if (gap < mg + cfg.followZone) {
+          target = Math.min(target, Math.max(0, (gap - mg) * cfg.brakeRate));
         }
       }
 
-      // Smooth speed change
+      // Smooth speed
       car.speed += (target - car.speed) * cfg.lerpRate;
-      if (car.speed < 0.02) car.speed = 0;
-
+      if (car.speed < 0.03) car.speed = 0;
       car.d += car.speed;
 
-      // Hard gap — never overlap
+      // Hard gap
       if (i > 0) {
-        var maxD = cars[i - 1].d - minGapBetween(car, cars[i - 1]);
-        if (car.d > maxD) {
-          car.d = maxD;
-          car.speed = Math.min(car.speed, cars[i - 1].speed);
+        var ahead2 = cars[i - 1];
+        var mg2 = minGap(car, ahead2);
+        if (ahead2.d - car.d < mg2) {
+          car.d = ahead2.d - mg2;
+          car.speed = Math.min(car.speed, ahead2.speed);
         }
       }
 
-      // Stall detection
-      if (car.speed < 0.2) {
-        stalledCount++;
-        if (car.d < cfg.rampEnd) rampBlocked = true;
+      if (car.d < 0) car.d = 0;
+
+      // Fade past gate on exit
+      if (opts.fade && car.d > cfg.gateD) {
+        car.opacity = Math.max(0, 1 - (car.d - cfg.gateD) / (segLen - cfg.gateD));
+      } else {
+        car.opacity = 1;
       }
 
       car.color = carColor(car);
+    }
+  }
 
-      // Off the end → delivered
-      if (car.d > cfg.roadLength + 30) {
-        removedIds.push(car.id);
+  // ---- transitions ----
+
+  function canEnterExit() {
+    for (var j = 0; j < carsExit.length; j++) {
+      if (carsExit[j].d < cfg.minFollowPad + carsExit[j].w + cfg.carW) return false;
+    }
+    return true;
+  }
+
+  function canMergeAt(d, w) {
+    for (var i = 0; i < carsHwy.length; i++) {
+      var hw = carsHwy[i];
+      var needed = (hw.w + w) / 2 + cfg.minFollowPad;
+      if (Math.abs(hw.d - d) < needed) return false;
+    }
+    return true;
+  }
+
+  function tryHwyToExit() {
+    if (carsHwy.length === 0) return;
+    carsHwy.sort(function (a, b) { return b.d - a.d; });
+    var front = carsHwy[0];
+    if (front.d < cfg.lenHwy - 3) return;
+    if (canEnterExit()) {
+      carsHwy.splice(0, 1);
+      front.segment = 'exit';
+      front.d = Math.max(0, front.d - cfg.lenHwy);
+      carsExit.push(front);
+    } else {
+      front.d = cfg.lenHwy;
+      front.speed = 0;
+    }
+  }
+
+  function tryRampMerge() {
+    if (carsRamp.length === 0) return;
+    carsRamp.sort(function (a, b) { return b.d - a.d; });
+    var front = carsRamp[0];
+    if (front.d < cfg.lenRamp - 3) return;
+    if (canMergeAt(cfg.mergeD, front.w)) {
+      carsRamp.splice(0, 1);
+      front.segment = 'highway';
+      front.d = cfg.mergeD;
+      carsHwy.push(front);
+    } else {
+      front.d = cfg.lenRamp;
+      front.speed = 0;
+    }
+  }
+
+  // ---- main tick ----
+
+  function tick(now) {
+    totalFrames++;
+    tickAuto();
+    tickLight(now);
+
+    var removedIds = [];
+
+    // 1. Remove delivered
+    for (var i = carsExit.length - 1; i >= 0; i--) {
+      if (carsExit[i].d >= cfg.lenExit || carsExit[i].opacity <= 0.01) {
+        removedIds.push(carsExit[i].id);
+        deliveries.push(now);
+        carsExit.splice(i, 1);
       }
     }
 
-    // Remove delivered cars
-    for (var r = removedIds.length - 1; r >= 0; r--) {
-      for (var k = cars.length - 1; k >= 0; k--) {
-        if (cars[k].id === removedIds[r]) {
-          cars.splice(k, 1);
-          deliveredTimes.push(now);
-          break;
-        }
-      }
-    }
+    // 2. Move exit (downstream first — frees space)
+    moveSegment(carsExit, cfg.lenExit, { hasGate: true, fade: true });
 
-    if (stalledCount > 0) stalledFrames++;
+    // 3. Highway → exit
+    tryHwyToExit();
+
+    // 4. Move highway
+    var exitFull = !canEnterExit();
+    moveSegment(carsHwy, cfg.lenHwy, { endBlocked: exitFull });
+
+    // 5. Try transition again (car may have moved to end this tick)
+    tryHwyToExit();
+
+    // 6. Ramp → highway
+    tryRampMerge();
+
+    // 7. Move ramp
+    var mergeFull = !canMergeAt(cfg.mergeD, cfg.carW);
+    moveSegment(carsRamp, cfg.lenRamp, { endBlocked: mergeFull });
+
+    // 8. Try merge again
+    tryRampMerge();
+
+    // 9. Spawn
+    trySpawn(now);
 
     // Stats
     var cutoff = now - 5000;
-    while (deliveredTimes.length > 0 && deliveredTimes[0] < cutoff) deliveredTimes.shift();
-    var throughput = Math.round(deliveredTimes.length * 12);
+    while (deliveries.length > 0 && deliveries[0] < cutoff) deliveries.shift();
+    var throughput = Math.round(deliveries.length * 12);
 
-    var queued = 0;
-    for (var q = 0; q < cars.length; q++) {
-      if (cars[q].speed < 1 && cars[q].d >= cfg.rampEnd && cars[q].d <= cfg.gateD) queued++;
+    var all = allCars();
+    var stalledCount = 0;
+    var rampBlocked = false;
+    for (var s = 0; s < all.length; s++) {
+      if (all[s].speed < 0.15) {
+        stalledCount++;
+        if (all[s].segment === 'ramp' && all[s].d >= cfg.lenRamp - 5) rampBlocked = true;
+        if (all[s].segment === 'highway' && all[s].d < 10) rampBlocked = true;
+      }
     }
+    if (stalledCount > 0) stalledFrames++;
 
     var stallPct = totalFrames > 0 ? Math.round(stalledFrames / totalFrames * 100) : 0;
 
-    // Status
     var status;
     if (rampBlocked) {
-      status = { level: 'blocked', emoji: '\uD83D\uDD34', msg: 'Traffic backed up to the on-ramp \u2014 no new cars can enter' };
-    } else if (stalledCount > cars.length * 0.4) {
-      status = { level: 'congested', emoji: '\uD83D\uDFE1', msg: 'Highway congested \u2014 cars queuing behind the light' };
+      status = { level: 'blocked', msg: 'Traffic backed up to the on-ramp \u2014 no new cars can enter' };
+    } else if (stalledCount > all.length * 0.4) {
+      status = { level: 'congested', msg: 'Highway congested \u2014 cars queuing behind the light' };
     } else {
-      status = { level: 'flowing', emoji: '\uD83D\uDFE2', msg: 'Flowing \u2014 traffic moving freely' };
+      status = { level: 'flowing', msg: 'Flowing \u2014 traffic moving freely' };
     }
 
     return {
-      cars: cars,
+      cars: all,
+      removedIds: removedIds,
       lightIsGreen: lightIsGreen,
       greenPct: greenPct,
       autoMode: autoMode,
-      spawned: spawned,
-      removedIds: removedIds,
-      stats: { throughput: throughput, queued: queued, stallPct: stallPct },
+      stats: { throughput: throughput, queued: carsHwy.length + carsExit.length, stallPct: stallPct },
       status: status,
     };
   }
 
   return {
     tick: tick,
-    getCars: function () { return cars; },
+    getCars: allCars,
     setGreenPct: function (v) {
       greenPct = v;
       autoMode = false;
@@ -277,11 +365,15 @@ export function createSimulation(overrides, scaleFn) {
     },
     exitAuto: function () { autoMode = false; },
     isAuto: function () { return autoMode; },
-    getGreenPct: function () { return greenPct; },
-    isGreen: function () { return lightIsGreen; },
     setCycleStart: function (t) { cycleStart = t; },
     setLastSpawn: function (t) { lastSpawn = t; },
-    addCar: addCar,
+    addCar: function (segment, d, speed, scale) {
+      var car = makeCar(segment, d, speed, scale);
+      if (segment === 'ramp') carsRamp.push(car);
+      else if (segment === 'highway') carsHwy.push(car);
+      else if (segment === 'exit') carsExit.push(car);
+      return car;
+    },
     cfg: cfg,
   };
 }

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -18,12 +18,12 @@ export var DEFAULTS = {
   mergeD: 170,
   gateD: 130,
   carW: 20,
-  minFollowPad: 8,
+  minFollowPad: 14,
   speedMax: 3.5,
   spawnMs: 420,
   cycleTotal: 3000,
   greenPct: 80,
-  maxCars: 35,
+  maxCars: 25,
   lerpRate: 0.25,
   brakeRate: 0.3,
   followZone: 18,
@@ -177,9 +177,12 @@ export function createSimulation(overrides, scaleFn) {
         }
       }
 
-      // End-of-segment blocking
-      if (opts.endBlocked && car.d >= segLen - 8) {
-        target = 0;
+      // End-of-segment blocking — wide braking zone for smooth deceleration
+      if (opts.endBlocked) {
+        if (car.d >= segLen - 30) {
+          var distToEnd = segLen - car.d;
+          target = Math.min(target, Math.max(0, distToEnd * 0.15));
+        }
         if (car.d > segLen) { car.d = segLen; car.speed = 0; }
       }
 
@@ -223,11 +226,15 @@ export function createSimulation(overrides, scaleFn) {
 
   // ---- transitions ----
 
-  function canEnterExit() {
+  function canEnterExit(enterW) {
+    var w = enterW || cfg.carW;
+    var minD = Infinity;
     for (var j = 0; j < carsExit.length; j++) {
-      if (carsExit[j].d < cfg.minFollowPad + carsExit[j].w + cfg.carW) return false;
+      if (carsExit[j].d < minD) minD = carsExit[j].d;
     }
-    return true;
+    // Cars enter exit at d=12, so check from that offset
+    var entryD = 12;
+    return (minD - entryD) > (w + cfg.carW) / 2 + cfg.minFollowPad;
   }
 
   function canMergeAt(d, w) {
@@ -242,16 +249,22 @@ export function createSimulation(overrides, scaleFn) {
   function tryHwyToExit() {
     if (carsHwy.length === 0) return;
     carsHwy.sort(function (a, b) { return b.d - a.d; });
-    var front = carsHwy[0];
-    if (front.d < cfg.lenHwy - 3) return;
-    if (canEnterExit()) {
-      carsHwy.splice(0, 1);
-      front.segment = 'exit';
-      front.d = Math.max(0, front.d - cfg.lenHwy);
-      carsExit.push(front);
-    } else {
-      front.d = cfg.lenHwy;
-      front.speed = 0;
+    while (carsHwy.length > 0) {
+      var front = carsHwy[0];
+      if (front.d < cfg.lenHwy - 5) break;
+      if (canEnterExit(front.w)) {
+        carsHwy.splice(0, 1);
+        front.segment = 'exit';
+        // Start past the fork point so cars don't overlap with blocked highway cars
+        front.d = 12;
+        front.speed = Math.min(front.speed, cfg.speedMax * 0.8);
+        carsExit.push(front);
+      } else {
+        // Block a few px before the absolute end to leave visual room for the fork
+        front.d = cfg.lenHwy - 4;
+        front.speed = 0;
+        break;
+      }
     }
   }
 
@@ -296,7 +309,7 @@ export function createSimulation(overrides, scaleFn) {
     tryHwyToExit();
 
     // 4. Move highway
-    var exitFull = !canEnterExit();
+    var exitFull = !canEnterExit(cfg.carW);
     moveSegment(carsHwy, cfg.lenHwy, { endBlocked: exitFull });
 
     // 5. Try transition again (car may have moved to end this tick)

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -440,7 +440,11 @@ export function createSimulation(overrides, scaleFn) {
     var spawn = trySpawn(now);
     if (spawn.kind === 'blocked') {
       spawnBlockedTicks++;
-    } else if (spawn.kind === 'spawned') {
+    } else if (spawn.kind !== 'cooldown') {
+      // Reset on 'spawned' (car entered) and 'capped' (at capacity but
+      // entrances not physically blocked).  Only 'cooldown' preserves
+      // the counter — the spawn timer hasn't elapsed so we can't tell
+      // whether the entrance is clear.
       spawnBlockedTicks = 0;
     }
 

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -179,6 +179,15 @@ export function createSimulation(overrides, scaleFn) {
 
   function moveSegment(cars, segLen, opts) {
     cars.sort(function (a, b) { return b.d - a.d; });
+    var phantoms = opts.phantoms || [];
+
+    // Merge phantoms into a sorted list of obstacles (d descending)
+    // so they integrate with the following-distance logic.
+    var obstacles = cars.slice();
+    for (var p = 0; p < phantoms.length; p++) {
+      obstacles.push(phantoms[p]);
+    }
+    obstacles.sort(function (a, b) { return b.d - a.d; });
 
     for (var i = 0; i < cars.length; i++) {
       var car = cars[i];
@@ -205,11 +214,18 @@ export function createSimulation(overrides, scaleFn) {
         if (car.d > segLen) { car.d = segLen; car.speed = 0; }
       }
 
-      // Following distance
-      if (i > 0) {
-        var ahead = cars[i - 1];
-        var gap = ahead.d - car.d;
-        var mg = minGap(car, ahead);
+      // Following distance — find nearest obstacle ahead (real or phantom)
+      var nearestAhead = null;
+      for (var oi = 0; oi < obstacles.length; oi++) {
+        var ob = obstacles[oi];
+        if (ob === car) continue;
+        if (ob.d > car.d && (!nearestAhead || ob.d < nearestAhead.d)) {
+          nearestAhead = ob;
+        }
+      }
+      if (nearestAhead) {
+        var gap = nearestAhead.d - car.d;
+        var mg = (car.w + (nearestAhead.w || cfg.carW)) / 2 + cfg.minFollowPad;
         if (gap < mg + cfg.followZone) {
           target = Math.min(target, Math.max(0, (gap - mg) * cfg.brakeRate));
         }
@@ -220,13 +236,12 @@ export function createSimulation(overrides, scaleFn) {
       if (car.speed < 0.03) car.speed = 0;
       car.d += car.speed;
 
-      // Hard gap
-      if (i > 0) {
-        var ahead2 = cars[i - 1];
-        var mg2 = minGap(car, ahead2);
-        if (ahead2.d - car.d < mg2) {
-          car.d = ahead2.d - mg2;
-          car.speed = Math.min(car.speed, ahead2.speed);
+      // Hard gap — enforce against nearest real or phantom obstacle ahead
+      if (nearestAhead) {
+        var mg2 = (car.w + (nearestAhead.w || cfg.carW)) / 2 + cfg.minFollowPad;
+        if (nearestAhead.d - car.d < mg2) {
+          car.d = nearestAhead.d - mg2;
+          car.speed = Math.min(car.speed, nearestAhead.speed != null ? nearestAhead.speed : 0);
         }
       }
 
@@ -244,6 +259,40 @@ export function createSimulation(overrides, scaleFn) {
 
       car.color = carColor(car);
     }
+  }
+
+  // ---- phantom obstacle builders ----
+  // Project cars from adjacent segments into this segment's coordinate
+  // space so the smooth following/braking physics prevents visual overlap
+  // at merge and fork junctions.
+
+  function hwyPhantoms() {
+    var ph = [];
+    // Exit cars near entry → appear at highway d = lenHwy + exitCar.d
+    for (var e = 0; e < carsExit.length; e++) {
+      if (carsExit[e].d < cfg.exitEntryD + 40) {
+        ph.push({ d: cfg.lenHwy + carsExit[e].d, w: carsExit[e].w, speed: carsExit[e].speed });
+      }
+    }
+    // Cont cars near entry → appear at highway d = lenHwy + contCar.d
+    for (var c = 0; c < carsCont.length; c++) {
+      if (carsCont[c].d < cfg.contEntryD + 40) {
+        ph.push({ d: cfg.lenHwy + carsCont[c].d, w: carsCont[c].w, speed: carsCont[c].speed });
+      }
+    }
+    return ph;
+  }
+
+  function rampPhantoms() {
+    var ph = [];
+    // Highway cars near mergeD → appear at ramp d = lenRamp + (hwyCar.d - mergeD)
+    for (var h = 0; h < carsHwy.length; h++) {
+      var dist = carsHwy[h].d - cfg.mergeD;
+      if (Math.abs(dist) < 50) {
+        ph.push({ d: cfg.lenRamp + dist, w: carsHwy[h].w, speed: carsHwy[h].speed });
+      }
+    }
+    return ph;
   }
 
   // ---- transitions ----
@@ -322,66 +371,6 @@ export function createSimulation(overrides, scaleFn) {
     }
   }
 
-  // ---- cross-segment proximity braking ----
-  // Cars on different segments share SVG space at junctions. Slow them
-  // to avoid visual overlap even though they're in different arrays.
-
-  function crossSegmentBrake() {
-    var pad = cfg.minFollowPad;
-
-    // Merge zone: ramp cars approaching end vs highway cars near mergeD
-    for (var r = 0; r < carsRamp.length; r++) {
-      var rc = carsRamp[r];
-      if (rc.d < cfg.lenRamp - 40) continue;
-      for (var h = 0; h < carsHwy.length; h++) {
-        var hc = carsHwy[h];
-        if (Math.abs(hc.d - cfg.mergeD) > 40) continue;
-        // Virtual distance: how close they are to the merge point
-        var rDist = cfg.lenRamp - rc.d;
-        var hDist = Math.abs(hc.d - cfg.mergeD);
-        var proximity = rDist + hDist;
-        var needed = (rc.w + hc.w) / 2 + pad;
-        if (proximity < needed + 15) {
-          var brake = Math.max(0, (proximity - needed) * 0.15);
-          rc.speed = Math.min(rc.speed, brake);
-        }
-      }
-    }
-
-    // Fork zone: highway cars approaching end vs exit/cont cars near entry
-    for (var hi = 0; hi < carsHwy.length; hi++) {
-      var hwc = carsHwy[hi];
-      if (hwc.d < cfg.lenHwy - 40) continue;
-      var hwyDist = cfg.lenHwy - hwc.d;
-
-      // Check exit cars near entry
-      for (var e = 0; e < carsExit.length; e++) {
-        var ec = carsExit[e];
-        if (ec.d > cfg.exitEntryD + 30) continue;
-        var eDist = ec.d;
-        var prox = hwyDist + eDist;
-        var need = (hwc.w + ec.w) / 2 + pad;
-        if (prox < need + 15) {
-          var br = Math.max(0, (prox - need) * 0.15);
-          hwc.speed = Math.min(hwc.speed, br);
-        }
-      }
-
-      // Check cont cars near entry
-      for (var cc = 0; cc < carsCont.length; cc++) {
-        var co = carsCont[cc];
-        if (co.d > cfg.contEntryD + 30) continue;
-        var cDist = co.d;
-        var prox2 = hwyDist + cDist;
-        var need2 = (hwc.w + co.w) / 2 + pad;
-        if (prox2 < need2 + 15) {
-          var br2 = Math.max(0, (prox2 - need2) * 0.15);
-          hwc.speed = Math.min(hwc.speed, br2);
-        }
-      }
-    }
-  }
-
   // ---- main tick ----
 
   function tick(now) {
@@ -417,7 +406,7 @@ export function createSimulation(overrides, scaleFn) {
 
     // 5. Move highway — block only if BOTH exit and cont are full
     var forkFull = !canEnterExit(cfg.carW) && !canEnterCont(cfg.carW);
-    moveSegment(carsHwy, cfg.lenHwy, { endBlocked: forkFull });
+    moveSegment(carsHwy, cfg.lenHwy, { endBlocked: forkFull, phantoms: hwyPhantoms() });
 
     // 6. Try transition again (car may have moved to end this tick)
     tryHwyToExit();
@@ -425,17 +414,14 @@ export function createSimulation(overrides, scaleFn) {
     // 7. Ramp → highway
     tryRampMerge();
 
-    // 8. Move ramp
+    // 8. Move ramp (with highway phantoms at merge zone)
     var mergeFull = !canMergeAt(cfg.mergeD, cfg.carW);
-    moveSegment(carsRamp, cfg.lenRamp, { endBlocked: mergeFull });
+    moveSegment(carsRamp, cfg.lenRamp, { endBlocked: mergeFull, phantoms: rampPhantoms() });
 
     // 9. Try merge again
     tryRampMerge();
 
-    // 10. Cross-segment proximity braking (prevent visual overlap at junctions)
-    crossSegmentBrake();
-
-    // 11. Spawn
+    // 10. Spawn
     var spawned = trySpawn(now);
     if (!spawned && now - lastSpawn >= cfg.spawnMs) {
       spawnBlockedTicks++;

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -20,24 +20,25 @@ export var DEFAULTS = {
   mergeD: 170,
   gateD: 130,
   carW: 20,
-  minFollowPad: 14,
+  minFollowPad: 26,
   speedMax: 3.5,
-  spawnMs: 420,
+  spawnMs: 500,
   cycleTotal: 3000,
   greenPct: 80,
-  maxCars: 25,
+  maxCars: 16,
   lerpRate: 0.25,
   brakeRate: 0.3,
   followZone: 18,
   autoSpeed: 0.15,
   autoMin: 5,
   autoMax: 100,
-  scaleMin: 0.7,
-  scaleMax: 1.3,
+  scaleMin: 0.8,
+  scaleMax: 1.15,
   spawnBlockedThreshold: 8,
-  exitEntryD: 12,
+  exitEntryD: 22,
+  contEntryD: 18,
   hwyForkThreshold: 5,
-  hwyBlockedOffset: 4,
+  hwyBlockedOffset: 10,
   rampMergeThreshold: 3,
 };
 
@@ -197,9 +198,9 @@ export function createSimulation(overrides, scaleFn) {
 
       // End-of-segment blocking — wide braking zone for smooth deceleration
       if (opts.endBlocked) {
-        if (car.d >= segLen - 30) {
+        if (car.d >= segLen - 50) {
           var distToEnd = segLen - car.d;
-          target = Math.min(target, Math.max(0, distToEnd * 0.15));
+          target = Math.min(target, Math.max(0, distToEnd * 0.12));
         }
         if (car.d > segLen) { car.d = segLen; car.speed = 0; }
       }
@@ -273,7 +274,7 @@ export function createSimulation(overrides, scaleFn) {
       if (!lead || carsCont[j].d < lead.d) lead = carsCont[j];
     }
     if (!lead) return true;
-    return lead.d > (w + lead.w) / 2 + cfg.minFollowPad;
+    return (lead.d - cfg.contEntryD) > (w + lead.w) / 2 + cfg.minFollowPad;
   }
 
   function tryHwyToExit() {
@@ -293,7 +294,7 @@ export function createSimulation(overrides, scaleFn) {
         // Exit full — continue east
         carsHwy.splice(0, 1);
         front.segment = 'cont';
-        front.d = 0;
+        front.d = cfg.contEntryD;
         front.speed = Math.min(front.speed, cfg.speedMax);
         carsCont.push(front);
       } else {

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -158,8 +158,8 @@ export function createSimulation(overrides, scaleFn) {
   }
 
   function trySpawn(now) {
-    if (totalCars() >= cfg.maxCars) return null;
-    if (now - lastSpawn < cfg.spawnMs) return null;
+    if (totalCars() >= cfg.maxCars) return { kind: 'capped' };
+    if (now - lastSpawn < cfg.spawnMs) return { kind: 'cooldown' };
 
     var src = spawnSrc;
     spawnSrc = 1 - spawnSrc;
@@ -171,8 +171,11 @@ export function createSimulation(overrides, scaleFn) {
       car = trySpawnAt('ramp', carsRamp) || trySpawnAt('highway', carsHwy);
     }
 
-    if (car) lastSpawn = now;
-    return car;
+    if (car) {
+      lastSpawn = now;
+      return { kind: 'spawned', car: car };
+    }
+    return { kind: 'blocked' };
   }
 
   // ---- movement within a segment ----
@@ -326,6 +329,15 @@ export function createSimulation(overrides, scaleFn) {
     return (lead.d - cfg.contEntryD) > (w + lead.w) / 2 + cfg.minFollowPad;
   }
 
+  function leadNearEnd(cars, segLen, threshold) {
+    var lead = null;
+    for (var i = 0; i < cars.length; i++) {
+      if (!lead || cars[i].d > lead.d) lead = cars[i];
+    }
+    if (!lead || lead.d < segLen - threshold) return null;
+    return lead;
+  }
+
   function tryHwyToExit() {
     if (carsHwy.length === 0) return;
     carsHwy.sort(function (a, b) { return b.d - a.d; });
@@ -339,8 +351,8 @@ export function createSimulation(overrides, scaleFn) {
         front.d = cfg.exitEntryD;
         front.speed = Math.min(front.speed, cfg.speedMax * 0.8);
         carsExit.push(front);
-      } else if (canEnterCont(front.w)) {
-        // Exit full — continue east
+      } else if (lightIsGreen && canEnterCont(front.w)) {
+        // Exit spacing is temporarily full while traffic is flowing — continue east.
         carsHwy.splice(0, 1);
         front.segment = 'cont';
         front.d = cfg.contEntryD;
@@ -404,8 +416,10 @@ export function createSimulation(overrides, scaleFn) {
     // 4. Highway → exit or continuation
     tryHwyToExit();
 
-    // 5. Move highway — block only if BOTH exit and cont are full
-    var forkFull = !canEnterExit(cfg.carW) && !canEnterCont(cfg.carW);
+    // 5. Move highway — block when the lead car has no permitted fork path.
+    var hwyLead = leadNearEnd(carsHwy, cfg.lenHwy, cfg.hwyForkThreshold);
+    var forkFull = !!hwyLead && !canEnterExit(hwyLead.w)
+      && (!lightIsGreen || !canEnterCont(hwyLead.w));
     moveSegment(carsHwy, cfg.lenHwy, { endBlocked: forkFull, phantoms: hwyPhantoms() });
 
     // 6. Try transition again (car may have moved to end this tick)
@@ -415,17 +429,18 @@ export function createSimulation(overrides, scaleFn) {
     tryRampMerge();
 
     // 8. Move ramp (with highway phantoms at merge zone)
-    var mergeFull = !canMergeAt(cfg.mergeD, cfg.carW);
+    var rampLead = leadNearEnd(carsRamp, cfg.lenRamp, cfg.rampMergeThreshold);
+    var mergeFull = !!rampLead && !canMergeAt(cfg.mergeD, rampLead.w);
     moveSegment(carsRamp, cfg.lenRamp, { endBlocked: mergeFull, phantoms: rampPhantoms() });
 
     // 9. Try merge again
     tryRampMerge();
 
     // 10. Spawn
-    var spawned = trySpawn(now);
-    if (!spawned && now - lastSpawn >= cfg.spawnMs) {
+    var spawn = trySpawn(now);
+    if (spawn.kind === 'blocked') {
       spawnBlockedTicks++;
-    } else if (spawned) {
+    } else if (spawn.kind === 'spawned') {
       spawnBlockedTicks = 0;
     }
 


### PR DESCRIPTION
## Summary

Redesigns the highway backpressure animation with a multi-route layout that better illustrates how backpressure cascades through a log pipeline.

### New layout
- **Two source on-ramps**: cars enter from the left (highway) and bottom-left (on-ramp), representing multiple log sources
- **Merge zone**: on-ramp cars merge into the highway
- **Exit ramp**: all cars exit via a ramp with a traffic light (the destination/collector)
- **Faded continuation**: highway visually continues past the fork but all traffic takes the exit
- **Backpressure cascade**: when the exit light turns red, cars queue → highway blocks → on-ramp stalls → no new data enters

### Visual improvements
- Cars fade out as they pass the traffic light and approach the destination
- Traffic light dynamically positioned along the exit ramp curve
- Status text updates in real-time: flowing → congested → blocked (in red)
- Wider viewBox (800×300 vs 800×195) for the taller layout

### Technical changes
- **`highway-sim.mjs`**: Complete rewrite with multi-segment model (ramp/highway/exit), merge logic, transition logic, fade calculation
- **`HighwayBackpressure.astro`**: New SVG layout with segment-aware car positioning and dynamic traffic light placement
- **Tests**: 27 tests covering all segments, transitions, fade, cascade, and status detection

### Test plan
- `node --test book/src/components/__tests__/highway-sim.test.mjs` — 27/27 pass
- Visual verification with Playwright screenshots (flowing + backpressure states)
- Astro build succeeds

Relates to #2258

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign highway backpressure animation with multi-segment road layout
> - Replaces the single-lane road in [HighwayBackpressure.astro](https://github.com/strawgate/fastforward/pull/2277/files#diff-47399e83c747483e8e2291c0d77604fec3da890d28b1c54ef22a4f09b7b1350c) with a four-segment layout: on-ramp, highway, exit ramp, and continuation.
> - Refactors [highway-sim.mjs](https://github.com/strawgate/fastforward/pull/2277/files#diff-3cd598b368f6c25e5fdb6d5543ce9386ecc712ab90450994da39111e7797fbf0) to model per-segment car movement with ramp merging, highway-to-exit/continuation fork logic, alternating dual-source spawning, and opacity fading past the exit gate.
> - Repositions the traffic light dynamically on the exit path using tangent/perpendicular calculations, replacing the previous fixed placement.
> - Updates the public API: `addCar` now requires a segment name; `getGreenPct` and `isGreen` are removed; `tick` returns `lightIsGreen` and `greenPct` directly.
> - Risk: breaking API changes to `addCar` and removed accessors will break any external callers relying on the old single-lane simulation interface.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bb8495.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->