### PR TITLE
feat(docs): slot-based highway backpressure simulation

### DIFF
--- a/book/src/components/HighwayBackpressure.astro
+++ b/book/src/components/HighwayBackpressure.astro
@@ -189,9 +189,23 @@ import { createSimulation } from './highway-sim.mjs';
   var lenExit = pathExit.getTotalLength();
   var lenCont = pathCont.getTotalLength();
 
-  // mergeD: where x=200 on the straight highway from x=30 to x=560
-  var mergeD = Math.round(lenHwy * 170 / 530);
-  var gateD = Math.round(lenExit * 0.62);
+  var SIM_FRAMES = 10; // sim advances every 10 render frames (250ms at 25ms/frame)
+  var CAR_W = 20, CAR_H = 10;
+
+  // Create simulation with measured path lengths
+  var sim = createSimulation({
+    lenRamp: lenRamp,
+    lenHwy: lenHwy,
+    lenExit: lenExit,
+    lenCont: lenCont,
+    carW: CAR_W,
+    greenPct: 80,
+    autoSpeed: 0.15 * SIM_FRAMES, // compensate for slower sim tick rate
+  });
+  sim.setCycleStart(Date.now());
+
+  // Gate position for traffic light rendering
+  var gateD = sim.getSlotD('exit', sim.cfg.gateSlot);
 
   // ---- Position traffic light on exit ramp ----
   (function() {
@@ -202,13 +216,11 @@ import { createSimulation } from './highway-sim.mjs';
     var cosP = Math.cos(perpAngle);
     var sinP = Math.sin(perpAngle);
 
-    // Stop line across the road (±14px from center)
     stopLine.setAttribute('x1', String((p.x + cosP * 14).toFixed(1)));
     stopLine.setAttribute('y1', String((p.y + sinP * 14).toFixed(1)));
     stopLine.setAttribute('x2', String((p.x - cosP * 14).toFixed(1)));
     stopLine.setAttribute('y2', String((p.y - sinP * 14).toFixed(1)));
 
-    // Light housing offset to the outside of the curve
     var ox = p.x + cosP * 30;
     var oy = p.y + sinP * 30;
     lightHousing.setAttribute('transform', 'translate(' + ox.toFixed(1) + ',' + oy.toFixed(1) + ')');
@@ -216,21 +228,8 @@ import { createSimulation } from './highway-sim.mjs';
     lightG.style.display = '';
   })();
 
-  var CAR_W = 20, CAR_H = 10;
   var TICK_MS = 25;
-
-  // Create simulation with measured path lengths
-  var sim = createSimulation({
-    lenRamp: lenRamp,
-    lenHwy: lenHwy,
-    lenExit: lenExit,
-    lenCont: lenCont,
-    mergeD: mergeD,
-    gateD: gateD,
-    carW: CAR_W,
-    greenPct: 80,
-  });
-  sim.setCycleStart(Date.now());
+  var LERP_RATE = 0.25; // visual interpolation speed per frame
 
   // Segment → SVG path mapping
   var pathMap = { ramp: pathRamp, highway: pathHwy, exit: pathExit, cont: pathCont };
@@ -251,6 +250,7 @@ import { createSimulation } from './highway-sim.mjs';
 
   // ---- DOM car management ----
   var carEls = {};
+  var visualD = {}; // per-car visual interpolation state
 
   function createCarEl(car) {
     var w = CAR_W * car.scale;
@@ -316,6 +316,7 @@ import { createSimulation } from './highway-sim.mjs';
 
     carsG.appendChild(g);
     carEls[car.id] = { g: g, body: body };
+    visualD[car.id] = car.targetD; // start at target position
   }
 
   function removeCarEl(id) {
@@ -323,6 +324,8 @@ import { createSimulation } from './highway-sim.mjs';
     if (el && el.g.parentNode) {
       el.g.parentNode.removeChild(el.g);
       delete carEls[id];
+      delete visualD[id];
+      delete lastSegment[id];
     }
   }
 
@@ -331,7 +334,16 @@ import { createSimulation } from './highway-sim.mjs';
     if (!el) return;
     var seg = car.segment;
     var len = lenMap[seg];
-    var d = Math.min(Math.max(0, car.d), len);
+
+    // Lerp visualD toward car.targetD for smooth motion
+    var vd = visualD[car.id];
+    if (vd == null) vd = car.targetD;
+    vd += (car.targetD - vd) * LERP_RATE;
+    // Snap when very close to avoid endless micro-drifting
+    if (Math.abs(car.targetD - vd) < 0.5) vd = car.targetD;
+    visualD[car.id] = vd;
+
+    var d = Math.min(Math.max(0, vd), len);
     var p = posAt(seg, d);
     var a = angleAt(seg, d);
     el.g.setAttribute('transform', 'translate(' + p.x.toFixed(1) + ',' + p.y.toFixed(1) + ') rotate(' + a.toFixed(1) + ')');
@@ -346,63 +358,81 @@ import { createSimulation } from './highway-sim.mjs';
   }
 
   // ---- Main render loop ----
+  // Sim ticks every SIM_FRAMES render frames to keep car speed natural.
+  // Render frames interpolate visual positions for smoothness.
   var lastStatus = '';
   var timer = null;
   var frameCount = 0;
+  var lastFrame = null; // most recent sim.tick() result
+
+  // Track which segment each car was on last frame (for transition detection)
+  var lastSegment = {};
 
   function tick() {
     var now = Date.now();
-    var frame = sim.tick(now);
     frameCount++;
 
-    var allCars = frame.cars;
-    for (var c = 0; c < allCars.length; c++) {
-      if (!carEls[allCars[c].id]) createCarEl(allCars[c]);
-    }
-    for (var r = 0; r < frame.removedIds.length; r++) {
-      removeCarEl(frame.removedIds[r]);
-    }
-    for (var u = 0; u < allCars.length; u++) {
-      updateCarEl(allCars[u]);
-    }
+    // Advance simulation every SIM_FRAMES render frames
+    if (frameCount % SIM_FRAMES === 0 || !lastFrame) {
+      lastFrame = sim.tick(now);
 
-    // Traffic light visuals
-    if (lRed && lGreen) {
-      if (frame.lightIsGreen) {
-        lRed.setAttribute('fill', '#3a1111');
-        lGreen.setAttribute('fill', '#22c55e');
-      } else {
-        lRed.setAttribute('fill', '#ef4444');
-        lGreen.setAttribute('fill', '#113a16');
+      var allCars = lastFrame.cars;
+      for (var c = 0; c < allCars.length; c++) {
+        var car = allCars[c];
+        if (!carEls[car.id]) createCarEl(car);
+        // Reset visualD on segment transition
+        if (lastSegment[car.id] && lastSegment[car.id] !== car.segment) {
+          visualD[car.id] = car.targetD;
+        }
+        lastSegment[car.id] = car.segment;
       }
-    }
+      for (var r = 0; r < lastFrame.removedIds.length; r++) {
+        removeCarEl(lastFrame.removedIds[r]);
+      }
 
-    // Sync slider in auto mode
-    if (frame.autoMode && slider) {
-      slider.value = String(frame.greenPct);
-      if (sliderDetail) sliderDetail.textContent = 'Auto \u00B7 Green ' + frame.greenPct + '%';
-    }
+      // Traffic light visuals
+      if (lRed && lGreen) {
+        if (lastFrame.lightIsGreen) {
+          lRed.setAttribute('fill', '#3a1111');
+          lGreen.setAttribute('fill', '#22c55e');
+        } else {
+          lRed.setAttribute('fill', '#ef4444');
+          lGreen.setAttribute('fill', '#113a16');
+        }
+      }
 
-    // Stats
-    if (frameCount % 8 === 0) {
-      if (sTput) sTput.textContent = frame.stats.throughput + '/min';
-      if (sQueue) sQueue.textContent = String(frame.stats.queued);
+      // Sync slider in auto mode
+      if (lastFrame.autoMode && slider) {
+        slider.value = String(lastFrame.greenPct);
+        if (sliderDetail) sliderDetail.textContent = 'Auto \u00B7 Green ' + lastFrame.greenPct + '%';
+      }
+
+      // Stats (every sim tick)
+      if (sTput) sTput.textContent = lastFrame.stats.throughput + '/min';
+      if (sQueue) sQueue.textContent = String(lastFrame.stats.queued);
       if (sStall) {
-        sStall.textContent = frame.stats.stallPct + '%';
-        sStall.style.color = frame.stats.stallPct > 50 ? 'var(--hw-car-stop)' : frame.stats.stallPct > 20 ? 'var(--hw-car-slow)' : '';
+        sStall.textContent = lastFrame.stats.stallPct + '%';
+        sStall.style.color = lastFrame.stats.stallPct > 50 ? 'var(--hw-car-stop)' : lastFrame.stats.stallPct > 20 ? 'var(--hw-car-slow)' : '';
+      }
+
+      // Status label
+      var msg = lastFrame.status.msg;
+      if (msg !== lastStatus) {
+        if (statusEl) statusEl.textContent = msg;
+        if (pipelineLabel) {
+          pipelineLabel.textContent = msg.toUpperCase();
+          var fill = lastFrame.status.level === 'blocked' ? 'var(--hw-car-stop)' : lastFrame.status.level === 'congested' ? 'var(--hw-car-slow)' : 'var(--hw-muted)';
+          pipelineLabel.setAttribute('fill', fill);
+        }
+        lastStatus = msg;
       }
     }
 
-    // Status label
-    var msg = frame.status.msg;
-    if (msg !== lastStatus) {
-      if (statusEl) statusEl.textContent = msg;
-      if (pipelineLabel) {
-        pipelineLabel.textContent = msg.toUpperCase();
-        var fill = frame.status.level === 'blocked' ? 'var(--hw-car-stop)' : frame.status.level === 'congested' ? 'var(--hw-car-slow)' : 'var(--hw-muted)';
-        pipelineLabel.setAttribute('fill', fill);
+    // Always: update visual positions (smooth interpolation every render frame)
+    if (lastFrame) {
+      for (var u = 0; u < lastFrame.cars.length; u++) {
+        updateCarEl(lastFrame.cars[u]);
       }
-      lastStatus = msg;
     }
   }
 
@@ -421,10 +451,10 @@ import { createSimulation } from './highway-sim.mjs';
 
   // ---- Seed initial cars ----
   function seedCars() {
-    sim.addCar('highway', 80, 3.5);
-    sim.addCar('highway', 200, 3.5);
-    sim.addCar('highway', 350, 3.5);
-    sim.addCar('ramp', 60, 3.5);
+    sim.addCar('highway', 2);
+    sim.addCar('highway', 6);
+    sim.addCar('highway', 10);
+    sim.addCar('ramp', 2);
   }
 
   // ---- Init ----

--- a/book/src/components/__tests__/highway-sim.test.mjs
+++ b/book/src/components/__tests__/highway-sim.test.mjs
@@ -1,7 +1,7 @@
 /**
  * Tests for highway-sim.mjs — Node 22 built-in test runner.
  *
- * Multi-route model: ramp → highway → exit (with traffic light on exit).
+ * Slot-based model: each segment has N slots, each holds at most one car.
  *
  * Run:  node --test book/src/components/__tests__/highway-sim.test.mjs
  */
@@ -21,12 +21,6 @@ function runTicks(sim, n, start, dt) {
     last = sim.tick(start + i * dt);
   }
   return last;
-}
-
-function newestCar(cars) {
-  return cars.reduce(function (newest, car) {
-    return !newest || car.id > newest.id ? car : newest;
-  }, null);
 }
 
 // ---------------------------------------------------------------------------
@@ -92,10 +86,10 @@ describe('car spawning', function () {
   });
 
   it('respects spawnMs cooldown', function () {
-    var sim = createSimulation({ spawnMs: 500, maxCars: 5 }, fixedScale(1));
+    var sim = createSimulation({ spawnMs: 500, maxCars: 10 }, fixedScale(1));
     sim.exitAuto();
-    sim.tick(600); // first spawn
-    sim.tick(700); // only 100ms later → no new spawn
+    sim.tick(600);
+    sim.tick(700);
     assert.equal(sim.getCars().length, 1, 'should not have spawned twice');
   });
 
@@ -105,49 +99,79 @@ describe('car spawning', function () {
     sim.tick(100);
     var cars = sim.getCars();
     assert.equal(cars.length, 1);
-    assert.equal(newestCar(cars).segment, 'highway');
+    assert.equal(cars[0].segment, 'highway');
 
     sim.tick(200);
     cars = sim.getCars();
     assert.equal(cars.length, 2);
-    assert.equal(newestCar(cars).segment, 'ramp');
-
-    for (var t = 3; t <= 6; t++) {
-      sim.tick(t * 100);
-      cars = sim.getCars();
-      cars.sort(function (a, b) { return a.id - b.id; });
-      var newest = cars[cars.length - 1];
-      var previous = cars[cars.length - 2];
-      assert.notEqual(newest.segment, previous.segment, 'spawn source should alternate');
-    }
+    var segments = cars.map(function (c) { return c.segment; }).sort();
+    assert.ok(segments.indexOf('ramp') >= 0, 'second spawn should be ramp');
   });
 
   it('respects maxCars', function () {
     var sim = createSimulation({ maxCars: 2, spawnMs: 10 }, fixedScale(1));
     sim.exitAuto();
-    sim.addCar('highway', 200, 3);
-    sim.addCar('ramp', 100, 3);
+    sim.addCar('highway', 5);
+    sim.addCar('ramp', 2);
     sim.tick(1000);
     assert.equal(sim.getCars().length, 2, 'should not exceed maxCars');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Multi-segment transitions
+// Slot integrity — no overlap
+// ---------------------------------------------------------------------------
+
+describe('slot integrity', function () {
+  it('no two cars ever share a slot', function () {
+    var sim = createSimulation({
+      greenPct: 0, cycleTotal: 100, spawnMs: 50, maxCars: 20,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    for (var t = 0; t < 200; t++) {
+      var frame = sim.tick(t * 100);
+      var occupied = {};
+      for (var c = 0; c < frame.cars.length; c++) {
+        var car = frame.cars[c];
+        var key = car.segment + ':' + car.slot;
+        assert.ok(!occupied[key], 'slot collision at ' + key + ' on tick ' + t);
+        occupied[key] = true;
+      }
+    }
+  });
+
+  it('addCar rejects occupied slot', function () {
+    var sim = createSimulation({}, fixedScale(1));
+    sim.addCar('highway', 3);
+    assert.throws(function () {
+      sim.addCar('highway', 3);
+    }, /occupied/);
+  });
+
+  it('addCar rejects invalid slot index', function () {
+    var sim = createSimulation({}, fixedScale(1));
+    assert.throws(function () {
+      sim.addCar('highway', 999);
+    }, /invalid slot/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Segment transitions
 // ---------------------------------------------------------------------------
 
 describe('segment transitions', function () {
   it('ramp cars merge onto highway', function () {
     var sim = createSimulation({
-      lenRamp: 180, lenHwy: 530, lenExit: 210,
-      mergeD: 170, gateD: 130, greenPct: 100,
-      cycleTotal: 100, spawnMs: 99999, maxCars: 5,
+      slotsRamp: 5, slotsHwy: 15, mergeSlot: 5,
+      greenPct: 100, cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar('ramp', 175, 3.5); // near end of ramp
-    for (var t = 0; t < 20; t++) {
-      sim.tick(t * 25);
+    sim.addCar('ramp', 4); // last ramp slot
+    for (var t = 0; t < 10; t++) {
+      sim.tick(t * 100);
     }
     var cars = sim.getCars();
     var onHwy = cars.filter(function (c) { return c.segment === 'highway'; });
@@ -156,223 +180,232 @@ describe('segment transitions', function () {
 
   it('highway cars transition to exit', function () {
     var sim = createSimulation({
-      lenRamp: 180, lenHwy: 530, lenExit: 210,
-      mergeD: 170, gateD: 130, greenPct: 100,
-      cycleTotal: 100, spawnMs: 99999, maxCars: 5,
+      slotsHwy: 15, slotsExit: 6,
+      greenPct: 100, cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar('highway', 525, 3.5); // near end of highway
-    for (var t = 0; t < 20; t++) {
-      sim.tick(t * 25);
+    sim.addCar('highway', 14); // last highway slot
+    var transitioned = false;
+    for (var t = 0; t < 10; t++) {
+      var frame = sim.tick(t * 100);
+      var onExit = frame.cars.filter(function (c) { return c.segment === 'exit'; });
+      if (onExit.length >= 1 || frame.removedIds.length > 0) {
+        transitioned = true;
+        break;
+      }
     }
-    var cars = sim.getCars();
-    var onExit = cars.filter(function (c) { return c.segment === 'exit'; });
-    assert.ok(onExit.length >= 1, 'highway car should have transitioned to exit');
+    assert.ok(transitioned, 'highway car should have transitioned to exit (or been delivered)');
   });
 
   it('exit cars are delivered (removed) at end of exit', function () {
     var sim = createSimulation({
-      lenRamp: 180, lenHwy: 530, lenExit: 210,
-      mergeD: 170, gateD: 130, greenPct: 100,
-      cycleTotal: 100, spawnMs: 99999, maxCars: 5,
+      slotsExit: 6, greenPct: 100, cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
     sim.setLastSpawn(99999);
-    sim.addCar('exit', 200, 3.5); // near end of exit
-    var delivered = false;
+    sim.addCar('exit', 5); // last exit slot
+    var frame = sim.tick(100);
+    assert.ok(frame.removedIds.length > 0, 'car should have been delivered');
+  });
+
+  it('ramp merge is blocked when mergeSlot is occupied', function () {
+    var sim = createSimulation({
+      slotsRamp: 5, slotsHwy: 15, slotsExit: 6, slotsCont: 0,
+      mergeSlot: 5, gateSlot: 4,
+      greenPct: 0, cycleTotal: 100, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.addCar('ramp', 4);
+    // Fill highway from mergeSlot to end and exit (no cont = no overflow)
+    for (var i = 5; i < 15; i++) sim.addCar('highway', i);
+    for (var e = 0; e < 6; e++) sim.addCar('exit', e);
+    sim.tick(100);
+    var rampCars = sim.getCars().filter(function (c) { return c.segment === 'ramp'; });
+    assert.ok(rampCars.length >= 1, 'ramp car should stay on ramp when merge blocked');
+  });
+
+  it('highway car goes to cont when exit is full and light is green', function () {
+    var sim = createSimulation({
+      slotsHwy: 15, slotsExit: 6, slotsCont: 6, gateSlot: 4,
+      greenPct: 100, cycleTotal: 100, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.addCar('highway', 14); // last hwy slot
+    // Fill all exit slots — with green light, exit will advance but
+    // tryHwyToExit runs BEFORE exit advancement, so exit[0] is still occupied
+    for (var i = 0; i < 6; i++) sim.addCar('exit', i);
+    sim.tick(100);
+    var contCars = sim.getCars().filter(function (c) { return c.segment === 'cont'; });
+    assert.ok(contCars.length >= 1, 'car should go to cont when exit is full during green');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Traffic light gate behavior
+// ---------------------------------------------------------------------------
+
+describe('traffic light gate', function () {
+  it('cars stop at gateSlot on red', function () {
+    var sim = createSimulation({
+      slotsExit: 6, gateSlot: 4,
+      greenPct: 0, cycleTotal: 100, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.addCar('exit', 2);
     for (var t = 0; t < 20; t++) {
-      var frame = sim.tick(t * 25);
-      if (frame.removedIds.length > 0) delivered = true;
-    }
-    assert.ok(delivered, 'car should have been delivered');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Following distance and hard gap
-// ---------------------------------------------------------------------------
-
-describe('following distance', function () {
-  it('cars never overlap within a segment', function () {
-    var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: 130,
-      lenExit: 210, lenHwy: 530, spawnMs: 99999,
-    }, fixedScale(1));
-    sim.setCycleStart(0);
-    sim.exitAuto();
-    // Pack cars on the exit segment before the gate
-    for (var i = 0; i < 5; i++) {
-      sim.addCar('exit', 10 + i * 25, 3.5);
-    }
-    for (var t = 0; t < 200; t++) {
-      sim.tick(t * 25);
-      var cars = sim.getCars().filter(function (c) { return c.segment === 'exit'; });
-      cars.sort(function (a, b) { return b.d - a.d; });
-      for (var j = 1; j < cars.length; j++) {
-        var gap = cars[j - 1].d - cars[j].d;
-        var minGap = (cars[j - 1].w + cars[j].w) / 2 + sim.cfg.minFollowPad;
-        assert.ok(gap >= minGap - 0.01,
-          'gap violation: ' + gap.toFixed(2) + ' < ' + minGap.toFixed(2));
-      }
-    }
-  });
-
-  it('trailing car brakes when getting close', function () {
-    var sim = createSimulation({
-      greenPct: 100, cycleTotal: 100, followZone: 18,
-      lenHwy: 530, spawnMs: 99999,
-    }, fixedScale(1));
-    sim.setCycleStart(0);
-    sim.exitAuto();
-    sim.addCar('highway', 40, 0); // stopped
-    sim.addCar('highway', 10, 3.5); // fast, approaching
-    for (var t = 0; t < 5; t++) {
-      sim.tick(t * 25);
-    }
-    var cars = sim.getCars().filter(function (c) { return c.segment === 'highway'; });
-    cars.sort(function (a, b) { return a.d - b.d; });
-    assert.ok(cars[0].speed < 3.5, 'trailing car should have braked');
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Red light stopping (on exit ramp)
-// ---------------------------------------------------------------------------
-
-describe('red light on exit', function () {
-  it('lead car stops at gateD on red', function () {
-    var gateD = 130;
-    var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: gateD,
-      lenExit: 210, lenHwy: 530, spawnMs: 99999,
-    }, fixedScale(1));
-    sim.setCycleStart(0);
-    sim.exitAuto();
-    sim.addCar('exit', gateD - 30, 3.5);
-    for (var t = 0; t < 50; t++) {
-      sim.tick(t * 25);
+      sim.tick(t * 100);
     }
     var car = sim.getCars().filter(function (c) { return c.segment === 'exit'; })[0];
     assert.ok(car, 'car should still be on exit');
-    assert.ok(car.d <= gateD + 0.01, 'car should stop at or before gateD');
-    assert.ok(car.speed < 0.2, 'car should be stopped');
+    assert.ok(car.slot <= 4, 'car should be at or before gateSlot');
+    assert.equal(car.speed, 0, 'car should be stopped');
+  });
+
+  it('cars past gate during green survive when light turns red', function () {
+    var sim = createSimulation({
+      slotsExit: 6, gateSlot: 3,
+      greenPct: 50, cycleTotal: 1000, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    // Place car past the gate
+    sim.addCar('exit', 1);
+
+    // Advance during green phase (t < 500ms)
+    for (var t = 0; t < 15; t++) {
+      sim.tick(t * 30);
+    }
+    var cars = sim.getCars().filter(function (c) { return c.segment === 'exit'; });
+    // Car should have advanced past gateSlot during green
+    var pastGate = cars.filter(function (c) { return c.slot > 3; });
+
+    // Now tick into red phase (t > 500ms)
+    for (var t2 = 15; t2 < 30; t2++) {
+      var frame = sim.tick(t2 * 50);
+    }
+    // Car that passed gate should still be advancing (not yanked back)
+    var remainingExit = frame.cars.filter(function (c) { return c.segment === 'exit'; });
+    // If car was delivered, that's fine too — it wasn't yanked back
+    if (remainingExit.length > 0) {
+      assert.ok(remainingExit[0].pastGate, 'car past gate should have pastGate=true');
+    }
+    // Key: car should NOT be stuck at gateSlot
+  });
+
+  it('red exit blocks highway — no cont bypass during red', function () {
+    var sim = createSimulation({
+      slotsHwy: 15, slotsExit: 6, slotsCont: 6, gateSlot: 4,
+      greenPct: 0, cycleTotal: 100, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.setCycleStart(0);
+    sim.exitAuto();
+    sim.addCar('highway', 14);
+    // Fill all exit slots
+    for (var i = 0; i < 6; i++) sim.addCar('exit', i);
+    sim.tick(100);
+    var contCars = sim.getCars().filter(function (c) { return c.segment === 'cont'; });
+    assert.equal(contCars.length, 0, 'should not route to cont when light is red');
+    var hwyCars = sim.getCars().filter(function (c) { return c.segment === 'highway'; });
+    assert.ok(hwyCars.length >= 1, 'car should stay on highway');
   });
 
   it('backpressure cascades: exit full → highway blocks', function () {
     var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: 130,
-      lenExit: 210, lenHwy: 530, lenRamp: 180, lenCont: 215,
-      mergeD: 170, spawnMs: 99999, minFollowPad: 8,
+      slotsHwy: 15, slotsExit: 6, slotsCont: 6, gateSlot: 4,
+      greenPct: 0, cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    // Fill exit ramp with stopped cars
-    for (var i = 0; i < 5; i++) {
-      sim.addCar('exit', 10 + i * 25, 0);
-    }
-    // Fill continuation with stopped cars packed tight
-    for (var j = 0; j < 8; j++) {
-      sim.addCar('cont', j * 25, 0);
-    }
-    // Car on highway near the fork
-    sim.addCar('highway', 525, 3.5);
-    // Only a few ticks — before cont cars can accelerate away
-    for (var t = 0; t < 5; t++) {
-      sim.tick(t * 25);
-    }
+    // Fill exit
+    for (var i = 0; i < 6; i++) sim.addCar('exit', i);
+    // Car on highway at the end
+    sim.addCar('highway', 14);
+    sim.tick(100);
     var hwyCars = sim.getCars().filter(function (c) { return c.segment === 'highway'; });
     assert.ok(hwyCars.length > 0, 'car should still be on highway');
-    assert.ok(hwyCars[0].speed < 1, 'highway car should be blocked by full exit+cont');
-  });
-
-  it('red exit saturation blocks instead of bypassing through continuation', function () {
-    var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100,
-      lenExit: 210, lenHwy: 530, lenCont: 215,
-      gateD: 130, spawnMs: 99999,
-    }, fixedScale(1));
-    sim.setCycleStart(0);
-    sim.exitAuto();
-    sim.setLastSpawn(99999);
-    sim.addCar('exit', 12, 0);
-    sim.addCar('highway', 528, 3.5);
-
-    var frame = sim.tick(100);
-    var hwyCars = frame.cars.filter(function (c) { return c.segment === 'highway'; });
-    var contCars = frame.cars.filter(function (c) { return c.segment === 'cont'; });
-
-    assert.equal(contCars.length, 0, 'red exit saturation should not route into continuation');
-    assert.equal(hwyCars.length, 1, 'car should remain on highway');
-    assert.ok(hwyCars[0].speed < 1, 'car should brake at the fork');
+    assert.equal(hwyCars[0].speed, 0, 'highway car should be stopped');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Car fade on exit past gate
+// Car fade
 // ---------------------------------------------------------------------------
 
 describe('car fade', function () {
-  it('cars past gateD on exit fade toward 0', function () {
+  it('cars past gateSlot on exit fade toward 0', function () {
     var sim = createSimulation({
-      greenPct: 100, cycleTotal: 100, gateD: 100,
-      lenExit: 210, lenHwy: 530, spawnMs: 99999,
+      slotsExit: 6, gateSlot: 2,
+      greenPct: 100, cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar('exit', 150, 3.5); // already past gate
+    sim.addCar('exit', 4); // past gate
     var frame = sim.tick(0);
     var car = frame.cars.filter(function (c) { return c.segment === 'exit'; })[0];
-    assert.ok(car.opacity < 1, 'car past gateD should have opacity < 1');
+    assert.ok(car.opacity < 1, 'car past gateSlot should have opacity < 1');
   });
 
-  it('cars before gateD on exit have full opacity', function () {
+  it('cars before gateSlot on exit have full opacity', function () {
     var sim = createSimulation({
-      greenPct: 100, cycleTotal: 100, gateD: 130,
-      lenExit: 210, lenHwy: 530, spawnMs: 99999,
+      slotsExit: 6, gateSlot: 4,
+      greenPct: 100, cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar('exit', 50, 3.5);
+    sim.addCar('exit', 2);
     var frame = sim.tick(0);
     var car = frame.cars.filter(function (c) { return c.segment === 'exit'; })[0];
-    assert.equal(car.opacity, 1, 'car before gateD should have full opacity');
+    assert.equal(car.opacity, 1, 'car before gateSlot should have full opacity');
+  });
+
+  it('cont cars fade over full length', function () {
+    var sim = createSimulation({
+      slotsCont: 6, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.exitAuto();
+    sim.addCar('cont', 3); // middle of cont
+    var frame = sim.tick(0);
+    var car = frame.cars.filter(function (c) { return c.segment === 'cont'; })[0];
+    assert.ok(car.opacity < 1, 'cont car should be fading');
+    assert.ok(car.opacity > 0, 'cont car should not be fully faded in middle');
   });
 });
 
 // ---------------------------------------------------------------------------
-// Stats computation
+// Stats
 // ---------------------------------------------------------------------------
 
 describe('stats', function () {
   it('throughput counts deliveries in last 5 seconds', function () {
     var sim = createSimulation({
-      lenExit: 100, lenHwy: 200, lenRamp: 100,
-      mergeD: 50, gateD: 80, greenPct: 100,
-      cycleTotal: 100, spawnMs: 99999,
+      slotsExit: 6, greenPct: 100, cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar('exit', 95, 3.5); // near exit end
+    sim.addCar('exit', 5); // last slot — will be removed
     var frame;
-    for (var t = 0; t < 40; t++) {
-      frame = sim.tick(t * 25);
+    for (var t = 0; t < 5; t++) {
+      frame = sim.tick(t * 100);
     }
     assert.ok(frame.stats.throughput > 0, 'should have recorded delivery');
   });
 
   it('stallPct increases when cars are stalled', function () {
     var sim = createSimulation({
-      greenPct: 0, cycleTotal: 100, gateD: 130,
-      lenExit: 210, lenHwy: 530, spawnMs: 99999,
+      slotsExit: 6, gateSlot: 4,
+      greenPct: 0, cycleTotal: 100, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar('exit', 125, 0); // stopped near gate
+    sim.addCar('exit', 3); // near gate, will stop
     var frame;
     for (var t = 0; t < 20; t++) {
-      frame = sim.tick(t * 25);
+      frame = sim.tick(t * 100);
     }
     assert.ok(frame.stats.stallPct > 0, 'stall% should be > 0');
   });
@@ -415,7 +448,7 @@ describe('car size variety', function () {
     var sim = createSimulation({ maxCars: 20, spawnMs: 99999 });
     sim.exitAuto();
     for (var i = 0; i < 10; i++) {
-      sim.addCar('highway', i * 50, 3.5);
+      sim.addCar('highway', i);
     }
     var cars = sim.getCars();
     var widths = new Set(cars.map(function (c) { return c.w; }));
@@ -423,11 +456,11 @@ describe('car size variety', function () {
   });
 
   it('fixedScale produces uniform scale but shape-dependent widths', function () {
-    var sim = createSimulation({}, fixedScale(1.0));
-    sim.addCar('highway', 0, 3.5);
-    sim.addCar('highway', 100, 3.5);
-    sim.addCar('highway', 200, 3.5);
-    sim.addCar('highway', 300, 3.5);
+    var sim = createSimulation({ slotsHwy: 15 }, fixedScale(1.0));
+    sim.addCar('highway', 0);
+    sim.addCar('highway', 5);
+    sim.addCar('highway', 10);
+    sim.addCar('highway', 14);
     var cars = sim.getCars();
     for (var i = 0; i < cars.length; i++) {
       assert.equal(cars[i].scale, 1.0);
@@ -445,11 +478,11 @@ describe('car size variety', function () {
 describe('status', function () {
   it('reports flowing when everything is moving', function () {
     var sim = createSimulation({
-      greenPct: 100, cycleTotal: 100, lenHwy: 530, spawnMs: 99999,
+      greenPct: 100, cycleTotal: 100, slotsHwy: 15, spawnMs: 99999,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    sim.addCar('highway', 200, 3.5);
+    sim.addCar('highway', 5);
     var frame = sim.tick(0);
     assert.equal(frame.status.level, 'flowing');
   });
@@ -457,29 +490,18 @@ describe('status', function () {
   it('reports blocked when entrance is blocked', function () {
     var sim = createSimulation({
       greenPct: 0, cycleTotal: 100,
-      lenHwy: 530, lenRamp: 180, lenExit: 210, lenCont: 215,
-      mergeD: 170, gateD: 130, spawnMs: 10,
-      spawnBlockedThreshold: 5, maxCars: 60,
+      slotsHwy: 15, slotsRamp: 5, slotsExit: 6, slotsCont: 0,
+      mergeSlot: 5, gateSlot: 4, spawnMs: 10,
+      spawnBlockedThreshold: 5, maxCars: 40,
     }, fixedScale(1));
     sim.setCycleStart(0);
     sim.exitAuto();
-    // Fill exit to create backpressure
-    for (var i = 0; i < 4; i++) {
-      sim.addCar('exit', 20 + i * 28, 0);
-    }
-    // Fill continuation too
-    for (var ic = 0; ic < 3; ic++) {
-      sim.addCar('cont', 5 + ic * 25, 0);
-    }
-    // Fill highway back toward start — blocks spawn space
-    for (var j = 0; j < 18; j++) {
-      sim.addCar('highway', 10 + j * 28, 0);
-    }
-    // Stuck ramp car — blocks ramp spawn space
-    sim.addCar('ramp', 5, 0);
+    // Fill all slots (no cont = no overflow escape)
+    for (var i = 0; i < 15; i++) sim.addCar('highway', i);
+    for (var j = 0; j < 5; j++) sim.addCar('ramp', j);
+    for (var e = 0; e < 6; e++) sim.addCar('exit', e);
     var frame;
-    // Run enough ticks for spawnBlockedThreshold to trigger
-    for (var t = 0; t < 30; t++) {
+    for (var t = 0; t < 20; t++) {
       frame = sim.tick(t * 25);
     }
     assert.equal(frame.status.level, 'blocked');
@@ -491,8 +513,7 @@ describe('status', function () {
       greenPct: 100, cycleTotal: 100,
     }, fixedScale(1));
     sim.exitAuto();
-    sim.addCar('highway', 200, 3.5);
-
+    sim.addCar('highway', 5);
     var frame;
     for (var t = 0; t < 10; t++) {
       frame = sim.tick(t * 25);
@@ -502,15 +523,79 @@ describe('status', function () {
 });
 
 // ---------------------------------------------------------------------------
-// Public test helpers
+// Slot position mapping
+// ---------------------------------------------------------------------------
+
+describe('slot positions', function () {
+  it('getSlotD returns evenly spaced positions', function () {
+    var sim = createSimulation({ slotsHwy: 15, lenHwy: 530 }, fixedScale(1));
+    var d0 = sim.getSlotD('highway', 0);
+    var d14 = sim.getSlotD('highway', 14);
+    assert.equal(d0, 0);
+    assert.ok(Math.abs(d14 - 530) < 0.01, 'last slot should be at segment end');
+  });
+
+  it('car targetD matches slot position', function () {
+    var sim = createSimulation({}, fixedScale(1));
+    var car = sim.addCar('highway', 7);
+    var expected = sim.getSlotD('highway', 7);
+    assert.equal(car.targetD, expected);
+  });
+
+  it('keeps legacy d synchronized with targetD after slot movement', function () {
+    var sim = createSimulation({ greenPct: 100, spawnMs: 99999 }, fixedScale(1));
+    sim.exitAuto();
+    var car = sim.addCar('highway', 1);
+    sim.tick(1000);
+    assert.equal(car.d, car.targetD);
+    assert.equal(car.d, sim.getSlotD('highway', 2));
+  });
+
+  it('keeps a car stopped at the last slot when it cannot advance', function () {
+    var sim = createSimulation({
+      slotsHwy: 3, slotsRamp: 3, slotsExit: 2, slotsCont: 0,
+      mergeSlot: 1, gateSlot: 0, greenPct: 0, spawnMs: 99999,
+    }, fixedScale(1));
+    sim.exitAuto();
+    sim.addCar('exit', 0);
+    sim.addCar('highway', 1);
+    sim.addCar('highway', 2);
+    var car = sim.addCar('ramp', 2);
+    sim.tick(1000);
+    assert.equal(car.slot, 2);
+    assert.equal(car.speed, 0);
+  });
+
+  it('keeps fade opacity finite when gate slot is at segment end', function () {
+    var sim = createSimulation({ slotsExit: 3, gateSlot: 2, greenPct: 100, spawnMs: 99999 }, fixedScale(1));
+    sim.exitAuto();
+    var car = sim.addCar('exit', 2);
+    car.pastGate = true;
+    sim.tick(1000);
+    assert.equal(Number.isFinite(car.opacity), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test helper controls
 // ---------------------------------------------------------------------------
 
 describe('test helper controls', function () {
   it('rejects unknown segment names', function () {
     var sim = createSimulation({}, fixedScale(1));
     assert.throws(function () {
-      sim.addCar('unknown', 0, 0);
-    }, /unknown highway simulation segment/);
+      sim.addCar('unknown', 0);
+    }, /unknown segment/);
+    assert.throws(function () {
+      sim.getSlots('unknown');
+    }, /unknown segment/);
     assert.equal(sim.getCars().length, 0);
+  });
+
+  it('newly added stopped cars use stopped color until they move', function () {
+    var sim = createSimulation({}, fixedScale(1));
+    var car = sim.addCar('highway', 0);
+    assert.equal(car.speed, 0);
+    assert.equal(car.color, 'stop');
   });
 });

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -200,6 +200,7 @@ export function createSimulation(overrides, scaleFn) {
           // (placed here manually or reached gate during red) — stop
           car.speed = 0;
           car.targetD = slotDArr[i];
+          car.d = car.targetD;
           car.color = carColor(car);
           continue;
         }
@@ -212,6 +213,7 @@ export function createSimulation(overrides, scaleFn) {
         if (opts.hasGate && !lightIsGreen && !car.pastGate && nextSlot > cfg.gateSlot) {
           car.speed = 0;
           car.targetD = slotDArr[i];
+          car.d = car.targetD;
           car.color = carColor(car);
           continue;
         }

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -1,45 +1,40 @@
 /**
  * Highway backpressure simulation — pure logic, no DOM.
  *
- * Multi-route model:
- *   highway: cars enter from left, travel right to the fork
- *   ramp:    cars enter from bottom-left, merge into highway at mergeD
- *   exit:    cars leave highway via exit ramp (has traffic light)
- *   cont:    cars continue east past the fork (fade out, always flowing)
+ * Slot-based model: each road segment has a fixed number of slots.
+ * Each slot holds at most one car. Cars advance one slot per tick
+ * when the next slot is empty.
  *
- * At the fork, cars prefer the exit ramp. When the exit backs up,
- * cars that can't exit continue east. Eventually the backup cascades
- * to block the highway and on-ramp entrances.
+ * Multi-route layout:
+ *   highway: cars enter from left, travel right to the fork
+ *   ramp:    cars enter from bottom-left, merge into highway at mergeSlot
+ *   exit:    cars leave highway via exit ramp (has traffic light at gateSlot)
+ *   cont:    cars continue east past the fork (always flowing, fade out)
  */
 
 export var DEFAULTS = {
-  lenRamp: 180,
-  lenHwy: 530,
-  lenExit: 210,
-  lenCont: 215,
-  mergeD: 170,
-  gateD: 130,
+  slotsHwy: 15,
+  slotsRamp: 5,
+  slotsExit: 6,
+  slotsCont: 6,
+  mergeSlot: 5,       // highway slot where ramp merges in
+  gateSlot: 4,        // exit slot where traffic light is
   carW: 20,
-  minFollowPad: 14,
-  speedMax: 3.5,
   spawnMs: 420,
   cycleTotal: 3000,
   greenPct: 80,
   maxCars: 22,
-  lerpRate: 0.25,
-  brakeRate: 0.3,
-  followZone: 18,
   autoSpeed: 0.15,
   autoMin: 5,
   autoMax: 100,
   scaleMin: 0.8,
   scaleMax: 1.15,
   spawnBlockedThreshold: 8,
-  exitEntryD: 0,
-  contEntryD: 0,
-  hwyForkThreshold: 5,
-  hwyBlockedOffset: 2,
-  rampMergeThreshold: 3,
+  // Segment d-lengths for rendering (used to compute slot positions)
+  lenHwy: 530,
+  lenRamp: 180,
+  lenExit: 210,
+  lenCont: 215,
 };
 
 var SHAPES = ['sedan', 'truck', 'compact', 'van'];
@@ -59,17 +54,33 @@ export function createSimulation(overrides, scaleFn) {
     return cfg.scaleMin + Math.random() * (cfg.scaleMax - cfg.scaleMin);
   };
 
-  var nextId = 0;
-  var carsRamp = [];
-  var carsHwy = [];
-  var carsExit = [];
-  var carsCont = [];
+  // Compute slot d-positions for each segment
+  function slotPositions(count, segLen) {
+    var positions = [];
+    var spacing = count > 1 ? segLen / (count - 1) : 0;
+    for (var i = 0; i < count; i++) {
+      positions.push(i * spacing);
+    }
+    return positions;
+  }
 
+  var hwySlotD = slotPositions(cfg.slotsHwy, cfg.lenHwy);
+  var rampSlotD = slotPositions(cfg.slotsRamp, cfg.lenRamp);
+  var exitSlotD = slotPositions(cfg.slotsExit, cfg.lenExit);
+  var contSlotD = slotPositions(cfg.slotsCont, cfg.lenCont);
+
+  // Slot arrays — null means empty, otherwise holds a car object
+  var hwySlots = new Array(cfg.slotsHwy).fill(null);
+  var rampSlots = new Array(cfg.slotsRamp).fill(null);
+  var exitSlots = new Array(cfg.slotsExit).fill(null);
+  var contSlots = new Array(cfg.slotsCont).fill(null);
+
+  var nextId = 0;
   var lightIsGreen = true;
   var greenPct = cfg.greenPct;
   var cycleStart = 0;
   var lastSpawn = -Infinity;
-  var spawnSrc = 0; // alternates 0=hwy, 1=ramp
+  var spawnSrc = 0;
 
   var autoMode = true;
   var autoVal = greenPct;
@@ -82,52 +93,84 @@ export function createSimulation(overrides, scaleFn) {
 
   // ---- helpers ----
 
-  function makeCar(segment, d, speed, scale) {
+  function makeCar(segment, slotIdx, scale) {
     var s = scale != null ? scale : getScale();
     var shape = SHAPES[nextId % SHAPES.length];
     var shapeMul = SHAPE_W[shape] || 1;
-    var car = {
+    var slotD = getSlotD(segment, slotIdx);
+    return {
       id: nextId++,
       segment: segment,
-      d: d != null ? d : 0,
-      speed: speed != null ? speed : cfg.speedMax,
+      slot: slotIdx,
+      d: slotD,
+      targetD: slotD,
+      speed: 0,
       scale: s,
       w: cfg.carW * s * shapeMul,
       shape: shape,
-      color: 'flow',
+      color: 'stop',
       opacity: 1,
+      pastGate: false,
     };
-    car.color = carColor(car);
-    return car;
   }
 
-  function nextCarWidth(scale) {
-    var shape = SHAPES[nextId % SHAPES.length];
-    return cfg.carW * scale * (SHAPE_W[shape] || 1);
+  function getSlotD(segment, slotIdx) {
+    if (segment === 'highway') return hwySlotD[slotIdx] || 0;
+    if (segment === 'ramp') return rampSlotD[slotIdx] || 0;
+    if (segment === 'exit') return exitSlotD[slotIdx] || 0;
+    if (segment === 'cont') return contSlotD[slotIdx] || 0;
+    return 0;
+  }
+
+  function getSlots(segment) {
+    if (segment === 'highway') return hwySlots;
+    if (segment === 'ramp') return rampSlots;
+    if (segment === 'exit') return exitSlots;
+    if (segment === 'cont') return contSlots;
+    return null;
+  }
+
+  function getSegLen(segment) {
+    if (segment === 'highway') return cfg.lenHwy;
+    if (segment === 'ramp') return cfg.lenRamp;
+    if (segment === 'exit') return cfg.lenExit;
+    if (segment === 'cont') return cfg.lenCont;
+    return 0;
+  }
+
+  function allCars() {
+    var result = [];
+    var segments = [hwySlots, rampSlots, exitSlots, contSlots];
+    for (var s = 0; s < segments.length; s++) {
+      for (var i = 0; i < segments[s].length; i++) {
+        if (segments[s][i]) result.push(segments[s][i]);
+      }
+    }
+    return result;
+  }
+
+  function totalCars() {
+    var count = 0;
+    var segments = [hwySlots, rampSlots, exitSlots, contSlots];
+    for (var s = 0; s < segments.length; s++) {
+      for (var i = 0; i < segments[s].length; i++) {
+        if (segments[s][i]) count++;
+      }
+    }
+    return count;
   }
 
   function carColor(car) {
     if (car.speed < 0.15) return 'stop';
-    if (car.speed < cfg.speedMax * 0.35) return 'slow';
+    if (car.speed < 1.5) return 'slow';
     return 'flow';
-  }
-
-  function minGap(a, b) {
-    return (a.w + b.w) / 2 + cfg.minFollowPad;
-  }
-
-  function allCars() {
-    return carsRamp.concat(carsHwy, carsExit, carsCont);
-  }
-
-  function totalCars() {
-    return carsRamp.length + carsHwy.length + carsExit.length + carsCont.length;
   }
 
   // ---- light ----
 
   function tickLight(now) {
     if (greenPct >= 100) { lightIsGreen = true; return; }
+    if (greenPct <= 0) { lightIsGreen = false; return; }
     var elapsed = (now - cycleStart) % cfg.cycleTotal;
     lightIsGreen = elapsed < cfg.cycleTotal * greenPct / 100;
   }
@@ -140,262 +183,189 @@ export function createSimulation(overrides, scaleFn) {
     greenPct = Math.round(autoVal);
   }
 
-  // ---- spawning ----
+  // ---- segment advancement ----
 
-  function hasSpawnSpace(cars, entrantW) {
-    for (var j = 0; j < cars.length; j++) {
-      if (cars[j].d < (entrantW + cars[j].w) / 2 + cfg.minFollowPad) return false;
+  function advanceSegment(slots, slotDArr, segLen, opts) {
+    opts = opts || {};
+    // Process from the end (highest slot) to start, so each car
+    // sees the already-advanced state of the car ahead.
+    for (var i = slots.length - 1; i >= 0; i--) {
+      var car = slots[i];
+      if (!car) continue;
+
+      // Gate check — exit segment only
+      if (opts.hasGate && !lightIsGreen && !car.pastGate) {
+        if (i >= cfg.gateSlot) {
+          // Car is at or past the gate slot but hasn't been marked past gate
+          // (placed here manually or reached gate during red) — stop
+          car.speed = 0;
+          car.targetD = slotDArr[i];
+          car.color = carColor(car);
+          continue;
+        }
+      }
+
+      // Try to advance to next slot
+      var nextSlot = i + 1;
+      if (nextSlot < slots.length && slots[nextSlot] === null) {
+        // Gate blocking: can't advance past gateSlot if light is red
+        if (opts.hasGate && !lightIsGreen && !car.pastGate && nextSlot > cfg.gateSlot) {
+          car.speed = 0;
+          car.targetD = slotDArr[i];
+          car.color = carColor(car);
+          continue;
+        }
+
+        // Move forward
+        slots[i] = null;
+        slots[nextSlot] = car;
+        car.slot = nextSlot;
+        car.targetD = slotDArr[nextSlot];
+        car.speed = 3.5;
+
+        // Mark as past gate when crossing the gate slot
+        if (opts.hasGate && nextSlot > cfg.gateSlot) {
+          car.pastGate = true;
+        }
+      } else {
+        // Can't advance — stopped
+        car.speed = 0;
+        car.targetD = slotDArr[i];
+      }
+
+      // Fade for exit (past gate) and cont (full length)
+      if (opts.fadePastGate && car.pastGate) {
+        var gatePos = slotDArr[cfg.gateSlot] || 0;
+        var fadeLen = segLen - gatePos;
+        car.opacity = fadeLen > 0 ? Math.max(0, 1 - (car.targetD - gatePos) / fadeLen) : 0;
+      } else if (opts.fadeFullLen) {
+        car.opacity = segLen > 0 ? Math.max(0, 1 - car.targetD / segLen) : 0;
+      } else {
+        car.opacity = 1;
+      }
+
+      car.d = car.targetD;
+      car.color = carColor(car);
     }
-    return true;
   }
 
-  function trySpawnAt(segment, cars) {
-    var scale = getScale();
-    if (!hasSpawnSpace(cars, nextCarWidth(scale))) return null;
-    var car = makeCar(segment, 0, null, scale);
-    cars.push(car);
-    return car;
+  // ---- transitions ----
+
+  function tryHwyToExit() {
+    var lastHwy = cfg.slotsHwy - 1;
+    var car = hwySlots[lastHwy];
+    if (!car) return;
+
+    // Prefer exit ramp
+    if (exitSlots[0] === null) {
+      hwySlots[lastHwy] = null;
+      car.segment = 'exit';
+      car.slot = 0;
+      car.targetD = exitSlotD[0];
+      car.pastGate = false;
+      exitSlots[0] = car;
+      return;
+    }
+
+    // Continuation (only when light is green — prevents bypass during red)
+    if (lightIsGreen && contSlots[0] === null) {
+      hwySlots[lastHwy] = null;
+      car.segment = 'cont';
+      car.slot = 0;
+      car.targetD = contSlotD[0];
+      contSlots[0] = car;
+      return;
+    }
+
+    // Both full — car stays; mark as stopped
+    car.speed = 0;
   }
+
+  function tryRampMerge() {
+    var lastRamp = cfg.slotsRamp - 1;
+    var car = rampSlots[lastRamp];
+    if (!car) return;
+
+    // Merge into highway at mergeSlot if empty
+    if (hwySlots[cfg.mergeSlot] === null) {
+      rampSlots[lastRamp] = null;
+      car.segment = 'highway';
+      car.slot = cfg.mergeSlot;
+      car.targetD = hwySlotD[cfg.mergeSlot];
+      hwySlots[cfg.mergeSlot] = car;
+    } else {
+      car.speed = 0;
+    }
+  }
+
+  // ---- spawning ----
 
   function trySpawn(now) {
     if (totalCars() >= cfg.maxCars) return { kind: 'capped' };
     if (now - lastSpawn < cfg.spawnMs) return { kind: 'cooldown' };
 
+    var spawned = false;
+
+    // Alternate preferred source
     var src = spawnSrc;
     spawnSrc = 1 - spawnSrc;
-    var car = null;
 
     if (src === 0) {
-      car = trySpawnAt('highway', carsHwy) || trySpawnAt('ramp', carsRamp);
+      if (hwySlots[0] === null) {
+        hwySlots[0] = makeCar('highway', 0);
+        spawned = true;
+      } else if (rampSlots[0] === null) {
+        rampSlots[0] = makeCar('ramp', 0);
+        spawned = true;
+      }
     } else {
-      car = trySpawnAt('ramp', carsRamp) || trySpawnAt('highway', carsHwy);
+      if (rampSlots[0] === null) {
+        rampSlots[0] = makeCar('ramp', 0);
+        spawned = true;
+      } else if (hwySlots[0] === null) {
+        hwySlots[0] = makeCar('highway', 0);
+        spawned = true;
+      }
     }
 
-    if (car) {
+    if (spawned) {
       lastSpawn = now;
-      return { kind: 'spawned', car: car };
+      return { kind: 'spawned' };
     }
+
+    // Both entrances physically blocked
     return { kind: 'blocked' };
   }
 
-  // ---- movement within a segment ----
+  // ---- removal ----
 
-  function moveSegment(cars, segLen, opts) {
-    cars.sort(function (a, b) { return b.d - a.d; });
-    var phantoms = opts.phantoms || [];
+  function removeDelivered(now) {
+    var removedIds = [];
 
-    // Merge phantoms into a sorted list of obstacles (d descending)
-    // so they integrate with the following-distance logic.
-    var obstacles = cars.slice();
-    for (var p = 0; p < phantoms.length; p++) {
-      obstacles.push(phantoms[p]);
-    }
-    obstacles.sort(function (a, b) { return b.d - a.d; });
-
-    for (var i = 0; i < cars.length; i++) {
-      var car = cars[i];
-      var target = cfg.speedMax;
-
-      // Gate (light) — only on exit. Hard stop at traffic light.
-      if (opts.hasGate && !lightIsGreen && car.d < cfg.gateD + 1) {
-        var gateGap = cfg.gateD - car.d;
-        if (gateGap < cfg.followZone + car.w / 2) {
-          target = Math.min(target, Math.max(0, gateGap * cfg.brakeRate));
-        }
-      }
-
-      // End-of-segment blocking — smooth braking zone
-      if (opts.endBlocked) {
-        if (car.d >= segLen - 50) {
-          var distToEnd = segLen - car.d;
-          target = Math.min(target, Math.max(0, distToEnd * 0.12));
-        }
-        if (car.d > segLen) {
-          car.d -= (car.d - segLen) * 0.5;
-          car.speed *= 0.3;
-        }
-      }
-
-      // Following distance — find nearest obstacle ahead (real or phantom)
-      var nearestAhead = null;
-      for (var oi = 0; oi < obstacles.length; oi++) {
-        var ob = obstacles[oi];
-        if (ob === car) continue;
-        if (ob.d > car.d && (!nearestAhead || ob.d < nearestAhead.d)) {
-          nearestAhead = ob;
-        }
-      }
-      if (nearestAhead) {
-        var gap = nearestAhead.d - car.d;
-        var mg = (car.w + (nearestAhead.w || cfg.carW)) / 2 + cfg.minFollowPad;
-        if (gap < mg + cfg.followZone) {
-          target = Math.min(target, Math.max(0, (gap - mg) * cfg.brakeRate));
-        }
-      }
-
-      // Smooth speed
-      car.speed += (target - car.speed) * cfg.lerpRate;
-      if (car.speed < 0.03) car.speed = 0;
-      car.d += car.speed;
-
-      // Hard gate clamp — car must not overshoot the traffic light
-      if (opts.hasGate && !lightIsGreen && car.d > cfg.gateD) {
-        car.d = cfg.gateD;
-        car.speed = 0;
-      }
-
-      // Hard gap enforcement — prevent overlap, match speed of car ahead
-      if (nearestAhead) {
-        var mg2 = (car.w + (nearestAhead.w || cfg.carW)) / 2 + cfg.minFollowPad;
-        if (nearestAhead.d - car.d < mg2) {
-          car.d = nearestAhead.d - mg2;
-          car.speed = Math.min(car.speed, nearestAhead.speed != null ? nearestAhead.speed : 0);
-        }
-      }
-
-      if (car.d < 0) car.d = 0;
-
-      // Fade past gate on exit, or full-length fade on continuation
-      if (opts.fade && opts.fadeLen) {
-        var fadeStart = opts.fadeStart || 0;
-        car.opacity = Math.max(0, 1 - (car.d - fadeStart) / opts.fadeLen);
-      } else if (opts.fade && car.d > cfg.gateD) {
-        car.opacity = Math.max(0, 1 - (car.d - cfg.gateD) / (segLen - cfg.gateD));
-      } else {
-        car.opacity = 1;
-      }
-
-      car.color = carColor(car);
-    }
-
-    // Post-loop gap enforcement pass — cars sorted by d descending (leader first)
-    // Push each follower back if it overlaps the car ahead
-    for (var gi = 1; gi < cars.length; gi++) {
-      var ahead2 = cars[gi - 1];
-      var behind = cars[gi];
-      var reqGap = (ahead2.w + behind.w) / 2 + cfg.minFollowPad;
-      if (ahead2.d - behind.d < reqGap) {
-        behind.d = ahead2.d - reqGap;
-        behind.speed = Math.min(behind.speed, ahead2.speed);
+    // Exit: remove cars at last slot (delivered) or fully faded
+    var lastExit = cfg.slotsExit - 1;
+    for (var i = lastExit; i >= 0; i--) {
+      var ec = exitSlots[i];
+      if (!ec) continue;
+      if (i === lastExit || ec.opacity <= 0.01) {
+        removedIds.push(ec.id);
+        deliveries.push(now);
+        exitSlots[i] = null;
       }
     }
-  }
 
-  // ---- phantom obstacle builders ----
-  // Project cars from adjacent segments into this segment's coordinate
-  // space so the smooth following/braking physics prevents visual overlap
-  // at merge and fork junctions.
-
-  function hwyPhantoms() {
-    var ph = [];
-    // Exit cars near entry → appear at highway d = lenHwy + exitCar.d
-    for (var e = 0; e < carsExit.length; e++) {
-      if (carsExit[e].d < cfg.exitEntryD + 40) {
-        ph.push({ d: cfg.lenHwy + carsExit[e].d, w: carsExit[e].w, speed: carsExit[e].speed });
+    // Cont: remove cars at last slot or fully faded
+    var lastCont = cfg.slotsCont - 1;
+    for (var j = lastCont; j >= 0; j--) {
+      var cc = contSlots[j];
+      if (!cc) continue;
+      if (j === lastCont || cc.opacity <= 0.01) {
+        removedIds.push(cc.id);
+        contSlots[j] = null;
       }
     }
-    // Cont cars near entry → appear at highway d = lenHwy + contCar.d
-    for (var c = 0; c < carsCont.length; c++) {
-      if (carsCont[c].d < cfg.contEntryD + 40) {
-        ph.push({ d: cfg.lenHwy + carsCont[c].d, w: carsCont[c].w, speed: carsCont[c].speed });
-      }
-    }
-    return ph;
-  }
 
-  function rampPhantoms() {
-    var ph = [];
-    // Highway cars near mergeD → appear at ramp d = lenRamp + (hwyCar.d - mergeD)
-    for (var h = 0; h < carsHwy.length; h++) {
-      var dist = carsHwy[h].d - cfg.mergeD;
-      if (Math.abs(dist) < 50) {
-        ph.push({ d: cfg.lenRamp + dist, w: carsHwy[h].w, speed: carsHwy[h].speed });
-      }
-    }
-    return ph;
-  }
-
-  // ---- transitions ----
-
-  function canEnterExit(enterW) {
-    var w = enterW || cfg.carW;
-    var lead = null;
-    for (var j = 0; j < carsExit.length; j++) {
-      if (!lead || carsExit[j].d < lead.d) lead = carsExit[j];
-    }
-    if (!lead) return true;
-    return (lead.d - cfg.exitEntryD) > (w + lead.w) / 2 + cfg.minFollowPad;
-  }
-
-  function canMergeAt(d, w) {
-    for (var i = 0; i < carsHwy.length; i++) {
-      var hw = carsHwy[i];
-      var needed = (hw.w + w) / 2 + cfg.minFollowPad;
-      if (Math.abs(hw.d - d) < needed) return false;
-    }
-    return true;
-  }
-
-  function canEnterCont(enterW) {
-    var w = enterW || cfg.carW;
-    var lead = null;
-    for (var j = 0; j < carsCont.length; j++) {
-      if (!lead || carsCont[j].d < lead.d) lead = carsCont[j];
-    }
-    if (!lead) return true;
-    return (lead.d - cfg.contEntryD) > (w + lead.w) / 2 + cfg.minFollowPad;
-  }
-
-  function leadNearEnd(cars, segLen, threshold) {
-    var lead = null;
-    for (var i = 0; i < cars.length; i++) {
-      if (!lead || cars[i].d > lead.d) lead = cars[i];
-    }
-    if (!lead || lead.d < segLen - threshold) return null;
-    return lead;
-  }
-
-  function tryHwyToExit() {
-    if (carsHwy.length === 0) return;
-    carsHwy.sort(function (a, b) { return b.d - a.d; });
-    while (carsHwy.length > 0) {
-      var front = carsHwy[0];
-      if (front.d < cfg.lenHwy - cfg.hwyForkThreshold) break;
-      if (canEnterExit(front.w)) {
-        carsHwy.splice(0, 1);
-        front.segment = 'exit';
-        front.d = cfg.exitEntryD;
-        front.speed = Math.min(front.speed, cfg.speedMax * 0.8);
-        carsExit.push(front);
-      } else if (lightIsGreen && canEnterCont(front.w)) {
-        carsHwy.splice(0, 1);
-        front.segment = 'cont';
-        front.d = cfg.contEntryD;
-        front.speed = Math.min(front.speed, cfg.speedMax);
-        carsCont.push(front);
-      } else {
-        // Both paths full — block at the fork
-        front.d = cfg.lenHwy - cfg.hwyBlockedOffset;
-        front.speed = 0;
-        break;
-      }
-    }
-  }
-
-  function tryRampMerge() {
-    if (carsRamp.length === 0) return;
-    carsRamp.sort(function (a, b) { return b.d - a.d; });
-    var front = carsRamp[0];
-    if (front.d < cfg.lenRamp - cfg.rampMergeThreshold) return;
-    if (canMergeAt(cfg.mergeD, front.w)) {
-      carsRamp.splice(0, 1);
-      front.segment = 'highway';
-      front.d = cfg.mergeD;
-      carsHwy.push(front);
-    } else {
-      front.d = cfg.lenRamp;
-      front.speed = 0;
-    }
+    return removedIds;
   }
 
   // ---- main tick ----
@@ -405,48 +375,30 @@ export function createSimulation(overrides, scaleFn) {
     tickAuto();
     tickLight(now);
 
-    var removedIds = [];
+    // 1. Remove delivered
+    var removedIds = removeDelivered(now);
 
-    // 1. Remove delivered (exit faded, cont off-screen)
-    for (var i = carsExit.length - 1; i >= 0; i--) {
-      if (carsExit[i].d >= cfg.lenExit || carsExit[i].opacity <= 0.01) {
-        removedIds.push(carsExit[i].id);
-        deliveries.push(now);
-        carsExit.splice(i, 1);
-      }
-    }
-    for (var ic = carsCont.length - 1; ic >= 0; ic--) {
-      if (carsCont[ic].d >= cfg.lenCont || carsCont[ic].opacity <= 0.01) {
-        removedIds.push(carsCont[ic].id);
-        carsCont.splice(ic, 1);
-      }
-    }
+    // 2. Advance continuation (downstream first — frees slots)
+    advanceSegment(contSlots, contSlotD, cfg.lenCont, { fadeFullLen: true });
 
-    // 2. Move continuation (always free-flowing, fade out)
-    moveSegment(carsCont, cfg.lenCont, { fade: true, fadeStart: 0, fadeLen: cfg.lenCont });
-
-    // 3. Move exit (downstream first — frees space)
-    moveSegment(carsExit, cfg.lenExit, { hasGate: true, fade: true });
-
-    // 4. Highway → exit or continuation
+    // 3. Highway → exit/cont transition (before exit advancement,
+    //    so a full exit causes overflow to cont)
     tryHwyToExit();
 
-    // 5. Move highway — block when the lead car has no permitted fork path.
-    var hwyLead = leadNearEnd(carsHwy, cfg.lenHwy, cfg.hwyForkThreshold);
-    var forkFull = !!hwyLead && !canEnterExit(hwyLead.w)
-      && (!lightIsGreen || !canEnterCont(hwyLead.w));
-    moveSegment(carsHwy, cfg.lenHwy, { endBlocked: forkFull, phantoms: hwyPhantoms() });
+    // 4. Advance exit
+    advanceSegment(exitSlots, exitSlotD, cfg.lenExit, { hasGate: true, fadePastGate: true });
 
-    // 6. Try transition again (car may have moved to end this tick)
+    // 5. Advance highway
+    advanceSegment(hwySlots, hwySlotD, cfg.lenHwy);
+
+    // 6. Try transition again (after highway advancement freed the lead car)
     tryHwyToExit();
 
-    // 7. Ramp → highway
+    // 7. Ramp → highway merge (before ramp advancement)
     tryRampMerge();
 
-    // 8. Move ramp (with highway phantoms at merge zone)
-    var rampLead = leadNearEnd(carsRamp, cfg.lenRamp, cfg.rampMergeThreshold);
-    var mergeFull = !!rampLead && !canMergeAt(cfg.mergeD, rampLead.w);
-    moveSegment(carsRamp, cfg.lenRamp, { endBlocked: mergeFull, phantoms: rampPhantoms() });
+    // 8. Advance ramp
+    advanceSegment(rampSlots, rampSlotD, cfg.lenRamp);
 
     // 9. Try merge again
     tryRampMerge();
@@ -456,10 +408,6 @@ export function createSimulation(overrides, scaleFn) {
     if (spawn.kind === 'blocked') {
       spawnBlockedTicks++;
     } else if (spawn.kind !== 'cooldown') {
-      // Reset on 'spawned' (car entered) and 'capped' (at capacity but
-      // entrances not physically blocked).  Only 'cooldown' preserves
-      // the counter — the spawn timer hasn't elapsed so we can't tell
-      // whether the entrance is clear.
       spawnBlockedTicks = 0;
     }
 
@@ -477,7 +425,6 @@ export function createSimulation(overrides, scaleFn) {
 
     var stallPct = totalFrames > 0 ? Math.round(stalledFrames / totalFrames * 100) : 0;
 
-    // Status — only "blocked" when spawn entrance is actually blocked
     var status;
     if (spawnBlockedTicks >= cfg.spawnBlockedThreshold) {
       status = { level: 'blocked', msg: 'Traffic backed up to the on-ramp \u2014 no new cars can enter' };
@@ -511,17 +458,28 @@ export function createSimulation(overrides, scaleFn) {
     isAuto: function () { return autoMode; },
     setCycleStart: function (t) { cycleStart = t; },
     setLastSpawn: function (t) { lastSpawn = t; },
-    addCar: function (segment, d, speed, scale) {
-      if (segment !== 'ramp' && segment !== 'highway' && segment !== 'exit' && segment !== 'cont') {
-        throw new Error('unknown highway simulation segment: ' + segment);
+    addCar: function (segment, slotIdx, speed, scale) {
+      var slots = getSlots(segment);
+      if (!slots) {
+        throw new Error('unknown segment ' + segment);
       }
-      var car = makeCar(segment, d, speed, scale);
-      if (segment === 'ramp') carsRamp.push(car);
-      else if (segment === 'highway') carsHwy.push(car);
-      else if (segment === 'exit') carsExit.push(car);
-      else if (segment === 'cont') carsCont.push(car);
+      if (slotIdx < 0 || slotIdx >= slots.length) {
+        throw new Error('invalid slot ' + slotIdx + ' for segment ' + segment);
+      }
+      if (slots[slotIdx] !== null) {
+        throw new Error('slot ' + slotIdx + ' on ' + segment + ' is occupied');
+      }
+      var car = makeCar(segment, slotIdx, scale);
+      if (speed != null) car.speed = speed;
+      slots[slotIdx] = car;
       return car;
     },
+    getSlots: function (segment) {
+      var slots = getSlots(segment);
+      if (!slots) throw new Error('unknown segment ' + segment);
+      return slots.slice();
+    },
+    getSlotD: getSlotD,
     cfg: cfg,
   };
 }


### PR DESCRIPTION
## Summary

Replaces continuous float physics in the highway backpressure animation with a discrete slot-based model, fixing three fundamental bugs:

1. **Gate clamp yanking cars back** — cars now have a `pastGate` flag; once past the traffic light during green, they keep moving even when the light turns red
2. **Spawning stops under backpressure** — slot 0 checks are independent per source (highway/ramp); the system can always spawn if there's physical room
3. **Car overlap at intersections** — each slot holds exactly one car; overlap is impossible by construction

## Changes

### `highway-sim.mjs` — complete rewrite
- Slot arrays replace float position arrays (`hwySlots[15]`, `rampSlots[5]`, `exitSlots[6]`, `contSlots[6]`)
- Deterministic per-tick logic: advance downstream first, then transitions
- `tryHwyToExit` runs before exit advancement so cont overflow works during green→red transitions
- Cars have `slot`, `targetD`, `pastGate` fields
- Same public API shape: `createSimulation()`, `tick()`, `fixedScale()`, `DEFAULTS`

### `HighwayBackpressure.astro` — visual interpolation layer
- Sim ticks every 10 render frames (250ms) for natural car speed
- `visualD` per car lerps toward `car.targetD` each 25ms render frame for smooth motion
- Segment transition resets `visualD` to prevent interpolation artifacts
- `autoSpeed` scaled by 10x to compensate for slower sim tick rate

### `highway-sim.test.mjs` — tests rewritten and extended
- Adapted all tests for slot-based API (`addCar(segment, slotIdx)` instead of `(segment, d, speed)`)
- New: slot integrity — no two cars ever share a slot
- New: `pastGate` survives light change
- New: cont only during green; red blocks bypass
- New: review regressions for `CAR_W` initialization order, legacy `car.d` sync, stopped-color initialization, blocked last-slot speed, unknown segment errors, and finite fade opacity

## Test plan

- `node --test book/src/components/__tests__/highway-sim.test.mjs` — 41/41 pass
- `npm --prefix book run build` — blocked locally because this fresh worktree has no `book/node_modules`; the WASM prebuild completed, then `astro` was not found. CI is running the docs build with dependencies installed.

Relates to #2258

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace continuous-physics highway simulation with slot-based discrete movement
> - Rewrites [highway-sim.mjs](https://github.com/strawgate/fastforward/pull/2303/files#diff-3cd598b368f6c25e5fdb6d5543ce9386ecc712ab90450994da39111e7797fbf0) to move cars slot-by-slot per segment instead of using continuous distance/following physics; each slot holds at most one car and advancement is blocked when the next slot is occupied or the gate is red.
> - Adds `getSlotD`, `getSlots` public accessors and changes `addCar` to accept `(segment, slotIdx)` instead of distances/speeds, throwing on invalid or occupied slots.
> - Updates [HighwayBackpressure.astro](https://github.com/strawgate/fastforward/pull/2303/files#diff-47399e83c747483e8e2291c0d77604fec3da890d28b1c54ef22a4f09b7b1350c) to drive traffic light placement and car seeding from slot indices, and adds per-car visual interpolation (`LERP_RATE`) so SVG positions animate smoothly between discrete sim ticks.
> - The render loop now advances the simulation only every `SIM_FRAMES` frames while visual interpolation runs every frame.
> - Behavioral Change: simulation config parameters (e.g. `mergeD`, `gateD`, `speedMax`, follow/brake constants) are replaced by slot counts (`slotsHwy`, `slotsRamp`, etc.) and `mergeSlot`/`gateSlot` indices; existing `addCar` call signatures are incompatible.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ff6f44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->