### PR TITLE
docs: fix quickstart command order

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ The [documentation site](https://strawgate.github.io/fastforward/) has interacti
 git clone https://github.com/strawgate/fastforward.git && cd fastforward
 cargo build --release -p logfwd
 
-# Generate some test data and filter it with SQL
+# Generate some test data
 ./target/release/logfwd generate-json 100000 logs.json
-./target/release/logfwd run --config config.yaml
 ```
 
 ```yaml
@@ -50,6 +49,10 @@ transform: |
 output:
   type: stdout
   format: console
+```
+
+```bash
+./target/release/logfwd run --config config.yaml
 ```
 
 Only error records with slow durations make it through — everything else is filtered by the SQL transform.

--- a/book/src/content/docs/quick-start.mdx
+++ b/book/src/content/docs/quick-start.mdx
@@ -11,7 +11,7 @@ import DataFlowAnimation from '../../components/DataFlowAnimation.astro';
 FastForward is a research project exploring how to build a fast log forwarder with Rust. This guide gets you from zero to a working pipeline in about 15 minutes.
 
 :::note
-The binary is currently named `logfwd` and will be renamed to `ff` in a future release. Docker images and `git clone` commands reference `memagent` (the original repo name).
+The binary is currently named `logfwd` and will be renamed to `ff` in a future release. Docker images still reference `memagent` (the original image name).
 :::
 
 ## Install


### PR DESCRIPTION
## Summary

Follow-up to #2278.

- Move the README run command after the sample config so the copy-paste flow is executable.
- Clarify that only Docker images still use the original memagent image name; source install uses the FastForward repo.

## Verification

- npm --prefix book ci
- npm --prefix book run build
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix quickstart command order in README and docs
> - Splits the quick-start bash block in [README.md](https://github.com/strawgate/fastforward/pull/2285/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) so the `run --config` command appears in a separate block after the YAML config, matching the correct execution order.
> - Updates the note in [quick-start.mdx](https://github.com/strawgate/fastforward/pull/2285/files#diff-31efc63a9fc3b86b6ea61a96a30b95e70b4108e502d79d125394327cc144c01c) to clarify that Docker images still reference `memagent` as the original image name, removing the mention of `git clone` commands.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5251b23.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->