### PR TITLE
fix: harden config env expansion diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ name = "logfwd-config"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_path_to_error",
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = [
 ] }
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
+serde_path_to_error = "0.1"
 sonic-rs = "0.5"
 tokio = { version = "1" }
 tracing = "0.1"

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -963,6 +963,35 @@ server:
 
 If the variable is not set, config loading fails fast with a validation error.
 
+Exact unquoted placeholders use YAML scalar typing after expansion. This lets numeric
+and boolean fields read values directly from the environment:
+
+```yaml
+pipelines:
+  app:
+    workers: ${LOGFWD_WORKERS}
+```
+
+Quote a placeholder, or tag it with `!!str`, when the expanded value should remain
+a string even if it looks like a YAML number, boolean, or null:
+
+```yaml
+input:
+  type: file
+  path: "${LOG_PATH}"
+```
+
+Placeholders embedded inside longer strings always remain strings:
+
+```yaml
+output:
+  type: file
+  path: "/var/log/${SERVICE_NAME}.jsonl"
+```
+
+Environment variables can also appear in mapping keys. If expansion produces duplicate
+keys, config loading fails.
+
 ---
 
 ## Complete example

--- a/crates/logfwd-config/Cargo.toml
+++ b/crates/logfwd-config/Cargo.toml
@@ -14,7 +14,8 @@ otlp-research = []
 
 [dependencies]
 serde = { workspace = true }
-serde_yaml_ng = "0.10"
+serde_path_to_error = { workspace = true }
+serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
 

--- a/crates/logfwd-config/src/load.rs
+++ b/crates/logfwd-config/src/load.rs
@@ -57,13 +57,22 @@ impl Config {
         let (marked_yaml, quoted_placeholders) = mark_quoted_exact_env_placeholders(yaml);
         let mut value: Value = serde_yaml_ng::from_str(&marked_yaml)?;
         expand_env_vars_in_yaml_value(&mut value, &quoted_placeholders)?;
-        let raw: RawConfig = serde_yaml_ng::from_value(value)?;
+        let raw = deserialize_raw_config_with_path(value)?;
         Self::from_raw(raw, base_path)
     }
 
     /// Expand `${VAR}` environment variables in raw YAML without parsing.
     pub fn expand_env_str(yaml: &str) -> Result<String, ConfigError> {
         expand_env_vars(yaml)
+    }
+
+    /// Expand `${VAR}` environment variables using the same YAML-aware scalar
+    /// rules as [`Config::load_str`], then serialize the expanded YAML tree.
+    pub fn expand_env_yaml_str(yaml: &str) -> Result<String, ConfigError> {
+        let (marked_yaml, quoted_placeholders) = mark_quoted_exact_env_placeholders(yaml);
+        let mut value: Value = serde_yaml_ng::from_str(&marked_yaml)?;
+        expand_env_vars_in_yaml_value(&mut value, &quoted_placeholders)?;
+        serde_yaml_ng::to_string(&value).map_err(ConfigError::from)
     }
 
     fn from_raw(raw: RawConfig, base_path: Option<&Path>) -> Result<Self, ConfigError> {
@@ -138,6 +147,18 @@ impl Config {
         cfg.validate_with_base_path(base_path)?;
         Ok(cfg)
     }
+}
+
+fn deserialize_raw_config_with_path(value: Value) -> Result<RawConfig, ConfigError> {
+    serde_path_to_error::deserialize(value).map_err(|err| {
+        let path = err.path().to_string();
+        let inner = err.into_inner();
+        if path == "." {
+            ConfigError::Validation(format!("config deserialization error: {inner}"))
+        } else {
+            ConfigError::Validation(format!("config deserialization error at '{path}': {inner}"))
+        }
+    })
 }
 
 fn expand_env_vars_in_yaml_value(

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1219,6 +1219,7 @@ impl Config {
                             // Resolve globs against base_path so relative glob
                             // patterns compare correctly with resolved output paths.
                             let resolved = path_for_config_compare(p, base_path);
+                            let resolved = normalize_path_key_for_compare(&resolved);
                             glob_input_patterns.push(resolved.to_string_lossy().into_owned());
                         } else {
                             let pb = path_for_config_compare(p, base_path);
@@ -1266,7 +1267,7 @@ impl Config {
                     }
 
                     // Check if the output path could match any glob input pattern.
-                    let resolved_out_path = out_pb.to_string_lossy();
+                    let resolved_out_path = out_norm.to_string_lossy();
                     for glob_pattern in &glob_input_patterns {
                         if is_glob_match_possible(glob_pattern, &resolved_out_path) {
                             return Err(ConfigError::Validation(format!(

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -33,6 +33,57 @@ fn env_lock() -> MutexGuard<'static, ()> {
 }
 
 #[test]
+fn config_deserialization_error_includes_simple_layout_field_path() {
+    let yaml = r#"
+input:
+  type: generator
+output:
+  type: stdout
+  batch_size: not-a-number
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("config deserialization error at"),
+        "error should include a deserialization path: {err}"
+    );
+    assert!(err.contains("output"), "error should name output: {err}");
+    assert!(
+        err.contains("batch_size"),
+        "error should name batch_size: {err}"
+    );
+}
+
+#[test]
+fn config_deserialization_error_includes_pipeline_field_path() {
+    let yaml = r#"
+pipelines:
+  app:
+    workers: not-a-number
+    inputs:
+      - type: generator
+    outputs:
+      - type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("config deserialization error at"),
+        "error should include a deserialization path: {err}"
+    );
+    assert!(
+        err.contains("pipelines"),
+        "error should name pipelines: {err}"
+    );
+    assert!(err.contains("app"), "error should name pipeline key: {err}");
+    assert!(err.contains("workers"), "error should name workers: {err}");
+    assert!(
+        !err.contains("outputs"),
+        "error should point at the direct pipeline field, not outputs: {err}"
+    );
+}
+
+#[test]
 fn issue_1855_env_expansion_preserves_yaml_hash_content() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855", "/var/log/my app #1.log");
@@ -46,6 +97,36 @@ output:
 "#;
 
     let config = Config::load_str(yaml).expect("config should parse after env expansion");
+    let input = &config.pipelines["default"].inputs[0];
+    let path = match &input.type_config {
+        logfwd_config::InputTypeConfig::File(file) => file.path.as_str(),
+        _ => panic!("expected file input"),
+    };
+
+    assert_eq!(path, "/var/log/my app #1.log");
+}
+
+#[test]
+fn issue_1855_effective_yaml_preserves_yaml_hash_content() {
+    let _env_lock = env_lock();
+    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_EFFECTIVE", "/var/log/my app #1.log");
+
+    let yaml = r#"
+input:
+  type: file
+  path: ${LOGFWD_ISSUE_1855_EFFECTIVE}
+output:
+  type: stdout
+"#;
+
+    let expanded =
+        Config::expand_env_yaml_str(yaml).expect("YAML-aware env expansion should succeed");
+    assert!(
+        expanded.contains("#1.log"),
+        "expanded YAML should preserve hash content: {expanded}"
+    );
+
+    let config = Config::load_str(&expanded).expect("expanded YAML should remain parseable");
     let input = &config.pipelines["default"].inputs[0];
     let path = match &input.type_config {
         logfwd_config::InputTypeConfig::File(file) => file.path.as_str(),

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -745,7 +745,7 @@ fn cmd_effective_config(config_path: Option<&str>) -> Result<(), CliError> {
 
     let config_yaml = std::fs::read_to_string(&config_path)
         .map_err(|e| CliError::Config(format!("cannot read {config_path}: {e}")))?;
-    let effective_yaml = logfwd_config::Config::expand_env_str(&config_yaml)
+    let effective_yaml = logfwd_config::Config::expand_env_yaml_str(&config_yaml)
         .map_err(|e| CliError::Config(e.to_string()))?;
 
     // Read-only validation for inspection flows: reject configs that would


### PR DESCRIPTION
## Summary

- Route `effective-config` through the same YAML-aware environment expansion path used by config loading, so env values containing YAML-significant characters remain data.
- Add path-aware typed config deserialization diagnostics with `serde_path_to_error`.
- Tighten normalized file glob/output path comparison and document the exact env substitution semantics.
- Add regressions for effective config YAML output, deserialization paths, and existing validation gaps.

## Validation

- `cargo test -p logfwd-config --test validation_gaps -- --nocapture`
- `cargo test -p logfwd-config --lib load::tests -- --nocapture`
- `cargo test -p logfwd-config --lib feedback_loop_tests -- --nocapture`
- `cargo clippy -p logfwd-config -- -D warnings`
- `cargo clippy -p logfwd -- -D warnings`
- `just toml-check`
- `git diff --check`

## Notes

This PR intentionally keeps the fan-out research artifacts local and untracked; the committed scope is the focused config hardening patch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden config env expansion and deserialization diagnostics with field path context
> - Deserialization errors for config now include a dotted field path (e.g. `at 'pipelines.app.workers'`) using `serde_path_to_error` instead of a generic message, via a new `deserialize_raw_config_with_path` helper in [load.rs](https://github.com/strawgate/fastforward/pull/2296/files#diff-fb31534d8a74c3f06f4aa9e958063240bd152480a32f1aa350ee2dbc923aa2a8).
> - Adds `Config::expand_env_yaml_str` for YAML-aware env expansion that preserves scalar typing (e.g. unquoted values stay numeric/boolean), replacing the plain string substitution previously used in `cmd_effective_config`.
> - Feedback loop validation in [validate.rs](https://github.com/strawgate/fastforward/pull/2296/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) now compares normalized path forms when checking file input globs against output paths.
> - Documents YAML scalar typing behavior, quoting rules, and env var usage in mapping keys in the config reference docs.
> - Behavioral Change: `effective-config` output now reflects YAML-typed expansion; unquoted env var values may render as non-string scalars where they previously appeared as strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3137920.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->