### PR TITLE
fix: smooth intersection transitions and gate physics

### DIFF
--- a/book/src/components/__tests__/highway-sim.test.mjs
+++ b/book/src/components/__tests__/highway-sim.test.mjs
@@ -202,9 +202,9 @@ describe('following distance', function () {
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    // Pack cars on the exit segment with proper spacing
+    // Pack cars on the exit segment before the gate
     for (var i = 0; i < 5; i++) {
-      sim.addCar('exit', 30 + i * 40, 3.5);
+      sim.addCar('exit', 10 + i * 25, 3.5);
     }
     for (var t = 0; t < 200; t++) {
       sim.tick(t * 25);

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -35,10 +35,10 @@ export var DEFAULTS = {
   scaleMin: 0.8,
   scaleMax: 1.15,
   spawnBlockedThreshold: 8,
-  exitEntryD: 22,
-  contEntryD: 18,
+  exitEntryD: 0,
+  contEntryD: 0,
   hwyForkThreshold: 5,
-  hwyBlockedOffset: 10,
+  hwyBlockedOffset: 2,
   rampMergeThreshold: 3,
 };
 
@@ -196,25 +196,24 @@ export function createSimulation(overrides, scaleFn) {
       var car = cars[i];
       var target = cfg.speedMax;
 
-      // Gate (light) — only on exit
-      if (opts.hasGate && !lightIsGreen && car.d <= cfg.gateD && car.d > cfg.gateD - 35) {
-        var someoneCloser = (i > 0 && cars[i - 1].d <= cfg.gateD && cars[i - 1].d > car.d);
-        if (!someoneCloser) {
-          target = 0;
-          if (car.d + car.speed > cfg.gateD) {
-            car.d = cfg.gateD;
-            car.speed = 0;
-          }
+      // Gate (light) — only on exit. Hard stop at traffic light.
+      if (opts.hasGate && !lightIsGreen && car.d < cfg.gateD + 1) {
+        var gateGap = cfg.gateD - car.d;
+        if (gateGap < cfg.followZone + car.w / 2) {
+          target = Math.min(target, Math.max(0, gateGap * cfg.brakeRate));
         }
       }
 
-      // End-of-segment blocking — wide braking zone for smooth deceleration
+      // End-of-segment blocking — smooth braking zone
       if (opts.endBlocked) {
         if (car.d >= segLen - 50) {
           var distToEnd = segLen - car.d;
           target = Math.min(target, Math.max(0, distToEnd * 0.12));
         }
-        if (car.d > segLen) { car.d = segLen; car.speed = 0; }
+        if (car.d > segLen) {
+          car.d -= (car.d - segLen) * 0.5;
+          car.speed *= 0.3;
+        }
       }
 
       // Following distance — find nearest obstacle ahead (real or phantom)
@@ -239,7 +238,13 @@ export function createSimulation(overrides, scaleFn) {
       if (car.speed < 0.03) car.speed = 0;
       car.d += car.speed;
 
-      // Hard gap — enforce against nearest real or phantom obstacle ahead
+      // Hard gate clamp — car must not overshoot the traffic light
+      if (opts.hasGate && !lightIsGreen && car.d > cfg.gateD) {
+        car.d = cfg.gateD;
+        car.speed = 0;
+      }
+
+      // Hard gap enforcement — prevent overlap, match speed of car ahead
       if (nearestAhead) {
         var mg2 = (car.w + (nearestAhead.w || cfg.carW)) / 2 + cfg.minFollowPad;
         if (nearestAhead.d - car.d < mg2) {
@@ -261,6 +266,18 @@ export function createSimulation(overrides, scaleFn) {
       }
 
       car.color = carColor(car);
+    }
+
+    // Post-loop gap enforcement pass — cars sorted by d descending (leader first)
+    // Push each follower back if it overlaps the car ahead
+    for (var gi = 1; gi < cars.length; gi++) {
+      var ahead2 = cars[gi - 1];
+      var behind = cars[gi];
+      var reqGap = (ahead2.w + behind.w) / 2 + cfg.minFollowPad;
+      if (ahead2.d - behind.d < reqGap) {
+        behind.d = ahead2.d - reqGap;
+        behind.speed = Math.min(behind.speed, ahead2.speed);
+      }
     }
   }
 
@@ -345,14 +362,12 @@ export function createSimulation(overrides, scaleFn) {
       var front = carsHwy[0];
       if (front.d < cfg.lenHwy - cfg.hwyForkThreshold) break;
       if (canEnterExit(front.w)) {
-        // Take the exit ramp
         carsHwy.splice(0, 1);
         front.segment = 'exit';
         front.d = cfg.exitEntryD;
         front.speed = Math.min(front.speed, cfg.speedMax * 0.8);
         carsExit.push(front);
       } else if (lightIsGreen && canEnterCont(front.w)) {
-        // Exit spacing is temporarily full while traffic is flowing — continue east.
         carsHwy.splice(0, 1);
         front.segment = 'cont';
         front.d = cfg.contEntryD;


### PR DESCRIPTION
## Summary

Smooths out the highway backpressure animation at intersections (merge/fork points and traffic light).

### Changes

- **Smooth gate braking**: Cars decelerate gradually toward the traffic light using a braking zone (`gateGap * brakeRate`) instead of hard-stopping when they \*might* overshoot. A hard clamp at gateD prevents overshoot.
- **Soft endBlocked overshoot**: When a car overshoots a segment end, it's pulled back gradually (`0.5 * overshoot`) instead of snapping to segLen.
- **Zero entry offsets** (`exitEntryD=0, contEntryD=0`): Cars entering exit/cont segments start at d=0 instead of teleporting to d=22/18.
- **Smaller hwyBlockedOffset** (2 vs 10): Less visual jump when a car stops at the highway fork.
- **Post-loop gap enforcement pass**: After all per-car physics, a second pass ensures no overlap — needed because gate clamping can push the lead car backward into followers.
- **Test fix**: Overlap test now places cars before gateD to avoid invalid initial state.

### Test plan

- All 30 highway-sim tests pass (`node --test book/src/components/__tests__/highway-sim.test.mjs`)
- Visual verification via Playwright screenshots: flowing, congested, and blocked states all render properly with no car overlap

Relates to #2277

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix gate braking, overshoot handling, and gap enforcement in highway simulation
> - Cars approaching a red gate now decelerate smoothly based on distance (`gateGap`/`brakeRate`) and are hard-clamped to never overshoot the gate, replacing the previous windowed stop check.
> - Segment-end overshoot is now resolved by pulling the car back halfway and damping speed to 30%, replacing an abrupt clamp-and-zero approach.
> - A post-update pass iterates cars by descending position and pushes any follower that overlaps the car ahead back to the minimum gap, capping its speed to the leader's.
> - Entry distances for exit/cont segments (`exitEntryD`, `contEntryD`) are changed from 22/18 to 0, and `hwyBlockedOffset` is reduced from 10 to 2.
> - Behavioral Change: vehicles transitioning from highway to exit/cont segments now spawn at `d=0` instead of mid-segment, and all gap/gate physics behave differently at boundaries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 708690a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->