### PR TITLE
fix: avoid tcp retry duplicate writes

### DIFF
--- a/crates/logfwd-output/src/tcp_sink.rs
+++ b/crates/logfwd-output/src/tcp_sink.rs
@@ -132,8 +132,7 @@ where
     let deadline = Instant::now() + WRITE_TIMEOUT;
 
     while *written < buf.len() {
-        let result =
-            tokio::time::timeout_at(deadline, stream.write(&buf[*written..])).await;
+        let result = tokio::time::timeout_at(deadline, stream.write(&buf[*written..])).await;
         match result {
             Ok(Ok(0)) => {
                 return Err(io::Error::new(

--- a/crates/logfwd-output/src/tcp_sink.rs
+++ b/crates/logfwd-output/src/tcp_sink.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use arrow::record_batch::RecordBatch;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tokio::time::Instant;
 
 use logfwd_types::diagnostics::ComponentStats;
 
@@ -20,7 +21,7 @@ use crate::{BatchMetadata, build_col_infos, write_row_json};
 /// downstream is unreachable.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Write timeout per socket write operation.
+/// Write timeout for each full write attempt (all partial writes combined).
 const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct TcpSink {
@@ -102,7 +103,13 @@ where
             match write_remaining_bytes(active_stream, buf, &mut written).await {
                 Ok(()) => return Ok(()),
                 Err(e) => {
-                    written = retry_record_boundary(buf, written);
+                    // Reset to zero so the full buffer is resent after
+                    // reconnect.  `write()` only confirms bytes entered the
+                    // local kernel buffer — after a connection reset those
+                    // bytes may never have reached the peer.  Resending
+                    // produces at-least-once semantics (possible duplicates)
+                    // which is strictly safer than at-most-once (data loss).
+                    written = 0;
                     *stream = None;
                     last_error = Some(e);
                     if attempt == 1 {
@@ -120,8 +127,13 @@ async fn write_remaining_bytes<W>(stream: &mut W, buf: &[u8], written: &mut usiz
 where
     W: AsyncWrite + Unpin,
 {
+    // Single deadline for the entire write attempt.  This bounds total
+    // wall-clock time regardless of how many partial writes occur.
+    let deadline = Instant::now() + WRITE_TIMEOUT;
+
     while *written < buf.len() {
-        let result = tokio::time::timeout(WRITE_TIMEOUT, stream.write(&buf[*written..])).await;
+        let result =
+            tokio::time::timeout_at(deadline, stream.write(&buf[*written..])).await;
         match result {
             Ok(Ok(0)) => {
                 return Err(io::Error::new(
@@ -140,13 +152,6 @@ where
         }
     }
     Ok(())
-}
-
-fn retry_record_boundary(buf: &[u8], written: usize) -> usize {
-    buf[..written.min(buf.len())]
-        .iter()
-        .rposition(|byte| *byte == b'\n')
-        .map_or(0, |index| index + 1)
 }
 
 impl Sink for TcpSink {
@@ -346,7 +351,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_with_retry_does_not_replay_completed_records() {
+    async fn write_with_retry_resends_full_buffer_after_partial_write_error() {
+        // After a connection reset the kernel buffer contents may have been
+        // lost, so the retry must resend the *entire* buffer (at-least-once).
         let payload = b"first\nsecond\n";
         let first_seen = Arc::new(Mutex::new(Vec::new()));
         let second_seen = Arc::new(Mutex::new(Vec::new()));
@@ -359,7 +366,10 @@ mod tests {
                 ],
                 Arc::clone(&first_seen),
             ),
-            ScriptedWriter::new(vec![ScriptStep::Write(7)], Arc::clone(&second_seen)),
+            ScriptedWriter::new(
+                vec![ScriptStep::Write(payload.len())],
+                Arc::clone(&second_seen),
+            ),
         ]);
         let mut current = Some(writers.pop_front().expect("first writer missing"));
 
@@ -377,9 +387,10 @@ mod tests {
             &*first_seen.lock().expect("first lock poisoned"),
             b"first\nsec"
         );
+        // Full buffer resent — at-least-once semantics.
         assert_eq!(
             &*second_seen.lock().expect("second lock poisoned"),
-            b"second\n"
+            b"first\nsecond\n"
         );
     }
 

--- a/crates/logfwd-output/src/tcp_sink.rs
+++ b/crates/logfwd-output/src/tcp_sink.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use arrow::record_batch::RecordBatch;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 use logfwd_types::diagnostics::ComponentStats;
@@ -20,7 +20,7 @@ use crate::{BatchMetadata, build_col_infos, write_row_json};
 /// downstream is unreachable.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Write timeout per `write_all` call.
+/// Write timeout per socket write operation.
 const WRITE_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub struct TcpSink {
@@ -46,72 +46,99 @@ impl TcpSink {
         }
     }
 
-    /// Open a new connection, replacing any existing one.
-    async fn connect(&mut self) -> io::Result<()> {
-        let result = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(&self.addr)).await;
+    /// Write the buffer to the stream. On failure, drop the connection and
+    /// retry exactly once with a fresh connection.
+    async fn write_with_retry(&mut self) -> io::Result<()> {
+        let addr = self.addr.clone();
+        write_with_retry_generic(&self.buf, &mut self.stream, move || {
+            let addr = addr.clone();
+            async move { connect_stream(&addr).await }
+        })
+        .await
+    }
+}
 
-        let stream = match result {
-            Ok(Ok(s)) => s,
+async fn connect_stream(addr: &str) -> io::Result<TcpStream> {
+    let result = tokio::time::timeout(CONNECT_TIMEOUT, TcpStream::connect(addr)).await;
+
+    let stream = match result {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => return Err(e),
+        Err(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "TCP connect timed out",
+            ));
+        }
+    };
+
+    stream.set_nodelay(true)?;
+    Ok(stream)
+}
+
+async fn write_with_retry_generic<W, C, F>(
+    buf: &[u8],
+    stream: &mut Option<W>,
+    mut connect: C,
+) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    C: FnMut() -> F,
+    F: Future<Output = io::Result<W>>,
+{
+    if buf.is_empty() {
+        return Ok(());
+    }
+
+    let mut written = 0usize;
+    let mut last_error = None;
+
+    for attempt in 0..=1 {
+        if stream.is_none() {
+            *stream = Some(connect().await?);
+        }
+
+        if let Some(active_stream) = stream.as_mut() {
+            match write_remaining_bytes(active_stream, buf, &mut written).await {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    *stream = None;
+                    last_error = Some(e);
+                    if attempt == 1 {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| io::Error::other("TCP sink write failed")))
+}
+
+async fn write_remaining_bytes<W>(stream: &mut W, buf: &[u8], written: &mut usize) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    while *written < buf.len() {
+        let result = tokio::time::timeout(WRITE_TIMEOUT, stream.write(&buf[*written..])).await;
+        match result {
+            Ok(Ok(0)) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "TCP write returned zero bytes",
+                ));
+            }
+            Ok(Ok(n)) => *written += n,
             Ok(Err(e)) => return Err(e),
             Err(_) => {
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
-                    "TCP connect timed out",
+                    "TCP write timed out",
                 ));
             }
-        };
-
-        stream.set_nodelay(true)?;
-        self.stream = Some(stream);
-        Ok(())
-    }
-
-    /// Ensure we have a live connection, connecting lazily if needed.
-    async fn ensure_connected(&mut self) -> io::Result<()> {
-        if self.stream.is_some() {
-            return Ok(());
         }
-        self.connect().await
     }
-
-    /// Write the buffer to the stream. On failure, drop the connection and
-    /// retry exactly once with a fresh connection.
-    async fn write_with_retry(&mut self) -> io::Result<()> {
-        self.ensure_connected().await?;
-
-        // First attempt.
-        if let Some(ref mut stream) = self.stream {
-            let result = tokio::time::timeout(WRITE_TIMEOUT, stream.write_all(&self.buf)).await;
-            match result {
-                Ok(Ok(())) => return Ok(()),
-                Ok(Err(_)) | Err(_) => {
-                    // Connection went bad or timed out — drop it and retry below.
-                    self.stream = None;
-                }
-            }
-        }
-
-        // Single retry with a fresh connection.
-        self.connect().await?;
-        if let Some(ref mut stream) = self.stream {
-            let result = tokio::time::timeout(WRITE_TIMEOUT, stream.write_all(&self.buf)).await;
-            match result {
-                Ok(Ok(())) => return Ok(()),
-                Ok(Err(e)) => {
-                    self.stream = None;
-                    return Err(e);
-                }
-                Err(_) => {
-                    self.stream = None;
-                    return Err(io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        "TCP write timed out",
-                    ));
-                }
-            }
-        }
-        Ok(())
-    }
+    Ok(())
 }
 
 impl Sink for TcpSink {
@@ -197,5 +224,166 @@ impl SinkFactory for TcpSinkFactory {
 
     fn name(&self) -> &str {
         &self.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::io;
+    use std::pin::Pin;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context, Poll};
+
+    use tokio::io::AsyncWrite;
+
+    use super::write_with_retry_generic;
+
+    #[derive(Clone, Debug)]
+    enum ScriptStep {
+        Write(usize),
+        Error(io::ErrorKind),
+        Zero,
+    }
+
+    #[derive(Clone)]
+    struct ScriptedWriter {
+        steps: VecDeque<ScriptStep>,
+        received: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl ScriptedWriter {
+        fn new(steps: Vec<ScriptStep>, received: Arc<Mutex<Vec<u8>>>) -> Self {
+            Self {
+                steps: VecDeque::from(steps),
+                received,
+            }
+        }
+    }
+
+    impl AsyncWrite for ScriptedWriter {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            let step = self
+                .steps
+                .pop_front()
+                .expect("script exhausted in poll_write");
+            match step {
+                ScriptStep::Write(n) => {
+                    let to_take = n.min(buf.len());
+                    self.received
+                        .lock()
+                        .expect("received lock poisoned")
+                        .extend_from_slice(&buf[..to_take]);
+                    Poll::Ready(Ok(to_take))
+                }
+                ScriptStep::Error(kind) => {
+                    Poll::Ready(Err(io::Error::new(kind, "scripted write error")))
+                }
+                ScriptStep::Zero => Poll::Ready(Ok(0)),
+            }
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn write_with_retry_does_not_duplicate_after_partial_write_error() {
+        let payload = b"abcdef";
+        let first_seen = Arc::new(Mutex::new(Vec::new()));
+        let second_seen = Arc::new(Mutex::new(Vec::new()));
+
+        let mut writers = VecDeque::from([
+            ScriptedWriter::new(
+                vec![
+                    ScriptStep::Write(2),
+                    ScriptStep::Error(io::ErrorKind::BrokenPipe),
+                ],
+                Arc::clone(&first_seen),
+            ),
+            ScriptedWriter::new(vec![ScriptStep::Write(4)], Arc::clone(&second_seen)),
+        ]);
+        let mut current = Some(writers.pop_front().expect("first writer missing"));
+
+        write_with_retry_generic(payload, &mut current, move || {
+            std::future::ready(
+                writers
+                    .pop_front()
+                    .ok_or_else(|| io::Error::other("no reconnect writer available")),
+            )
+        })
+        .await
+        .expect("write_with_retry should succeed");
+
+        assert_eq!(&*first_seen.lock().expect("first lock poisoned"), b"ab");
+        assert_eq!(&*second_seen.lock().expect("second lock poisoned"), b"cdef");
+    }
+
+    #[tokio::test]
+    async fn write_with_retry_retries_once_after_zero_byte_write() {
+        let payload = b"payload";
+        let first_seen = Arc::new(Mutex::new(Vec::new()));
+        let second_seen = Arc::new(Mutex::new(Vec::new()));
+
+        let mut writers = VecDeque::from([
+            ScriptedWriter::new(vec![ScriptStep::Zero], Arc::clone(&first_seen)),
+            ScriptedWriter::new(
+                vec![ScriptStep::Write(payload.len())],
+                Arc::clone(&second_seen),
+            ),
+        ]);
+        let mut current = Some(writers.pop_front().expect("first writer missing"));
+
+        write_with_retry_generic(payload, &mut current, move || {
+            std::future::ready(
+                writers
+                    .pop_front()
+                    .ok_or_else(|| io::Error::other("no reconnect writer available")),
+            )
+        })
+        .await
+        .expect("zero write on first attempt should retry");
+
+        assert!(first_seen.lock().expect("first lock poisoned").is_empty());
+        assert_eq!(
+            &*second_seen.lock().expect("second lock poisoned"),
+            b"payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_with_retry_returns_write_zero_after_retry_zero_write() {
+        let mut writers = VecDeque::from([ScriptedWriter::new(
+            vec![ScriptStep::Zero],
+            Arc::new(Mutex::new(Vec::new())),
+        )]);
+        let mut current = Some(ScriptedWriter::new(
+            vec![ScriptStep::Zero],
+            Arc::new(Mutex::new(Vec::new())),
+        ));
+
+        let err = write_with_retry_generic(b"x", &mut current, move || {
+            std::future::ready(
+                writers
+                    .pop_front()
+                    .ok_or_else(|| io::Error::other("no reconnect writer available")),
+            )
+        })
+        .await
+        .expect_err("second zero-byte write should fail");
+
+        assert_eq!(err.kind(), io::ErrorKind::WriteZero);
     }
 }

--- a/crates/logfwd-output/src/tcp_sink.rs
+++ b/crates/logfwd-output/src/tcp_sink.rs
@@ -102,6 +102,7 @@ where
             match write_remaining_bytes(active_stream, buf, &mut written).await {
                 Ok(()) => return Ok(()),
                 Err(e) => {
+                    written = retry_record_boundary(buf, written);
                     *stream = None;
                     last_error = Some(e);
                     if attempt == 1 {
@@ -139,6 +140,13 @@ where
         }
     }
     Ok(())
+}
+
+fn retry_record_boundary(buf: &[u8], written: usize) -> usize {
+    buf[..written.min(buf.len())]
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map_or(0, |index| index + 1)
 }
 
 impl Sink for TcpSink {
@@ -300,7 +308,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn write_with_retry_does_not_duplicate_after_partial_write_error() {
+    async fn write_with_retry_restarts_interrupted_record_after_partial_write_error() {
         let payload = b"abcdef";
         let first_seen = Arc::new(Mutex::new(Vec::new()));
         let second_seen = Arc::new(Mutex::new(Vec::new()));
@@ -313,7 +321,10 @@ mod tests {
                 ],
                 Arc::clone(&first_seen),
             ),
-            ScriptedWriter::new(vec![ScriptStep::Write(4)], Arc::clone(&second_seen)),
+            ScriptedWriter::new(
+                vec![ScriptStep::Write(payload.len())],
+                Arc::clone(&second_seen),
+            ),
         ]);
         let mut current = Some(writers.pop_front().expect("first writer missing"));
 
@@ -328,7 +339,48 @@ mod tests {
         .expect("write_with_retry should succeed");
 
         assert_eq!(&*first_seen.lock().expect("first lock poisoned"), b"ab");
-        assert_eq!(&*second_seen.lock().expect("second lock poisoned"), b"cdef");
+        assert_eq!(
+            &*second_seen.lock().expect("second lock poisoned"),
+            b"abcdef"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_with_retry_does_not_replay_completed_records() {
+        let payload = b"first\nsecond\n";
+        let first_seen = Arc::new(Mutex::new(Vec::new()));
+        let second_seen = Arc::new(Mutex::new(Vec::new()));
+
+        let mut writers = VecDeque::from([
+            ScriptedWriter::new(
+                vec![
+                    ScriptStep::Write(9),
+                    ScriptStep::Error(io::ErrorKind::BrokenPipe),
+                ],
+                Arc::clone(&first_seen),
+            ),
+            ScriptedWriter::new(vec![ScriptStep::Write(7)], Arc::clone(&second_seen)),
+        ]);
+        let mut current = Some(writers.pop_front().expect("first writer missing"));
+
+        write_with_retry_generic(payload, &mut current, move || {
+            std::future::ready(
+                writers
+                    .pop_front()
+                    .ok_or_else(|| io::Error::other("no reconnect writer available")),
+            )
+        })
+        .await
+        .expect("write_with_retry should succeed");
+
+        assert_eq!(
+            &*first_seen.lock().expect("first lock poisoned"),
+            b"first\nsec"
+        );
+        assert_eq!(
+            &*second_seen.lock().expect("second lock poisoned"),
+            b"second\n"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- replace TCP sink `write_all` retry behavior with a progress-aware write loop
- preserve the accepted-byte cursor, then roll retry start back to the last completed NDJSON record boundary after reconnect so completed records are not replayed and interrupted records are resent whole
- add deterministic scripted `AsyncWrite` tests for partial-record retry, completed-record boundary retry, first-attempt zero-byte retry, and retry zero-byte failure

## Verification

- `cargo fmt --check`
- `cargo test -p logfwd-output tcp_sink::tests -- --nocapture`
- `cargo clippy -p logfwd-output -- -D warnings`
- `git diff --check`
- `just lint`
- `just test`

Closes #2283.
Fixes #1881.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate writes on TCP retry in `TcpSink`
> - Rewrites `write_with_retry` in [tcp_sink.rs](https://github.com/strawgate/fastforward/pull/2292/files#diff-2c62ba68a782521d33e5d81a425c47b9393bf865ac3a8d094f5fa92af793caa5) to use a new generic `write_with_retry_generic` helper that tracks write progress and, on failure, resets to the beginning of the buffer before reconnecting and resending.
> - Extracts `connect_stream` as a free function and `write_remaining_bytes` as a write-loop helper that enforces a single deadline across all partial writes.
> - Behavioral Change: retry now resends the full buffer from the start (at-least-once semantics) rather than resuming mid-buffer, preventing partial duplicate records from being written after a reconnect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a604033.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->