### PR TITLE
fix: validate remaining config gaps

### DIFF
--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -261,6 +261,11 @@ impl Config {
                                     )));
                                 }
                             }
+                            if o.max_recv_message_size_bytes == Some(0) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': otlp.max_recv_message_size_bytes must be at least 1"
+                                )));
+                            }
 
                             track_listen_addr_uniqueness(
                                 &mut seen_listen_addrs,
@@ -451,6 +456,11 @@ impl Config {
                             {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' input '{label}': sensor.control_path must not be empty"
+                                )));
+                            }
+                            if s.sensor.as_ref().and_then(|cfg| cfg.max_rows_per_poll) == Some(0) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': sensor.max_rows_per_poll must be at least 1"
                                 )));
                             }
                             if let Some(families) = s
@@ -1567,6 +1577,9 @@ pub fn validate_host_port(addr: &str) -> Result<(), String> {
     if !addr.starts_with('[') && host.contains(']') {
         return Err(format!("'{addr}' has an unmatched ']' in the host"));
     }
+    if !addr.starts_with('[') && host.contains('[') {
+        return Err(format!("'{addr}' has an unmatched '[' in the host"));
+    }
 
     if !addr.starts_with('[') && host.contains(':') {
         return Err(format!(
@@ -1731,6 +1744,12 @@ mod validate_host_port_tests {
         );
         // Unmatched closing bracket rejected (#1461)
         assert!(validate_host_port("foo]:4317").unwrap_err().contains("]"));
+        // Unmatched opening bracket rejected (#2060)
+        assert!(
+            validate_host_port("foo[bar:4317")
+                .unwrap_err()
+                .contains("[")
+        );
     }
 
     #[test]

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -619,3 +619,69 @@ pipelines:
         "unexpected error: {err}"
     );
 }
+
+#[test]
+fn issue_1958_generator_record_profile_preserves_null_attribute_values() {
+    let yaml = r#"
+input:
+  type: generator
+  generator:
+    profile: record
+    attributes:
+      deleted_at: null
+output:
+  type: stdout
+"#;
+
+    Config::load_str(yaml).expect("generator null attributes should remain supported");
+}
+
+#[test]
+fn issue_2060_reject_unmatched_opening_bracket_in_host_port() {
+    let yaml = r#"
+input:
+  type: udp
+  listen: foo[bar:4317
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(err.contains("unmatched '['"), "unexpected error: {err}");
+}
+
+#[test]
+fn issue_2062_reject_sensor_max_rows_per_poll_zero() {
+    let yaml = r#"
+input:
+  type: host_metrics
+  sensor:
+    max_rows_per_poll: 0
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("sensor.max_rows_per_poll") && err.contains("at least 1"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn issue_2178_reject_otlp_max_recv_message_size_bytes_zero() {
+    let yaml = r#"
+input:
+  type: otlp
+  listen: 127.0.0.1:4318
+  max_recv_message_size_bytes: 0
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("otlp.max_recv_message_size_bytes") && err.contains("at least 1"),
+        "unexpected error: {err}"
+    );
+}

--- a/crates/logfwd-transform/src/sql_transform.rs
+++ b/crates/logfwd-transform/src/sql_transform.rs
@@ -266,8 +266,12 @@ impl SqlTransform {
         use arrow::array::{ArrayRef, StringArray};
         use arrow::datatypes::{Field, Schema};
 
-        // Build a schema from referenced columns (or a fallback for SELECT *).
-        let fields: Vec<Field> = if self.analyzer.referenced_columns.is_empty() {
+        // Build a schema from the scanner-facing field names, not raw SQL
+        // identifier spelling. DataFusion normalizes unquoted identifiers
+        // during planning, and the scanner pushdown config mirrors that.
+        let scan_config = self.analyzer.scan_config();
+        let fields: Vec<Field> = if scan_config.extract_all || scan_config.wanted_fields.is_empty()
+        {
             // SELECT * — provide a minimal representative schema.
             vec![
                 Field::new(field_names::BODY, DataType::Utf8, true),
@@ -275,10 +279,10 @@ impl SqlTransform {
                 Field::new("msg", DataType::Utf8, true),
             ]
         } else {
-            self.analyzer
-                .referenced_columns
+            scan_config
+                .wanted_fields
                 .iter()
-                .map(|name| Field::new(name, DataType::Utf8, true))
+                .map(|field| Field::new(field.name.as_str(), DataType::Utf8, true))
                 .collect()
         };
 

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -1183,6 +1183,14 @@ fn validate_plan_accepts_filter_query() {
 }
 
 #[test]
+fn validate_plan_accepts_mixed_case_unquoted_identifier() {
+    let mut transform = SqlTransform::new("SELECT Level FROM logs").unwrap();
+    transform
+        .validate_plan()
+        .expect("unquoted identifiers should validate against scanner-normalized fields");
+}
+
+#[test]
 fn validate_plan_uses_null_probe_values_for_cast_paths() {
     let mut transform =
         SqlTransform::new("SELECT int(status) FROM logs WHERE int(status) <= 4").unwrap();

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1347,8 +1347,7 @@ fn validate_known_columns_read_only(
         return Ok(());
     }
 
-    let known: std::collections::HashSet<&str> =
-        known_columns.iter().copied().collect();
+    let known: std::collections::HashSet<&str> = known_columns.iter().copied().collect();
 
     let mut unknown: Vec<String> = scan_config
         .wanted_fields

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1260,18 +1260,18 @@ fn validate_transform_probe_read_only(
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
 
-    let fields: Vec<Field> = if transform.analyzer().referenced_columns.is_empty() {
+    let scan_config = transform.analyzer().scan_config();
+    let fields: Vec<Field> = if scan_config.extract_all || scan_config.wanted_fields.is_empty() {
         vec![
             Field::new("body", DataType::Utf8, true),
             Field::new("level", DataType::Utf8, true),
             Field::new("msg", DataType::Utf8, true),
         ]
     } else {
-        transform
-            .analyzer()
-            .referenced_columns
+        scan_config
+            .wanted_fields
             .iter()
-            .map(|name| Field::new(name, DataType::Utf8, true))
+            .map(|field| Field::new(field.name.as_str(), DataType::Utf8, true))
             .collect()
     };
 
@@ -1344,7 +1344,11 @@ fn validate_known_columns_read_only(
         .analyzer()
         .referenced_columns
         .iter()
-        .filter(|column| !known_columns.contains(column.as_str()))
+        .filter(|column| {
+            !known_columns
+                .iter()
+                .any(|known| known.eq_ignore_ascii_case(column))
+        })
         .cloned()
         .collect();
     unknown.sort_unstable();
@@ -2451,6 +2455,29 @@ transform: |
         assert!(
             read_only.is_err(),
             "read-only validation should reject unknown columns"
+        );
+    }
+
+    #[test]
+    fn issue_1955_dry_run_accepts_mixed_case_generator_logs_columns() {
+        let yaml = r#"
+input:
+  type: generator
+output:
+  type: null
+transform: |
+  SELECT Level FROM logs
+"#;
+        let config = logfwd_config::Config::load_str(yaml).expect("config should parse");
+        let runtime = validate_pipelines(&config, true, None);
+        let read_only = validate_pipelines_read_only(&config, None, |_name| {}, |_err| {});
+        assert!(
+            runtime.is_ok(),
+            "dry-run validation should accept case-insensitive column references"
+        );
+        assert!(
+            read_only.is_ok(),
+            "read-only validation should accept case-insensitive column references"
         );
     }
 

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1260,7 +1260,7 @@ fn validate_transform_probe_read_only(
     use arrow::datatypes::{DataType, Field, Schema};
     use arrow::record_batch::RecordBatch;
 
-    let scan_config = transform.analyzer().scan_config();
+    let scan_config = transform.scan_config();
     let fields: Vec<Field> = if scan_config.extract_all || scan_config.wanted_fields.is_empty() {
         vec![
             Field::new("body", DataType::Utf8, true),
@@ -1288,39 +1288,39 @@ fn validate_transform_probe_read_only(
         .map_err(|e| e.to_string())
 }
 
+const GENERATOR_LOGS_SIMPLE_COLUMNS: &[&str] = &[
+    "timestamp",
+    "level",
+    "message",
+    "duration_ms",
+    "request_id",
+    "service",
+    "status",
+];
+
 fn known_input_columns_read_only(
     input_cfg: &logfwd_config::InputConfig,
-) -> Option<std::collections::HashSet<&'static str>> {
+) -> Option<&'static [&'static str]> {
     use logfwd_config::{GeneratorComplexityConfig, GeneratorProfileConfig, InputTypeConfig};
 
     match &input_cfg.type_config {
         // Generator logs/simple has a stable built-in schema. Other profiles
         // or complexities are broader or user-defined, so skip strict checks.
         InputTypeConfig::Generator(generator_cfg) => {
-            let profile = generator_cfg
+            let is_logs_profile = generator_cfg
                 .generator
                 .as_ref()
-                .and_then(|cfg| cfg.profile.clone())
-                .unwrap_or(GeneratorProfileConfig::Logs);
-            let complexity = generator_cfg
+                .and_then(|cfg| cfg.profile.as_ref())
+                .is_none_or(|profile| matches!(profile, GeneratorProfileConfig::Logs));
+            let is_simple_complexity = generator_cfg
                 .generator
                 .as_ref()
-                .and_then(|cfg| cfg.complexity.clone())
-                .unwrap_or(GeneratorComplexityConfig::Simple);
-            if !matches!(profile, GeneratorProfileConfig::Logs)
-                || !matches!(complexity, GeneratorComplexityConfig::Simple)
-            {
+                .and_then(|cfg| cfg.complexity.as_ref())
+                .is_none_or(|complexity| matches!(complexity, GeneratorComplexityConfig::Simple));
+            if !is_logs_profile || !is_simple_complexity {
                 None
             } else {
-                Some(std::collections::HashSet::from([
-                    "timestamp",
-                    "level",
-                    "message",
-                    "duration_ms",
-                    "request_id",
-                    "service",
-                    "status",
-                ]))
+                Some(GENERATOR_LOGS_SIMPLE_COLUMNS)
             }
         }
         _ => None,
@@ -1330,26 +1330,27 @@ fn known_input_columns_read_only(
 fn validate_known_columns_read_only(
     input_name: &str,
     transform: &logfwd::transform::SqlTransform,
-    known_columns: Option<&std::collections::HashSet<&'static str>>,
+    known_columns: Option<&'static [&'static str]>,
 ) -> Result<(), String> {
     let Some(known_columns) = known_columns else {
         return Ok(());
     };
 
-    if transform.analyzer().uses_select_star {
+    let scan_config = transform.scan_config();
+    if scan_config.extract_all {
         return Ok(());
     }
 
-    let mut unknown: Vec<String> = transform
-        .analyzer()
-        .referenced_columns
+    let mut unknown: Vec<String> = scan_config
+        .wanted_fields
         .iter()
+        .map(|field| field.name.as_str())
         .filter(|column| {
             !known_columns
                 .iter()
                 .any(|known| known.eq_ignore_ascii_case(column))
         })
-        .cloned()
+        .map(str::to_owned)
         .collect();
     unknown.sort_unstable();
     unknown.dedup();
@@ -1358,7 +1359,7 @@ fn validate_known_columns_read_only(
         return Ok(());
     }
 
-    let mut supported: Vec<&str> = known_columns.iter().copied().collect();
+    let mut supported: Vec<&str> = known_columns.to_vec();
     supported.sort_unstable();
     Err(format!(
         "input '{input_name}': SQL references unknown column(s) {} for this input schema (known: {})",
@@ -1580,8 +1581,12 @@ fn validate_pipeline_read_only(
 
         let input_sql = input_cfg.sql.as_deref().unwrap_or(pipeline_sql);
         let mut transform = SqlTransform::new(input_sql).map_err(|e| e.to_string())?;
-        let known_columns = known_input_columns_read_only(input_cfg);
-        validate_known_columns_read_only(&input_name, &transform, known_columns.as_ref())?;
+        let known_columns = if config.enrichment.is_empty() {
+            known_input_columns_read_only(input_cfg)
+        } else {
+            None
+        };
+        validate_known_columns_read_only(&input_name, &transform, known_columns)?;
         #[cfg(feature = "datafusion")]
         {
             if let Some(ref db) = geo_database {
@@ -2493,9 +2498,42 @@ transform: |
 "#;
         let config = logfwd_config::Config::load_str(yaml).expect("config should parse");
         let runtime = validate_pipelines(&config, true, None);
+        let read_only = validate_pipelines_read_only(&config, None, |_name| {}, |_err| {});
         assert!(
             runtime.is_err(),
             "dry-run validation should reject fields embedded only inside message"
+        );
+        assert!(
+            read_only.is_err(),
+            "read-only validation should reject fields embedded only inside message"
+        );
+    }
+
+    #[test]
+    fn issue_1955_dry_run_skips_strict_check_when_enrichment_tables_are_present() {
+        let yaml = r#"
+input:
+  type: generator
+output:
+  type: null
+enrichment:
+  - type: static
+    table_name: labels
+    labels:
+      environment: production
+transform: |
+  SELECT labels.environment FROM logs CROSS JOIN labels
+"#;
+        let config = logfwd_config::Config::load_str(yaml).expect("config should parse");
+        let runtime = validate_pipelines(&config, true, None);
+        let read_only = validate_pipelines_read_only(&config, None, |_name| {}, |_err| {});
+        assert!(
+            runtime.is_ok(),
+            "dry-run validation should not reject enrichment-only columns"
+        );
+        assert!(
+            read_only.is_ok(),
+            "read-only validation should not reject enrichment-only columns"
         );
     }
 

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1336,19 +1336,32 @@ fn validate_known_columns_read_only(
         return Ok(());
     };
 
+    // SELECT * expands to whatever the engine provides — skip validation.
+    let analyzer = transform.analyzer();
+    if analyzer.uses_select_star {
+        return Ok(());
+    }
+
     let scan_config = transform.scan_config();
     if scan_config.extract_all {
         return Ok(());
     }
+
+    let known: std::collections::HashSet<&str> =
+        known_columns.iter().copied().collect();
 
     let mut unknown: Vec<String> = scan_config
         .wanted_fields
         .iter()
         .map(|field| field.name.as_str())
         .filter(|column| {
-            !known_columns
-                .iter()
-                .any(|known| known.eq_ignore_ascii_case(column))
+            // Strip table qualifier (e.g. "logs.level" -> "level").
+            let bare = match column.rfind('.') {
+                Some(pos) => &column[pos + 1..],
+                None => column,
+            };
+            // Lowercase before lookup — known_columns is all-lowercase.
+            !known.contains(bare.to_lowercase().as_str())
         })
         .map(str::to_owned)
         .collect();

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -1189,6 +1189,12 @@ where
 
     let mut errors = 0;
     for (name, pipe_cfg) in &config.pipelines {
+        if let Err(err) = validate_pipeline_read_only(pipe_cfg, base_path) {
+            on_error(format!("pipeline '{name}': {err}"));
+            errors += 1;
+            continue;
+        }
+
         match Pipeline::from_config(name, pipe_cfg, &meter, base_path) {
             Ok(mut pipeline) => {
                 // Execute a probe batch through the SQL plan to catch planning
@@ -1280,6 +1286,81 @@ fn validate_transform_probe_read_only(
         .execute_blocking(batch)
         .map(|_| ())
         .map_err(|e| e.to_string())
+}
+
+fn known_input_columns_read_only(
+    input_cfg: &logfwd_config::InputConfig,
+) -> Option<std::collections::HashSet<&'static str>> {
+    use logfwd_config::{GeneratorComplexityConfig, GeneratorProfileConfig, InputTypeConfig};
+
+    match &input_cfg.type_config {
+        // Generator logs/simple has a stable built-in schema. Other profiles
+        // or complexities are broader or user-defined, so skip strict checks.
+        InputTypeConfig::Generator(generator_cfg) => {
+            let profile = generator_cfg
+                .generator
+                .as_ref()
+                .and_then(|cfg| cfg.profile.clone())
+                .unwrap_or(GeneratorProfileConfig::Logs);
+            let complexity = generator_cfg
+                .generator
+                .as_ref()
+                .and_then(|cfg| cfg.complexity.clone())
+                .unwrap_or(GeneratorComplexityConfig::Simple);
+            if !matches!(profile, GeneratorProfileConfig::Logs)
+                || !matches!(complexity, GeneratorComplexityConfig::Simple)
+            {
+                None
+            } else {
+                Some(std::collections::HashSet::from([
+                    "timestamp",
+                    "level",
+                    "message",
+                    "duration_ms",
+                    "request_id",
+                    "service",
+                    "status",
+                ]))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn validate_known_columns_read_only(
+    input_name: &str,
+    transform: &logfwd::transform::SqlTransform,
+    known_columns: Option<&std::collections::HashSet<&'static str>>,
+) -> Result<(), String> {
+    let Some(known_columns) = known_columns else {
+        return Ok(());
+    };
+
+    if transform.analyzer().uses_select_star {
+        return Ok(());
+    }
+
+    let mut unknown: Vec<String> = transform
+        .analyzer()
+        .referenced_columns
+        .iter()
+        .filter(|column| !known_columns.contains(column.as_str()))
+        .cloned()
+        .collect();
+    unknown.sort_unstable();
+    unknown.dedup();
+
+    if unknown.is_empty() {
+        return Ok(());
+    }
+
+    let mut supported: Vec<&str> = known_columns.iter().copied().collect();
+    supported.sort_unstable();
+    Err(format!(
+        "input '{input_name}': SQL references unknown column(s) {} for this input schema (known: {})",
+        unknown.join(", "),
+        supported.join(", ")
+    ))
 }
 
 fn validate_pipeline_read_only(
@@ -1495,6 +1576,8 @@ fn validate_pipeline_read_only(
 
         let input_sql = input_cfg.sql.as_deref().unwrap_or(pipeline_sql);
         let mut transform = SqlTransform::new(input_sql).map_err(|e| e.to_string())?;
+        let known_columns = known_input_columns_read_only(input_cfg);
+        validate_known_columns_read_only(&input_name, &transform, known_columns.as_ref())?;
         #[cfg(feature = "datafusion")]
         {
             if let Some(ref db) = geo_database {
@@ -2345,6 +2428,67 @@ transform: |
         assert!(
             read_only.is_err(),
             "effective-config validation should reject duplicate aliases"
+        );
+    }
+
+    #[test]
+    fn issue_1955_dry_run_rejects_unknown_generator_logs_column() {
+        let yaml = r#"
+input:
+  type: generator
+output:
+  type: null
+transform: |
+  SELECT missing_column FROM logs
+"#;
+        let config = logfwd_config::Config::load_str(yaml).expect("config should parse");
+        let runtime = validate_pipelines(&config, true, None);
+        let read_only = validate_pipelines_read_only(&config, None, |_name| {}, |_err| {});
+        assert!(
+            runtime.is_err(),
+            "dry-run validation should reject unknown columns"
+        );
+        assert!(
+            read_only.is_err(),
+            "read-only validation should reject unknown columns"
+        );
+    }
+
+    #[test]
+    fn issue_1955_dry_run_rejects_generator_message_source_parts() {
+        let yaml = r#"
+input:
+  type: generator
+output:
+  type: null
+transform: |
+  SELECT method FROM logs
+"#;
+        let config = logfwd_config::Config::load_str(yaml).expect("config should parse");
+        let runtime = validate_pipelines(&config, true, None);
+        assert!(
+            runtime.is_err(),
+            "dry-run validation should reject fields embedded only inside message"
+        );
+    }
+
+    #[test]
+    fn issue_1955_dry_run_skips_strict_check_for_complex_generator_logs() {
+        let yaml = r#"
+input:
+  type: generator
+  generator:
+    complexity: complex
+output:
+  type: null
+transform: |
+  SELECT bytes_in FROM logs
+"#;
+        let config = logfwd_config::Config::load_str(yaml).expect("config should parse");
+        let read_only = validate_pipelines_read_only(&config, None, |_name| {}, |_err| {});
+        assert!(
+            read_only.is_ok(),
+            "complex generator profile has additional fields and should not use simple schema checks"
         );
     }
 

--- a/crates/logfwd/src/transform.rs
+++ b/crates/logfwd/src/transform.rs
@@ -46,6 +46,7 @@ mod passthrough {
 
     pub struct QueryAnalyzer {
         pub referenced_columns: HashSet<String>,
+        pub uses_select_star: bool,
     }
 
     pub struct SqlTransform {
@@ -64,6 +65,7 @@ mod passthrough {
             Ok(Self {
                 analyzer: QueryAnalyzer {
                     referenced_columns: HashSet::new(),
+                    uses_select_star: true,
                 },
             })
         }


### PR DESCRIPTION
## Summary

- reject invalid zero values for OTLP receive size and sensor `max_rows_per_poll`
- reject unmatched `[` in non-IPv6 host:port validation
- preserve generator `record` null attributes with regression coverage
- make dry-run/validate reject unknown columns for generator `logs` inputs when the schema is stable and known

## Notes

The SQL validation piece is intentionally conservative: it only applies strict column checks to generator `logs` with `simple` complexity. Dynamic/user-defined schemas and richer generator profiles skip the strict check to avoid false positives. I also tightened the cloud output before PR by removing internal message parts (`method`, `path`, `id`) from the known top-level field set.

## Verification

- `cargo fmt --check`
- `cargo test -p logfwd-config --test validation_gaps -- --nocapture`
- `cargo test -p logfwd issue_1955 -- --nocapture`
- `cargo clippy -p logfwd-config -p logfwd -- -D warnings`
- `git diff --check`
- `just lint`

Closes #2282.
Refs #1955 #1958 #2060 #2062 #2178.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix config validation gaps for zero-value fields, unmatched brackets, and unknown SQL columns
> - Adds validation errors for `max_recv_message_size_bytes: 0` on OTLP inputs and `sensor.max_rows_per_poll: 0` on host_metrics inputs in [`validate.rs`](https://github.com/strawgate/fastforward/pull/2295/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68).
> - Rejects hostnames containing an unmatched `[` character (e.g. `foo[bar:4317`) in `validate_host_port`.
> - Adds strict column validation in [`main.rs`](https://github.com/strawgate/fastforward/pull/2295/files#diff-48e7b38d2f38857cdef3f17a929b768683b2c5ee185fe3c4fb45ae95d4bcdbe4) for generator `logs/simple` pipelines without enrichment, rejecting SQL that references columns not in the known schema.
> - Fixes `validate_plan` in [`sql_transform.rs`](https://github.com/strawgate/fastforward/pull/2295/files#diff-8ce3ccee08bc61e14a547e796ba428fad9ca0932d50fd3967d925cba11a8f2b7) to use scanner-normalized field names from `scan_config`, so mixed-case unquoted identifiers (e.g. `SELECT Level FROM logs`) no longer cause false validation failures.
> - Behavioral Change: pipelines previously accepted with zero-value sizes, unmatched brackets, or unknown generator columns will now fail validation with descriptive errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 872b40f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->