### PR TITLE
fix: cap HTTP input poll draining

### DIFF
--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -194,7 +194,8 @@ Receive newline-delimited payloads over HTTP `POST`.
 | `http.path` | string | No | Route path. Must start with `/`. Defaults to `/`. |
 | `http.strict_path` | boolean | No | When `true` (default), require exact path match. |
 | `http.method` | string | No | Accepted method. Defaults to `POST`. |
-| `http.max_request_body_size` | integer | No | Maximum request body size in bytes. Defaults to 20 MiB. |
+| `http.max_request_body_size` | integer | No | Maximum request body size in bytes. Defaults to 10 MiB. |
+| `http.max_drained_bytes_per_poll` | integer | No | Maximum bytes drained from the internal request queue per poll. Defaults to 1 GiB. |
 | `http.response_code` | integer | No | Success code. One of `200`, `201`, `202`, `204` (default `200`). |
 | `http.response_body` | string | No | Optional static success response body. Not allowed when `http.response_code: 204`. |
 
@@ -207,7 +208,8 @@ input:
     path: /ingest
     strict_path: true
     method: POST
-    max_request_body_size: 20971520
+    max_request_body_size: 10485760
+    max_drained_bytes_per_poll: 1073741824
     response_code: 200
     response_body: '{"ok":true}'
 ```

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -232,6 +232,11 @@ impl Config {
                                         "pipeline '{name}' input '{label}': http.max_request_body_size must be at least 1"
                                     )));
                                 }
+                                if http.max_drained_bytes_per_poll == Some(0) {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': http.max_drained_bytes_per_poll must be at least 1"
+                                    )));
+                                }
                                 if let Some(code) = http.response_code
                                     && !matches!(code, 200 | 201 | 202 | 204)
                                 {
@@ -2019,6 +2024,28 @@ pipelines:
         assert!(
             err.to_string()
                 .contains("http.response_body is not allowed when http.response_code is 204"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn http_max_drained_bytes_per_poll_zero_is_rejected() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: http
+        listen: 127.0.0.1:8081
+        format: json
+        http:
+          max_drained_bytes_per_poll: 0
+    outputs:
+      - type: null
+"#;
+        let err = Config::load_str(yaml).expect_err("zero drain cap must fail validation");
+        assert!(
+            err.to_string()
+                .contains("http.max_drained_bytes_per_poll must be at least 1"),
             "unexpected error: {err}"
         );
     }

--- a/crates/logfwd-io/src/http_input.rs
+++ b/crates/logfwd-io/src/http_input.rs
@@ -25,6 +25,8 @@ use crate::receiver_http::{parse_content_length, read_limited_body};
 
 /// Default max request body size (10 MiB).
 const DEFAULT_MAX_REQUEST_BODY_SIZE: usize = 10 * 1024 * 1024;
+/// Default max bytes drained per `poll()` call (1 GiB).
+const DEFAULT_MAX_DRAINED_BYTES_PER_POLL: usize = 1024 * 1024 * 1024;
 
 /// Bounded channel capacity — limits memory when the pipeline falls behind.
 const CHANNEL_BOUND: usize = 4096;
@@ -80,6 +82,8 @@ pub struct HttpInputOptions {
     pub method: HttpInputMethod,
     /// Max request body size in bytes.
     pub max_request_body_size: usize,
+    /// Max bytes drained from the internal queue per `poll()` call.
+    pub max_drained_bytes_per_poll: usize,
     /// HTTP response code for accepted requests.
     pub response_code: u16,
     /// Optional static response body for accepted requests.
@@ -93,6 +97,7 @@ impl Default for HttpInputOptions {
             strict_path: true,
             method: HttpInputMethod::Post,
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
+            max_drained_bytes_per_poll: DEFAULT_MAX_DRAINED_BYTES_PER_POLL,
             response_code: 200,
             response_body: None,
         }
@@ -113,6 +118,10 @@ pub struct HttpInput {
     is_running: Arc<AtomicBool>,
     /// Source-owned health snapshot for readiness and diagnostics.
     health: Arc<AtomicU8>,
+    /// Max bytes drained from internal request queue on each `poll()`.
+    max_drained_bytes_per_poll: usize,
+    /// Deferred request bytes that did not fit in the previous poll budget.
+    deferred_bytes: Option<Vec<u8>>,
 }
 
 #[derive(Clone)]
@@ -245,6 +254,8 @@ impl HttpInput {
             shutdown_tx: Some(shutdown_tx),
             is_running,
             health,
+            max_drained_bytes_per_poll: options.max_drained_bytes_per_poll,
+            deferred_bytes: None,
         })
     }
 
@@ -273,13 +284,44 @@ impl Drop for HttpInput {
 
 impl InputSource for HttpInput {
     fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
-        let Some(rx) = self.rx.as_ref() else {
+        if self.rx.is_none() {
             return Ok(vec![]);
-        };
+        }
 
         let mut all = Vec::new();
-        while let Ok(bytes) = rx.try_recv() {
-            all.extend_from_slice(&bytes);
+        if let Some(bytes) = self.deferred_bytes.take() {
+            if !append_capped(
+                &mut all,
+                bytes,
+                self.max_drained_bytes_per_poll,
+                &mut self.deferred_bytes,
+            ) {
+                return Ok(vec![InputEvent::Data {
+                    accounted_bytes: all.len() as u64,
+                    bytes: all,
+                    source_id: None,
+                }]);
+            }
+        }
+
+        loop {
+            let recv_result = {
+                let Some(rx) = self.rx.as_ref() else {
+                    break;
+                };
+                rx.try_recv()
+            };
+            let Ok(bytes) = recv_result else {
+                break;
+            };
+            if !append_capped(
+                &mut all,
+                bytes,
+                self.max_drained_bytes_per_poll,
+                &mut self.deferred_bytes,
+            ) {
+                break;
+            }
         }
 
         if all.is_empty() {
@@ -310,6 +352,28 @@ impl InputSource for HttpInput {
             stored
         }
     }
+}
+
+fn append_capped(
+    out: &mut Vec<u8>,
+    bytes: Vec<u8>,
+    max_drained_bytes_per_poll: usize,
+    deferred_bytes: &mut Option<Vec<u8>>,
+) -> bool {
+    if out.len() >= max_drained_bytes_per_poll {
+        *deferred_bytes = Some(bytes);
+        return false;
+    }
+
+    let remaining = max_drained_bytes_per_poll - out.len();
+    if bytes.len() <= remaining {
+        out.extend_from_slice(&bytes);
+        return true;
+    }
+
+    out.extend_from_slice(&bytes[..remaining]);
+    *deferred_bytes = Some(bytes[remaining..].to_vec());
+    false
 }
 
 async fn handle_request(
@@ -440,6 +504,9 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
         return Ok(None);
     };
     let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?.trim();
+    if parsed.is_empty() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
     Ok(Some(parsed.to_ascii_lowercase()))
 }
 
@@ -449,6 +516,12 @@ fn normalize_options(mut options: HttpInputOptions) -> io::Result<HttpInputOptio
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "http input max_request_body_size must be >= 1",
+        ));
+    }
+    if options.max_drained_bytes_per_poll == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "http input max_drained_bytes_per_poll must be >= 1",
         ));
     }
     if !is_valid_success_response_code(options.response_code) {
@@ -861,6 +934,39 @@ Connection: close\r\n\
     }
 
     #[test]
+    fn http_rejects_empty_content_encoding_header_before_enqueue() {
+        let mut input =
+            HttpInput::new_with_options("test", "127.0.0.1:0", HttpInputOptions::default())
+                .expect("http input binds");
+        let mut stream = TcpStream::connect(input.local_addr()).expect("connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("timeout");
+        let request = b"POST /ingest HTTP/1.1\r\n\
+Host: localhost\r\n\
+Content-Type: application/x-ndjson\r\n\
+Content-Encoding:   \r\n\
+Content-Length: 8\r\n\
+Connection: close\r\n\
+\r\n\
+{\"x\":1}\n";
+        stream.write_all(request).expect("write request");
+        stream.flush().expect("flush request");
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).expect("read response");
+        let text = String::from_utf8_lossy(&response);
+        assert!(
+            text.starts_with("HTTP/1.1 400"),
+            "expected 400 status line, got: {text}"
+        );
+        let data = poll_until_data(&mut input, Duration::from_millis(100));
+        assert!(
+            data.is_empty(),
+            "empty content-encoding must not enqueue data"
+        );
+    }
+
+    #[test]
     fn content_encoding_trims_optional_whitespace() {
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -874,6 +980,92 @@ Connection: close\r\n\
                 .as_deref(),
             Some("gzip")
         );
+    }
+
+    #[test]
+    fn content_encoding_absent_header_is_accepted() {
+        let headers = HeaderMap::new();
+        assert_eq!(
+            parse_content_encoding(&headers).expect("absent header must parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn http_poll_respects_max_drained_bytes_per_poll() {
+        let options = HttpInputOptions {
+            max_drained_bytes_per_poll: 8,
+            ..HttpInputOptions::default()
+        };
+        let mut input =
+            HttpInput::new_with_options("test", "127.0.0.1:0", options).expect("http input binds");
+        let mut first = TcpStream::connect(input.local_addr()).expect("connect first");
+        first
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("timeout first");
+        first
+            .write_all(
+                b"POST /ingest HTTP/1.1\r\n\
+Host: localhost\r\n\
+Content-Type: application/x-ndjson\r\n\
+Content-Length: 6\r\n\
+Connection: close\r\n\
+\r\n\
+11111\n",
+            )
+            .expect("write first request");
+        first.flush().expect("flush first request");
+        let mut first_response = Vec::new();
+        first
+            .read_to_end(&mut first_response)
+            .expect("read first response");
+        assert!(
+            String::from_utf8_lossy(&first_response).starts_with("HTTP/1.1 200"),
+            "first request should succeed"
+        );
+
+        let mut second = TcpStream::connect(input.local_addr()).expect("connect second");
+        second
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("timeout second");
+        second
+            .write_all(
+                b"POST /ingest HTTP/1.1\r\n\
+Host: localhost\r\n\
+Content-Type: application/x-ndjson\r\n\
+Content-Length: 6\r\n\
+Connection: close\r\n\
+\r\n\
+22222\n",
+            )
+            .expect("write second request");
+        second.flush().expect("flush second request");
+        let mut second_response = Vec::new();
+        second
+            .read_to_end(&mut second_response)
+            .expect("read second response");
+        assert!(
+            String::from_utf8_lossy(&second_response).starts_with("HTTP/1.1 200"),
+            "second request should succeed"
+        );
+
+        let first_poll = poll_until_data(&mut input, Duration::from_secs(2));
+        assert_eq!(
+            first_poll.len(),
+            8,
+            "poll should stop at max_drained_bytes_per_poll"
+        );
+
+        let second_poll = poll_until_data(&mut input, Duration::from_secs(2));
+        assert_eq!(
+            second_poll.len(),
+            4,
+            "remainder should be deferred to the next poll"
+        );
+
+        let mut merged = first_poll;
+        merged.extend_from_slice(&second_poll);
+        assert_eq!(merged, b"11111\n22222\n");
     }
 
     fn decode_observed_seq(bytes: &[u8]) -> BTreeSet<u64> {

--- a/crates/logfwd-io/src/http_input.rs
+++ b/crates/logfwd-io/src/http_input.rs
@@ -121,7 +121,13 @@ pub struct HttpInput {
     /// Max bytes drained from internal request queue on each `poll()`.
     max_drained_bytes_per_poll: usize,
     /// Deferred request bytes that did not fit in the previous poll budget.
-    deferred_bytes: Option<Vec<u8>>,
+    deferred_bytes: Option<DeferredBytes>,
+}
+
+#[derive(Debug)]
+struct DeferredBytes {
+    bytes: Vec<u8>,
+    offset: usize,
 }
 
 #[derive(Clone)]
@@ -289,14 +295,11 @@ impl InputSource for HttpInput {
         }
 
         let mut all = Vec::new();
-        if let Some(bytes) = self.deferred_bytes.take()
-            && !append_capped(
-                &mut all,
-                bytes,
-                self.max_drained_bytes_per_poll,
-                &mut self.deferred_bytes,
-            )
-        {
+        if !append_deferred_capped(
+            &mut all,
+            self.max_drained_bytes_per_poll,
+            &mut self.deferred_bytes,
+        ) {
             return Ok(vec![InputEvent::Data {
                 accounted_bytes: all.len() as u64,
                 bytes: all,
@@ -308,6 +311,7 @@ impl InputSource for HttpInput {
             if all.len() >= self.max_drained_bytes_per_poll {
                 break;
             }
+
             let recv_result = {
                 let Some(rx) = self.rx.as_ref() else {
                     break;
@@ -359,12 +363,12 @@ impl InputSource for HttpInput {
 
 fn append_capped(
     out: &mut Vec<u8>,
-    mut bytes: Vec<u8>,
+    bytes: Vec<u8>,
     max_drained_bytes_per_poll: usize,
-    deferred_bytes: &mut Option<Vec<u8>>,
+    deferred_bytes: &mut Option<DeferredBytes>,
 ) -> bool {
     if out.len() >= max_drained_bytes_per_poll {
-        *deferred_bytes = Some(bytes);
+        *deferred_bytes = Some(DeferredBytes { bytes, offset: 0 });
         return false;
     }
 
@@ -374,10 +378,39 @@ fn append_capped(
         return true;
     }
 
-    let overflow = bytes.split_off(remaining);
-    out.extend_from_slice(&bytes);
-    *deferred_bytes = Some(overflow);
+    out.extend_from_slice(&bytes[..remaining]);
+    *deferred_bytes = Some(DeferredBytes {
+        bytes,
+        offset: remaining,
+    });
     false
+}
+
+fn append_deferred_capped(
+    out: &mut Vec<u8>,
+    max_drained_bytes_per_poll: usize,
+    deferred_bytes: &mut Option<DeferredBytes>,
+) -> bool {
+    let Some(deferred) = deferred_bytes.as_mut() else {
+        return true;
+    };
+
+    if out.len() >= max_drained_bytes_per_poll {
+        return false;
+    }
+
+    let remaining = max_drained_bytes_per_poll - out.len();
+    let available = deferred.bytes.len().saturating_sub(deferred.offset);
+    let take = available.min(remaining);
+    out.extend_from_slice(&deferred.bytes[deferred.offset..deferred.offset + take]);
+    deferred.offset += take;
+
+    if deferred.offset >= deferred.bytes.len() {
+        *deferred_bytes = None;
+        true
+    } else {
+        false
+    }
 }
 
 async fn handle_request(

--- a/crates/logfwd-io/src/http_input.rs
+++ b/crates/logfwd-io/src/http_input.rs
@@ -289,22 +289,25 @@ impl InputSource for HttpInput {
         }
 
         let mut all = Vec::new();
-        if let Some(bytes) = self.deferred_bytes.take() {
-            if !append_capped(
+        if let Some(bytes) = self.deferred_bytes.take()
+            && !append_capped(
                 &mut all,
                 bytes,
                 self.max_drained_bytes_per_poll,
                 &mut self.deferred_bytes,
-            ) {
-                return Ok(vec![InputEvent::Data {
-                    accounted_bytes: all.len() as u64,
-                    bytes: all,
-                    source_id: None,
-                }]);
-            }
+            )
+        {
+            return Ok(vec![InputEvent::Data {
+                accounted_bytes: all.len() as u64,
+                bytes: all,
+                source_id: None,
+            }]);
         }
 
         loop {
+            if all.len() >= self.max_drained_bytes_per_poll {
+                break;
+            }
             let recv_result = {
                 let Some(rx) = self.rx.as_ref() else {
                     break;
@@ -356,7 +359,7 @@ impl InputSource for HttpInput {
 
 fn append_capped(
     out: &mut Vec<u8>,
-    bytes: Vec<u8>,
+    mut bytes: Vec<u8>,
     max_drained_bytes_per_poll: usize,
     deferred_bytes: &mut Option<Vec<u8>>,
 ) -> bool {
@@ -371,8 +374,9 @@ fn append_capped(
         return true;
     }
 
-    out.extend_from_slice(&bytes[..remaining]);
-    *deferred_bytes = Some(bytes[remaining..].to_vec());
+    let overflow = bytes.split_off(remaining);
+    out.extend_from_slice(&bytes);
+    *deferred_bytes = Some(overflow);
     false
 }
 

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -341,6 +341,9 @@ pub(super) fn build_input_state(
                 if let Some(max_request_body_size) = http.max_request_body_size {
                     options.max_request_body_size = max_request_body_size;
                 }
+                if let Some(max_drained_bytes_per_poll) = http.max_drained_bytes_per_poll {
+                    options.max_drained_bytes_per_poll = max_drained_bytes_per_poll;
+                }
                 if let Some(response_code) = http.response_code {
                     options.response_code = response_code;
                 }


### PR DESCRIPTION
## Summary

- Wire `http.max_drained_bytes_per_poll` into HTTP input runtime options and config validation.
- Cap bytes emitted from the HTTP input internal queue per `poll()` call, deferring overflow bytes to the next poll.
- Reject explicitly blank `Content-Encoding` headers before enqueueing request bytes.
- Update the config reference for the now-active drain cap and correct the documented default request body size to 10 MiB.

## Issue Notes

Addresses #2107, covering #1917 and #2012.

The drain cap is a per-poll aggregation bound. Request acceptance remains bounded separately by `http.max_request_body_size` and the existing bounded channel capacity.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p logfwd-io http_poll_respects_max_drained_bytes_per_poll -- --nocapture`
- `cargo test -p logfwd-io http_rejects_empty_content_encoding_header_before_enqueue -- --nocapture`
- `cargo test -p logfwd-io content_encoding_absent_header_is_accepted -- --nocapture`
- `cargo test -p logfwd-config http_max_drained_bytes_per_poll_zero_is_rejected -- --nocapture`
- `cargo test -p logfwd-io http_input::tests -- --nocapture`
- `cargo test -p logfwd-config validate_http_response_tests -- --nocapture`
- `npm --prefix book ci`
- `npm --prefix book run build`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap HTTP input poll draining to 1 GiB per poll with configurable `max_drained_bytes_per_poll`
> - Adds a per-poll byte budget to `HttpInput` polling: at most `max_drained_bytes_per_poll` bytes are returned per poll call, with overflow deferred to subsequent polls in order.
> - Introduces `http.max_drained_bytes_per_poll` config option (default 1 GiB), wired through from config into `HttpInputOptions` via [`input_build.rs`](https://github.com/strawgate/fastforward/pull/2287/files#diff-ca354d25bc72dec0d7f48518cd76a40d5bfab0a1f22f56449adbd8e2a81ffc4f).
> - Rejects `max_drained_bytes_per_poll=0` at both config validation and `HttpInput` construction time.
> - Fixes `parse_content_encoding` to reject empty `Content-Encoding` header values with a 400 response before enqueueing data.
> - Updates documented default for `http.max_request_body_size` from 20 MiB to 10 MiB in [`reference.mdx`](https://github.com/strawgate/fastforward/pull/2287/files#diff-6a69bd5c38c92acca3dd194d75d77551f1b8f6b98890da7e56f2c9cbe564aac4).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4693c42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->