### PR TITLE
fix: encode otlp uint64 attrs safely

### DIFF
--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -40,6 +40,8 @@ mod generated {
 const SCOPE_NAME: &[u8] = b"logfwd";
 /// Version emitted in the OTLP `InstrumentationScope.version` field (from Cargo.toml).
 const SCOPE_VERSION: &[u8] = env!("CARGO_PKG_VERSION").as_bytes();
+/// Default gRPC outbound message size guardrail.
+const DEFAULT_GRPC_MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 
 // ---------------------------------------------------------------------------
 // OtlpSink
@@ -540,6 +542,16 @@ impl OtlpSink {
             Compression::None => false,
         };
         let payload: &[u8] = if self.protocol == OtlpProtocol::Grpc {
+            if payload.len() > DEFAULT_GRPC_MAX_MESSAGE_BYTES {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "OTLP gRPC payload too large: {} bytes exceeds max {} bytes",
+                        payload.len(),
+                        DEFAULT_GRPC_MAX_MESSAGE_BYTES
+                    ),
+                ));
+            }
             write_grpc_frame(&mut self.grpc_buf, payload, payload_is_compressed)?;
             &self.grpc_buf
         } else {
@@ -783,6 +795,7 @@ enum AttrArray<'a> {
     Bytes(&'a BinaryArray),
     LargeBytes(&'a LargeBinaryArray),
     Int(&'a PrimitiveArray<Int64Type>),
+    UInt(&'a PrimitiveArray<UInt64Type>),
     Float(&'a PrimitiveArray<Float64Type>),
     Bool(&'a arrow::array::BooleanArray),
 }
@@ -813,6 +826,24 @@ impl AttrArray<'_> {
                 (!arr.is_null(row)).then(|| ResourceValueRef::Bytes(arr.value(row)))
             }
             Self::Int(arr) => (!arr.is_null(row)).then(|| ResourceValueRef::Int(arr.value(row))),
+            Self::UInt(arr) => {
+                if arr.is_null(row) {
+                    return None;
+                }
+                let value = arr.value(row);
+                match i64::try_from(value) {
+                    Ok(value) => Some(ResourceValueRef::Int(value)),
+                    Err(_) => {
+                        tracing::warn!(
+                            column = field_name,
+                            row,
+                            value,
+                            "skipping OTLP resource attribute: UInt64 value exceeds AnyValue.int_value range"
+                        );
+                        None
+                    }
+                }
+            }
             Self::Float(arr) => {
                 (!arr.is_null(row)).then(|| ResourceValueRef::Float(arr.value(row).to_bits()))
             }
@@ -1062,6 +1093,7 @@ fn resolve_batch_columns<'a>(
         if let Some(original_key) = resource_key {
             let resource_attr = match field.data_type() {
                 DataType::Int64 => AttrArray::Int(batch.column(idx).as_primitive::<Int64Type>()),
+                DataType::UInt64 => AttrArray::UInt(batch.column(idx).as_primitive::<UInt64Type>()),
                 DataType::Float64 => {
                     AttrArray::Float(batch.column(idx).as_primitive::<Float64Type>())
                 }
@@ -1109,6 +1141,7 @@ fn resolve_batch_columns<'a>(
         // `field.data_type()` avoids an `as_primitive` panic in that case.
         let attr = match field.data_type() {
             DataType::Int64 => AttrArray::Int(batch.column(idx).as_primitive::<Int64Type>()),
+            DataType::UInt64 => AttrArray::UInt(batch.column(idx).as_primitive::<UInt64Type>()),
             DataType::Float64 => AttrArray::Float(batch.column(idx).as_primitive::<Float64Type>()),
             DataType::Boolean => AttrArray::Bool(batch.column(idx).as_boolean()),
             DataType::Binary => {
@@ -1483,6 +1516,30 @@ fn encode_col_attr(buf: &mut Vec<u8>, field_number: u32, col: &ColAttr<'_>, row:
             encode_varint(buf, anyvalue_inner as u64);
             encode_varint_field(buf, otlp::ANY_VALUE_INT_VALUE, value as u64);
         }
+        AttrArray::UInt(arr) => {
+            if col.has_nulls && arr.is_null(row) {
+                return;
+            }
+            let value = arr.value(row);
+            let Ok(value) = i64::try_from(value) else {
+                tracing::warn!(
+                    column = col.name.as_str(),
+                    row,
+                    value,
+                    "skipping OTLP attribute: UInt64 value exceeds AnyValue.int_value range"
+                );
+                return;
+            };
+            let anyvalue_inner = 1 + varint_len(value as u64);
+            let kv_inner =
+                col.kv_key_cost + bytes_field_size(otlp::KEY_VALUE_VALUE, anyvalue_inner);
+            encode_tag(buf, field_number, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, kv_inner as u64);
+            buf.extend_from_slice(&col.key_encoding);
+            encode_tag(buf, otlp::KEY_VALUE_VALUE, otlp::WIRE_TYPE_LEN);
+            encode_varint(buf, anyvalue_inner as u64);
+            encode_varint_field(buf, otlp::ANY_VALUE_INT_VALUE, value as u64);
+        }
         AttrArray::Float(arr) => {
             if col.has_nulls && arr.is_null(row) {
                 return;
@@ -1736,6 +1793,28 @@ mod tests {
             }
             _ => panic!("Expected RetryAfter on 503 response, got: {:?}", result),
         }
+    }
+
+    #[tokio::test]
+    async fn grpc_oversized_payload_is_rejected_before_send() {
+        let mut sink = OtlpSink::new(
+            "test".into(),
+            "http://localhost:4317".into(),
+            OtlpProtocol::Grpc,
+            Compression::None,
+            vec![],
+            reqwest::Client::new(),
+            Arc::new(ComponentStats::new()),
+        )
+        .expect("sink must construct");
+
+        sink.encoder_buf = vec![0u8; DEFAULT_GRPC_MAX_MESSAGE_BYTES + 1];
+        let err = sink
+            .send_payload(1)
+            .await
+            .expect_err("oversized gRPC payload must return InvalidInput");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[test]
@@ -3554,6 +3633,83 @@ mod tests {
         assert_eq!(
             lr.time_unix_nano, EXPECTED_NS,
             "UInt64 time_unix_nano column must be encoded as LogRecord.time_unix_nano"
+        );
+    }
+
+    #[test]
+    fn uint64_attribute_encodes_as_int_when_representable() {
+        use arrow::array::UInt64Array;
+        use opentelemetry_proto::tonic::{
+            collector::logs::v1::ExportLogsServiceRequest, common::v1::any_value::Value,
+        };
+        use prost::Message;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("body", DataType::Utf8, true),
+            Field::new("count_u64", DataType::UInt64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("hello")])),
+                Arc::new(UInt64Array::from(vec![Some(42u64)])),
+            ],
+        )
+        .expect("valid batch");
+
+        let mut sink = make_sink();
+        sink.encode_batch(&batch, &make_metadata());
+
+        let request = ExportLogsServiceRequest::decode(sink.encoder_buf.as_slice())
+            .expect("prost must decode UInt64 attribute batch");
+        let attrs = &request.resource_logs[0].scope_logs[0].log_records[0].attributes;
+        let attr = attrs
+            .iter()
+            .find(|kv| kv.key == "count_u64")
+            .expect("count_u64 attribute must be present");
+
+        assert_eq!(
+            attr.value
+                .as_ref()
+                .and_then(|v| v.value.as_ref())
+                .and_then(|v| match v {
+                    Value::IntValue(v) => Some(*v),
+                    _ => None,
+                }),
+            Some(42),
+            "representable UInt64 must encode as AnyValue.int_value"
+        );
+    }
+
+    #[test]
+    fn uint64_attribute_over_i64_max_is_dropped() {
+        use arrow::array::UInt64Array;
+        use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+        use prost::Message;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("body", DataType::Utf8, true),
+            Field::new("count_u64", DataType::UInt64, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("hello")])),
+                Arc::new(UInt64Array::from(vec![Some(u64::MAX)])),
+            ],
+        )
+        .expect("valid batch");
+
+        let mut sink = make_sink();
+        sink.encode_batch(&batch, &make_metadata());
+
+        let request = ExportLogsServiceRequest::decode(sink.encoder_buf.as_slice())
+            .expect("prost must decode oversized UInt64 attribute batch");
+        let attrs = &request.resource_logs[0].scope_logs[0].log_records[0].attributes;
+
+        assert!(
+            attrs.iter().all(|kv| kv.key != "count_u64"),
+            "out-of-range UInt64 must not be stringified or wrapped into int_value"
         );
     }
 

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -3637,7 +3637,7 @@ mod tests {
     }
 
     #[test]
-    fn uint64_attribute_encodes_as_int_when_representable() {
+    fn uint64_attribute_encodes_or_drops_by_int64_range() {
         use arrow::array::UInt64Array;
         use opentelemetry_proto::tonic::{
             collector::logs::v1::ExportLogsServiceRequest, common::v1::any_value::Value,
@@ -3651,8 +3651,8 @@ mod tests {
         let batch = RecordBatch::try_new(
             schema,
             vec![
-                Arc::new(StringArray::from(vec![Some("hello")])),
-                Arc::new(UInt64Array::from(vec![Some(42u64)])),
+                Arc::new(StringArray::from(vec![Some("ok"), Some("too-big")])),
+                Arc::new(UInt64Array::from(vec![Some(42u64), Some(u64::MAX)])),
             ],
         )
         .expect("valid batch");
@@ -3662,53 +3662,23 @@ mod tests {
 
         let request = ExportLogsServiceRequest::decode(sink.encoder_buf.as_slice())
             .expect("prost must decode UInt64 attribute batch");
-        let attrs = &request.resource_logs[0].scope_logs[0].log_records[0].attributes;
-        let attr = attrs
+        let records = &request.resource_logs[0].scope_logs[0].log_records;
+        let first = records[0]
+            .attributes
             .iter()
             .find(|kv| kv.key == "count_u64")
             .expect("count_u64 attribute must be present");
 
         assert_eq!(
-            attr.value
-                .as_ref()
-                .and_then(|v| v.value.as_ref())
-                .and_then(|v| match v {
-                    Value::IntValue(v) => Some(*v),
-                    _ => None,
-                }),
+            first.value.as_ref().and_then(|v| match v.value.as_ref() {
+                Some(Value::IntValue(v)) => Some(*v),
+                _ => None,
+            }),
             Some(42),
             "representable UInt64 must encode as AnyValue.int_value"
         );
-    }
-
-    #[test]
-    fn uint64_attribute_over_i64_max_is_dropped() {
-        use arrow::array::UInt64Array;
-        use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
-        use prost::Message;
-
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("body", DataType::Utf8, true),
-            Field::new("count_u64", DataType::UInt64, true),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema,
-            vec![
-                Arc::new(StringArray::from(vec![Some("hello")])),
-                Arc::new(UInt64Array::from(vec![Some(u64::MAX)])),
-            ],
-        )
-        .expect("valid batch");
-
-        let mut sink = make_sink();
-        sink.encode_batch(&batch, &make_metadata());
-
-        let request = ExportLogsServiceRequest::decode(sink.encoder_buf.as_slice())
-            .expect("prost must decode oversized UInt64 attribute batch");
-        let attrs = &request.resource_logs[0].scope_logs[0].log_records[0].attributes;
-
         assert!(
-            attrs.iter().all(|kv| kv.key != "count_u64"),
+            records[1].attributes.iter().all(|kv| kv.key != "count_u64"),
             "out-of-range UInt64 must not be stringified or wrapped into int_value"
         );
     }


### PR DESCRIPTION
## Summary
- encode OTLP UInt64 attributes/resource attributes as AnyValue.int_value when they fit in the OTLP int64 range
- drop over-range UInt64 attributes with an explicit warning instead of stringifying or wrapping them
- reject oversized gRPC OTLP payloads locally before send to avoid retrying permanently unsendable batches

## Scope notes
This intentionally keeps #2105 scoped to the two still-open bugs, #2013 and #2058. The cloud output also touched Loki labels and ResourceLogs grouping, but #2105 says those were already resolved by earlier PRs, so those changes are not included here.

## Verification
- cargo test -p logfwd-output --lib otlp_sink::tests::uint64_attribute_encodes_as_int_when_representable -- --nocapture
- cargo test -p logfwd-output --lib otlp_sink::tests::uint64_attribute_over_i64_max_is_dropped -- --nocapture
- cargo test -p logfwd-output --lib otlp_sink::tests::grpc_oversized_payload_is_rejected_before_send -- --nocapture
- cargo test -p logfwd-output --lib otlp_sink::tests -- --nocapture
- cargo fmt --check
- git diff --check
- just ci

Fixes #2013.
Fixes #2058.
Closes #2105.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OTLP encoding of uint64 attributes and add gRPC payload size guard
> - Adds support for `UInt64`-typed attribute columns in [`otlp_sink.rs`](https://github.com/strawgate/fastforward/pull/2290/files#diff-56ca7e19db98793b4ef621c0d28a618a4c8af2bd492bc89cc8a21e845f25a43c): values within `i64` range are encoded as `AnyValue.int_value`; out-of-range values are dropped with a warning instead of being stringified or causing errors.
> - Adds a 4 MiB size guard to `OtlpSink.send_payload` for gRPC: payloads exceeding `DEFAULT_GRPC_MAX_MESSAGE_BYTES` return an `io::Error` with kind `InvalidInput` before any send is attempted.
> - Risk: gRPC payloads previously sent above 4 MiB will now be rejected with an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8db94d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->