### PR TITLE
fix: cap host metrics and wire receiver stats

### DIFF
--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -289,6 +289,7 @@ the build target.
 | `sensor.enabled_families` | array[string] | No | Optional enabled signal families. Omit to use defaults; set `[]` to disable all families. |
 | `sensor.emit_signal_rows` | boolean | No | Emit periodic per-family sample rows. Defaults to `true`. |
 | `sensor.max_rows_per_poll` | integer | No | Upper bound on data rows returned per collection cycle. Defaults to `256`. Set to `0` or omit for the default. |
+| `sensor.max_process_rows_per_poll` | integer | No | Upper bound on process snapshot rows returned per collection cycle. Defaults to `1024`. Set to `0` or omit for the default. |
 | `sensor.scrapers` | array[string] | No | List of scrapers to run. Supported values are: `cpu`, `memory`, `disk`, `network`, `filesystem`. |
 | `sensor.collection_interval_ms` | integer | No | Metrics collection cadence in milliseconds. Defaults to `10000`. |
 | `sensor.disk_include_devices` | array[string] | No | Optional list of disk devices to include in scraping. |

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -325,6 +325,8 @@ pub struct HostMetricsInputConfig {
     pub emit_signal_rows: Option<bool>,
     /// Upper bound on data rows emitted per collection cycle. Defaults to 256.
     pub max_rows_per_poll: Option<usize>,
+    /// Upper bound on process rows emitted per collection cycle. Defaults to 1024.
+    pub max_process_rows_per_poll: Option<usize>,
     /// Path to the compiled eBPF kernel binary (required for `linux_ebpf_sensor`).
     pub ebpf_binary_path: Option<String>,
     /// Maximum events to drain per poll cycle (default: 4096).

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -325,7 +325,9 @@ pub struct HostMetricsInputConfig {
     pub emit_signal_rows: Option<bool>,
     /// Upper bound on data rows emitted per collection cycle. Defaults to 256.
     pub max_rows_per_poll: Option<usize>,
-    /// Upper bound on process rows emitted per collection cycle. Defaults to 1024.
+    /// Upper bound on process rows emitted per collection cycle.
+    ///
+    /// Defaults to 1024. Set to 0 or omit for the default.
     pub max_process_rows_per_poll: Option<usize>,
     /// Path to the compiled eBPF kernel binary (required for `linux_ebpf_sensor`).
     pub ebpf_binary_path: Option<String>,

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -489,6 +489,7 @@ async fn handle_arrow_ipc_request(
         match state.tx.try_send(payload) {
             Ok(()) => {}
             Err(mpsc::TrySendError::Full(_)) => {
+                record_error(state.stats.as_ref());
                 send_error = Some(StatusCode::TOO_MANY_REQUESTS);
                 break;
             }
@@ -1017,14 +1018,17 @@ mod tests {
 
     #[test]
     fn receiver_reports_degraded_on_backpressure_and_recovers() {
-        let receiver = ArrowIpcReceiver::new_with_capacity(
+        let stats = Arc::new(ComponentStats::new());
+        let receiver = ArrowIpcReceiver::new_with_capacity_and_stats(
             "test-429",
             "127.0.0.1:0",
             ArrowIpcReceiverOptions::default(),
             1,
+            Some(Arc::clone(&stats)),
         )
         .expect("bind should succeed");
         let addr = receiver.local_addr();
+        wait_for_server(addr);
 
         let batch = make_test_batch();
         let ipc_bytes = serialize_batch(&batch);
@@ -1046,6 +1050,7 @@ mod tests {
             Err(e) => panic!("unexpected error: {e}"),
         };
         assert_eq!(status, 429);
+        assert_eq!(stats.errors(), 1);
         assert_eq!(receiver.health(), ComponentHealth::Degraded);
 
         let _ = receiver.try_recv_all();
@@ -1371,6 +1376,7 @@ mod tests {
         )
         .expect("bind should succeed");
         let addr = receiver.local_addr();
+        wait_for_server(addr);
 
         let url = format!("http://{addr}/v1/arrow");
         let result = loopback_http_client()

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -27,7 +27,7 @@ use axum::http::header::{CONTENT_ENCODING, CONTENT_TYPE};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::post;
-use logfwd_types::diagnostics::ComponentHealth;
+use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 use tokio::sync::oneshot;
 
 use crate::InputError;
@@ -75,6 +75,7 @@ struct ArrowIpcServerState {
     tx: mpsc::SyncSender<DecodedBatch>,
     shutdown: Arc<AtomicBool>,
     health: Arc<AtomicU8>,
+    stats: Option<Arc<ComponentStats>>,
     active_connections: Arc<std::sync::atomic::AtomicUsize>,
     max_connections: usize,
     max_message_size_bytes: usize,
@@ -104,7 +105,17 @@ impl ArrowIpcReceiver {
         addr: &str,
         options: ArrowIpcReceiverOptions,
     ) -> io::Result<Self> {
-        Self::new_with_capacity(name, addr, options, CHANNEL_BOUND)
+        Self::new_with_capacity_and_stats(name, addr, options, CHANNEL_BOUND, None)
+    }
+
+    /// Like [`Self::new`] but wires receiver diagnostics counters.
+    pub fn new_with_stats(
+        name: impl Into<String>,
+        addr: &str,
+        options: ArrowIpcReceiverOptions,
+        stats: Arc<ComponentStats>,
+    ) -> io::Result<Self> {
+        Self::new_with_capacity_and_stats(name, addr, options, CHANNEL_BOUND, Some(stats))
     }
 
     /// Like [`Self::new`] but with an explicit channel capacity. Useful for tests.
@@ -113,6 +124,17 @@ impl ArrowIpcReceiver {
         addr: &str,
         options: ArrowIpcReceiverOptions,
         capacity: usize,
+    ) -> io::Result<Self> {
+        Self::new_with_capacity_and_stats(name, addr, options, capacity, None)
+    }
+
+    /// Like [`Self::new_with_capacity`] but wires receiver diagnostics counters.
+    pub fn new_with_capacity_and_stats(
+        name: impl Into<String>,
+        addr: &str,
+        options: ArrowIpcReceiverOptions,
+        capacity: usize,
+        stats: Option<Arc<ComponentStats>>,
     ) -> io::Result<Self> {
         let std_listener = std::net::TcpListener::bind(addr)
             .map_err(|e| io::Error::other(format!("Arrow IPC receiver bind {addr}: {e}")))?;
@@ -130,6 +152,7 @@ impl ArrowIpcReceiver {
             tx,
             shutdown: Arc::clone(&shutdown),
             health: Arc::clone(&health),
+            stats,
             active_connections: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             max_connections: options.max_connections,
             max_message_size_bytes: options.max_message_size_bytes,
@@ -250,6 +273,18 @@ impl ArrowIpcReceiver {
     }
 }
 
+fn record_error(stats: Option<&Arc<ComponentStats>>) {
+    if let Some(stats) = stats {
+        stats.inc_errors();
+    }
+}
+
+fn record_parse_error(stats: Option<&Arc<ComponentStats>>) {
+    if let Some(stats) = stats {
+        stats.inc_parse_errors(1);
+    }
+}
+
 /// Decompress zstd body with size limit.
 fn decompress_zstd(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>, InputError> {
     let decoder = zstd::Decoder::new(body).map_err(|_| {
@@ -324,6 +359,7 @@ async fn handle_arrow_ipc_request(
 ) -> Response {
     if state.active_connections.fetch_add(1, Ordering::Relaxed) >= state.max_connections {
         state.active_connections.fetch_sub(1, Ordering::Relaxed);
+        record_error(state.stats.as_ref());
         return (
             StatusCode::TOO_MANY_REQUESTS,
             "too many concurrent connections",
@@ -336,21 +372,29 @@ async fn handle_arrow_ipc_request(
 
     let content_length = parse_content_length(&headers);
     if content_length.is_some_and(|body_len| body_len > state.max_message_size_bytes as u64) {
+        record_error(state.stats.as_ref());
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
 
     let content_encodings = match parse_content_encoding(&headers) {
         Ok(content_encoding) => content_encoding,
-        Err(status) => return (status, "invalid content-encoding header").into_response(),
+        Err(status) => {
+            record_error(state.stats.as_ref());
+            return (status, "invalid content-encoding header").into_response();
+        }
     };
     let content_type = match parse_content_type(&headers) {
         Ok(content_type) => content_type,
-        Err(status) => return (status, "invalid content-type header").into_response(),
+        Err(status) => {
+            record_error(state.stats.as_ref());
+            return (status, "invalid content-type header").into_response();
+        }
     };
 
     let body = match read_limited_body(body, state.max_message_size_bytes, content_length).await {
         Ok(body) => body,
         Err(status) => {
+            record_error(state.stats.as_ref());
             let message = if status == StatusCode::PAYLOAD_TOO_LARGE {
                 "payload too large"
             } else {
@@ -380,9 +424,11 @@ async fn handle_arrow_ipc_request(
         match decompress_zstd(&body, state.max_message_size_bytes) {
             Ok(body) => body,
             Err(InputError::Receiver(msg)) => {
+                record_parse_error(state.stats.as_ref());
                 return (StatusCode::BAD_REQUEST, msg).into_response();
             }
             Err(_) => {
+                record_parse_error(state.stats.as_ref());
                 return (
                     StatusCode::BAD_REQUEST,
                     "zstd decompression failed: invalid header",
@@ -394,9 +440,11 @@ async fn handle_arrow_ipc_request(
         match decompress_lz4(&body, state.max_message_size_bytes) {
             Ok(body) => body,
             Err(InputError::Receiver(msg)) => {
+                record_parse_error(state.stats.as_ref());
                 return (StatusCode::BAD_REQUEST, msg).into_response();
             }
             Err(_) => {
+                record_parse_error(state.stats.as_ref());
                 return (StatusCode::BAD_REQUEST, "lz4 decompression failed").into_response();
             }
         }
@@ -406,8 +454,14 @@ async fn handle_arrow_ipc_request(
 
     let batches = match decode_ipc_stream(&body) {
         Ok(batches) => batches,
-        Err(InputError::Receiver(msg)) => return (StatusCode::BAD_REQUEST, msg).into_response(),
-        Err(_) => return (StatusCode::BAD_REQUEST, "invalid Arrow IPC stream").into_response(),
+        Err(InputError::Receiver(msg)) => {
+            record_parse_error(state.stats.as_ref());
+            return (StatusCode::BAD_REQUEST, msg).into_response();
+        }
+        Err(_) => {
+            record_parse_error(state.stats.as_ref());
+            return (StatusCode::BAD_REQUEST, "invalid Arrow IPC stream").into_response();
+        }
     };
 
     let mut send_error: Option<StatusCode> = None;
@@ -439,6 +493,7 @@ async fn handle_arrow_ipc_request(
                 break;
             }
             Err(mpsc::TrySendError::Disconnected(_)) => {
+                record_error(state.stats.as_ref());
                 send_error = Some(StatusCode::SERVICE_UNAVAILABLE);
                 break;
             }
@@ -575,6 +630,7 @@ impl InputSource for ArrowIpcReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use logfwd_types::diagnostics::ComponentStats;
 
     // Regression test for issue #1142: clean shutdown
     #[test]
@@ -601,6 +657,37 @@ mod tests {
     use arrow::array::{Int64Array, StringArray};
     use arrow::datatypes::{DataType, Field, Schema};
     use std::sync::Arc;
+    use std::time::Instant;
+
+    fn loopback_http_client() -> ureq::Agent {
+        ureq::Agent::config_builder()
+            .proxy(None)
+            .timeout_global(Some(std::time::Duration::from_secs(5)))
+            .build()
+            .into()
+    }
+
+    fn wait_until<F>(timeout: std::time::Duration, mut predicate: F, failure_message: &str)
+    where
+        F: FnMut() -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if predicate() {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(predicate(), "{failure_message}");
+    }
+
+    fn wait_for_server(addr: std::net::SocketAddr) {
+        wait_until(
+            std::time::Duration::from_secs(2),
+            || std::net::TcpStream::connect(addr).is_ok(),
+            "Arrow IPC receiver did not accept connections",
+        );
+    }
 
     fn test_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
@@ -918,6 +1005,7 @@ mod tests {
         )
         .expect("bind should succeed");
         let addr = receiver.local_addr();
+        wait_for_server(addr);
 
         let url = format!("http://{addr}/v1/arrow");
         let result = ureq::get(&url).call();
@@ -1269,5 +1357,65 @@ mod tests {
             Err(e) => panic!("unexpected error: {e}"),
         };
         assert_eq!(status, 400);
+    }
+
+    #[test]
+    fn malformed_arrow_lz4_payload_increments_parse_errors_when_stats_hooked() {
+        let stats = Arc::new(ComponentStats::new());
+        let receiver = ArrowIpcReceiver::new_with_capacity_and_stats(
+            "test-stats-parse",
+            "127.0.0.1:0",
+            ArrowIpcReceiverOptions::default(),
+            16,
+            Some(Arc::clone(&stats)),
+        )
+        .expect("bind should succeed");
+        let addr = receiver.local_addr();
+
+        let url = format!("http://{addr}/v1/arrow");
+        let result = loopback_http_client()
+            .post(&url)
+            .header("Content-Type", "application/vnd.apache.arrow.stream")
+            .header("Content-Encoding", "lz4")
+            .send(b"bad" as &[u8]);
+        let status = match result {
+            Ok(resp) => resp.status().as_u16(),
+            Err(ureq::Error::StatusCode(code)) => code,
+            Err(e) => panic!("unexpected error: {e}"),
+        };
+        assert_eq!(status, 400);
+        assert_eq!(stats.parse_errors(), 1);
+        assert_eq!(stats.errors(), 0);
+    }
+
+    #[test]
+    fn disconnected_pipeline_increments_errors_when_stats_hooked() {
+        let stats = Arc::new(ComponentStats::new());
+        let mut receiver = ArrowIpcReceiver::new_with_capacity_and_stats(
+            "test-stats-errors",
+            "127.0.0.1:0",
+            ArrowIpcReceiverOptions::default(),
+            16,
+            Some(Arc::clone(&stats)),
+        )
+        .expect("bind should succeed");
+        let addr = receiver.local_addr();
+        wait_for_server(addr);
+        receiver.rx.take();
+
+        let batch = make_test_batch();
+        let ipc_bytes = serialize_batch(&batch);
+        let url = format!("http://{addr}/v1/arrow");
+        let result = loopback_http_client()
+            .post(&url)
+            .header("Content-Type", "application/vnd.apache.arrow.stream")
+            .send(&ipc_bytes);
+        let status = match result {
+            Ok(resp) => resp.status().as_u16(),
+            Err(ureq::Error::StatusCode(code)) => code,
+            Err(e) => panic!("unexpected error: {e}"),
+        };
+        assert_eq!(status, 503);
+        assert_eq!(stats.errors(), 1);
     }
 }

--- a/crates/logfwd-io/src/host_metrics.rs
+++ b/crates/logfwd-io/src/host_metrics.rs
@@ -11,6 +11,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::{cmp::Ordering, collections::BinaryHeap};
 
 use arrow::array::{ArrayRef, BooleanArray, Float32Array, StringArray, UInt32Array, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
@@ -20,6 +21,32 @@ use serde::Deserialize;
 use sysinfo::{Networks, Process, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 use crate::input::{InputEvent, InputSource};
+
+#[derive(Clone, Copy)]
+struct SelectedProcess<'a> {
+    pid: u32,
+    process: &'a Process,
+}
+
+impl Eq for SelectedProcess<'_> {}
+
+impl PartialEq for SelectedProcess<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.pid == other.pid
+    }
+}
+
+impl Ord for SelectedProcess<'_> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.pid.cmp(&other.pid)
+    }
+}
+
+impl PartialOrd for SelectedProcess<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 /// Platform target for a platform sensor input.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -677,15 +704,37 @@ impl HostMetricsCommon {
         limit: usize,
     ) -> usize {
         let limit = limit.min(self.cfg.max_process_rows_per_poll);
-        let mut procs: Vec<(&sysinfo::Pid, &Process)> = self.system.processes().iter().collect();
-        procs.sort_unstable_by_key(|(pid, _)| pid.as_u32());
+        if limit == 0 {
+            return 0;
+        }
+
+        let mut procs = BinaryHeap::with_capacity(limit);
+        for (pid, process) in self.system.processes() {
+            let selected = SelectedProcess {
+                pid: pid.as_u32(),
+                process,
+            };
+            if procs.len() < limit {
+                procs.push(selected);
+            } else if procs
+                .peek()
+                .is_some_and(|largest| selected.pid < largest.pid)
+            {
+                procs.pop();
+                procs.push(selected);
+            }
+        }
+        let mut procs = procs.into_vec();
+        procs.sort_unstable_by_key(|selected| selected.pid);
 
         let mut emitted = 0usize;
-        for (pid, process) in procs.into_iter().take(limit) {
+        for selected in procs {
+            let pid = selected.pid;
+            let process = selected.process;
             let disk_usage = process.disk_usage();
             let mut row = self.base_row(control, "process", "snapshot", "ok", "process snapshot");
             row.signal_family = Some("process".to_string());
-            row.process_pid = Some(pid.as_u32());
+            row.process_pid = Some(pid);
             row.process_parent_pid = process.parent().map(sysinfo::Pid::as_u32);
             row.process_name = Some(os_to_string(process.name()));
             row.process_cmd = Some(os_vec_to_string(process.cmd()));
@@ -709,7 +758,7 @@ impl HostMetricsCommon {
             row.process_run_time_secs = Some(process.run_time());
             row.process_open_files = process.open_files().map(|n| n as u64);
             row.process_thread_count = process.tasks().map(|t| t.len() as u64);
-            row.process_container_id = extract_container_id(pid.as_u32());
+            row.process_container_id = extract_container_id(pid);
             out.push(row);
             emitted += 1;
         }
@@ -2030,6 +2079,10 @@ mod tests {
             .filter(|(_, kind)| kind.as_deref() == Some("snapshot"))
             .filter(|(family, _)| family.as_deref() == Some("process"))
             .count();
+        assert!(
+            snapshot_count > 0,
+            "expected process snapshot rows to be emitted so the cap can be validated"
+        );
         assert!(
             snapshot_count <= 3,
             "max_process_rows_per_poll should cap process rows, got {snapshot_count}"

--- a/crates/logfwd-io/src/host_metrics.rs
+++ b/crates/logfwd-io/src/host_metrics.rs
@@ -133,6 +133,11 @@ pub struct HostMetricsConfig {
     pub emit_signal_rows: bool,
     /// Upper bound on data rows emitted per collection cycle.
     pub max_rows_per_poll: usize,
+    /// Upper bound on process rows emitted per collection cycle.
+    ///
+    /// This cap is applied after family budgeting to prevent unbounded memory
+    /// growth when hosts expose very large process tables.
+    pub max_process_rows_per_poll: usize,
 }
 
 impl Default for HostMetricsConfig {
@@ -144,6 +149,7 @@ impl Default for HostMetricsConfig {
             enabled_families: None,
             emit_signal_rows: true,
             max_rows_per_poll: 256,
+            max_process_rows_per_poll: 1024,
         }
     }
 }
@@ -670,6 +676,7 @@ impl HostMetricsCommon {
         out: &mut Vec<SensorRow>,
         limit: usize,
     ) -> usize {
+        let limit = limit.min(self.cfg.max_process_rows_per_poll);
         let mut procs: Vec<(&sysinfo::Pid, &Process)> = self.system.processes().iter().collect();
         procs.sort_unstable_by_key(|(pid, _)| pid.as_u32());
 
@@ -1994,6 +2001,38 @@ mod tests {
         assert!(
             snapshot_count <= 3,
             "max_rows_per_poll should cap data rows, got {snapshot_count}"
+        );
+    }
+
+    #[test]
+    fn max_process_rows_per_poll_caps_process_collection() {
+        let mut input = HostMetricsInput::new(
+            "sensor",
+            host_target(),
+            HostMetricsConfig {
+                enabled_families: Some(vec!["process".to_string()]),
+                emit_signal_rows: false,
+                max_rows_per_poll: usize::MAX,
+                max_process_rows_per_poll: 3,
+                ..HostMetricsConfig::default()
+            },
+        )
+        .expect("host metrics input should construct");
+
+        let events = input.poll().expect("poll should succeed");
+        let batch = first_batch(&events);
+
+        let families = string_col(batch, "signal_family");
+        let kinds = string_col(batch, "event_kind");
+        let snapshot_count = families
+            .iter()
+            .zip(kinds.iter())
+            .filter(|(_, kind)| kind.as_deref() == Some("snapshot"))
+            .filter(|(family, _)| family.as_deref() == Some("process"))
+            .count();
+        assert!(
+            snapshot_count <= 3,
+            "max_process_rows_per_poll should cap process rows, got {snapshot_count}"
         );
     }
 

--- a/crates/logfwd-io/src/host_metrics.rs
+++ b/crates/logfwd-io/src/host_metrics.rs
@@ -135,6 +135,8 @@ const WINDOWS_FAMILIES: &[SignalFamily] = &[
     SignalFamily::Authz,
 ];
 
+const DEFAULT_MAX_PROCESS_ROWS_PER_POLL: usize = 1024;
+
 fn target_signal_families(target: HostMetricsTarget) -> &'static [SignalFamily] {
     match target {
         HostMetricsTarget::Linux => LINUX_FAMILIES,
@@ -163,7 +165,8 @@ pub struct HostMetricsConfig {
     /// Upper bound on process rows emitted per collection cycle.
     ///
     /// This cap is applied after family budgeting to prevent unbounded memory
-    /// growth when hosts expose very large process tables.
+    /// growth when hosts expose very large process tables. The default is 1024;
+    /// `0` also means "use the default".
     pub max_process_rows_per_poll: usize,
 }
 
@@ -176,7 +179,7 @@ impl Default for HostMetricsConfig {
             enabled_families: None,
             emit_signal_rows: true,
             max_rows_per_poll: 256,
-            max_process_rows_per_poll: 1024,
+            max_process_rows_per_poll: DEFAULT_MAX_PROCESS_ROWS_PER_POLL,
         }
     }
 }
@@ -708,8 +711,9 @@ impl HostMetricsCommon {
             return 0;
         }
 
-        let mut procs = BinaryHeap::with_capacity(limit);
-        for (pid, process) in self.system.processes() {
+        let processes = self.system.processes();
+        let mut procs = BinaryHeap::with_capacity(limit.min(processes.len()));
+        for (pid, process) in processes {
             let selected = SelectedProcess {
                 pid: pid.as_u32(),
                 process,
@@ -1103,7 +1107,7 @@ impl HostMetricsInput {
     pub fn new(
         name: impl Into<String>,
         target: HostMetricsTarget,
-        cfg: HostMetricsConfig,
+        mut cfg: HostMetricsConfig,
     ) -> io::Result<Self> {
         let name = name.into();
         let host_platform = current_host_platform().as_str().ok_or_else(|| {
@@ -1123,6 +1127,9 @@ impl HostMetricsInput {
                     host_platform
                 ),
             ));
+        }
+        if cfg.max_process_rows_per_poll == 0 {
+            cfg.max_process_rows_per_poll = DEFAULT_MAX_PROCESS_ROWS_PER_POLL;
         }
 
         let control = ControlState {
@@ -2086,6 +2093,42 @@ mod tests {
         assert!(
             snapshot_count <= 3,
             "max_process_rows_per_poll should cap process rows, got {snapshot_count}"
+        );
+    }
+
+    #[test]
+    fn zero_max_process_rows_per_poll_uses_runtime_default() {
+        let mut input = HostMetricsInput::new(
+            "sensor",
+            host_target(),
+            HostMetricsConfig {
+                enabled_families: Some(vec!["process".to_string()]),
+                emit_signal_rows: false,
+                max_rows_per_poll: usize::MAX,
+                max_process_rows_per_poll: 0,
+                ..HostMetricsConfig::default()
+            },
+        )
+        .expect("host metrics input should construct");
+
+        let events = input.poll().expect("poll should succeed");
+        let batch = first_batch(&events);
+
+        let families = string_col(batch, "signal_family");
+        let kinds = string_col(batch, "event_kind");
+        let snapshot_count = families
+            .iter()
+            .zip(kinds.iter())
+            .filter(|(_, kind)| kind.as_deref() == Some("snapshot"))
+            .filter(|(family, _)| family.as_deref() == Some("process"))
+            .count();
+        assert!(
+            snapshot_count > 0,
+            "expected default process cap to leave process rows enabled"
+        );
+        assert!(
+            snapshot_count <= DEFAULT_MAX_PROCESS_ROWS_PER_POLL,
+            "default process cap should apply when runtime config is 0, got {snapshot_count}"
         );
     }
 

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -28,7 +28,7 @@ use logfwd_otap_proto::otap::{
     ArrowPayloadType as ProtoArrowPayloadType, BatchArrowRecords as ProtoBatchArrowRecords,
     BatchStatus as ProtoBatchStatus, StatusCode as ProtoStatusCode,
 };
-use logfwd_types::diagnostics::ComponentHealth;
+use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 use prost::Message;
 use tokio::sync::oneshot;
 
@@ -82,12 +82,22 @@ struct OtapServerState {
     tx: mpsc::SyncSender<RecordBatch>,
     shutdown: Arc<AtomicBool>,
     health: Arc<AtomicU8>,
+    stats: Option<Arc<ComponentStats>>,
 }
 
 impl OtapReceiver {
     /// Bind an HTTP server on `addr` (e.g. "0.0.0.0:4317").
     pub fn new(name: impl Into<String>, addr: &str) -> io::Result<Self> {
-        Self::new_with_capacity(name, addr, CHANNEL_BOUND)
+        Self::new_with_capacity_and_stats(name, addr, CHANNEL_BOUND, None)
+    }
+
+    /// Like [`Self::new`] but wires receiver diagnostics counters.
+    pub fn new_with_stats(
+        name: impl Into<String>,
+        addr: &str,
+        stats: Arc<ComponentStats>,
+    ) -> io::Result<Self> {
+        Self::new_with_capacity_and_stats(name, addr, CHANNEL_BOUND, Some(stats))
     }
 
     /// Like [`Self::new`] but with an explicit channel capacity. Useful for tests.
@@ -95,6 +105,16 @@ impl OtapReceiver {
         name: impl Into<String>,
         addr: &str,
         capacity: usize,
+    ) -> io::Result<Self> {
+        Self::new_with_capacity_and_stats(name, addr, capacity, None)
+    }
+
+    /// Like [`Self::new_with_capacity`] but wires receiver diagnostics counters.
+    pub fn new_with_capacity_and_stats(
+        name: impl Into<String>,
+        addr: &str,
+        capacity: usize,
+        stats: Option<Arc<ComponentStats>>,
     ) -> io::Result<Self> {
         let std_listener = std::net::TcpListener::bind(addr)
             .map_err(|e| io::Error::other(format!("OTAP receiver bind {addr}: {e}")))?;
@@ -110,6 +130,7 @@ impl OtapReceiver {
             tx,
             shutdown: Arc::clone(&shutdown),
             health: Arc::clone(&health),
+            stats,
         });
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let shutdown_for_server = Arc::clone(&shutdown);
@@ -224,6 +245,18 @@ impl OtapReceiver {
     }
 }
 
+fn record_error(stats: Option<&Arc<ComponentStats>>) {
+    if let Some(stats) = stats {
+        stats.inc_errors();
+    }
+}
+
+fn record_parse_error(stats: Option<&Arc<ComponentStats>>) {
+    if let Some(stats) = stats {
+        stats.inc_parse_errors(1);
+    }
+}
+
 fn store_health_event(health: &AtomicU8, event: ReceiverHealthEvent) {
     let mut current = health.load(Ordering::Relaxed);
     loop {
@@ -243,7 +276,10 @@ async fn handle_otap_request(
 ) -> Response {
     let content_encoding = match parse_content_encoding(&headers) {
         Ok(content_encoding) => content_encoding,
-        Err(status) => return (status, "invalid content-encoding header").into_response(),
+        Err(status) => {
+            record_error(state.stats.as_ref());
+            return (status, "invalid content-encoding header").into_response();
+        }
     };
 
     match parse_content_type(&headers) {
@@ -257,19 +293,25 @@ async fn handle_otap_request(
             }
         }
         Ok(None) => {
+            record_error(state.stats.as_ref());
             return (StatusCode::UNSUPPORTED_MEDIA_TYPE, "missing content-type").into_response();
         }
-        Err(status) => return (status, "invalid content-type header").into_response(),
+        Err(status) => {
+            record_error(state.stats.as_ref());
+            return (status, "invalid content-type header").into_response();
+        }
     }
 
     let content_length = parse_content_length(&headers);
     if content_length.is_some_and(|body_len| body_len > MAX_REQUEST_BODY_SIZE as u64) {
+        record_error(state.stats.as_ref());
         return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
     }
 
     let body = match read_limited_body(body, MAX_REQUEST_BODY_SIZE, content_length).await {
         Ok(body) => body,
         Err(status) => {
+            record_error(state.stats.as_ref());
             let message = if status == StatusCode::PAYLOAD_TOO_LARGE {
                 "payload too large"
             } else {
@@ -283,13 +325,16 @@ async fn handle_otap_request(
         Some("gzip") => match decompress_gzip(&body, MAX_REQUEST_BODY_SIZE) {
             Ok(decompressed) => decompressed,
             Err(InputError::Io(_)) => {
+                record_parse_error(state.stats.as_ref());
                 return (StatusCode::PAYLOAD_TOO_LARGE, "payload too large").into_response();
             }
             Err(_) => {
+                record_parse_error(state.stats.as_ref());
                 return (StatusCode::BAD_REQUEST, "gzip decompression failed").into_response();
             }
         },
         Some(other) => {
+            record_error(state.stats.as_ref());
             return (
                 StatusCode::BAD_REQUEST,
                 format!("unsupported content-encoding: {other}"),
@@ -301,17 +346,24 @@ async fn handle_otap_request(
 
     let batch_records = match decode_batch_arrow_records(&body) {
         Ok(records) => records,
-        Err(msg) => return (StatusCode::BAD_REQUEST, msg.to_string()).into_response(),
+        Err(msg) => {
+            record_parse_error(state.stats.as_ref());
+            return (StatusCode::BAD_REQUEST, msg.to_string()).into_response();
+        }
     };
 
     let star = match assemble_star_schema(&batch_records.payloads) {
         Ok(star) => star,
-        Err(msg) => return (StatusCode::BAD_REQUEST, msg.to_string()).into_response(),
+        Err(msg) => {
+            record_parse_error(state.stats.as_ref());
+            return (StatusCode::BAD_REQUEST, msg.to_string()).into_response();
+        }
     };
 
     let flat = match star_to_flat(&star) {
         Ok(flat) => flat,
         Err(e) => {
+            record_parse_error(state.stats.as_ref());
             return (StatusCode::BAD_REQUEST, format!("star_to_flat failed: {e}")).into_response();
         }
     };
@@ -347,6 +399,7 @@ async fn handle_otap_request(
                 .into_response()
         }
         Err(mpsc::TrySendError::Disconnected(_)) => {
+            record_error(state.stats.as_ref());
             if !state.shutdown.load(Ordering::Relaxed) {
                 store_health_event(&state.health, ReceiverHealthEvent::FatalFailure);
             }
@@ -586,6 +639,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
     use flate2::Compression;
     use flate2::write::GzEncoder;
+    use logfwd_types::diagnostics::ComponentStats;
     use std::io::Seek as _;
     use std::io::Write as _;
     use std::sync::Arc;
@@ -1140,5 +1194,61 @@ mod tests {
         let decoded = ProtoBatchStatus::decode(resp.as_slice()).expect("decode status");
         assert_eq!(decoded.batch_id, 42);
         assert_eq!(decoded.status_code, BATCH_STATUS_OK as i32);
+    }
+
+    #[test]
+    fn invalid_otap_payload_increments_parse_errors_when_stats_hooked() {
+        let stats = Arc::new(ComponentStats::new());
+        let receiver = OtapReceiver::new_with_capacity_and_stats(
+            "test-stats-parse",
+            "127.0.0.1:0",
+            16,
+            Some(Arc::clone(&stats)),
+        )
+        .expect("bind should succeed");
+        let addr = receiver.local_addr();
+
+        let url = format!("http://{addr}/v1/arrow_logs");
+        let result = loopback_http_client()
+            .post(&url)
+            .header("Content-Type", "application/x-protobuf")
+            .send(b"invalid protobuf payload" as &[u8]);
+        let status = match result {
+            Ok(resp) => resp.status().as_u16(),
+            Err(ureq::Error::StatusCode(code)) => code,
+            Err(e) => panic!("unexpected error: {e}"),
+        };
+        assert_eq!(status, 400);
+        assert_eq!(stats.parse_errors(), 1);
+        assert_eq!(stats.errors(), 0);
+    }
+
+    #[test]
+    fn disconnected_pipeline_increments_errors_when_stats_hooked() {
+        let stats = Arc::new(ComponentStats::new());
+        let mut receiver = OtapReceiver::new_with_capacity_and_stats(
+            "test-stats-errors",
+            "127.0.0.1:0",
+            16,
+            Some(Arc::clone(&stats)),
+        )
+        .expect("bind should succeed");
+        let addr = receiver.local_addr();
+        receiver.rx.take();
+
+        let logs_ipc = serialize_batch_to_ipc(&make_logs_batch());
+        let proto = encode_batch_arrow_records(1, &[(PAYLOAD_TYPE_LOGS, &logs_ipc)]);
+        let url = format!("http://{addr}/v1/arrow_logs");
+        let result = loopback_http_client()
+            .post(&url)
+            .header("Content-Type", "application/x-protobuf")
+            .send(&proto);
+        let status = match result {
+            Ok(resp) => resp.status().as_u16(),
+            Err(ureq::Error::StatusCode(code)) => code,
+            Err(e) => panic!("unexpected error: {e}"),
+        };
+        assert_eq!(status, 503);
+        assert_eq!(stats.errors(), 1);
     }
 }

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -285,6 +285,7 @@ async fn handle_otap_request(
     match parse_content_type(&headers) {
         Ok(Some(content_type)) => {
             if content_type != "application/x-protobuf" {
+                record_error(state.stats.as_ref());
                 return (
                     StatusCode::UNSUPPORTED_MEDIA_TYPE,
                     "unsupported content-type",
@@ -667,6 +668,14 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         assert!(predicate(), "{failure_message}");
+    }
+
+    fn wait_for_server(addr: std::net::SocketAddr) {
+        wait_until(
+            Duration::from_secs(2),
+            || std::net::TcpStream::connect(addr).is_ok(),
+            "OTAP receiver did not accept connections",
+        );
     }
 
     fn tempfile_payload(bytes: &[u8]) -> std::fs::File {
@@ -1095,9 +1104,16 @@ mod tests {
 
     #[test]
     fn receiver_rejects_unsupported_content_type() {
-        let receiver = OtapReceiver::new_with_capacity("test-415", "127.0.0.1:0", 16)
-            .expect("bind should succeed");
+        let stats = Arc::new(ComponentStats::new());
+        let receiver = OtapReceiver::new_with_capacity_and_stats(
+            "test-415",
+            "127.0.0.1:0",
+            16,
+            Some(Arc::clone(&stats)),
+        )
+        .expect("bind should succeed");
         let addr = receiver.local_addr();
+        wait_for_server(addr);
 
         let url = format!("http://{addr}/v1/arrow_logs");
         let payload = tempfile_payload(b"{}");
@@ -1109,6 +1125,7 @@ mod tests {
             Err(ureq::Error::StatusCode(code)) => assert_eq!(code, 415),
             other => panic!("expected 415, got {other:?}"),
         }
+        assert_eq!(stats.errors(), 1);
     }
 
     #[test]
@@ -1207,6 +1224,7 @@ mod tests {
         )
         .expect("bind should succeed");
         let addr = receiver.local_addr();
+        wait_for_server(addr);
 
         let url = format!("http://{addr}/v1/arrow_logs");
         let result = loopback_http_client()
@@ -1234,6 +1252,7 @@ mod tests {
         )
         .expect("bind should succeed");
         let addr = receiver.local_addr();
+        wait_for_server(addr);
         receiver.rx.take();
 
         let logs_ipc = serialize_batch_to_ipc(&make_logs_batch());

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -392,6 +392,7 @@ async fn handle_otap_request(
                 .into_response()
         }
         Err(mpsc::TrySendError::Full(_)) => {
+            record_error(state.stats.as_ref());
             store_health_event(&state.health, ReceiverHealthEvent::Backpressure);
             (
                 StatusCode::TOO_MANY_REQUESTS,
@@ -1161,9 +1162,16 @@ mod tests {
 
     #[test]
     fn receiver_returns_429_when_channel_full() {
-        let receiver = OtapReceiver::new_with_capacity("test-429", "127.0.0.1:0", 1)
-            .expect("bind should succeed");
+        let stats = Arc::new(ComponentStats::new());
+        let receiver = OtapReceiver::new_with_capacity_and_stats(
+            "test-429",
+            "127.0.0.1:0",
+            1,
+            Some(Arc::clone(&stats)),
+        )
+        .expect("bind should succeed");
         let addr = receiver.local_addr();
+        wait_for_server(addr);
 
         let logs_ipc = serialize_batch_to_ipc(&make_logs_batch());
         let proto = encode_batch_arrow_records(1, &[(PAYLOAD_TYPE_LOGS, &logs_ipc)]);
@@ -1191,6 +1199,7 @@ mod tests {
         };
         assert_eq!(status, 429, "expected 429, got {status}");
         assert_eq!(receiver.health(), ComponentHealth::Degraded);
+        assert_eq!(stats.errors(), 1);
 
         // Drain so the receiver is valid.
         let _ = receiver.try_recv_all();

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -317,8 +317,13 @@ pub(super) fn build_input_state(
             if let Some(v) = a.max_message_size_bytes {
                 options.max_message_size_bytes = v;
             }
-            let source = logfwd_io::arrow_ipc_receiver::ArrowIpcReceiver::new(name, addr, options)
-                .map_err(|e| format!("input '{name}': failed to start Arrow IPC receiver: {e}"))?;
+            let source = logfwd_io::arrow_ipc_receiver::ArrowIpcReceiver::new_with_stats(
+                name,
+                addr,
+                options,
+                Arc::clone(&stats),
+            )
+            .map_err(|e| format!("input '{name}': failed to start Arrow IPC receiver: {e}"))?;
             (Box::new(source), format, 4 * 1024 * 1024)
         }
         InputTypeConfig::Http(h) => {
@@ -694,6 +699,10 @@ fn build_host_metrics_config(
             .and_then(|c| c.max_rows_per_poll)
             .filter(|&n| n > 0)
             .unwrap_or(256),
+        max_process_rows_per_poll: cfg
+            .and_then(|c| c.max_process_rows_per_poll)
+            .filter(|&n| n > 0)
+            .unwrap_or(1024),
     }
 }
 
@@ -918,6 +927,25 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn build_host_metrics_config_uses_defaults() {
+        let cfg = build_host_metrics_config(None);
+        assert_eq!(cfg.max_rows_per_poll, 256);
+        assert_eq!(cfg.max_process_rows_per_poll, 1024);
+    }
+
+    #[test]
+    fn build_host_metrics_config_ignores_zero_caps() {
+        let input = HostMetricsInputConfig {
+            max_rows_per_poll: Some(0),
+            max_process_rows_per_poll: Some(0),
+            ..HostMetricsInputConfig::default()
+        };
+        let cfg = build_host_metrics_config(Some(&input));
+        assert_eq!(cfg.max_rows_per_poll, 256);
+        assert_eq!(cfg.max_process_rows_per_poll, 1024);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #2281.

- Add `sensor.max_process_rows_per_poll` for `host_metrics` with a 1024 default and apply it as a hard process snapshot cap in addition to the existing per-poll row budget.
- Wire `ComponentStats` into Arrow IPC structured receiver construction and add stats hooks for request errors and parse/decode failures.
- Add equivalent stats hooks and tests for the OTAP receiver module.
- Document the new host metrics cap in the configuration reference.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p logfwd-runtime build_host_metrics_config_ -- --nocapture`
- `cargo test -p logfwd-io max_process_rows_per_poll_caps_process_collection -- --nocapture`
- `cargo test -p logfwd-io stats_hooked -- --nocapture`
- `cargo clippy -p logfwd-io -p logfwd-runtime -- -D warnings`

## Notes

The cloud attempt originally included an invalid Arrow stream HTTP test that was flaky in this local environment. I replaced it with a deterministic malformed LZ4 Arrow payload path that exercises the same receiver parse-error counter.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap host metrics process rows per poll and wire receiver diagnostics stats
> - Adds `max_process_rows_per_poll` (default 1024) to `HostMetricsConfig`, capping process snapshot rows emitted per collection cycle; when more processes exist than the cap, only the lowest PIDs are selected via a `BinaryHeap`.
> - Wires `ComponentStats` into `ArrowIpcReceiver` and `OtapReceiver` so that error and parse-error counters are incremented on validation failures, decompression errors, decoding errors, and backpressure events.
> - Updates the runtime in [input_build.rs](https://github.com/strawgate/fastforward/pull/2297/files#diff-ca354d25bc72dec0d7f48518cd76a40d5bfab0a1f22f56449adbd8e2a81ffc4f) to pass the active `ComponentStats` handle when constructing Arrow IPC inputs and to propagate `max_process_rows_per_poll` from config.
> - Documents the new `sensor.max_process_rows_per_poll` key in [reference.mdx](https://github.com/strawgate/fastforward/pull/2297/files#diff-6a69bd5c38c92acca3dd194d75d77551f1b8f6b98890da7e56f2c9cbe564aac4).
> - Behavioral Change: host metrics collection now emits at most 1024 process rows per poll by default, where previously there was no such cap.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e95618.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->