### PR TITLE
fix: wire supported output config options

### DIFF
--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -433,6 +433,8 @@ Ship to Elasticsearch via the Bulk API.
 | `index` | string | No | `logs` | Target index name. Must not be empty, and must not contain Elasticsearch-reserved characters or prefixes. |
 | `compression` | string | No | `none` | `gzip` or `none`. |
 | `request_mode` | string | No | `buffered` | `buffered` or `streaming`. `streaming` currently requires `compression: none`. |
+| `request_timeout_ms` | integer | No | `30000` | HTTP request timeout in milliseconds. Must be >= 1 when set. |
+| `tls` | object | No | — | Optional TLS client options (`ca_file`, `cert_file`, `key_file`, `insecure_skip_verify`) for HTTPS endpoints. |
 | `auth` | object | No | — | Optional bearer token or custom headers for HTTP auth. |
 
 Bulk payloads are split before they exceed `5242880` bytes (5 MiB). That limit is internal and is not a YAML field.
@@ -448,6 +450,10 @@ output:
     bearer_token: "${ES_TOKEN}"
 ```
 
+`retry_attempts`, `retry_initial_backoff_ms`, `retry_max_backoff_ms`, `batch_size`, and
+`batch_timeout_ms` are currently rejected for Elasticsearch outputs because per-output
+retry/batch controls are not wired into the Elasticsearch sink yet.
+
 ### `loki` output
 
 Push to Grafana Loki.
@@ -455,6 +461,8 @@ Push to Grafana Loki.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `endpoint` | string | Yes | Loki base URL. The `/loki/api/v1/push` path is appended automatically. |
+| `request_timeout_ms` | integer | No | HTTP request timeout in milliseconds (default: `30000`). Must be >= 1 when set. |
+| `tls` | object | No | Optional TLS client options (`ca_file`, `cert_file`, `key_file`, `insecure_skip_verify`) for HTTPS endpoints. |
 | `tenant_id` | string | No | Optional value sent as `X-Scope-OrgID` for multi-tenant Loki deployments. |
 | `static_labels` | map[string,string] | No | Static labels applied to every pushed log stream. Keys and values must be non-empty. |
 | `label_columns` | array[string] | No | Additional log columns to promote as Loki labels. |
@@ -475,6 +483,10 @@ output:
 
 `compression` is not supported for Loki outputs.
 
+`retry_attempts`, `retry_initial_backoff_ms`, `retry_max_backoff_ms`, `batch_size`, and
+`batch_timeout_ms` are currently rejected for Loki outputs because the Loki sink does not
+implement per-output retry/batch controls yet.
+
 ### `file` output
 
 Write records to a file.
@@ -490,6 +502,26 @@ output:
   path: /var/log/logfwd/capture.ndjson
   format: json
 ```
+
+### `tcp` output
+
+Send newline-delimited JSON records to a TCP endpoint.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `endpoint` | string | Yes | Host:port destination (for example `tcp.example.com:9000`). |
+
+`format`, `compression`, `tls`, retry, and batch controls are currently rejected for TCP outputs.
+
+### `udp` output
+
+Send newline-delimited JSON records as UDP datagrams.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `endpoint` | string | Yes | Host:port destination (for example `udp.example.com:514`). |
+
+`format`, `compression`, `tls`, retry, and batch controls are currently rejected for UDP outputs.
 
 ### `parquet` output *(not yet supported)*
 
@@ -508,7 +540,7 @@ Write records to Parquet files.
 | `otlp` | Implemented | OTLP protobuf over HTTP or gRPC. |
 | `http` | Not yet supported | Reserved for newline-delimited JSON over HTTP POST. |
 | `stdout` | Implemented | Print to stdout (JSON, console, or text). |
-| `elasticsearch` | Implemented | Elasticsearch Bulk API with retry and request-mode controls. |
+| `elasticsearch` | Implemented | Elasticsearch Bulk API with index/compression/request-mode controls. |
 | `loki` | Implemented | Grafana Loki push API with label grouping. |
 | `file` | Implemented | Write NDJSON or text to a local file. |
 | `null` | Implemented | Drop records intentionally for tests and benchmark baselines. |

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -867,12 +867,16 @@ impl Config {
                         )));
                     }
 
+                    if !matches!(
+                        output.output_type,
+                        OutputType::Otlp | OutputType::Elasticsearch | OutputType::Loki
+                    ) && output.tls.is_some()
+                    {
+                        return Err(ConfigError::Validation(format!(
+                            "pipeline '{name}' output '{label}': 'tls' is only supported for otlp, elasticsearch, and loki outputs"
+                        )));
+                    }
                     if output.output_type != OutputType::Otlp {
-                        if output.tls.is_some() {
-                            return Err(ConfigError::Validation(format!(
-                                "pipeline '{name}' output '{label}': 'tls' is only supported for otlp outputs"
-                            )));
-                        }
                         if output.headers.is_some() {
                             return Err(ConfigError::Validation(format!(
                                 "pipeline '{name}' output '{label}': 'headers' is only supported for otlp outputs"
@@ -893,9 +897,13 @@ impl Config {
                                 "pipeline '{name}' output '{label}': 'retry_max_backoff_ms' is only supported for otlp outputs"
                             )));
                         }
-                        if output.request_timeout_ms.is_some() {
+                        if !matches!(
+                            output.output_type,
+                            OutputType::Elasticsearch | OutputType::Loki
+                        ) && output.request_timeout_ms.is_some()
+                        {
                             return Err(ConfigError::Validation(format!(
-                                "pipeline '{name}' output '{label}': 'request_timeout_ms' is only supported for otlp outputs"
+                                "pipeline '{name}' output '{label}': 'request_timeout_ms' is only supported for otlp, elasticsearch, and loki outputs"
                             )));
                         }
                         if output.batch_timeout_ms.is_some() {
@@ -906,12 +914,17 @@ impl Config {
                     }
 
                     // Validate OTLP-specific field values when set.
+                    if matches!(
+                        output.output_type,
+                        OutputType::Otlp | OutputType::Elasticsearch | OutputType::Loki
+                    ) && output.request_timeout_ms == Some(0)
+                    {
+                        return Err(ConfigError::Validation(format!(
+                            "pipeline '{name}' output '{label}': 'request_timeout_ms' must be at least 1"
+                        )));
+                    }
+
                     if output.output_type == OutputType::Otlp {
-                        if output.request_timeout_ms == Some(0) {
-                            return Err(ConfigError::Validation(format!(
-                                "pipeline '{name}' output '{label}': 'request_timeout_ms' must be at least 1"
-                            )));
-                        }
                         if output.batch_timeout_ms == Some(0) {
                             return Err(ConfigError::Validation(format!(
                                 "pipeline '{name}' output '{label}': 'batch_timeout_ms' must be at least 1"
@@ -2529,6 +2542,62 @@ pipelines:
 "#;
         let err = Config::load_str(yaml).unwrap_err().to_string();
         assert!(err.contains("'retry_attempts' is only supported for otlp outputs"));
+    }
+
+    #[test]
+    fn elasticsearch_accepts_tls_and_request_timeout_ms() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: file
+        path: /tmp/test.log
+    outputs:
+      - type: elasticsearch
+        endpoint: https://localhost:9200
+        request_timeout_ms: 5000
+        tls:
+          insecure_skip_verify: true
+"#;
+        Config::load_str(yaml).expect("elasticsearch should accept tls and request_timeout_ms");
+    }
+
+    #[test]
+    fn loki_accepts_tls_and_request_timeout_ms() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: file
+        path: /tmp/test.log
+    outputs:
+      - type: loki
+        endpoint: https://localhost:3100
+        request_timeout_ms: 5000
+        tls:
+          insecure_skip_verify: true
+"#;
+        Config::load_str(yaml).expect("loki should accept tls and request_timeout_ms");
+    }
+
+    #[test]
+    fn elasticsearch_rejects_zero_request_timeout_ms() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: file
+        path: /tmp/test.log
+    outputs:
+      - type: elasticsearch
+        endpoint: https://localhost:9200
+        request_timeout_ms: 0
+"#;
+        let err = Config::load_str(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("request_timeout_ms") && err.contains("at least 1"),
+            "expected zero timeout rejection, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -827,6 +827,13 @@ impl ElasticsearchSinkFactory {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Creates an Elasticsearch sink factory with a caller-provided HTTP client builder.
+    ///
+    /// The caller owns all cross-cutting HTTP client policy on `client_builder`, including
+    /// request timeout, connection-pool sizing, TLS roots, mTLS identity, and certificate
+    /// verification behavior. This constructor validates Elasticsearch-specific request
+    /// mode and compression compatibility, then builds and reuses one `reqwest::Client`
+    /// for every sink created by the factory.
     pub fn new_with_client(
         name: String,
         endpoint: String,

--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -1,6 +1,7 @@
 use std::io;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use arrow::ipc::reader::StreamReader;
 use arrow::record_batch::RecordBatch;
@@ -811,6 +812,31 @@ impl ElasticsearchSinkFactory {
         request_mode: ElasticsearchRequestMode,
         stats: Arc<ComponentStats>,
     ) -> io::Result<Self> {
+        Self::new_with_client(
+            name,
+            endpoint,
+            index,
+            headers,
+            compress,
+            request_mode,
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .pool_max_idle_per_host(64),
+            stats,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_client(
+        name: String,
+        endpoint: String,
+        index: String,
+        headers: Vec<(String, String)>,
+        compress: bool,
+        request_mode: ElasticsearchRequestMode,
+        client_builder: reqwest::ClientBuilder,
+        stats: Arc<ComponentStats>,
+    ) -> io::Result<Self> {
         if compress && request_mode == ElasticsearchRequestMode::Streaming {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -829,15 +855,7 @@ impl ElasticsearchSinkFactory {
             })
             .collect::<io::Result<Vec<_>>>()?;
 
-        // 30s timeout: generous enough for large bulk responses, short enough to
-        // detect dead connections before the pipeline stalls.
-        // 64 max idle per host: allows all workers (typically ≤16) to keep warm
-        // connections without excessive socket churn.
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .pool_max_idle_per_host(64)
-            .build()
-            .map_err(io::Error::other)?;
+        let client = client_builder.build().map_err(io::Error::other)?;
 
         let endpoint = endpoint.trim_end_matches('/').to_string();
         let bulk_url = format!(
@@ -1928,7 +1946,7 @@ mod tests {
 
     #[test]
     fn split_result_keeps_retryable_result_visible() {
-        let delay = std::time::Duration::from_secs(3);
+        let delay = Duration::from_secs(3);
         let result = ElasticsearchSink::merge_split_send_results(
             crate::sink::SendResult::Rejected("left bad doc".to_string()),
             crate::sink::SendResult::RetryAfter(delay),
@@ -1944,7 +1962,7 @@ mod tests {
     fn split_result_io_error_takes_precedence_over_retry() {
         let result = ElasticsearchSink::merge_split_send_results(
             crate::sink::SendResult::IoError(io::Error::other("network")),
-            crate::sink::SendResult::RetryAfter(std::time::Duration::from_secs(3)),
+            crate::sink::SendResult::RetryAfter(Duration::from_secs(3)),
         );
 
         assert!(

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -20,7 +20,10 @@ use crate::stdout::{StdoutFormat, StdoutSinkFactory};
 use crate::tcp_sink::TcpSinkFactory;
 use crate::udp_sink::UdpSinkFactory;
 
-fn build_http_client_builder(cfg: &OutputConfig) -> reqwest::ClientBuilder {
+fn build_http_client_builder(
+    name: &str,
+    cfg: &OutputConfig,
+) -> Result<reqwest::ClientBuilder, OutputError> {
     let mut client_builder = reqwest::Client::builder()
         .timeout(Duration::from_millis(
             cfg.request_timeout_ms.unwrap_or(30_000),
@@ -31,25 +34,39 @@ fn build_http_client_builder(cfg: &OutputConfig) -> reqwest::ClientBuilder {
         if tls.insecure_skip_verify {
             client_builder = client_builder.danger_accept_invalid_certs(true);
         }
-        if let Some(ca) = &tls.ca_file
-            && let Ok(ca_cert) = std::fs::read(ca)
-            && let Ok(cert) = reqwest::Certificate::from_pem(&ca_cert)
-        {
+        if let Some(ca) = &tls.ca_file {
+            let ca_cert = read_tls_file(name, "ca_file", ca)?;
+            let cert = reqwest::Certificate::from_pem(&ca_cert).map_err(|e| {
+                OutputError::Construction(format!(
+                    "output '{name}': invalid tls ca_file '{ca}': {e}"
+                ))
+            })?;
             client_builder = client_builder.add_root_certificate(cert);
         }
-        if let (Some(cert), Some(key)) = (&tls.cert_file, &tls.key_file)
-            && let (Ok(cert_data), Ok(key_data)) = (std::fs::read(cert), std::fs::read(key))
-        {
+        if let (Some(cert), Some(key)) = (&tls.cert_file, &tls.key_file) {
+            let cert_data = read_tls_file(name, "cert_file", cert)?;
+            let key_data = read_tls_file(name, "key_file", key)?;
             let mut pem = cert_data;
             pem.push(b'\n');
             pem.extend(key_data);
-            if let Ok(identity) = reqwest::Identity::from_pem(&pem) {
-                client_builder = client_builder.identity(identity);
-            }
+            let identity = reqwest::Identity::from_pem(&pem).map_err(|e| {
+                OutputError::Construction(format!(
+                    "output '{name}': invalid tls cert_file/key_file '{cert}'/'{key}': {e}"
+                ))
+            })?;
+            client_builder = client_builder.identity(identity);
         }
     }
 
-    client_builder
+    Ok(client_builder)
+}
+
+fn read_tls_file(name: &str, field: &str, path: &str) -> Result<Vec<u8>, OutputError> {
+    std::fs::read(path).map_err(|e| {
+        OutputError::Construction(format!(
+            "output '{name}': failed to read tls {field} '{path}': {e}"
+        ))
+    })
 }
 
 /// Build an `Arc<dyn SinkFactory>` from an output configuration.
@@ -97,7 +114,7 @@ pub fn build_sink_factory(
                 auth_headers,
                 compress,
                 request_mode,
-                build_http_client_builder(cfg),
+                build_http_client_builder(name, cfg)?,
                 stats,
             )
             .map_err(|e| {
@@ -120,7 +137,7 @@ pub fn build_sink_factory(
                     .collect(),
                 cfg.label_columns.clone().unwrap_or_default(),
                 auth_headers,
-                build_http_client_builder(cfg),
+                build_http_client_builder(name, cfg)?,
                 stats,
             )
             .map_err(|e| {
@@ -211,7 +228,7 @@ pub fn build_sink_factory(
                 }
             };
 
-            let client_builder = build_http_client_builder(cfg);
+            let client_builder = build_http_client_builder(name, cfg)?;
 
             let mut all_headers = auth_headers;
             if let Some(cfg_headers) = &cfg.headers {
@@ -329,6 +346,7 @@ pub fn build_sink_factory(
 mod tests {
     use super::build_sink_factory;
     use std::collections::HashMap;
+    use std::fs;
     use std::sync::Arc;
 
     use logfwd_config::{OutputConfig, OutputType};
@@ -388,6 +406,61 @@ mod tests {
         assert!(
             result.is_ok(),
             "loki should accept tls/request_timeout config"
+        );
+    }
+
+    #[test]
+    fn build_sink_factory_elasticsearch_rejects_unreadable_tls_ca_file() {
+        let cfg = OutputConfig {
+            output_type: OutputType::Elasticsearch,
+            endpoint: Some("https://localhost:9200".to_string()),
+            tls: Some(logfwd_config::TlsClientConfig {
+                ca_file: Some("/path/that/does/not/exist/ca.pem".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let result = build_sink_factory("es", &cfg, None, Arc::new(ComponentStats::new()));
+        let err = match result {
+            Ok(_) => panic!("missing tls ca_file should reject sink construction"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("failed to read tls ca_file"));
+    }
+
+    #[test]
+    fn build_sink_factory_loki_rejects_malformed_tls_ca_file() {
+        let path = std::env::temp_dir().join(format!(
+            "logfwd-output-invalid-ca-{}.pem",
+            std::process::id()
+        ));
+        fs::write(
+            &path,
+            b"-----BEGIN CERTIFICATE-----\nnot-valid-base64\n-----END CERTIFICATE-----\n",
+        )
+        .expect("write invalid ca file");
+        let path = path.to_string_lossy().into_owned();
+        let cfg = OutputConfig {
+            output_type: OutputType::Loki,
+            endpoint: Some("https://localhost:3100".to_string()),
+            tls: Some(logfwd_config::TlsClientConfig {
+                ca_file: Some(path.clone()),
+                ..Default::default()
+            }),
+            static_labels: Some(HashMap::from([("app".to_string(), "logfwd".to_string())])),
+            ..Default::default()
+        };
+
+        let result = build_sink_factory("loki", &cfg, None, Arc::new(ComponentStats::new()));
+        let _ = fs::remove_file(path);
+        let err = match result {
+            Ok(_) => panic!("malformed tls ca_file should reject sink construction"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("builder error"),
+            "unexpected error: {err}"
         );
     }
 }

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use logfwd_config::{Format, OutputConfig, OutputType};
 use logfwd_types::diagnostics::ComponentStats;
@@ -18,6 +19,38 @@ use crate::sink::SinkFactory;
 use crate::stdout::{StdoutFormat, StdoutSinkFactory};
 use crate::tcp_sink::TcpSinkFactory;
 use crate::udp_sink::UdpSinkFactory;
+
+fn build_http_client_builder(cfg: &OutputConfig) -> reqwest::ClientBuilder {
+    let mut client_builder = reqwest::Client::builder()
+        .timeout(Duration::from_millis(
+            cfg.request_timeout_ms.unwrap_or(30_000),
+        ))
+        .pool_max_idle_per_host(64);
+
+    if let Some(tls) = &cfg.tls {
+        if tls.insecure_skip_verify {
+            client_builder = client_builder.danger_accept_invalid_certs(true);
+        }
+        if let Some(ca) = &tls.ca_file
+            && let Ok(ca_cert) = std::fs::read(ca)
+            && let Ok(cert) = reqwest::Certificate::from_pem(&ca_cert)
+        {
+            client_builder = client_builder.add_root_certificate(cert);
+        }
+        if let (Some(cert), Some(key)) = (&tls.cert_file, &tls.key_file)
+            && let (Ok(cert_data), Ok(key_data)) = (std::fs::read(cert), std::fs::read(key))
+        {
+            let mut pem = cert_data;
+            pem.push(b'\n');
+            pem.extend(key_data);
+            if let Ok(identity) = reqwest::Identity::from_pem(&pem) {
+                client_builder = client_builder.identity(identity);
+            }
+        }
+    }
+
+    client_builder
+}
 
 /// Build an `Arc<dyn SinkFactory>` from an output configuration.
 ///
@@ -57,13 +90,14 @@ pub fn build_sink_factory(
                 Some("streaming") => ElasticsearchRequestMode::Streaming,
                 _ => ElasticsearchRequestMode::Buffered,
             };
-            let factory = ElasticsearchSinkFactory::new(
+            let factory = ElasticsearchSinkFactory::new_with_client(
                 name.to_string(),
                 endpoint.clone(),
                 index,
                 auth_headers,
                 compress,
                 request_mode,
+                build_http_client_builder(cfg),
                 stats,
             )
             .map_err(|e| {
@@ -75,7 +109,7 @@ pub fn build_sink_factory(
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': loki requires 'endpoint'"))
             })?;
-            let factory = LokiSinkFactory::new(
+            let factory = LokiSinkFactory::new_with_client(
                 name.to_string(),
                 endpoint.clone(),
                 cfg.tenant_id.clone(),
@@ -86,6 +120,7 @@ pub fn build_sink_factory(
                     .collect(),
                 cfg.label_columns.clone().unwrap_or_default(),
                 auth_headers,
+                build_http_client_builder(cfg),
                 stats,
             )
             .map_err(|e| {
@@ -176,36 +211,7 @@ pub fn build_sink_factory(
                 }
             };
 
-            let mut client_builder = reqwest::Client::builder()
-                .timeout(std::time::Duration::from_millis(
-                    cfg.request_timeout_ms.unwrap_or(30_000),
-                ))
-                .pool_max_idle_per_host(64);
-
-            #[allow(clippy::collapsible_if)]
-            if let Some(tls) = &cfg.tls {
-                if tls.insecure_skip_verify {
-                    client_builder = client_builder.danger_accept_invalid_certs(true);
-                }
-                if let Some(ca) = &tls.ca_file {
-                    if let Ok(ca_cert) = std::fs::read(ca) {
-                        if let Ok(cert) = reqwest::Certificate::from_pem(&ca_cert) {
-                            client_builder = client_builder.add_root_certificate(cert);
-                        }
-                    }
-                }
-                if let (Some(cert), Some(key)) = (&tls.cert_file, &tls.key_file) {
-                    if let (Ok(cert_data), Ok(key_data)) = (std::fs::read(cert), std::fs::read(key))
-                    {
-                        let mut pem = cert_data;
-                        pem.push(b'\n');
-                        pem.extend(key_data);
-                        if let Ok(identity) = reqwest::Identity::from_pem(&pem) {
-                            client_builder = client_builder.identity(identity);
-                        }
-                    }
-                }
-            }
+            let client_builder = build_http_client_builder(cfg);
 
             let mut all_headers = auth_headers;
             if let Some(cfg_headers) = &cfg.headers {
@@ -322,6 +328,7 @@ pub fn build_sink_factory(
 #[cfg(test)]
 mod tests {
     use super::build_sink_factory;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use logfwd_config::{OutputConfig, OutputType};
@@ -340,6 +347,47 @@ mod tests {
         assert!(
             result.is_ok(),
             "arrow_ipc should accept explicit 'none' compression"
+        );
+    }
+
+    #[test]
+    fn build_sink_factory_elasticsearch_accepts_tls_and_request_timeout() {
+        let cfg = OutputConfig {
+            output_type: OutputType::Elasticsearch,
+            endpoint: Some("https://localhost:9200".to_string()),
+            request_timeout_ms: Some(5_000),
+            tls: Some(logfwd_config::TlsClientConfig {
+                insecure_skip_verify: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let result = build_sink_factory("es", &cfg, None, Arc::new(ComponentStats::new()));
+        assert!(
+            result.is_ok(),
+            "elasticsearch should accept tls/request_timeout config"
+        );
+    }
+
+    #[test]
+    fn build_sink_factory_loki_accepts_tls_and_request_timeout() {
+        let cfg = OutputConfig {
+            output_type: OutputType::Loki,
+            endpoint: Some("https://localhost:3100".to_string()),
+            request_timeout_ms: Some(5_000),
+            tls: Some(logfwd_config::TlsClientConfig {
+                insecure_skip_verify: true,
+                ..Default::default()
+            }),
+            static_labels: Some(HashMap::from([("app".to_string(), "logfwd".to_string())])),
+            ..Default::default()
+        };
+
+        let result = build_sink_factory("loki", &cfg, None, Arc::new(ComponentStats::new()));
+        assert!(
+            result.is_ok(),
+            "loki should accept tls/request_timeout config"
         );
     }
 }

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -43,18 +43,31 @@ fn build_http_client_builder(
             })?;
             client_builder = client_builder.add_root_certificate(cert);
         }
-        if let (Some(cert), Some(key)) = (&tls.cert_file, &tls.key_file) {
-            let cert_data = read_tls_file(name, "cert_file", cert)?;
-            let key_data = read_tls_file(name, "key_file", key)?;
-            let mut pem = cert_data;
-            pem.push(b'\n');
-            pem.extend(key_data);
-            let identity = reqwest::Identity::from_pem(&pem).map_err(|e| {
-                OutputError::Construction(format!(
-                    "output '{name}': invalid tls cert_file/key_file '{cert}'/'{key}': {e}"
-                ))
-            })?;
-            client_builder = client_builder.identity(identity);
+        match (&tls.cert_file, &tls.key_file) {
+            (Some(cert), Some(key)) => {
+                let cert_data = read_tls_file(name, "cert_file", cert)?;
+                let key_data = read_tls_file(name, "key_file", key)?;
+                let mut pem = cert_data;
+                pem.push(b'\n');
+                pem.extend(key_data);
+                let identity = reqwest::Identity::from_pem(&pem).map_err(|e| {
+                    OutputError::Construction(format!(
+                        "output '{name}': invalid tls cert_file/key_file '{cert}'/'{key}': {e}"
+                    ))
+                })?;
+                client_builder = client_builder.identity(identity);
+            }
+            (Some(_), None) => {
+                return Err(OutputError::Construction(format!(
+                    "output '{name}': tls cert_file requires tls key_file"
+                )));
+            }
+            (None, Some(_)) => {
+                return Err(OutputError::Construction(format!(
+                    "output '{name}': tls key_file requires tls cert_file"
+                )));
+            }
+            (None, None) => {}
         }
     }
 
@@ -462,5 +475,46 @@ mod tests {
             err.to_string().contains("builder error"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn build_sink_factory_rejects_tls_cert_without_key() {
+        let cfg = OutputConfig {
+            output_type: OutputType::Elasticsearch,
+            endpoint: Some("https://localhost:9200".to_string()),
+            tls: Some(logfwd_config::TlsClientConfig {
+                cert_file: Some("/tmp/client.pem".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let result = build_sink_factory("es", &cfg, None, Arc::new(ComponentStats::new()));
+        let err = match result {
+            Ok(_) => panic!("half-configured mTLS identity should reject sink construction"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("cert_file requires tls key_file"));
+    }
+
+    #[test]
+    fn build_sink_factory_rejects_tls_key_without_cert() {
+        let cfg = OutputConfig {
+            output_type: OutputType::Loki,
+            endpoint: Some("https://localhost:3100".to_string()),
+            tls: Some(logfwd_config::TlsClientConfig {
+                key_file: Some("/tmp/client.key".to_string()),
+                ..Default::default()
+            }),
+            static_labels: Some(HashMap::from([("app".to_string(), "logfwd".to_string())])),
+            ..Default::default()
+        };
+
+        let result = build_sink_factory("loki", &cfg, None, Arc::new(ComponentStats::new()));
+        let err = match result {
+            Ok(_) => panic!("half-configured mTLS identity should reject sink construction"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("key_file requires tls cert_file"));
     }
 }

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -38,6 +38,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 use arrow::array::AsArray;
 use arrow::datatypes::DataType;
@@ -504,10 +505,30 @@ impl LokiSinkFactory {
         headers: Vec<(String, String)>,
         stats: Arc<ComponentStats>,
     ) -> io::Result<Self> {
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(io::Error::other)?;
+        Self::new_with_client(
+            name,
+            endpoint,
+            tenant_id,
+            static_labels,
+            label_columns,
+            headers,
+            reqwest::Client::builder().timeout(Duration::from_secs(30)),
+            stats,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_client(
+        name: String,
+        endpoint: String,
+        tenant_id: Option<String>,
+        static_labels: Vec<(String, String)>,
+        label_columns: Vec<String>,
+        headers: Vec<(String, String)>,
+        client_builder: reqwest::ClientBuilder,
+        stats: Arc<ComponentStats>,
+    ) -> io::Result<Self> {
+        let client = client_builder.build().map_err(io::Error::other)?;
 
         let parsed_headers = headers
             .into_iter()

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -518,6 +518,12 @@ impl LokiSinkFactory {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Creates a Loki sink factory with a caller-provided HTTP client builder.
+    ///
+    /// The caller owns all cross-cutting HTTP client policy on `client_builder`, including
+    /// request timeout, connection-pool sizing, TLS roots, mTLS identity, and certificate
+    /// verification behavior. This constructor parses Loki labels and headers, then builds
+    /// and reuses one `reqwest::Client` for every sink created by the factory.
     pub fn new_with_client(
         name: String,
         endpoint: String,


### PR DESCRIPTION
## Summary

Closes #2279.

Wires only output configuration fields that map to implemented runtime behavior and keeps unsupported fields rejected instead of accepting dead config.

## Implemented / deferred matrix

| Area | Status | Evidence |
|---|---|---|
| Elasticsearch `request_timeout_ms` | Implemented | Shared HTTP client builder now applies the configured timeout to the Elasticsearch reqwest client. |
| Elasticsearch `tls` | Implemented | Elasticsearch factory now accepts the same TLS client builder inputs already used by OTLP. |
| Loki `request_timeout_ms` | Implemented | Loki factory now accepts a configured reqwest client builder with timeout. |
| Loki `tls` | Implemented | Loki factory now accepts the shared TLS-capable client builder. |
| Elasticsearch/Loki retry + batch controls | Deferred and rejected | Sinks do not implement per-output retry/batch controls yet, so validation continues to reject those fields and docs state that explicitly. |
| TCP/UDP optional output controls | Deferred and rejected | Existing TCP/UDP sinks expose endpoint-only behavior. Docs now state unsupported controls are rejected. |
| File output options | No runtime gap found in this pass | Existing file output path/format behavior is already documented; rotation/compression/buffering are not implemented and were not added as schema-only placeholders. |
| Parquet / HTTP output / file-input features | Out of scope | Left untouched per issue scope. |

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p logfwd-config request_timeout_ms -- --nocapture`
- `cargo test -p logfwd-config accepts_tls_and_request_timeout_ms -- --nocapture`
- `cargo test -p logfwd-output build_sink_factory_ -- --nocapture`
- `cargo clippy -p logfwd-config -p logfwd-output -- -D warnings`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire TLS and request timeout config options to Elasticsearch and Loki outputs
> - Extends validation in [`validate.rs`](https://github.com/strawgate/fastforward/pull/2304/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) to accept `tls` and `request_timeout_ms` on Elasticsearch and Loki outputs (previously only allowed on OTLP), and enforces `request_timeout_ms >= 1` for all three.
> - Adds `new_with_client` constructors to [`elasticsearch.rs`](https://github.com/strawgate/fastforward/pull/2304/files#diff-b9095bc7efeb6ecbe346137059311c896d924d2c2f753a727aa4781e16486def) and [`loki.rs`](https://github.com/strawgate/fastforward/pull/2304/files#diff-1bc2e0eadd25a290f776d0bb22aa248a0dfefee5e49c32d486e2d963e8f08bce) that accept a `reqwest::ClientBuilder`, enabling external control over timeout and TLS settings.
> - Adds a `build_http_client_builder` helper in [`factory.rs`](https://github.com/strawgate/fastforward/pull/2304/files#diff-38138875bb6a160b3328cc8507d27d322ae4c2f810e755490e66ce6088078fac) that constructs a `ClientBuilder` from `OutputConfig`, applying timeout, CA cert, and mTLS identity when configured.
> - Risk: OTLP sink construction now fails fast on unreadable or malformed TLS files and requires both `cert_file` and `key_file` for mTLS, instead of silently ignoring issues.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bf8de4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->