### PR TITLE
fix: validate OTAP star schema edges

### DIFF
--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -592,19 +592,23 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
     // severity_number
     if let Ok(sev_num_idx) = logs_schema.index_of("severity_number") {
         let sev_num_arr = star.logs.column(sev_num_idx);
-        if matches!(sev_num_arr.data_type(), DataType::Int32) {
-            let col_pos = ensure_int_col("severity_number", &mut flat_cols, &mut col_index);
-            protected_log_fact_cols.insert("severity_number".to_string());
-            let sev_num_arr = sev_num_arr
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .ok_or_else(|| ArrowError::SchemaError("severity_number not Int32".to_string()))?;
-            for row in 0..num_rows {
-                if !sev_num_arr.is_null(row)
-                    && let TypedColumn::Int(ref mut v) = flat_cols[col_pos].1
-                {
-                    v[row] = Some(i64::from(sev_num_arr.value(row)));
-                }
+        if !matches!(sev_num_arr.data_type(), DataType::Int32) {
+            return Err(ArrowError::SchemaError(format!(
+                "severity_number must be Int32, got {}",
+                sev_num_arr.data_type()
+            )));
+        }
+        let col_pos = ensure_int_col("severity_number", &mut flat_cols, &mut col_index);
+        protected_log_fact_cols.insert("severity_number".to_string());
+        let sev_num_arr = sev_num_arr
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .ok_or_else(|| ArrowError::SchemaError("severity_number not Int32".to_string()))?;
+        for row in 0..num_rows {
+            if !sev_num_arr.is_null(row)
+                && let TypedColumn::Int(ref mut v) = flat_cols[col_pos].1
+            {
+                v[row] = Some(i64::from(sev_num_arr.value(row)));
             }
         }
     }
@@ -612,21 +616,25 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
     // trace_id (16-byte fixed binary) -> lowercase hex string
     if let Ok(trace_idx) = logs_schema.index_of("trace_id") {
         let trace_arr = star.logs.column(trace_idx);
-        if matches!(trace_arr.data_type(), DataType::FixedSizeBinary(16)) {
-            let col_pos = ensure_str_col("trace_id", &mut flat_cols, &mut col_index);
-            protected_log_fact_cols.insert("trace_id".to_string());
-            let trace_arr = trace_arr
-                .as_any()
-                .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
-                .ok_or_else(|| {
-                    ArrowError::SchemaError("trace_id not FixedSizeBinary(16)".to_string())
-                })?;
-            for row in 0..num_rows {
-                if !trace_arr.is_null(row)
-                    && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
-                {
-                    v[row] = Some(hex_encode_lower(trace_arr.value(row)));
-                }
+        if !matches!(trace_arr.data_type(), DataType::FixedSizeBinary(16)) {
+            return Err(ArrowError::SchemaError(format!(
+                "trace_id must be FixedSizeBinary(16), got {}",
+                trace_arr.data_type()
+            )));
+        }
+        let col_pos = ensure_str_col("trace_id", &mut flat_cols, &mut col_index);
+        protected_log_fact_cols.insert("trace_id".to_string());
+        let trace_arr = trace_arr
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+            .ok_or_else(|| {
+                ArrowError::SchemaError("trace_id not FixedSizeBinary(16)".to_string())
+            })?;
+        for row in 0..num_rows {
+            if !trace_arr.is_null(row)
+                && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
+            {
+                v[row] = Some(hex_encode_lower(trace_arr.value(row)));
             }
         }
     }
@@ -634,21 +642,23 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
     // span_id (8-byte fixed binary) -> lowercase hex string
     if let Ok(span_idx) = logs_schema.index_of("span_id") {
         let span_arr = star.logs.column(span_idx);
-        if matches!(span_arr.data_type(), DataType::FixedSizeBinary(8)) {
-            let col_pos = ensure_str_col("span_id", &mut flat_cols, &mut col_index);
-            protected_log_fact_cols.insert("span_id".to_string());
-            let span_arr = span_arr
-                .as_any()
-                .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
-                .ok_or_else(|| {
-                    ArrowError::SchemaError("span_id not FixedSizeBinary(8)".to_string())
-                })?;
-            for row in 0..num_rows {
-                if !span_arr.is_null(row)
-                    && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
-                {
-                    v[row] = Some(hex_encode_lower(span_arr.value(row)));
-                }
+        if !matches!(span_arr.data_type(), DataType::FixedSizeBinary(8)) {
+            return Err(ArrowError::SchemaError(format!(
+                "span_id must be FixedSizeBinary(8), got {}",
+                span_arr.data_type()
+            )));
+        }
+        let col_pos = ensure_str_col("span_id", &mut flat_cols, &mut col_index);
+        protected_log_fact_cols.insert("span_id".to_string());
+        let span_arr = span_arr
+            .as_any()
+            .downcast_ref::<arrow::array::FixedSizeBinaryArray>()
+            .ok_or_else(|| ArrowError::SchemaError("span_id not FixedSizeBinary(8)".to_string()))?;
+        for row in 0..num_rows {
+            if !span_arr.is_null(row)
+                && let TypedColumn::Str(ref mut v) = flat_cols[col_pos].1
+            {
+                v[row] = Some(hex_encode_lower(span_arr.value(row)));
             }
         }
     }
@@ -656,19 +666,23 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
     // flags
     if let Ok(flags_idx) = logs_schema.index_of("flags") {
         let flags_arr = star.logs.column(flags_idx);
-        if matches!(flags_arr.data_type(), DataType::UInt32) {
-            let col_pos = ensure_int_col("flags", &mut flat_cols, &mut col_index);
-            protected_log_fact_cols.insert("flags".to_string());
-            let flags_arr = flags_arr
-                .as_any()
-                .downcast_ref::<UInt32Array>()
-                .ok_or_else(|| ArrowError::SchemaError("flags not UInt32".to_string()))?;
-            for row in 0..num_rows {
-                if !flags_arr.is_null(row)
-                    && let TypedColumn::Int(ref mut v) = flat_cols[col_pos].1
-                {
-                    v[row] = Some(i64::from(flags_arr.value(row)));
-                }
+        if !matches!(flags_arr.data_type(), DataType::UInt32) {
+            return Err(ArrowError::SchemaError(format!(
+                "flags must be UInt32, got {}",
+                flags_arr.data_type()
+            )));
+        }
+        let col_pos = ensure_int_col("flags", &mut flat_cols, &mut col_index);
+        protected_log_fact_cols.insert("flags".to_string());
+        let flags_arr = flags_arr
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .ok_or_else(|| ArrowError::SchemaError("flags not UInt32".to_string()))?;
+        for row in 0..num_rows {
+            if !flags_arr.is_null(row)
+                && let TypedColumn::Int(ref mut v) = flat_cols[col_pos].1
+            {
+                v[row] = Some(i64::from(flags_arr.value(row)));
             }
         }
     }
@@ -3266,6 +3280,67 @@ mod tests {
                 .contains("time_unix_nano must be Timestamp(Nanosecond)"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn star_to_flat_returns_error_for_unsupported_optional_logs_column_types() {
+        let logs_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt32, false),
+            Field::new("resource_id", DataType::UInt32, false),
+            Field::new("scope_id", DataType::UInt32, false),
+            Field::new("severity_number", DataType::Utf8, true),
+        ]));
+        let logs = RecordBatch::try_new(
+            logs_schema,
+            vec![
+                Arc::new(UInt32Array::from(vec![0u32])),
+                Arc::new(UInt32Array::from(vec![0u32])),
+                Arc::new(UInt32Array::from(vec![0u32])),
+                Arc::new(StringArray::from(vec![Some("9")])),
+            ],
+        )
+        .expect("valid malformed logs batch");
+        let star = StarSchema {
+            logs,
+            log_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+            resource_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+            scope_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+        };
+
+        let err = star_to_flat(&star).expect_err("invalid severity_number type must fail");
+        assert!(
+            err.to_string().contains("severity_number must be Int32"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_string_log_attr_survives_star_roundtrip() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("message", DataType::Utf8, true),
+            Field::new("user.id", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("first"), Some("second")])),
+                Arc::new(StringArray::from(vec![Some(""), Some("alice")])),
+            ],
+        )
+        .expect("valid batch");
+
+        let star = flat_to_star(&batch).expect("flat_to_star");
+        let roundtrip = star_to_flat(&star).expect("star_to_flat");
+
+        let idx = roundtrip.schema().index_of("user.id").expect("user.id");
+        let values = roundtrip
+            .column(idx)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("utf8");
+        assert!(!values.is_null(0), "empty string must not become NULL");
+        assert_eq!(values.value(0), "");
+        assert_eq!(values.value(1), "alice");
     }
 
     /// Conflict struct columns (e.g. `status: Struct { int, str }`) must be

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -3314,6 +3314,70 @@ mod tests {
         );
     }
 
+    fn assert_optional_logs_column_type_error(field: Field, column: ArrayRef, expected: &str) {
+        let field_name = field.name().clone();
+        let logs_schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::UInt32, false),
+            Field::new("resource_id", DataType::UInt32, false),
+            Field::new("scope_id", DataType::UInt32, false),
+            field,
+        ]));
+        let logs = RecordBatch::try_new(
+            logs_schema,
+            vec![
+                Arc::new(UInt32Array::from(vec![0u32])),
+                Arc::new(UInt32Array::from(vec![0u32])),
+                Arc::new(UInt32Array::from(vec![0u32])),
+                column,
+            ],
+        )
+        .expect("valid malformed logs batch");
+        let star = StarSchema {
+            logs,
+            log_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+            resource_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+            scope_attrs: RecordBatch::new_empty(Arc::new(attrs_schema())),
+        };
+
+        let err = star_to_flat(&star).expect_err("invalid optional LOGS column type must fail");
+        let message = err.to_string();
+        assert!(
+            message.contains(&field_name),
+            "expected error to mention {field_name}, got: {message}"
+        );
+        assert!(
+            message.contains(expected),
+            "expected error to mention {expected}, got: {message}"
+        );
+    }
+
+    #[test]
+    fn star_to_flat_returns_error_for_unsupported_trace_id_type() {
+        assert_optional_logs_column_type_error(
+            Field::new("trace_id", DataType::Utf8, true),
+            Arc::new(StringArray::from(vec![Some("not-binary")])) as ArrayRef,
+            "FixedSizeBinary(16)",
+        );
+    }
+
+    #[test]
+    fn star_to_flat_returns_error_for_unsupported_span_id_type() {
+        assert_optional_logs_column_type_error(
+            Field::new("span_id", DataType::Utf8, true),
+            Arc::new(StringArray::from(vec![Some("not-binary")])) as ArrayRef,
+            "FixedSizeBinary(8)",
+        );
+    }
+
+    #[test]
+    fn star_to_flat_returns_error_for_unsupported_flags_type() {
+        assert_optional_logs_column_type_error(
+            Field::new("flags", DataType::Int64, true),
+            Arc::new(Int64Array::from(vec![Some(1i64)])) as ArrayRef,
+            "UInt32",
+        );
+    }
+
     #[test]
     fn empty_string_log_attr_survives_star_roundtrip() {
         let schema = Arc::new(Schema::new(vec![

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -584,6 +584,9 @@ mod tests {
         UInt32Array,
     };
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::Write as _;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
@@ -1025,6 +1028,53 @@ mod tests {
             Err(ureq::Error::StatusCode(code)) => assert_eq!(code, 405),
             other => panic!("expected 405, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn receiver_rejects_unsupported_content_type() {
+        let receiver = OtapReceiver::new_with_capacity("test-415", "127.0.0.1:0", 16)
+            .expect("bind should succeed");
+        let addr = receiver.local_addr();
+
+        let url = format!("http://{addr}/v1/arrow_logs");
+        let result = loopback_http_client()
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .send(b"{}" as &[u8]);
+        match result {
+            Err(ureq::Error::StatusCode(code)) => assert_eq!(code, 415),
+            other => panic!("expected 415, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn receiver_rejects_truncated_gzip_body() {
+        let receiver = OtapReceiver::new_with_capacity("test-gzip-truncated", "127.0.0.1:0", 16)
+            .expect("bind should succeed");
+        let addr = receiver.local_addr();
+
+        let logs_ipc = serialize_batch_to_ipc(&make_logs_batch());
+        let proto = encode_batch_arrow_records(9, &[(PAYLOAD_TYPE_LOGS, &logs_ipc)]);
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder
+            .write_all(&proto)
+            .expect("should write OTAP payload to gzip stream");
+        let mut gzip = encoder.finish().expect("should finish gzip stream");
+        gzip.truncate(gzip.len().saturating_sub(4));
+
+        let url = format!("http://{addr}/v1/arrow_logs");
+        let result = loopback_http_client()
+            .post(&url)
+            .header("Content-Type", "application/x-protobuf")
+            .header("Content-Encoding", "gzip")
+            .send(&gzip);
+
+        let status: u16 = match result {
+            Ok(resp) => resp.status().as_u16(),
+            Err(ureq::Error::StatusCode(code)) => code,
+            Err(err) => panic!("unexpected transport error: {err}"),
+        };
+        assert_eq!(status, 400, "truncated gzip body must be rejected");
     }
 
     #[test]

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -586,6 +586,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use flate2::Compression;
     use flate2::write::GzEncoder;
+    use std::io::Seek as _;
     use std::io::Write as _;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -612,6 +613,14 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         assert!(predicate(), "{failure_message}");
+    }
+
+    fn tempfile_payload(bytes: &[u8]) -> std::fs::File {
+        let mut file = tempfile::tempfile().expect("create tempfile payload");
+        file.write_all(bytes).expect("write tempfile payload");
+        file.flush().expect("flush tempfile payload");
+        file.rewind().expect("rewind tempfile payload");
+        file
     }
 
     // Regression test for issue #1142: clean shutdown
@@ -1037,10 +1046,11 @@ mod tests {
         let addr = receiver.local_addr();
 
         let url = format!("http://{addr}/v1/arrow_logs");
+        let payload = tempfile_payload(b"{}");
         let result = loopback_http_client()
             .post(&url)
             .header("Content-Type", "application/json")
-            .send(b"{}" as &[u8]);
+            .send(payload);
         match result {
             Err(ureq::Error::StatusCode(code)) => assert_eq!(code, 415),
             other => panic!("expected 415, got {other:?}"),
@@ -1063,11 +1073,12 @@ mod tests {
         gzip.truncate(gzip.len().saturating_sub(4));
 
         let url = format!("http://{addr}/v1/arrow_logs");
+        let payload = tempfile_payload(&gzip);
         let result = loopback_http_client()
             .post(&url)
             .header("Content-Type", "application/x-protobuf")
             .header("Content-Encoding", "gzip")
-            .send(&gzip);
+            .send(payload);
 
         let status: u16 = match result {
             Ok(resp) => resp.status().as_u16(),


### PR DESCRIPTION
## Summary

- Make `star_to_flat` fail fast when optional LOGS fact columns have unsupported types instead of silently dropping them.
- Add regression coverage that empty string log attributes survive flat -> star -> flat roundtrip.
- Add OTAP receiver regression tests for unsupported `Content-Type` and truncated gzip bodies.

## Issue Notes

Addresses #2090.

Cloud fan-in found #1899, #1900, and #1997 are stale in current behavior, so this PR locks them down with regression tests. #2020 is the confirmed behavior change: unsupported optional LOGS fact column types now return schema errors.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p logfwd-arrow star_to_flat_returns_error_for_unsupported_optional_logs_column_types -- --nocapture`
- `cargo test -p logfwd-arrow empty_string_log_attr_survives_star_roundtrip -- --nocapture`
- `cargo test -p logfwd-io receiver_rejects_unsupported_content_type -- --nocapture`
- `cargo test -p logfwd-io receiver_rejects_truncated_gzip_body -- --nocapture`
- `cargo test -p logfwd-arrow star_schema::tests:: -- --nocapture`
- `cargo test -p logfwd-io otap_receiver::tests:: -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate OTAP star schema edge column types in `star_to_flat`
> - `star_to_flat` in [star_schema.rs](https://github.com/strawgate/fastforward/pull/2288/files#diff-fb28eb9d8306708fff07b41c8d2b450df493a129ad9ffa16eceed5676b3a0f62) now returns `ArrowError::SchemaError` when optional LOGS columns have unexpected types (`severity_number`≠Int32, `trace_id`≠FixedSizeBinary(16), `span_id`≠FixedSizeBinary(8), `flags`≠UInt32), instead of silently skipping them.
> - Tests are added to [otap_receiver.rs](https://github.com/strawgate/fastforward/pull/2288/files#diff-d857a8f6754a55babf2b290bc90d4dc983d53420419d6c33740dd7bab066964a) covering rejection of unsupported content types (415) and truncated gzip bodies (400).
> - Behavioral Change: callers that previously relied on silent column skipping for mismatched types will now receive an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 764566a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->