### PR TITLE
docs: align elasticsearch examples and limits

### DIFF
--- a/book/src/content/docs/configuration/outputs.mdx
+++ b/book/src/content/docs/configuration/outputs.mdx
@@ -92,6 +92,8 @@ Streaming mode is experimental and currently requires `compression: none`. Use `
 | `request_mode` | string | No | `buffered` | `buffered` or experimental `streaming` (streaming currently requires `compression: none`) |
 | `auth` | object | No | — | Bearer token or custom headers |
 
+Bulk payloads are split before they exceed `5242880` bytes (5 MiB). That limit is internal and is not a YAML field.
+
 </TabItem>
 <TabItem label="Loki">
 

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -435,6 +435,8 @@ Ship to Elasticsearch via the Bulk API.
 | `request_mode` | string | No | `buffered` | `buffered` or `streaming`. `streaming` currently requires `compression: none`. |
 | `auth` | object | No | — | Optional bearer token or custom headers for HTTP auth. |
 
+Bulk payloads are split before they exceed `5242880` bytes (5 MiB). That limit is internal and is not a YAML field.
+
 ```yaml
 output:
   type: elasticsearch

--- a/dev-docs/research/per-input-sql-analysis.md
+++ b/dev-docs/research/per-input-sql-analysis.md
@@ -350,6 +350,7 @@ pipelines:
 
     enrichment:
       - type: geo_database
+        format: mmdb
         path: /etc/logfwd/GeoIP2-City.mmdb
 
     outputs:
@@ -562,6 +563,7 @@ pipelines:
     enrichment:
       - type: host_info
       - type: geo_database
+        format: mmdb
         path: /etc/logfwd/GeoIP2-City.mmdb
 
     outputs:

--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -194,6 +194,7 @@ Each log record produces 2 lines: an action line and a document line. The bulk A
 ## Performance Notes
 
 - The sink reuses buffers to minimize allocations (hot path optimization)
+- Bulk payloads are split before they exceed `5242880` bytes (5 MiB)
 - HTTP requests include retry logic with exponential backoff (100ms → 200ms → 400ms)
 - Transient errors (429, 5xx, network failures) are automatically retried up to 3 times
 - Response parsing checks for per-document errors and fails the entire batch if any document fails


### PR DESCRIPTION
## Summary

- document the Elasticsearch sink's internal 5 MiB bulk split limit without presenting it as a YAML field
- add the same behavior note to the Elasticsearch example README
- fix two `geo_database` examples in the per-input SQL research note to include required `format: mmdb`

## Fan-in Notes

Cloud output for #2280 found most linked issues were already fixed on `main`. I did not apply the cloud diff verbatim because one recommendation would have made `max_bulk_bytes` look like accepted YAML config; the current `OutputConfig` does not accept that field.

## Verification

- `git diff --check`
- `rg -n "max_bulk_bytes|5 MiB|5242880|type: geo_database" book/src/content/docs/configuration/reference.mdx book/src/content/docs/configuration/outputs.mdx examples/elasticsearch/README.md dev-docs/research/per-input-sql-analysis.md crates/logfwd-output/src/elasticsearch.rs`
- `npm --prefix book ci`
- `npm --prefix book run build`

Closes #2280.
Refs #2023 #2054.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document Elasticsearch bulk payload split limit of 5 MiB
> Adds a note across the Elasticsearch docs and examples stating that bulk payloads are split before they exceed 5242880 bytes (5 MiB), and that this limit is internal and not configurable via YAML. Also adds `format: mmdb` to geo_database enrichment examples in [per-input-sql-analysis.md](https://github.com/strawgate/fastforward/pull/2293/files#diff-c2c03512868dc0e20e544ed101012670baeeb29cd9ea5bb66d484efc2e90ae76).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf9c04d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->