### PR TITLE
fix: parse config env values through schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ dependencies = [
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "url",
+ "varsubst",
 ]
 
 [[package]]
@@ -5494,6 +5495,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "varsubst"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd6209bc6e22b483a4de08947851a172f7a4436fd4d19e96d5752844d4d1c3f"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "config"
+version = "0.15.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+dependencies = [
+ "pathdiff",
+ "serde_core",
+ "winnow",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,8 +2858,8 @@ dependencies = [
 name = "logfwd-config"
 version = "0.1.0"
 dependencies = [
+ "config",
  "serde",
- "serde_path_to_error",
  "serde_yaml_ng",
  "thiserror 2.0.18",
  "url",
@@ -3553,6 +3564,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -6006,6 +6023,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ csv = "1"
 flate2 = "1"
 wasm-bindgen = "0.2"
 js-sys = "0.3"
+varsubst = { version = "0.0.1", default-features = false }
 
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ chrono = { version = "0.4.44", default-features = false }
 clap = "4.5"
 clap_complete = "4.5"
 clap_complete_nushell = "4.6"
+config = { version = "0.15.22", default-features = false }
 arrow-json = "58"
 datafusion = { version = "53", default-features = false, features = [
     "sql",
@@ -76,7 +77,6 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = [
 ] }
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
-serde_path_to_error = "0.1"
 sonic-rs = "0.5"
 tokio = { version = "1" }
 tracing = "0.1"

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -952,8 +952,9 @@ storage:
 
 Any value in the config file can reference an environment variable with `${VAR}`.
 Variable names must start with an ASCII letter or `_`, and then contain only
-ASCII letters, digits, or `_`. `$VAR` and default expressions such as
-`${VAR:fallback}` are not expanded.
+ASCII letters, digits, or `_`. `$VAR` stays literal, and default expressions
+such as `${VAR:fallback}` are rejected because `:` is not valid in variable
+names.
 
 ```yaml
 output:

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -950,7 +950,10 @@ storage:
 
 ## Environment variable substitution
 
-Any value in the config file can reference an environment variable with `${VAR}`:
+Any value in the config file can reference an environment variable with `${VAR}`.
+Variable names must start with an ASCII letter or `_`, and then contain only
+ASCII letters, digits, or `_`. `$VAR` and default expressions such as
+`${VAR:fallback}` are not expanded.
 
 ```yaml
 output:

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -966,6 +966,9 @@ server:
 ```
 
 If the variable is not set, config loading fails fast with a validation error.
+An unterminated reference such as `${VAR` is preserved literally so existing
+config text is not rewritten accidentally; completed placeholders before that
+literal tail are still expanded.
 
 Environment variables are expanded as string data. The typed config schema then
 parses those strings into the field type, so numeric and boolean fields can read

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -967,8 +967,9 @@ server:
 
 If the variable is not set, config loading fails fast with a validation error.
 
-Exact unquoted placeholders use YAML scalar typing after expansion. This lets numeric
-and boolean fields read values directly from the environment:
+Environment variables are expanded as string data. The typed config schema then
+parses those strings into the field type, so numeric and boolean fields can read
+values directly from the environment without treating the env value as YAML:
 
 ```yaml
 pipelines:
@@ -976,13 +977,13 @@ pipelines:
     workers: ${LOGFWD_WORKERS}
 ```
 
-Quote a placeholder, or tag it with `!!str`, when the expanded value should remain
-a string even if it looks like a YAML number, boolean, or null:
+String fields remain strings even when the expanded value looks like a YAML
+number, boolean, or null:
 
 ```yaml
 input:
   type: file
-  path: "${LOG_PATH}"
+  path: ${LOG_PATH}
 ```
 
 Placeholders embedded inside longer strings always remain strings:

--- a/crates/logfwd-config/Cargo.toml
+++ b/crates/logfwd-config/Cargo.toml
@@ -18,6 +18,7 @@ serde_path_to_error = { workspace = true }
 serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }
+varsubst = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/logfwd-config/Cargo.toml
+++ b/crates/logfwd-config/Cargo.toml
@@ -13,8 +13,8 @@ default = []
 otlp-research = []
 
 [dependencies]
+config = { workspace = true }
 serde = { workspace = true }
-serde_path_to_error = { workspace = true }
 serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true }

--- a/crates/logfwd-config/src/env.rs
+++ b/crates/logfwd-config/src/env.rs
@@ -1,38 +1,170 @@
 use crate::types::ConfigError;
+use std::collections::HashMap;
 
 pub(crate) fn expand_env_vars(text: &str) -> Result<String, ConfigError> {
-    let mut result = String::with_capacity(text.len());
-    let mut chars = text.chars().peekable();
+    if !text.contains("${") {
+        return Ok(text.to_owned());
+    }
 
-    while let Some(ch) = chars.next() {
-        if ch == '$' && chars.peek() == Some(&'{') {
-            chars.next();
-            let mut var_name = String::new();
-            let mut found_close = false;
-            for c in chars.by_ref() {
-                if c == '}' {
-                    found_close = true;
-                    break;
-                }
-                var_name.push(c);
-            }
-            if !found_close {
-                result.push_str("${");
-                result.push_str(&var_name);
-                continue;
-            }
-            match std::env::var(&var_name) {
-                Ok(val) => result.push_str(&val),
-                Err(_) => {
-                    return Err(ConfigError::Validation(format!(
-                        "environment variable '{var_name}' is not set"
-                    )));
-                }
-            }
-        } else {
-            result.push(ch);
+    let env_vars: HashMap<String, String> = std::env::vars_os()
+        .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
+        .collect();
+    let expanded = substitute_or_preserve_unterminated(text, &env_vars)?;
+
+    let present_vars: HashMap<String, String> = env_vars
+        .keys()
+        .map(|key| (key.clone(), String::new()))
+        .collect();
+    let masked = substitute_or_preserve_unterminated(text, &present_vars)?;
+    if let Some(var_name) = first_braced_placeholder(&masked) {
+        return Err(ConfigError::Validation(format!(
+            "environment variable '{var_name}' is not set"
+        )));
+    }
+
+    Ok(expanded)
+}
+
+fn substitute_or_preserve_unterminated(
+    text: &str,
+    variables: &HashMap<String, String>,
+) -> Result<String, ConfigError> {
+    varsubst::substitute(text, variables).or_else(|err| match err {
+        varsubst::SubstError::UnclosedBrace { .. } => Ok(text.to_owned()),
+        other @ varsubst::SubstError::InvalidVarName { .. } => Err(ConfigError::Validation(
+            format!("invalid environment variable substitution: {other}"),
+        )),
+    })
+}
+
+fn first_braced_placeholder(text: &str) -> Option<&str> {
+    let start = text.find("${")?.saturating_add(2);
+    let end = text[start..].find('}')?;
+    Some(&text[start..start + end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_env_vars;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, MutexGuard};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: tests that mutate process environment hold ENV_LOCK.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
         }
     }
 
-    Ok(result)
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(val) => {
+                    // SAFETY: tests that mutate process environment hold ENV_LOCK.
+                    unsafe { std::env::set_var(self.key, val) }
+                }
+                None => {
+                    // SAFETY: tests that mutate process environment hold ENV_LOCK.
+                    unsafe { std::env::remove_var(self.key) }
+                }
+            }
+        }
+    }
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        ENV_LOCK.lock().expect("env lock should not be poisoned")
+    }
+
+    #[test]
+    fn braced_env_var_expands() {
+        let _guard = env_lock();
+        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_BRACED", "expanded");
+
+        let expanded =
+            expand_env_vars("value=${LOGFWD_ENV_TEST_BRACED}").expect("env should expand");
+
+        assert_eq!(expanded, "value=expanded");
+    }
+
+    #[test]
+    fn missing_env_var_is_rejected() {
+        let err =
+            expand_env_vars("${LOGFWD_ENV_TEST_MISSING}").expect_err("missing env should fail");
+
+        assert!(
+            err.to_string().contains("LOGFWD_ENV_TEST_MISSING"),
+            "error should name missing variable: {err}"
+        );
+    }
+
+    #[test]
+    fn unterminated_env_var_is_preserved() {
+        let expanded = expand_env_vars("value=${LOGFWD_ENV_TEST_UNTERMINATED")
+            .expect("unterminated variable should be preserved");
+
+        assert_eq!(expanded, "value=${LOGFWD_ENV_TEST_UNTERMINATED");
+    }
+
+    #[test]
+    fn dollar_name_syntax_is_literal() {
+        let _guard = env_lock();
+        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_SHORT", "expanded");
+
+        let expanded =
+            expand_env_vars("value=$LOGFWD_ENV_TEST_SHORT").expect("env should not expand");
+
+        assert_eq!(expanded, "value=$LOGFWD_ENV_TEST_SHORT");
+    }
+
+    #[test]
+    fn default_value_syntax_is_rejected() {
+        let err = expand_env_vars("value=${LOGFWD_ENV_TEST_DEFAULT:fallback}")
+            .expect_err("default syntax should be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("invalid environment variable substitution"),
+            "error should describe invalid substitution: {err}"
+        );
+    }
+
+    #[test]
+    fn regex_backslashes_and_end_anchor_without_env_are_literal() {
+        let regex = r"/([^/]+)/[^/]+\\.log$";
+
+        let expanded = expand_env_vars(regex).expect("regex should not be treated as env syntax");
+
+        assert_eq!(expanded, regex);
+    }
+
+    #[test]
+    fn backslashes_with_env_placeholder_are_literal() {
+        let _guard = env_lock();
+        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_FILE", "app.log");
+
+        let expanded = expand_env_vars(r"C:\logs\${LOGFWD_ENV_TEST_FILE}")
+            .expect("backslashes should remain literal");
+
+        assert_eq!(expanded, r"C:\logs\app.log");
+    }
+
+    #[test]
+    fn env_value_containing_placeholder_text_is_not_recursively_expanded() {
+        let _guard = env_lock();
+        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_LITERAL", "${NOT_RECURSIVE}");
+
+        let expanded = expand_env_vars("${LOGFWD_ENV_TEST_LITERAL}")
+            .expect("env value should be inserted literally");
+
+        assert_eq!(expanded, "${NOT_RECURSIVE}");
+    }
 }

--- a/crates/logfwd-config/src/env.rs
+++ b/crates/logfwd-config/src/env.rs
@@ -2,6 +2,11 @@ use crate::types::ConfigError;
 use std::collections::HashMap;
 use std::env;
 
+/// Expands braced `${VAR}` placeholders using the process environment.
+///
+/// Only braced placeholders are expanded. Unbraced `$VAR` text stays literal,
+/// invalid closed placeholders return validation errors, and an unterminated
+/// `${VAR` tail is preserved after expanding any complete placeholders before it.
 pub(crate) fn expand_env_vars(text: &str) -> Result<String, ConfigError> {
     if !text.contains("${") {
         return Ok(text.to_owned());

--- a/crates/logfwd-config/src/env.rs
+++ b/crates/logfwd-config/src/env.rs
@@ -1,21 +1,54 @@
 use crate::types::ConfigError;
 use std::collections::HashMap;
+use std::env;
 
 pub(crate) fn expand_env_vars(text: &str) -> Result<String, ConfigError> {
     if !text.contains("${") {
         return Ok(text.to_owned());
     }
 
-    let env_vars: HashMap<String, String> = std::env::vars_os()
-        .filter_map(|(key, value)| Some((key.into_string().ok()?, value.into_string().ok()?)))
-        .collect();
-    let expanded = substitute_or_preserve_unterminated(text, &env_vars)?;
+    expand_env_vars_with(text, lookup_env_var)
+}
 
-    let present_vars: HashMap<String, String> = env_vars
-        .keys()
-        .map(|key| (key.clone(), String::new()))
-        .collect();
-    let masked = substitute_or_preserve_unterminated(text, &present_vars)?;
+fn expand_env_vars_with<F>(text: &str, mut lookup: F) -> Result<String, ConfigError>
+where
+    F: FnMut(&str) -> Result<Option<String>, ConfigError>,
+{
+    match first_unclosed_placeholder_start(text)? {
+        Some(start) => {
+            let expanded_prefix = expand_closed_env_vars(&text[..start], &mut lookup)?;
+            Ok(format!("{expanded_prefix}{}", &text[start..]))
+        }
+        None => expand_closed_env_vars(text, &mut lookup),
+    }
+}
+
+fn lookup_env_var(name: &str) -> Result<Option<String>, ConfigError> {
+    match env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(_)) => Err(ConfigError::Validation(format!(
+            "environment variable '{name}' is not valid Unicode"
+        ))),
+    }
+}
+
+fn expand_closed_env_vars<F>(text: &str, lookup: &mut F) -> Result<String, ConfigError>
+where
+    F: FnMut(&str) -> Result<Option<String>, ConfigError>,
+{
+    validate_substitution_syntax(text)?;
+
+    let mut variables: HashMap<&str, String> = HashMap::new();
+    for name in braced_placeholder_names(text) {
+        if let Some(value) = lookup(name)? {
+            variables.entry(name).or_insert(value);
+        }
+    }
+
+    let expanded = substitute_validated(text, &variables)?;
+    let present_vars: HashMap<&str, &str> = variables.keys().map(|key| (*key, "")).collect();
+    let masked = substitute_validated(text, &present_vars)?;
     if let Some(var_name) = first_braced_placeholder(&masked) {
         return Err(ConfigError::Validation(format!(
             "environment variable '{var_name}' is not set"
@@ -25,22 +58,65 @@ pub(crate) fn expand_env_vars(text: &str) -> Result<String, ConfigError> {
     Ok(expanded)
 }
 
-fn substitute_or_preserve_unterminated(
-    text: &str,
-    variables: &HashMap<String, String>,
-) -> Result<String, ConfigError> {
-    varsubst::substitute(text, variables).or_else(|err| match err {
-        varsubst::SubstError::UnclosedBrace { .. } => Ok(text.to_owned()),
-        other @ varsubst::SubstError::InvalidVarName { .. } => Err(ConfigError::Validation(
-            format!("invalid environment variable substitution: {other}"),
+fn validate_substitution_syntax(text: &str) -> Result<(), ConfigError> {
+    let variables: HashMap<&str, &str> = HashMap::new();
+    substitute_validated(text, &variables).map(|_| ())
+}
+
+fn substitute_validated<K, V>(text: &str, variables: &HashMap<K, V>) -> Result<String, ConfigError>
+where
+    K: AsRef<str> + std::hash::Hash + Eq,
+    V: AsRef<str>,
+{
+    varsubst::substitute(text, variables).map_err(|err| match err {
+        varsubst::SubstError::UnclosedBrace { position } => ConfigError::Validation(format!(
+            "unclosed environment variable substitution at character {position}"
         )),
+        varsubst::SubstError::InvalidVarName { .. } => {
+            ConfigError::Validation(format!("invalid environment variable substitution: {err}"))
+        }
     })
 }
 
+fn first_unclosed_placeholder_start(text: &str) -> Result<Option<usize>, ConfigError> {
+    let variables: HashMap<&str, &str> = HashMap::new();
+    match varsubst::substitute(text, &variables) {
+        Ok(_) => Ok(None),
+        Err(varsubst::SubstError::UnclosedBrace { position }) => {
+            Ok(Some(char_position_to_byte_index(text, position)))
+        }
+        Err(err @ varsubst::SubstError::InvalidVarName { .. }) => Err(ConfigError::Validation(
+            format!("invalid environment variable substitution: {err}"),
+        )),
+    }
+}
+
+fn char_position_to_byte_index(text: &str, position: usize) -> usize {
+    text.char_indices()
+        .nth(position)
+        .map_or(text.len(), |(index, _)| index)
+}
+
+fn braced_placeholder_names(text: &str) -> Vec<&str> {
+    let mut names = Vec::new();
+    let mut offset = 0;
+
+    while let Some(start_rel) = text[offset..].find("${") {
+        let name_start = offset + start_rel + 2;
+        if let Some(end_rel) = text[name_start..].find('}') {
+            let name_end = name_start + end_rel;
+            names.push(&text[name_start..name_end]);
+            offset = name_end + 1;
+        } else {
+            break;
+        }
+    }
+
+    names
+}
+
 fn first_braced_placeholder(text: &str) -> Option<&str> {
-    let start = text.find("${")?.saturating_add(2);
-    let end = text[start..].find('}')?;
-    Some(&text[start..start + end])
+    braced_placeholder_names(text).into_iter().next()
 }
 
 #[cfg(test)]
@@ -61,6 +137,13 @@ mod tests {
             let previous = std::env::var_os(key);
             // SAFETY: tests that mutate process environment hold ENV_LOCK.
             unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            // SAFETY: tests that mutate process environment hold ENV_LOCK.
+            unsafe { std::env::remove_var(key) };
             Self { key, previous }
         }
     }
@@ -97,6 +180,9 @@ mod tests {
 
     #[test]
     fn missing_env_var_is_rejected() {
+        let _guard = env_lock();
+        let _var = EnvVarGuard::unset("LOGFWD_ENV_TEST_MISSING");
+
         let err =
             expand_env_vars("${LOGFWD_ENV_TEST_MISSING}").expect_err("missing env should fail");
 
@@ -108,10 +194,22 @@ mod tests {
 
     #[test]
     fn unterminated_env_var_is_preserved() {
+        let _guard = env_lock();
         let expanded = expand_env_vars("value=${LOGFWD_ENV_TEST_UNTERMINATED")
             .expect("unterminated variable should be preserved");
 
         assert_eq!(expanded, "value=${LOGFWD_ENV_TEST_UNTERMINATED");
+    }
+
+    #[test]
+    fn closed_vars_before_unterminated_tail_are_expanded() {
+        let _guard = env_lock();
+        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_BRACED", "expanded");
+
+        let expanded = expand_env_vars("${LOGFWD_ENV_TEST_BRACED}${LOGFWD_ENV_TEST_UNTERMINATED")
+            .expect("closed variables before an unterminated tail should expand");
+
+        assert_eq!(expanded, "expanded${LOGFWD_ENV_TEST_UNTERMINATED",);
     }
 
     #[test]
@@ -127,6 +225,7 @@ mod tests {
 
     #[test]
     fn default_value_syntax_is_rejected() {
+        let _guard = env_lock();
         let err = expand_env_vars("value=${LOGFWD_ENV_TEST_DEFAULT:fallback}")
             .expect_err("default syntax should be rejected");
 
@@ -139,6 +238,7 @@ mod tests {
 
     #[test]
     fn regex_backslashes_and_end_anchor_without_env_are_literal() {
+        let _guard = env_lock();
         let regex = r"/([^/]+)/[^/]+\\.log$";
 
         let expanded = expand_env_vars(regex).expect("regex should not be treated as env syntax");

--- a/crates/logfwd-config/src/env.rs
+++ b/crates/logfwd-config/src/env.rs
@@ -97,26 +97,25 @@ fn char_position_to_byte_index(text: &str, position: usize) -> usize {
         .map_or(text.len(), |(index, _)| index)
 }
 
-fn braced_placeholder_names(text: &str) -> Vec<&str> {
-    let mut names = Vec::new();
+fn braced_placeholder_names(text: &str) -> impl Iterator<Item = &str> {
     let mut offset = 0;
 
-    while let Some(start_rel) = text[offset..].find("${") {
+    std::iter::from_fn(move || {
+        let start_rel = text[offset..].find("${")?;
         let name_start = offset + start_rel + 2;
         if let Some(end_rel) = text[name_start..].find('}') {
             let name_end = name_start + end_rel;
-            names.push(&text[name_start..name_end]);
             offset = name_end + 1;
+            Some(&text[name_start..name_end])
         } else {
-            break;
+            offset = text.len();
+            None
         }
-    }
-
-    names
+    })
 }
 
 fn first_braced_placeholder(text: &str) -> Option<&str> {
-    braced_placeholder_names(text).into_iter().next()
+    braced_placeholder_names(text).next()
 }
 
 #[cfg(test)]

--- a/crates/logfwd-config/src/load.rs
+++ b/crates/logfwd-config/src/load.rs
@@ -9,6 +9,7 @@ use crate::types::{
 use config as config_rs;
 use serde::Deserialize;
 use serde_yaml_ng::Value;
+use serde_yaml_ng::value::Tag;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -221,7 +222,12 @@ fn yaml_value_to_config_value(value: Value) -> Result<config_rs::Value, ConfigEr
             }
             config_rs::ValueKind::Table(map)
         }
-        Value::Tagged(tagged) => return yaml_value_to_config_value(tagged.value),
+        Value::Tagged(tagged) => {
+            if is_yaml_string_tag(&tagged.tag) {
+                return yaml_value_to_config_value(tagged.value);
+            }
+            return Err(unsupported_yaml_tag_error(&tagged.tag));
+        }
     };
 
     Ok(config_rs::Value::new(None, kind))
@@ -233,7 +239,13 @@ fn yaml_key_to_config_key(key: Value) -> Result<String, ConfigError> {
         Value::Bool(value) => Ok(value.to_string()),
         Value::Number(value) => Ok(value.to_string()),
         Value::String(value) => Ok(value),
-        Value::Tagged(tagged) => yaml_key_to_config_key(tagged.value),
+        Value::Tagged(tagged) => {
+            if is_yaml_string_tag(&tagged.tag) {
+                yaml_key_to_config_key(tagged.value)
+            } else {
+                Err(unsupported_yaml_tag_error(&tagged.tag))
+            }
+        }
         Value::Sequence(_) | Value::Mapping(_) => Err(ConfigError::Validation(
             "YAML mapping keys must be scalar values".into(),
         )),
@@ -263,7 +275,7 @@ fn expand_env_vars_in_yaml_value(value: &mut Value) -> Result<(), ConfigError> {
             }
         }
         Value::Tagged(tagged) => {
-            if tagged.tag == "str" || tagged.tag == "tag:yaml.org,2002:str" {
+            if is_yaml_string_tag(&tagged.tag) {
                 // An explicit string tag (!!str or !str) means the user
                 // wants a string value. Env substitution already produces
                 // string data, so unwrap the tag after expansion.
@@ -279,4 +291,12 @@ fn expand_env_vars_in_yaml_value(value: &mut Value) -> Result<(), ConfigError> {
     }
 
     Ok(())
+}
+
+fn is_yaml_string_tag(tag: &Tag) -> bool {
+    tag == "str" || tag == "tag:yaml.org,2002:str"
+}
+
+fn unsupported_yaml_tag_error(tag: &Tag) -> ConfigError {
+    ConfigError::Validation(format!("unsupported explicit YAML tag in config: {tag}"))
 }

--- a/crates/logfwd-config/src/load.rs
+++ b/crates/logfwd-config/src/load.rs
@@ -1,4 +1,7 @@
 use crate::env::expand_env_vars;
+use crate::serde_helpers::{
+    deserialize_option_strict_string, deserialize_string_map_strict_values,
+};
 use crate::types::{
     Config, ConfigError, EnrichmentConfig, InputConfig, OutputConfig, PipelineConfig, ServerConfig,
     StorageConfig,
@@ -13,11 +16,12 @@ use std::path::Path;
 #[serde(deny_unknown_fields)]
 struct RawConfig {
     input: Option<InputConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     transform: Option<String>,
     output: Option<OutputConfig>,
     #[serde(default)]
     enrichment: Vec<EnrichmentConfig>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_map_strict_values")]
     resource_attrs: HashMap<String, String>,
     pipelines: Option<HashMap<String, PipelineConfig>>,
     #[serde(default)]

--- a/crates/logfwd-config/src/load.rs
+++ b/crates/logfwd-config/src/load.rs
@@ -143,30 +143,12 @@ impl Config {
 }
 
 fn deserialize_raw_config_with_path(value: Value) -> Result<RawConfig, ConfigError> {
-    let config = config_rs::Config::builder()
-        .add_source(YamlValueSource {
-            root: yaml_value_to_config_root(value)?,
-        })
-        .build()
-        .map_err(config_deserialization_error)?;
-    config
-        .try_deserialize()
-        .map_err(config_deserialization_error)
-}
-
-#[derive(Clone, Debug)]
-struct YamlValueSource {
-    root: config_rs::Map<String, config_rs::Value>,
-}
-
-impl config_rs::Source for YamlValueSource {
-    fn clone_into_box(&self) -> Box<dyn config_rs::Source + Send + Sync> {
-        Box::new(self.clone())
-    }
-
-    fn collect(&self) -> Result<config_rs::Map<String, config_rs::Value>, config_rs::ConfigError> {
-        Ok(self.root.clone())
-    }
+    config_rs::Value::new(
+        None,
+        config_rs::ValueKind::Table(yaml_value_to_config_root(value)?),
+    )
+    .try_deserialize()
+    .map_err(config_deserialization_error)
 }
 
 fn config_deserialization_error(err: config_rs::ConfigError) -> ConfigError {

--- a/crates/logfwd-config/src/load.rs
+++ b/crates/logfwd-config/src/load.rs
@@ -3,21 +3,11 @@ use crate::types::{
     Config, ConfigError, EnrichmentConfig, InputConfig, OutputConfig, PipelineConfig, ServerConfig,
     StorageConfig,
 };
+use config as config_rs;
 use serde::Deserialize;
 use serde_yaml_ng::Value;
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::LazyLock;
-
-/// Process-unique seed embedded in placeholder markers so that no static user
-/// string can collide with a marker. Derived from the address of a private
-/// static, which varies per process (ASLR).
-static PLACEHOLDER_SEED: LazyLock<u64> = LazyLock::new(|| {
-    static ANCHOR: u8 = 0;
-    let addr = std::ptr::addr_of!(ANCHOR) as u64;
-    // Mix bits so the value looks opaque rather than a raw address.
-    addr.wrapping_mul(0x517c_c1b7_2722_0a95)
-});
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -54,9 +44,8 @@ impl Config {
         yaml: &str,
         base_path: Option<&Path>,
     ) -> Result<Self, ConfigError> {
-        let (marked_yaml, quoted_placeholders) = mark_quoted_exact_env_placeholders(yaml);
-        let mut value: Value = serde_yaml_ng::from_str(&marked_yaml)?;
-        expand_env_vars_in_yaml_value(&mut value, &quoted_placeholders)?;
+        let mut value: Value = serde_yaml_ng::from_str(yaml)?;
+        expand_env_vars_in_yaml_value(&mut value)?;
         let raw = deserialize_raw_config_with_path(value)?;
         Self::from_raw(raw, base_path)
     }
@@ -66,12 +55,11 @@ impl Config {
         expand_env_vars(yaml)
     }
 
-    /// Expand `${VAR}` environment variables using the same YAML-aware scalar
-    /// rules as [`Config::load_str`], then serialize the expanded YAML tree.
+    /// Expand `${VAR}` environment variables inside a parsed YAML tree, then
+    /// serialize the expanded tree. Expanded environment values remain strings.
     pub fn expand_env_yaml_str(yaml: &str) -> Result<String, ConfigError> {
-        let (marked_yaml, quoted_placeholders) = mark_quoted_exact_env_placeholders(yaml);
-        let mut value: Value = serde_yaml_ng::from_str(&marked_yaml)?;
-        expand_env_vars_in_yaml_value(&mut value, &quoted_placeholders)?;
+        let mut value: Value = serde_yaml_ng::from_str(yaml)?;
+        expand_env_vars_in_yaml_value(&mut value)?;
         serde_yaml_ng::to_string(&value).map_err(ConfigError::from)
     }
 
@@ -150,46 +138,119 @@ impl Config {
 }
 
 fn deserialize_raw_config_with_path(value: Value) -> Result<RawConfig, ConfigError> {
-    serde_path_to_error::deserialize(value).map_err(|err| {
-        let path = err.path().to_string();
-        let inner = err.into_inner();
-        if path == "." {
-            ConfigError::Validation(format!("config deserialization error: {inner}"))
-        } else {
-            ConfigError::Validation(format!("config deserialization error at '{path}': {inner}"))
-        }
-    })
+    let config = config_rs::Config::builder()
+        .add_source(YamlValueSource {
+            root: yaml_value_to_config_root(value)?,
+        })
+        .build()
+        .map_err(config_deserialization_error)?;
+    config
+        .try_deserialize()
+        .map_err(config_deserialization_error)
 }
 
-fn expand_env_vars_in_yaml_value(
-    value: &mut Value,
-    quoted_placeholders: &HashMap<String, String>,
-) -> Result<(), ConfigError> {
+#[derive(Clone, Debug)]
+struct YamlValueSource {
+    root: config_rs::Map<String, config_rs::Value>,
+}
+
+impl config_rs::Source for YamlValueSource {
+    fn clone_into_box(&self) -> Box<dyn config_rs::Source + Send + Sync> {
+        Box::new(self.clone())
+    }
+
+    fn collect(&self) -> Result<config_rs::Map<String, config_rs::Value>, config_rs::ConfigError> {
+        Ok(self.root.clone())
+    }
+}
+
+fn config_deserialization_error(err: config_rs::ConfigError) -> ConfigError {
+    ConfigError::Validation(format!("config deserialization error: {err}"))
+}
+
+fn yaml_value_to_config_root(
+    value: Value,
+) -> Result<config_rs::Map<String, config_rs::Value>, ConfigError> {
+    match yaml_value_to_config_value(value)?.kind {
+        config_rs::ValueKind::Nil => Ok(config_rs::Map::new()),
+        config_rs::ValueKind::Table(map) => Ok(map),
+        _ => Err(ConfigError::Validation(
+            "config root must be a YAML mapping".into(),
+        )),
+    }
+}
+
+fn yaml_value_to_config_value(value: Value) -> Result<config_rs::Value, ConfigError> {
+    let kind = match value {
+        Value::Null => config_rs::ValueKind::Nil,
+        Value::Bool(value) => config_rs::ValueKind::Boolean(value),
+        Value::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                config_rs::ValueKind::I64(value)
+            } else if let Some(value) = value.as_u64() {
+                config_rs::ValueKind::U64(value)
+            } else if let Some(value) = value.as_f64() {
+                config_rs::ValueKind::Float(value)
+            } else {
+                return Err(ConfigError::Validation(
+                    "unsupported YAML numeric value in config".into(),
+                ));
+            }
+        }
+        Value::String(value) => config_rs::ValueKind::String(value),
+        Value::Sequence(values) => config_rs::ValueKind::Array(
+            values
+                .into_iter()
+                .map(yaml_value_to_config_value)
+                .collect::<Result<_, _>>()?,
+        ),
+        Value::Mapping(values) => {
+            let mut map = config_rs::Map::new();
+            for (key, value) in values {
+                let key = yaml_key_to_config_key(key)?;
+                let value = yaml_value_to_config_value(value)?;
+                if map.insert(key, value).is_some() {
+                    return Err(ConfigError::Validation(
+                        "environment variable expansion produced duplicate YAML mapping key".into(),
+                    ));
+                }
+            }
+            config_rs::ValueKind::Table(map)
+        }
+        Value::Tagged(tagged) => return yaml_value_to_config_value(tagged.value),
+    };
+
+    Ok(config_rs::Value::new(None, kind))
+}
+
+fn yaml_key_to_config_key(key: Value) -> Result<String, ConfigError> {
+    match key {
+        Value::Null => Ok("null".to_string()),
+        Value::Bool(value) => Ok(value.to_string()),
+        Value::Number(value) => Ok(value.to_string()),
+        Value::String(value) => Ok(value),
+        Value::Tagged(tagged) => yaml_key_to_config_key(tagged.value),
+        Value::Sequence(_) | Value::Mapping(_) => Err(ConfigError::Validation(
+            "YAML mapping keys must be scalar values".into(),
+        )),
+    }
+}
+
+fn expand_env_vars_in_yaml_value(value: &mut Value) -> Result<(), ConfigError> {
     match value {
         Value::String(text) => {
-            if let Some(original) = quoted_placeholders.get(text.as_str()) {
-                *text = expand_env_vars(original)?;
-                return Ok(());
-            }
-
-            let original = text.clone();
-            let expanded = expand_env_vars(&original)?;
-            if is_exact_env_placeholder(&original) {
-                *value = coerce_expanded_yaml_scalar(&expanded);
-            } else {
-                *text = expanded;
-            }
+            *text = expand_env_vars(text)?;
         }
         Value::Sequence(items) => {
             for item in items {
-                expand_env_vars_in_yaml_value(item, quoted_placeholders)?;
+                expand_env_vars_in_yaml_value(item)?;
             }
         }
         Value::Mapping(map) => {
             let old = std::mem::take(map);
             for (mut key, mut val) in old {
-                expand_env_vars_in_yaml_value(&mut key, quoted_placeholders)?;
-                expand_env_vars_in_yaml_value(&mut val, quoted_placeholders)?;
+                expand_env_vars_in_yaml_value(&mut key)?;
+                expand_env_vars_in_yaml_value(&mut val)?;
                 if map.insert(key, val).is_some() {
                     return Err(ConfigError::Validation(
                         "environment variable expansion produced duplicate YAML mapping key".into(),
@@ -200,375 +261,18 @@ fn expand_env_vars_in_yaml_value(
         Value::Tagged(tagged) => {
             if tagged.tag == "str" || tagged.tag == "tag:yaml.org,2002:str" {
                 // An explicit string tag (!!str or !str) means the user
-                // wants a string value — expand env vars but skip coercion,
-                // then unwrap the tag so serde sees a plain string.
+                // wants a string value. Env substitution already produces
+                // string data, so unwrap the tag after expansion.
                 if let Value::String(text) = &mut tagged.value {
                     let expanded = expand_env_vars(text)?;
                     *value = Value::String(expanded);
                     return Ok(());
                 }
             }
-            expand_env_vars_in_yaml_value(&mut tagged.value, quoted_placeholders)?;
+            expand_env_vars_in_yaml_value(&mut tagged.value)?;
         }
         _ => {}
     }
 
     Ok(())
-}
-
-fn is_exact_env_placeholder(text: &str) -> bool {
-    let Some(name) = text
-        .strip_prefix("${")
-        .and_then(|rest| rest.strip_suffix('}'))
-    else {
-        return false;
-    };
-    !name.is_empty() && !name.contains("${") && !name.contains('}')
-}
-
-fn coerce_expanded_yaml_scalar(text: &str) -> Value {
-    match serde_yaml_ng::from_str::<Value>(text) {
-        Ok(value @ (Value::Null | Value::Bool(_) | Value::Number(_))) => value,
-        _ => Value::String(text.to_owned()),
-    }
-}
-
-fn mark_quoted_exact_env_placeholders(yaml: &str) -> (String, HashMap<String, String>) {
-    let mut marked = String::with_capacity(yaml.len());
-    let mut placeholders = HashMap::new();
-    let mut cursor = 0usize;
-    let mut chars = yaml.char_indices().peekable();
-
-    while let Some((start, ch)) = chars.next() {
-        let quote @ ('\'' | '"') = ch else {
-            continue;
-        };
-        if !is_yaml_quoted_scalar_start(yaml, start) {
-            continue;
-        }
-
-        let Some((end, text)) = scan_yaml_quoted_scalar(yaml, start, quote) else {
-            continue;
-        };
-        while chars.peek().is_some_and(|(idx, _)| *idx < end) {
-            chars.next();
-        }
-
-        marked.push_str(&yaml[cursor..start]);
-        if is_exact_env_placeholder(&text) {
-            // The marker must not collide with user strings. We embed a
-            // process-unique seed so that no static literal can match.
-            let marker = format!(
-                "__LOGFWD_QEP_{seed}_{n}__",
-                seed = *PLACEHOLDER_SEED,
-                n = placeholders.len(),
-            );
-            marked.push(quote);
-            marked.push_str(&marker);
-            marked.push(quote);
-            placeholders.insert(marker, text);
-        } else {
-            marked.push_str(&yaml[start..end]);
-        }
-        cursor = end;
-    }
-    marked.push_str(&yaml[cursor..]);
-
-    (marked, placeholders)
-}
-
-fn is_yaml_quoted_scalar_start(yaml: &str, quote_start: usize) -> bool {
-    let line_start = yaml[..quote_start]
-        .rfind('\n')
-        .map_or(0, |idx| idx.saturating_add(1));
-
-    // Reject quotes that appear inside a YAML block scalar (| or >).
-    // Block scalar content lines are indented beyond the indicator line.
-    // Walk backwards from the current line to find the nearest non-blank,
-    // non-comment line with lower indentation that might introduce a block
-    // scalar.
-    if is_inside_block_scalar(yaml, line_start) {
-        return false;
-    }
-
-    let mut before_quote = yaml[line_start..quote_start].trim_end();
-    loop {
-        if before_quote
-            .chars()
-            .rev()
-            .find(|ch| !ch.is_whitespace())
-            .is_none_or(|ch| matches!(ch, ':' | '-' | ',' | '[' | '{' | '?'))
-        {
-            return true;
-        }
-
-        let Some((token_start, token)) = trailing_yaml_token(before_quote) else {
-            return false;
-        };
-        if !is_yaml_tag_or_anchor_token(token) {
-            return false;
-        }
-        before_quote = before_quote[..token_start].trim_end();
-    }
-}
-
-/// Returns `true` when `line_start` falls inside a YAML block scalar.
-///
-/// A block scalar is introduced by `|` or `>` (optionally followed by
-/// chomping/indentation indicators) as the last significant token on a line.
-/// Every subsequent line whose indentation is strictly greater than the
-/// indicator line is part of the scalar body.
-fn is_inside_block_scalar(yaml: &str, line_start: usize) -> bool {
-    let current_indent = line_indent(yaml, line_start);
-
-    // Walk backwards through preceding lines.
-    let mut search_end = line_start.saturating_sub(1);
-    while search_end > 0 {
-        let prev_line_start = yaml[..search_end].rfind('\n').map_or(0, |idx| idx + 1);
-        let prev_line = &yaml[prev_line_start..search_end];
-        let prev_indent = count_leading_spaces(prev_line);
-
-        // Skip blank lines (they can appear inside block scalars).
-        if prev_line.trim().is_empty() {
-            search_end = prev_line_start.saturating_sub(1);
-            if prev_line_start == 0 {
-                break;
-            }
-            continue;
-        }
-
-        // If this line has lower indentation, it could be the block indicator.
-        if prev_indent < current_indent {
-            let trimmed = strip_yaml_inline_comment(prev_line).trim_end();
-            // Check for block scalar indicator at end of line: `|`, `>`,
-            // or with chomping/indentation indicators like `|+`, `|-`, `|2`.
-            if let Some(last_segment) = trimmed.split_whitespace().last()
-                && is_block_scalar_indicator(last_segment)
-            {
-                return block_scalar_body_reaches_line(
-                    yaml,
-                    search_end + 1,
-                    line_start,
-                    prev_indent,
-                );
-            }
-            // Also check if the whole trimmed line ends with the indicator
-            // (handles `key: |` where the last space-separated token is `|`).
-            if is_block_scalar_indicator(trimmed) {
-                return block_scalar_body_reaches_line(
-                    yaml,
-                    search_end + 1,
-                    line_start,
-                    prev_indent,
-                );
-            }
-            // Mixed-indentation block bodies can include lines with lower
-            // indentation than the current line. Keep scanning upward; if we
-            // later find an indicator, validate that every intervening
-            // non-blank line remains indented beyond that indicator.
-        }
-
-        // Same or higher indentation: this line is a peer or content line,
-        // keep searching upward.
-        search_end = prev_line_start.saturating_sub(1);
-        if prev_line_start == 0 {
-            break;
-        }
-    }
-
-    false
-}
-
-fn block_scalar_body_reaches_line(
-    yaml: &str,
-    body_start: usize,
-    line_start: usize,
-    indicator_indent: usize,
-) -> bool {
-    let mut cursor = body_start;
-    while cursor < line_start {
-        let line_end = yaml[cursor..line_start]
-            .find('\n')
-            .map_or(line_start, |idx| cursor + idx);
-        let line = &yaml[cursor..line_end];
-        if !line.trim().is_empty() && count_leading_spaces(line) <= indicator_indent {
-            return false;
-        }
-        cursor = line_end.saturating_add(1);
-    }
-    true
-}
-
-fn strip_yaml_inline_comment(line: &str) -> &str {
-    for (idx, ch) in line.char_indices() {
-        if ch == '#'
-            && (idx == 0
-                || line[..idx]
-                    .chars()
-                    .next_back()
-                    .is_some_and(char::is_whitespace))
-        {
-            return &line[..idx];
-        }
-    }
-    line
-}
-
-fn is_block_scalar_indicator(s: &str) -> bool {
-    let s = s.trim_end();
-    let Some(rest) = s.strip_prefix(['|', '>']) else {
-        return false;
-    };
-
-    let mut has_indent = false;
-    let mut has_chomp = false;
-    for ch in rest.chars() {
-        match ch {
-            '0'..='9' if !has_indent => has_indent = true,
-            '+' | '-' if !has_chomp => has_chomp = true,
-            _ => return false,
-        }
-    }
-
-    true
-}
-
-fn trailing_yaml_token(s: &str) -> Option<(usize, &str)> {
-    let trimmed = s.trim_end();
-    if trimmed.is_empty() {
-        return None;
-    }
-    let token_start = trimmed
-        .char_indices()
-        .rev()
-        .find_map(|(idx, ch)| ch.is_whitespace().then_some(idx + ch.len_utf8()))
-        .unwrap_or(0);
-    Some((token_start, &trimmed[token_start..]))
-}
-
-fn is_yaml_tag_or_anchor_token(token: &str) -> bool {
-    token.starts_with('!') || (token.starts_with('&') && token.len() > 1)
-}
-
-fn line_indent(yaml: &str, line_start: usize) -> usize {
-    count_leading_spaces(&yaml[line_start..])
-}
-
-fn count_leading_spaces(s: &str) -> usize {
-    s.chars().take_while(|ch| *ch == ' ').count()
-}
-
-fn scan_yaml_quoted_scalar(yaml: &str, quote_start: usize, quote: char) -> Option<(usize, String)> {
-    let mut text = String::new();
-    let body_start = quote_start + quote.len_utf8();
-    let mut chars = yaml[body_start..].char_indices().peekable();
-
-    while let Some((rel_idx, ch)) = chars.next() {
-        let idx = body_start + rel_idx;
-        if quote == '\'' && ch == '\'' {
-            if chars.peek().is_some_and(|(_, next)| *next == '\'') {
-                chars.next();
-                text.push('\'');
-                continue;
-            }
-            return Some((idx + ch.len_utf8(), text));
-        }
-        if quote == '"' && ch == '"' {
-            return Some((idx + ch.len_utf8(), text));
-        }
-        if quote == '"' && ch == '\\' {
-            if let Some((_, escaped)) = chars.next() {
-                text.push('\\');
-                text.push(escaped);
-            }
-            continue;
-        }
-        text.push(ch);
-    }
-
-    None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::mark_quoted_exact_env_placeholders;
-
-    #[test]
-    fn quoted_exact_env_placeholder_is_marked() {
-        let (marked, placeholders) =
-            mark_quoted_exact_env_placeholders(r#"path: "${LOGFWD_TEST_PATH}""#);
-
-        assert_eq!(placeholders.len(), 1);
-        let (marker, original) = placeholders.iter().next().unwrap();
-        assert_eq!(original, "${LOGFWD_TEST_PATH}");
-        // The marker is embedded in double quotes in the YAML.
-        let expected = format!(r#"path: "{marker}""#);
-        assert_eq!(marked, expected);
-    }
-
-    #[test]
-    fn escaped_double_quoted_env_placeholder_is_not_marked() {
-        let yaml = r#"path: "\${LOGFWD_TEST_PATH}""#;
-
-        let (marked, placeholders) = mark_quoted_exact_env_placeholders(yaml);
-
-        assert_eq!(marked, yaml);
-        assert!(placeholders.is_empty());
-    }
-
-    #[test]
-    fn tagged_quoted_env_placeholder_is_marked() {
-        let (marked, placeholders) =
-            mark_quoted_exact_env_placeholders(r#"path: !!str "${LOGFWD_TEST_PATH}""#);
-
-        assert_eq!(placeholders.len(), 1);
-        let (marker, original) = placeholders.iter().next().unwrap();
-        assert_eq!(original, "${LOGFWD_TEST_PATH}");
-        let expected = format!(r#"path: !!str "{marker}""#);
-        assert_eq!(marked, expected);
-    }
-
-    #[test]
-    fn non_specific_tagged_quoted_env_placeholder_is_marked() {
-        let (marked, placeholders) =
-            mark_quoted_exact_env_placeholders(r#"path: ! "${LOGFWD_TEST_PATH}""#);
-
-        assert_eq!(placeholders.len(), 1);
-        let (marker, original) = placeholders.iter().next().unwrap();
-        assert_eq!(original, "${LOGFWD_TEST_PATH}");
-        let expected = format!(r#"path: ! "{marker}""#);
-        assert_eq!(marked, expected);
-    }
-
-    #[test]
-    fn anchored_quoted_env_placeholder_is_marked() {
-        let (marked, placeholders) =
-            mark_quoted_exact_env_placeholders(r#"path: &p "${LOGFWD_TEST_PATH}""#);
-
-        assert_eq!(placeholders.len(), 1);
-        let (marker, original) = placeholders.iter().next().unwrap();
-        assert_eq!(original, "${LOGFWD_TEST_PATH}");
-        let expected = format!(r#"path: &p "{marker}""#);
-        assert_eq!(marked, expected);
-    }
-
-    #[test]
-    fn digit_first_block_scalar_indicator_hides_content_quotes() {
-        let yaml = "note: |2+\n  \"${LOGFWD_TEST_PATH}\"\n";
-        let quote_start = yaml
-            .find('"')
-            .expect("fixture should contain a quoted block line");
-
-        assert!(!super::is_yaml_quoted_scalar_start(yaml, quote_start));
-    }
-
-    #[test]
-    fn commented_block_scalar_indicator_hides_content_quotes() {
-        let yaml = "note: | # keep this readable\n  \"${LOGFWD_TEST_PATH}\"\n";
-        let quote_start = yaml
-            .find('"')
-            .expect("fixture should contain a quoted block line");
-
-        assert!(!super::is_yaml_quoted_scalar_start(yaml, quote_start));
-    }
 }

--- a/crates/logfwd-config/src/serde_helpers.rs
+++ b/crates/logfwd-config/src/serde_helpers.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
+use serde::de::{Error as DeError, Unexpected};
 use std::fmt;
-use std::str::FromStr;
+use std::marker::PhantomData;
+use std::{collections::HashMap, hash::Hash};
 
 pub(crate) fn deserialize_one_or_many<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
 where
@@ -24,43 +26,387 @@ pub(crate) fn deserialize_option_from_string_or_value<'de, T, D>(
     deserializer: D,
 ) -> Result<Option<T>, D::Error>
 where
-    T: Deserialize<'de> + FromStr,
-    T::Err: fmt::Display,
+    T: StrictScalar,
     D: serde::Deserializer<'de>,
 {
-    Option::<StringOrValue<T>>::deserialize(deserializer)?
-        .map(StringOrValue::into_value)
-        .transpose()
+    Ok(Option::<StrictScalarValue<T>>::deserialize(deserializer)?
+        .map(StrictScalarValue::into_inner))
 }
 
 pub(crate) fn deserialize_from_string_or_value<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
-    T: Deserialize<'de> + FromStr,
-    T::Err: fmt::Display,
+    T: StrictScalar,
     D: serde::Deserializer<'de>,
 {
-    StringOrValue::<T>::deserialize(deserializer)?.into_value()
+    Ok(StrictScalarValue::<T>::deserialize(deserializer)?.into_inner())
 }
 
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum StringOrValue<T> {
-    Value(T),
-    String(String),
-}
-
-impl<T> StringOrValue<T>
+pub(crate) fn deserialize_strict_string<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
-    T: FromStr,
-    T::Err: fmt::Display,
+    D: serde::Deserializer<'de>,
 {
-    fn into_value<E>(self) -> Result<T, E>
+    StrictString::deserialize(deserializer).map(StrictString::into_inner)
+}
+
+pub(crate) fn deserialize_option_strict_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<StrictString>::deserialize(deserializer)?.map(StrictString::into_inner))
+}
+
+pub(crate) fn deserialize_vec_strict_string<'de, D>(
+    deserializer: D,
+) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Vec::<StrictString>::deserialize(deserializer).map(strict_strings_into_inner)
+}
+
+pub(crate) fn deserialize_option_vec_strict_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<Vec<StrictString>>::deserialize(deserializer)?.map(strict_strings_into_inner))
+}
+
+pub(crate) fn deserialize_string_map_strict_values<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_map_strict_values(deserializer)
+}
+
+pub(crate) fn deserialize_option_string_map_strict_values<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(
+        Option::<HashMap<String, StrictString>>::deserialize(deserializer)?
+            .map(strict_string_map_into_inner),
+    )
+}
+
+fn deserialize_map_strict_values<'de, K, D>(deserializer: D) -> Result<HashMap<K, String>, D::Error>
+where
+    K: Deserialize<'de> + Eq + Hash,
+    D: serde::Deserializer<'de>,
+{
+    HashMap::<K, StrictString>::deserialize(deserializer).map(strict_string_map_into_inner)
+}
+
+fn strict_strings_into_inner(values: Vec<StrictString>) -> Vec<String> {
+    values.into_iter().map(StrictString::into_inner).collect()
+}
+
+fn strict_string_map_into_inner<K>(values: HashMap<K, StrictString>) -> HashMap<K, String>
+where
+    K: Eq + Hash,
+{
+    values
+        .into_iter()
+        .map(|(key, value)| (key, value.into_inner()))
+        .collect()
+}
+
+struct StrictScalarValue<T>(T);
+
+impl<T> StrictScalarValue<T> {
+    fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<'de, T> Deserialize<'de> for StrictScalarValue<T>
+where
+    T: StrictScalar,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        E: serde::de::Error,
+        D: serde::Deserializer<'de>,
     {
-        match self {
-            Self::Value(value) => Ok(value),
-            Self::String(value) => value.parse().map_err(E::custom),
+        struct StrictScalarVisitor<T> {
+            marker: PhantomData<T>,
         }
+
+        impl<T> serde::de::Visitor<'_> for StrictScalarVisitor<T>
+        where
+            T: StrictScalar,
+        {
+            type Value = StrictScalarValue<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                T::expecting(formatter)
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                T::from_bool(value).map(StrictScalarValue)
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                T::from_i64(value).map(StrictScalarValue)
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                T::from_u64(value).map(StrictScalarValue)
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                T::from_f64(value).map(StrictScalarValue)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                T::from_string(value).map(StrictScalarValue)
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                self.visit_str(&value)
+            }
+        }
+
+        deserializer.deserialize_any(StrictScalarVisitor {
+            marker: PhantomData,
+        })
+    }
+}
+
+// The `config` crate intentionally coerces between scalar kinds. These visitors
+// keep raw YAML strict while still letting env-expanded strings parse as typed
+// numeric and boolean fields.
+pub(crate) trait StrictScalar: Sized {
+    fn expecting(formatter: &mut fmt::Formatter<'_>) -> fmt::Result;
+
+    fn from_string<E>(value: &str) -> Result<Self, E>
+    where
+        E: DeError;
+
+    fn from_bool<E>(value: bool) -> Result<Self, E>
+    where
+        E: DeError,
+    {
+        Err(E::invalid_type(
+            Unexpected::Bool(value),
+            &StrictScalarExpected::<Self>::new(),
+        ))
+    }
+
+    fn from_i64<E>(value: i64) -> Result<Self, E>
+    where
+        E: DeError,
+    {
+        Err(E::invalid_type(
+            Unexpected::Signed(value),
+            &StrictScalarExpected::<Self>::new(),
+        ))
+    }
+
+    fn from_u64<E>(value: u64) -> Result<Self, E>
+    where
+        E: DeError,
+    {
+        Err(E::invalid_type(
+            Unexpected::Unsigned(value),
+            &StrictScalarExpected::<Self>::new(),
+        ))
+    }
+
+    fn from_f64<E>(value: f64) -> Result<Self, E>
+    where
+        E: DeError,
+    {
+        Err(E::invalid_type(
+            Unexpected::Float(value),
+            &StrictScalarExpected::<Self>::new(),
+        ))
+    }
+}
+
+struct StrictScalarExpected<T> {
+    marker: PhantomData<T>,
+}
+
+impl<T> StrictScalarExpected<T> {
+    fn new() -> Self {
+        Self {
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T> serde::de::Expected for StrictScalarExpected<T>
+where
+    T: StrictScalar,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        T::expecting(formatter)
+    }
+}
+
+impl StrictScalar for bool {
+    fn expecting(formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a boolean")
+    }
+
+    fn from_string<E>(value: &str) -> Result<Self, E>
+    where
+        E: DeError,
+    {
+        match value.to_ascii_lowercase().as_str() {
+            "1" | "true" | "on" | "yes" => Ok(true),
+            "0" | "false" | "off" | "no" => Ok(false),
+            _ => value.parse().map_err(E::custom),
+        }
+    }
+
+    fn from_bool<E>(value: bool) -> Result<Self, E>
+    where
+        E: DeError,
+    {
+        Ok(value)
+    }
+}
+
+macro_rules! impl_strict_unsigned {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl StrictScalar for $ty {
+                fn expecting(formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("an unsigned integer")
+                }
+
+                fn from_string<E>(value: &str) -> Result<Self, E>
+                where
+                    E: DeError,
+                {
+                    value.parse().map_err(E::custom)
+                }
+
+                fn from_i64<E>(value: i64) -> Result<Self, E>
+                where
+                    E: DeError,
+                {
+                    value.try_into().map_err(|_| {
+                        E::invalid_value(Unexpected::Signed(value), &StrictScalarExpected::<Self>::new())
+                    })
+                }
+
+                fn from_u64<E>(value: u64) -> Result<Self, E>
+                where
+                    E: DeError,
+                {
+                    value.try_into().map_err(|_| {
+                        E::invalid_value(Unexpected::Unsigned(value), &StrictScalarExpected::<Self>::new())
+                    })
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! impl_strict_signed {
+    ($($ty:ty),* $(,)?) => {
+        $(
+            impl StrictScalar for $ty {
+                fn expecting(formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("a signed integer")
+                }
+
+                fn from_string<E>(value: &str) -> Result<Self, E>
+                where
+                    E: DeError,
+                {
+                    value.parse().map_err(E::custom)
+                }
+
+                fn from_i64<E>(value: i64) -> Result<Self, E>
+                where
+                    E: DeError,
+                {
+                    value.try_into().map_err(|_| {
+                        E::invalid_value(Unexpected::Signed(value), &StrictScalarExpected::<Self>::new())
+                    })
+                }
+
+                fn from_u64<E>(value: u64) -> Result<Self, E>
+                where
+                    E: DeError,
+                {
+                    value.try_into().map_err(|_| {
+                        E::invalid_value(Unexpected::Unsigned(value), &StrictScalarExpected::<Self>::new())
+                    })
+                }
+            }
+        )*
+    };
+}
+
+impl_strict_unsigned!(u8, u16, u32, u64, usize);
+impl_strict_signed!(i32, i64);
+
+struct StrictString(String);
+
+impl StrictString {
+    fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for StrictString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct StrictStringVisitor;
+
+        impl serde::de::Visitor<'_> for StrictStringVisitor {
+            type Value = StrictString;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(StrictString(value.to_owned()))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(StrictString(value))
+            }
+        }
+
+        deserializer.deserialize_any(StrictStringVisitor)
     }
 }

--- a/crates/logfwd-config/src/serde_helpers.rs
+++ b/crates/logfwd-config/src/serde_helpers.rs
@@ -22,6 +22,10 @@ where
     }
 }
 
+/// Deserializes an optional numeric or boolean field from a strict YAML scalar.
+///
+/// Native YAML scalars must have the target kind, while string values are parsed
+/// through `T` so env-expanded values like `${PORT}` can populate typed fields.
 pub(crate) fn deserialize_option_from_string_or_value<'de, T, D>(
     deserializer: D,
 ) -> Result<Option<T>, D::Error>
@@ -33,6 +37,10 @@ where
         .map(StrictScalarValue::into_inner))
 }
 
+/// Deserializes a numeric or boolean field from a strict YAML scalar.
+///
+/// Native YAML scalars must have the target kind, while string values are parsed
+/// through `T` so env-expanded values like `${ENABLED}` can populate typed fields.
 pub(crate) fn deserialize_from_string_or_value<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: StrictScalar,
@@ -41,6 +49,7 @@ where
     Ok(StrictScalarValue::<T>::deserialize(deserializer)?.into_inner())
 }
 
+/// Deserializes a string field without accepting non-string YAML scalars.
 pub(crate) fn deserialize_strict_string<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -48,6 +57,7 @@ where
     StrictString::deserialize(deserializer).map(StrictString::into_inner)
 }
 
+/// Deserializes an optional string field without accepting non-string YAML scalars.
 pub(crate) fn deserialize_option_strict_string<'de, D>(
     deserializer: D,
 ) -> Result<Option<String>, D::Error>
@@ -57,6 +67,7 @@ where
     Ok(Option::<StrictString>::deserialize(deserializer)?.map(StrictString::into_inner))
 }
 
+/// Deserializes a string list without accepting non-string YAML scalars.
 pub(crate) fn deserialize_vec_strict_string<'de, D>(
     deserializer: D,
 ) -> Result<Vec<String>, D::Error>
@@ -66,6 +77,7 @@ where
     Vec::<StrictString>::deserialize(deserializer).map(strict_strings_into_inner)
 }
 
+/// Deserializes an optional string list without accepting non-string YAML scalars.
 pub(crate) fn deserialize_option_vec_strict_string<'de, D>(
     deserializer: D,
 ) -> Result<Option<Vec<String>>, D::Error>
@@ -75,6 +87,7 @@ where
     Ok(Option::<Vec<StrictString>>::deserialize(deserializer)?.map(strict_strings_into_inner))
 }
 
+/// Deserializes a string map whose values must be YAML strings.
 pub(crate) fn deserialize_string_map_strict_values<'de, D>(
     deserializer: D,
 ) -> Result<HashMap<String, String>, D::Error>
@@ -84,6 +97,7 @@ where
     deserialize_map_strict_values(deserializer)
 }
 
+/// Deserializes an optional string map whose values must be YAML strings.
 pub(crate) fn deserialize_option_string_map_strict_values<'de, D>(
     deserializer: D,
 ) -> Result<Option<HashMap<String, String>>, D::Error>
@@ -197,9 +211,11 @@ where
     }
 }
 
-// The `config` crate intentionally coerces between scalar kinds. These visitors
-// keep raw YAML strict while still letting env-expanded strings parse as typed
-// numeric and boolean fields.
+/// Parses scalar config fields while preserving raw YAML type strictness.
+///
+/// The `config` crate intentionally coerces between scalar kinds. This trait
+/// lets visitors keep raw YAML strict while still allowing env-expanded strings
+/// to parse as typed numeric and boolean fields.
 pub(crate) trait StrictScalar: Sized {
     fn expecting(formatter: &mut fmt::Formatter<'_>) -> fmt::Result;
 

--- a/crates/logfwd-config/src/serde_helpers.rs
+++ b/crates/logfwd-config/src/serde_helpers.rs
@@ -1,4 +1,6 @@
 use serde::Deserialize;
+use std::fmt;
+use std::str::FromStr;
 
 pub(crate) fn deserialize_one_or_many<'de, T, D>(deserializer: D) -> Result<Vec<T>, D::Error>
 where
@@ -15,5 +17,50 @@ where
     match OneOrMany::deserialize(deserializer)? {
         OneOrMany::Many(v) => Ok(v),
         OneOrMany::One(v) => Ok(vec![v]),
+    }
+}
+
+pub(crate) fn deserialize_option_from_string_or_value<'de, T, D>(
+    deserializer: D,
+) -> Result<Option<T>, D::Error>
+where
+    T: Deserialize<'de> + FromStr,
+    T::Err: fmt::Display,
+    D: serde::Deserializer<'de>,
+{
+    Option::<StringOrValue<T>>::deserialize(deserializer)?
+        .map(StringOrValue::into_value)
+        .transpose()
+}
+
+pub(crate) fn deserialize_from_string_or_value<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Deserialize<'de> + FromStr,
+    T::Err: fmt::Display,
+    D: serde::Deserializer<'de>,
+{
+    StringOrValue::<T>::deserialize(deserializer)?.into_value()
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StringOrValue<T> {
+    Value(T),
+    String(String),
+}
+
+impl<T> StringOrValue<T>
+where
+    T: FromStr,
+    T::Err: fmt::Display,
+{
+    fn into_value<E>(self) -> Result<T, E>
+    where
+        E: serde::de::Error,
+    {
+        match self {
+            Self::Value(value) => Ok(value),
+            Self::String(value) => value.parse().map_err(E::custom),
+        }
     }
 }

--- a/crates/logfwd-config/src/shared.rs
+++ b/crates/logfwd-config/src/shared.rs
@@ -4,6 +4,10 @@
 //! the same structs and naming for cross-cutting concerns like TLS, retries,
 //! batching, compression, and network settings.
 
+use crate::serde_helpers::{
+    deserialize_from_string_or_value, deserialize_option_from_string_or_value,
+    deserialize_option_strict_string,
+};
 use serde::Deserialize;
 
 // ── TLS ────────────────────────────────────────────────────────────────
@@ -16,13 +20,16 @@ use serde::Deserialize;
 #[serde(deny_unknown_fields)]
 pub struct TlsClientConfig {
     /// Path to CA certificate file for server verification.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub ca_file: Option<String>,
     /// Path to client certificate file (mTLS).
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub cert_file: Option<String>,
     /// Path to client private key file (mTLS).
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub key_file: Option<String>,
     /// Skip server certificate verification. Default: false.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_from_string_or_value")]
     pub insecure_skip_verify: bool,
 }
 
@@ -34,13 +41,16 @@ pub struct TlsClientConfig {
 #[serde(deny_unknown_fields)]
 pub struct TlsServerConfig {
     /// Path to server certificate file.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub cert_file: Option<String>,
     /// Path to server private key file.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub key_file: Option<String>,
     /// Path to CA certificate file for client verification (mTLS).
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub client_ca_file: Option<String>,
     /// Require client certificate authentication. Default: false.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_from_string_or_value")]
     pub require_client_auth: bool,
 }
 
@@ -57,10 +67,13 @@ pub type TlsInputConfig = TlsServerConfig;
 #[serde(deny_unknown_fields)]
 pub struct RetryConfig {
     /// Max retry attempts. Use -1 for infinite. Default: 3.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_attempts: Option<i32>,
     /// Initial backoff delay in seconds. Default: 1.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub initial_backoff_secs: Option<u64>,
     /// Maximum backoff delay in seconds. Default: 60.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_backoff_secs: Option<u64>,
 }
 
@@ -74,10 +87,13 @@ pub struct RetryConfig {
 #[serde(deny_unknown_fields)]
 pub struct BatchConfig {
     /// Maximum events per batch.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_events: Option<usize>,
     /// Maximum bytes per batch.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_bytes: Option<usize>,
     /// Max time before flushing a partial batch, in seconds.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub timeout_secs: Option<u64>,
 }
 
@@ -105,11 +121,15 @@ pub enum Compression {
 #[serde(deny_unknown_fields)]
 pub struct NetworkConfig {
     /// Request or send timeout in seconds.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub timeout_secs: Option<u64>,
     /// Connection establishment timeout in seconds.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub connection_timeout_secs: Option<u64>,
     /// Maximum concurrent connections.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_connections: Option<usize>,
     /// Maximum incoming message or packet size in bytes.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_message_size_bytes: Option<usize>,
 }

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -1,7 +1,9 @@
 use crate::compat;
 use crate::serde_helpers::{
     deserialize_from_string_or_value, deserialize_one_or_many,
-    deserialize_option_from_string_or_value,
+    deserialize_option_from_string_or_value, deserialize_option_strict_string,
+    deserialize_option_string_map_strict_values, deserialize_option_vec_strict_string,
+    deserialize_strict_string, deserialize_string_map_strict_values, deserialize_vec_strict_string,
 };
 use crate::shared::{TlsClientConfig, TlsInputConfig};
 use serde::Deserialize;
@@ -15,8 +17,9 @@ pub(crate) const PIPELINE_WORKERS_MAX: usize = 1024;
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AuthConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub bearer_token: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_map_strict_values")]
     pub headers: HashMap<String, String>,
 }
 
@@ -226,7 +229,7 @@ pub enum GeneratorComplexityConfig {
 #[serde(untagged)]
 pub enum GeneratorAttributeValueConfig {
     Null,
-    String(String),
+    String(#[serde(deserialize_with = "deserialize_strict_string")] String),
     Integer(i64),
     Float(f64),
     Bool(bool),
@@ -236,6 +239,7 @@ pub enum GeneratorAttributeValueConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GeneratorSequenceConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub field: String,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub start: Option<u64>,
@@ -250,6 +254,7 @@ pub struct GeneratorSequenceConfig {
 pub struct GeneratorTimestampConfig {
     /// ISO8601 datetime (`YYYY-MM-DDTHH:MM:SSZ`) or `"now"`.
     /// Default: `"2024-01-15T00:00:00Z"`.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub start: Option<String>,
     /// Milliseconds between events. Negative = backward. Default: 1.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -271,6 +276,7 @@ pub enum HttpMethodConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct HttpInputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub path: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub strict_path: Option<bool>,
@@ -284,6 +290,7 @@ pub struct HttpInputConfig {
     pub response_code: Option<u16>,
     /// Optional static body returned on successful ingest.
     /// Must be omitted when `response_code` is `204`.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub response_body: Option<String>,
 }
 
@@ -294,7 +301,7 @@ pub struct GeneratorInputConfig {
     pub events_per_second: Option<u64>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub num_lines: Option<u64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub message_template: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub field_count: Option<usize>,
@@ -310,6 +317,7 @@ pub struct GeneratorInputConfig {
     #[serde(default)]
     pub attributes: HashMap<String, GeneratorAttributeValueConfig>,
     pub sequence: Option<GeneratorSequenceConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub event_created_unix_nano_field: Option<String>,
     /// Timestamp configuration for the `logs` profile.
     pub timestamp: Option<GeneratorTimestampConfig>,
@@ -328,6 +336,7 @@ pub struct HostMetricsInputConfig {
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub emit_heartbeat: Option<bool>,
     /// Optional path to a JSON control file for runtime sensor tuning.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub control_path: Option<String>,
     /// How often to check `control_path` for updates. Defaults to 1_000 when omitted.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -335,6 +344,7 @@ pub struct HostMetricsInputConfig {
     /// Optional explicit enabled families for this platform.
     ///
     /// `None` means "use platform defaults". `Some([])` means "disable all".
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub enabled_families: Option<Vec<String>>,
     /// Emit periodic per-family sample rows. Defaults to true.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -343,48 +353,49 @@ pub struct HostMetricsInputConfig {
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_rows_per_poll: Option<usize>,
     /// Path to the compiled eBPF kernel binary (required for `linux_ebpf_sensor`).
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub ebpf_binary_path: Option<String>,
     /// Maximum events to drain per poll cycle (default: 4096).
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_events_per_poll: Option<usize>,
     /// Glob patterns for process names to include (e.g., `["nginx*", "python"]`).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub include_process_names: Option<Vec<String>>,
     /// Glob patterns for process names to exclude.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub exclude_process_names: Option<Vec<String>>,
     /// Specific event types to enable (e.g., `["process_exec", "tcp_connect"]`).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub include_event_types: Option<Vec<String>>,
     /// Specific event types to disable.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub exclude_event_types: Option<Vec<String>>,
     /// Ring buffer size in kilobytes.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub ring_buffer_size_kb: Option<usize>,
     /// Optional list of scrapers to run (e.g. `["cpu", "memory", "disk", "network", "filesystem"]`).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub scrapers: Option<Vec<String>>,
     /// Cadence for metrics collection in milliseconds.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub collection_interval_ms: Option<u64>,
     /// List of disk devices to include.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub disk_include_devices: Option<Vec<String>>,
     /// List of disk devices to exclude.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub disk_exclude_devices: Option<Vec<String>>,
     /// List of network interfaces to include.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub network_include_interfaces: Option<Vec<String>>,
     /// List of network interfaces to exclude.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub network_exclude_interfaces: Option<Vec<String>>,
     /// List of filesystem mount points to include.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub filesystem_include_mount_points: Option<Vec<String>>,
     /// List of filesystem mount points to exclude.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub filesystem_exclude_mount_points: Option<Vec<String>>,
 }
 
@@ -394,19 +405,19 @@ pub struct HostMetricsInputConfig {
 pub struct JournaldInputConfig {
     /// Systemd units to include. If empty, all units are collected.
     /// Unit names without a `.` are suffixed with `.service` automatically.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vec_strict_string")]
     pub include_units: Vec<String>,
     /// Systemd units to exclude.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vec_strict_string")]
     pub exclude_units: Vec<String>,
     /// Syslog identifiers (`SYSLOG_IDENTIFIER=`) to include.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vec_strict_string")]
     pub identifiers: Vec<String>,
     /// Priority/log levels (e.g. `0`, `3`, `info`, `err`) to include.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_vec_strict_string")]
     pub priorities: Vec<String>,
     /// Path to persist the cursor. Allows resuming after restarts.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub cursor_path: Option<String>,
     /// Include `_BOOT_ID` field in output (default: false).
     #[serde(default, deserialize_with = "deserialize_from_string_or_value")]
@@ -422,10 +433,13 @@ pub struct JournaldInputConfig {
     #[serde(default, deserialize_with = "deserialize_from_string_or_value")]
     pub since_now: bool,
     /// Path to `journalctl` binary. Defaults to `journalctl` (found via PATH).
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub journalctl_path: Option<String>,
     /// Custom journal directory (passed as `--directory=<path>`).
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub journal_directory: Option<String>,
     /// Journal namespace (passed as `--namespace=<ns>`).
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub journal_namespace: Option<String>,
     /// Backend to use for reading the journal.
     ///
@@ -475,8 +489,10 @@ impl Default for JournaldInputConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct InputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub name: Option<String>,
     pub format: Option<Format>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub sql: Option<String>,
     #[serde(flatten)]
     pub type_config: InputTypeConfig,
@@ -548,6 +564,7 @@ impl InputTypeConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FileTypeConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub path: String,
     /// File input poll cadence in milliseconds (default: 50, minimum: 1).
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -571,6 +588,7 @@ pub struct FileTypeConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct UdpTypeConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub listen: String,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_message_size_bytes: Option<usize>,
@@ -581,6 +599,7 @@ pub struct UdpTypeConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TcpTypeConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub listen: String,
     #[serde(default)]
     pub tls: Option<TlsInputConfig>,
@@ -595,9 +614,11 @@ pub struct TcpTypeConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OtlpTypeConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub listen: String,
     /// Prefix applied to OTLP resource attributes when flattening into columns.
     /// Defaults to `resource.attributes.` when omitted.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub resource_prefix: Option<String>,
     /// Experimental OTLP protobuf decode strategy. Defaults to `prost`.
     pub protobuf_decode_mode: Option<OtlpProtobufDecodeModeConfig>,
@@ -614,6 +635,7 @@ pub struct OtlpTypeConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct HttpTypeConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub listen: String,
     #[serde(default)]
     pub http: Option<HttpInputConfig>,
@@ -636,6 +658,7 @@ pub struct SensorTypeConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ArrowIpcTypeConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub listen: String,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_connections: Option<usize>,
@@ -663,23 +686,32 @@ pub struct S3TypeConfig {
 #[serde(deny_unknown_fields)]
 pub struct S3InputConfig {
     /// S3 bucket name.
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub bucket: String,
     /// AWS region (e.g. `"us-east-1"`). Defaults to `"us-east-1"`.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub region: Option<String>,
     /// Override S3 endpoint URL (e.g. `"http://localhost:9000"` for MinIO).
     /// When set, path-style addressing is used automatically.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub endpoint: Option<String>,
     /// Only process keys with this prefix.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub prefix: Option<String>,
     /// SQS queue URL for event-driven object discovery.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub sqs_queue_url: Option<String>,
     /// `ListObjectsV2` `StartAfter` key for resumable prefix scanning.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub start_after: Option<String>,
     /// AWS access key ID. Falls back to `AWS_ACCESS_KEY_ID` env var.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub access_key_id: Option<String>,
     /// AWS secret access key. Falls back to `AWS_SECRET_ACCESS_KEY` env var.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub secret_access_key: Option<String>,
     /// AWS session token for temporary credentials. Falls back to `AWS_SESSION_TOKEN` env var.
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub session_token: Option<String>,
     /// Range-GET part size in bytes. Default: 8 MiB.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -696,6 +728,7 @@ pub struct S3InputConfig {
     /// Compression override: `"auto"`, `"gzip"` (or `"gz"`), `"zstd"` (or
     /// `"zst"`), `"snappy"` (or `"sz"`), `"none"` (or `"identity"`).
     /// Default: `"auto"` (detect from key extension or Content-Encoding).
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub compression: Option<String>,
     /// Polling interval for `ListObjectsV2` mode in milliseconds. Default: 5000.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -705,27 +738,43 @@ pub struct S3InputConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct OutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub name: Option<String>,
     #[serde(rename = "type")]
     pub output_type: OutputType,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub endpoint: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub protocol: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub compression: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub request_mode: Option<String>,
     pub format: Option<Format>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub path: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub index: Option<String>,
     #[serde(default)]
     pub auth: Option<AuthConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub tenant_id: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_string_map_strict_values"
+    )]
     pub static_labels: Option<HashMap<String, String>>,
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
     pub label_columns: Option<Vec<String>>,
 
     /// Client TLS configuration for outbound connections.
     #[serde(default)]
     pub tls: Option<TlsClientConfig>,
     /// Custom HTTP headers to include in requests.
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_string_map_strict_values"
+    )]
     pub headers: Option<HashMap<String, String>>,
     /// Number of retry attempts for transient errors.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -746,7 +795,7 @@ pub struct OutputConfig {
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub batch_timeout_ms: Option<u64>,
     /// Host for socket-based IPC.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub host: Option<String>,
     /// Port for socket-based IPC.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -778,6 +827,7 @@ pub enum GeoDatabaseFormat {
 #[serde(deny_unknown_fields)]
 pub struct GeoDatabaseConfig {
     pub format: GeoDatabaseFormat,
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub path: String,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub refresh_interval: Option<u64>,
@@ -786,7 +836,9 @@ pub struct GeoDatabaseConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StaticEnrichmentConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub table_name: String,
+    #[serde(deserialize_with = "deserialize_string_map_strict_values")]
     pub labels: HashMap<String, String>,
 }
 
@@ -797,7 +849,10 @@ pub struct HostInfoConfig {}
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct K8sPathConfig {
-    #[serde(default = "default_k8s_table_name")]
+    #[serde(
+        default = "default_k8s_table_name",
+        deserialize_with = "deserialize_strict_string"
+    )]
     pub table_name: String,
 }
 
@@ -808,7 +863,9 @@ fn default_k8s_table_name() -> String {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CsvEnrichmentConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub table_name: String,
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub path: String,
     /// Reload the file from disk every N seconds. If absent the file is read
     /// once at startup and never reloaded.
@@ -819,7 +876,9 @@ pub struct CsvEnrichmentConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct JsonlEnrichmentConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub table_name: String,
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub path: String,
     /// Reload the file from disk every N seconds. If absent the file is read
     /// once at startup and never reloaded.
@@ -840,8 +899,10 @@ pub struct JsonlEnrichmentConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnvVarsEnrichmentConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub table_name: String,
     /// Environment variable name prefix to filter on (e.g. `"LOGFWD_META_"`).
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub prefix: String,
 }
 
@@ -857,7 +918,9 @@ pub struct ProcessInfoConfig {}
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct KvFileEnrichmentConfig {
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub table_name: String,
+    #[serde(deserialize_with = "deserialize_strict_string")]
     pub path: String,
     /// Reload the file from disk every N seconds (must be >= 1).
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
@@ -907,12 +970,13 @@ pub enum EnrichmentConfig {
 pub struct PipelineConfig {
     #[serde(default, deserialize_with = "deserialize_one_or_many")]
     pub inputs: Vec<InputConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub transform: Option<String>,
     #[serde(default, deserialize_with = "deserialize_one_or_many")]
     pub outputs: Vec<OutputConfig>,
     #[serde(default)]
     pub enrichment: Vec<EnrichmentConfig>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_map_strict_values")]
     pub resource_attrs: HashMap<String, String>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub workers: Option<usize>,
@@ -927,17 +991,22 @@ pub struct PipelineConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct ServerConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub diagnostics: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub log_level: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub metrics_endpoint: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub metrics_interval_secs: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub traces_endpoint: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct StorageConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub data_dir: Option<String>,
 }
 

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -1,5 +1,8 @@
 use crate::compat;
-use crate::serde_helpers::deserialize_one_or_many;
+use crate::serde_helpers::{
+    deserialize_from_string_or_value, deserialize_one_or_many,
+    deserialize_option_from_string_or_value,
+};
 use crate::shared::{TlsClientConfig, TlsInputConfig};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -234,6 +237,7 @@ pub enum GeneratorAttributeValueConfig {
 #[serde(deny_unknown_fields)]
 pub struct GeneratorSequenceConfig {
     pub field: String,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub start: Option<u64>,
 }
 
@@ -248,6 +252,7 @@ pub struct GeneratorTimestampConfig {
     /// Default: `"2024-01-15T00:00:00Z"`.
     pub start: Option<String>,
     /// Milliseconds between events. Negative = backward. Default: 1.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub step_ms: Option<i64>,
 }
 
@@ -267,11 +272,15 @@ pub enum HttpMethodConfig {
 #[serde(deny_unknown_fields)]
 pub struct HttpInputConfig {
     pub path: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub strict_path: Option<bool>,
     pub method: Option<HttpMethodConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_request_body_size: Option<usize>,
     /// Max bytes to drain per poll call. Default matches OTLP receiver (1GB).
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_drained_bytes_per_poll: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub response_code: Option<u16>,
     /// Optional static body returned on successful ingest.
     /// Must be omitted when `response_code` is `204`.
@@ -281,17 +290,20 @@ pub struct HttpInputConfig {
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct GeneratorInputConfig {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub events_per_second: Option<u64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub num_lines: Option<u64>,
     #[serde(default)]
     pub message_template: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub field_count: Option<usize>,
 
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub events_per_sec: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub batch_size: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub total_events: Option<u64>,
     pub complexity: Option<GeneratorComplexityConfig>,
     pub profile: Option<GeneratorProfileConfig>,
@@ -308,26 +320,32 @@ pub struct GeneratorInputConfig {
 #[serde(deny_unknown_fields)]
 pub struct HostMetricsInputConfig {
     /// Sensor sample cadence. Defaults to 10_000 when omitted.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub poll_interval_ms: Option<u64>,
     /// Deprecated no-op retained for backward compatibility.
     ///
     /// Sensor inputs are Arrow-native and do not emit heartbeat rows.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub emit_heartbeat: Option<bool>,
     /// Optional path to a JSON control file for runtime sensor tuning.
     pub control_path: Option<String>,
     /// How often to check `control_path` for updates. Defaults to 1_000 when omitted.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub control_reload_interval_ms: Option<u64>,
     /// Optional explicit enabled families for this platform.
     ///
     /// `None` means "use platform defaults". `Some([])` means "disable all".
     pub enabled_families: Option<Vec<String>>,
     /// Emit periodic per-family sample rows. Defaults to true.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub emit_signal_rows: Option<bool>,
     /// Upper bound on data rows emitted per collection cycle. Defaults to 256.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_rows_per_poll: Option<usize>,
     /// Path to the compiled eBPF kernel binary (required for `linux_ebpf_sensor`).
     pub ebpf_binary_path: Option<String>,
     /// Maximum events to drain per poll cycle (default: 4096).
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_events_per_poll: Option<usize>,
     /// Glob patterns for process names to include (e.g., `["nginx*", "python"]`).
     #[serde(default)]
@@ -342,13 +360,13 @@ pub struct HostMetricsInputConfig {
     #[serde(default)]
     pub exclude_event_types: Option<Vec<String>>,
     /// Ring buffer size in kilobytes.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub ring_buffer_size_kb: Option<usize>,
     /// Optional list of scrapers to run (e.g. `["cpu", "memory", "disk", "network", "filesystem"]`).
     #[serde(default)]
     pub scrapers: Option<Vec<String>>,
     /// Cadence for metrics collection in milliseconds.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub collection_interval_ms: Option<u64>,
     /// List of disk devices to include.
     #[serde(default)]
@@ -391,14 +409,17 @@ pub struct JournaldInputConfig {
     #[serde(default)]
     pub cursor_path: Option<String>,
     /// Include `_BOOT_ID` field in output (default: false).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_from_string_or_value")]
     pub include_boot_id: bool,
     /// Only include entries from the current boot (default: true).
-    #[serde(default = "default_true")]
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_from_string_or_value"
+    )]
     pub current_boot_only: bool,
     /// Only include entries appended after the receiver starts (default: false).
     /// When false, reads all history from the current boot.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_from_string_or_value")]
     pub since_now: bool,
     /// Path to `journalctl` binary. Defaults to `journalctl` (found via PATH).
     pub journalctl_path: Option<String>,
@@ -529,15 +550,21 @@ impl InputTypeConfig {
 pub struct FileTypeConfig {
     pub path: String,
     /// File input poll cadence in milliseconds (default: 50, minimum: 1).
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub poll_interval_ms: Option<u64>,
     /// File tail read buffer in bytes (default: 262_144, minimum: 1, maximum: 4_194_304).
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub read_buf_size: Option<usize>,
     /// Maximum bytes read per file per poll (default: 262_144, minimum: 1).
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub per_file_read_budget_bytes: Option<usize>,
     /// Immediate repoll budget armed when a file poll hits read budget
     /// (default: 8, set to 0 to disable adaptive fast repolls).
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub adaptive_fast_polls_max: Option<u8>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_open_files: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub glob_rescan_interval_ms: Option<u64>,
 }
 
@@ -545,9 +572,9 @@ pub struct FileTypeConfig {
 #[serde(deny_unknown_fields)]
 pub struct UdpTypeConfig {
     pub listen: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_message_size_bytes: Option<usize>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub so_rcvbuf: Option<usize>,
 }
 
@@ -557,11 +584,11 @@ pub struct TcpTypeConfig {
     pub listen: String,
     #[serde(default)]
     pub tls: Option<TlsInputConfig>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_connections: Option<usize>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub connection_timeout_ms: Option<u64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub read_timeout_ms: Option<u64>,
 }
 
@@ -574,13 +601,13 @@ pub struct OtlpTypeConfig {
     pub resource_prefix: Option<String>,
     /// Experimental OTLP protobuf decode strategy. Defaults to `prost`.
     pub protobuf_decode_mode: Option<OtlpProtobufDecodeModeConfig>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_recv_message_size_bytes: Option<usize>,
     #[serde(default)]
     pub tls: Option<TlsInputConfig>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub grpc_keepalive_time_ms: Option<u64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub grpc_max_concurrent_streams: Option<u32>,
 }
 
@@ -610,9 +637,9 @@ pub struct SensorTypeConfig {
 #[serde(deny_unknown_fields)]
 pub struct ArrowIpcTypeConfig {
     pub listen: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_connections: Option<usize>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_message_size_bytes: Option<usize>,
 }
 
@@ -655,18 +682,23 @@ pub struct S3InputConfig {
     /// AWS session token for temporary credentials. Falls back to `AWS_SESSION_TOKEN` env var.
     pub session_token: Option<String>,
     /// Range-GET part size in bytes. Default: 8 MiB.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub part_size_bytes: Option<u64>,
     /// Max concurrent range GET tasks per object. Default: 8.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_concurrent_fetches: Option<usize>,
     /// Max objects being fetched simultaneously. Default: 4.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_concurrent_objects: Option<usize>,
     /// SQS visibility timeout in seconds. Default: 300.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub visibility_timeout_secs: Option<u32>,
     /// Compression override: `"auto"`, `"gzip"` (or `"gz"`), `"zstd"` (or
     /// `"zst"`), `"snappy"` (or `"sz"`), `"none"` (or `"identity"`).
     /// Default: `"auto"` (detect from key extension or Content-Encoding).
     pub compression: Option<String>,
     /// Polling interval for `ListObjectsV2` mode in milliseconds. Default: 5000.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub poll_interval_ms: Option<u64>,
 }
 
@@ -696,37 +728,37 @@ pub struct OutputConfig {
     #[serde(default)]
     pub headers: Option<HashMap<String, String>>,
     /// Number of retry attempts for transient errors.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub retry_attempts: Option<u32>,
     /// Initial backoff delay for retries.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub retry_initial_backoff_ms: Option<u64>,
     /// Maximum backoff delay for retries.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub retry_max_backoff_ms: Option<u64>,
     /// Timeout for each HTTP request.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub request_timeout_ms: Option<u64>,
     /// Maximum number of log records to send per batch.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub batch_size: Option<usize>,
     /// Maximum time to wait before sending a batch.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub batch_timeout_ms: Option<u64>,
     /// Host for socket-based IPC.
     #[serde(default)]
     pub host: Option<String>,
     /// Port for socket-based IPC.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub port: Option<u16>,
     /// Write the legacy IPC format (default: false).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub write_legacy_ipc_format: Option<bool>,
     /// Buffer size for the IPC writer in bytes.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub buffer_size_bytes: Option<usize>,
     /// Whether to write the schema immediately upon connection.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub write_schema_on_connect: Option<bool>,
 }
 
@@ -747,6 +779,7 @@ pub enum GeoDatabaseFormat {
 pub struct GeoDatabaseConfig {
     pub format: GeoDatabaseFormat,
     pub path: String,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub refresh_interval: Option<u64>,
 }
 
@@ -779,6 +812,7 @@ pub struct CsvEnrichmentConfig {
     pub path: String,
     /// Reload the file from disk every N seconds. If absent the file is read
     /// once at startup and never reloaded.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub refresh_interval: Option<u64>,
 }
 
@@ -789,6 +823,7 @@ pub struct JsonlEnrichmentConfig {
     pub path: String,
     /// Reload the file from disk every N seconds. If absent the file is read
     /// once at startup and never reloaded.
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub refresh_interval: Option<u64>,
 }
 
@@ -825,6 +860,7 @@ pub struct KvFileEnrichmentConfig {
     pub table_name: String,
     pub path: String,
     /// Reload the file from disk every N seconds (must be >= 1).
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub refresh_interval: Option<u64>,
 }
 
@@ -878,9 +914,13 @@ pub struct PipelineConfig {
     pub enrichment: Vec<EnrichmentConfig>,
     #[serde(default)]
     pub resource_attrs: HashMap<String, String>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub workers: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub batch_target_bytes: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub batch_timeout_ms: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub poll_interval_ms: Option<u64>,
 }
 
@@ -890,6 +930,7 @@ pub struct ServerConfig {
     pub diagnostics: Option<String>,
     pub log_level: Option<String>,
     pub metrics_endpoint: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub metrics_interval_secs: Option<u64>,
     pub traces_endpoint: Option<String>,
 }

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -84,7 +84,161 @@ pipelines:
 }
 
 #[test]
-fn issue_1855_env_expansion_preserves_yaml_hash_content() {
+fn raw_yaml_number_for_string_field_is_rejected() {
+    let yaml = r#"
+input:
+  type: file
+  path: 123
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("config deserialization error"),
+        "error should come from deserialization: {err}"
+    );
+    assert!(
+        err.contains("string"),
+        "error should expect a string: {err}"
+    );
+}
+
+#[test]
+fn raw_yaml_bool_for_string_field_is_rejected() {
+    let yaml = r#"
+input:
+  type: http
+  listen: 127.0.0.1:8080
+  http:
+    path: true
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("config deserialization error"),
+        "error should come from deserialization: {err}"
+    );
+    assert!(
+        err.contains("string"),
+        "error should expect a string: {err}"
+    );
+}
+
+#[test]
+fn raw_yaml_bool_for_numeric_field_is_rejected() {
+    let yaml = r#"
+pipelines:
+  app:
+    workers: true
+    inputs:
+      - type: generator
+    outputs:
+      - type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("config deserialization error"),
+        "error should come from deserialization: {err}"
+    );
+    assert!(
+        err.contains("unsigned integer"),
+        "error should expect an unsigned integer: {err}"
+    );
+}
+
+#[test]
+fn raw_yaml_float_for_integer_field_is_rejected() {
+    let yaml = r#"
+pipelines:
+  app:
+    workers: 1.5
+    inputs:
+      - type: generator
+    outputs:
+      - type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("config deserialization error"),
+        "error should come from deserialization: {err}"
+    );
+    assert!(
+        err.contains("unsigned integer"),
+        "error should expect an unsigned integer: {err}"
+    );
+}
+
+#[test]
+fn raw_yaml_number_for_bool_field_is_rejected() {
+    let yaml = r#"
+input:
+  type: http
+  listen: 127.0.0.1:8080
+  http:
+    strict_path: 1
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("config deserialization error"),
+        "error should come from deserialization: {err}"
+    );
+    assert!(
+        err.contains("boolean"),
+        "error should expect a boolean: {err}"
+    );
+}
+
+#[test]
+fn generator_attribute_scalar_types_are_preserved() {
+    let yaml = r#"
+input:
+  type: generator
+  generator:
+    profile: record
+    attributes:
+      count: 7
+      enabled: true
+      label: "7"
+output:
+  type: stdout
+"#;
+
+    let config = Config::load_str(yaml).expect("generator attributes should parse");
+    let input = &config.pipelines["default"].inputs[0];
+    let attributes = match &input.type_config {
+        logfwd_config::InputTypeConfig::Generator(generator) => generator
+            .generator
+            .as_ref()
+            .expect("generator config should be present")
+            .attributes
+            .clone(),
+        _ => panic!("expected generator input"),
+    };
+
+    assert!(matches!(
+        attributes["count"],
+        logfwd_config::GeneratorAttributeValueConfig::Integer(7)
+    ));
+    assert!(matches!(
+        attributes["enabled"],
+        logfwd_config::GeneratorAttributeValueConfig::Bool(true)
+    ));
+    assert!(matches!(
+        attributes["label"],
+        logfwd_config::GeneratorAttributeValueConfig::String(ref value) if value == "7"
+    ));
+}
+
+#[test]
+fn env_expansion_preserves_yaml_hash_content() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855", "/var/log/my app #1.log");
 
@@ -107,7 +261,7 @@ output:
 }
 
 #[test]
-fn issue_1855_effective_yaml_preserves_yaml_hash_content() {
+fn effective_yaml_preserves_yaml_hash_content() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_EFFECTIVE", "/var/log/my app #1.log");
 
@@ -137,7 +291,7 @@ output:
 }
 
 #[test]
-fn issue_1855_env_strings_are_parsed_by_typed_schema() {
+fn env_numeric_string_is_parsed_by_typed_schema() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_WORKERS", "4");
 
@@ -165,7 +319,7 @@ pipelines:
 }
 
 #[test]
-fn issue_1855_env_strings_are_parsed_as_bools_by_typed_schema() {
+fn env_bool_string_is_parsed_by_typed_schema() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_STRICT_PATH", "false");
 
@@ -192,7 +346,7 @@ output:
 }
 
 #[test]
-fn issue_1855_quoted_env_expansion_preserves_string_scalars() {
+fn quoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_QUOTED_PATH", "1234");
 
@@ -215,7 +369,7 @@ output:
 }
 
 #[test]
-fn issue_1855_tagged_quoted_env_expansion_preserves_string_scalars() {
+fn tagged_quoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_TAGGED_PATH", "true");
 
@@ -238,7 +392,7 @@ output:
 }
 
 #[test]
-fn issue_1855_tagged_unquoted_env_expansion_preserves_string_scalars() {
+fn tagged_unquoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_TAGGED_UNQUOTED", "123");
 
@@ -263,7 +417,7 @@ output:
 }
 
 #[test]
-fn issue_1855_anchored_quoted_env_expansion_preserves_string_scalars() {
+fn anchored_quoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_ANCHORED_PATH", "true");
 
@@ -286,7 +440,7 @@ output:
 }
 
 #[test]
-fn issue_1855_mixed_env_uses_schema_for_types_and_strings_for_string_fields() {
+fn mixed_env_uses_schema_for_types_and_strings_for_string_fields() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_MIXED", "4");
 
@@ -312,7 +466,7 @@ pipelines:
 }
 
 #[test]
-fn issue_1855_plain_scalar_apostrophe_is_not_treated_as_quote_boundary() {
+fn plain_scalar_apostrophe_is_not_treated_as_quote_boundary() {
     let yaml = r#"
 input:
   type: file
@@ -332,7 +486,7 @@ output:
 }
 
 #[test]
-fn issue_1855_block_scalar_mixed_indentation_expands() {
+fn block_scalar_mixed_indentation_expands() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_BLOCK_FIELD", "message");
 
@@ -362,7 +516,7 @@ pipelines:
 }
 
 #[test]
-fn issue_1855_single_quoted_yaml_escape_survives_env_expansion() {
+fn single_quoted_yaml_escape_survives_env_expansion() {
     let yaml = r#"
 pipelines:
   test:
@@ -383,7 +537,7 @@ pipelines:
 }
 
 #[test]
-fn issue_1855_env_expanded_mapping_key_collision_is_rejected() {
+fn env_expanded_mapping_key_collision_is_rejected() {
     let _env_lock = env_lock();
     let _env_a = EnvVarGuard::set("LOGFWD_ISSUE_1855_KEY_A", "prod");
     let _env_b = EnvVarGuard::set("LOGFWD_ISSUE_1855_KEY_B", "prod");
@@ -409,7 +563,7 @@ pipelines:
 }
 
 #[test]
-fn issue_1855_env_expansion_applies_to_mapping_keys() {
+fn env_expansion_applies_to_mapping_keys() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_PIPELINE", "from-env");
 

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -439,6 +439,82 @@ output:
 }
 
 #[test]
+fn explicit_string_yaml_tag_preserves_string_field() {
+    let yaml = r#"
+input:
+  type: file
+  path: !!str 123
+output:
+  type: stdout
+"#;
+
+    let config = Config::load_str(yaml).expect("explicit string tag should parse as string");
+    let input = &config.pipelines["default"].inputs[0];
+    let path = match &input.type_config {
+        logfwd_config::InputTypeConfig::File(file) => file.path.as_str(),
+        _ => panic!("expected file input"),
+    };
+
+    assert_eq!(path, "123");
+}
+
+#[test]
+fn non_string_core_yaml_tag_for_string_field_is_rejected() {
+    let yaml = r#"
+input:
+  type: file
+  path: !!int "123"
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("config deserialization error"),
+        "error should come from deserialization: {err}"
+    );
+    assert!(
+        err.contains("string"),
+        "error should expect a string: {err}"
+    );
+}
+
+#[test]
+fn custom_yaml_tag_for_string_field_is_rejected() {
+    let yaml = r#"
+input:
+  type: file
+  path: !custom "123"
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("unsupported explicit YAML tag"),
+        "error should reject unsupported explicit tags: {err}"
+    );
+}
+
+#[test]
+fn custom_yaml_tag_for_mapping_key_is_rejected() {
+    let yaml = r#"
+input:
+  type: generator
+output:
+  type: stdout
+resource_attrs:
+  !custom key: value
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("unsupported explicit YAML tag"),
+        "error should reject unsupported explicit mapping-key tags: {err}"
+    );
+}
+
+#[test]
 fn anchored_quoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_ANCHORED_PATH", "true");

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -238,6 +238,46 @@ output:
 }
 
 #[test]
+fn env_generator_attribute_values_remain_strings() {
+    let _env_lock = env_lock();
+    let _count = EnvVarGuard::set("LOGFWD_ISSUE_1855_GENERATOR_COUNT", "7");
+    let _enabled = EnvVarGuard::set("LOGFWD_ISSUE_1855_GENERATOR_ENABLED", "true");
+
+    let yaml = r#"
+input:
+  type: generator
+  generator:
+    profile: record
+    attributes:
+      count: ${LOGFWD_ISSUE_1855_GENERATOR_COUNT}
+      enabled: ${LOGFWD_ISSUE_1855_GENERATOR_ENABLED}
+output:
+  type: stdout
+"#;
+
+    let config = Config::load_str(yaml).expect("generator attributes should parse");
+    let input = &config.pipelines["default"].inputs[0];
+    let attributes = match &input.type_config {
+        logfwd_config::InputTypeConfig::Generator(generator) => generator
+            .generator
+            .as_ref()
+            .expect("generator config should be present")
+            .attributes
+            .clone(),
+        _ => panic!("expected generator input"),
+    };
+
+    assert!(matches!(
+        attributes["count"],
+        logfwd_config::GeneratorAttributeValueConfig::String(ref value) if value == "7"
+    ));
+    assert!(matches!(
+        attributes["enabled"],
+        logfwd_config::GeneratorAttributeValueConfig::String(ref value) if value == "true"
+    ));
+}
+
+#[test]
 fn env_expansion_preserves_yaml_hash_content() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855", "/var/log/my app #1.log");

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -197,6 +197,27 @@ output:
 }
 
 #[test]
+fn top_level_dotted_yaml_key_is_rejected_as_unknown_field() {
+    let yaml = r#"
+server.log_level: debug
+input:
+  type: generator
+output:
+  type: stdout
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("unknown field"),
+        "dotted YAML key should remain literal and be rejected: {err}"
+    );
+    assert!(
+        err.contains("server.log_level"),
+        "error should name the literal dotted key: {err}"
+    );
+}
+
+#[test]
 fn generator_attribute_scalar_types_are_preserved() {
     let yaml = r#"
 input:

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -44,7 +44,7 @@ output:
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
-        err.contains("config deserialization error at"),
+        err.contains("config deserialization error"),
         "error should include a deserialization path: {err}"
     );
     assert!(err.contains("output"), "error should name output: {err}");
@@ -68,7 +68,7 @@ pipelines:
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
-        err.contains("config deserialization error at"),
+        err.contains("config deserialization error"),
         "error should include a deserialization path: {err}"
     );
     assert!(
@@ -137,7 +137,7 @@ output:
 }
 
 #[test]
-fn issue_1855_env_expansion_preserves_non_string_scalars() {
+fn issue_1855_env_strings_are_parsed_by_typed_schema() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_WORKERS", "4");
 
@@ -151,8 +151,44 @@ pipelines:
       - type: stdout
 "#;
 
-    let config = Config::load_str(yaml).expect("config should parse env-backed numeric scalar");
+    let config = Config::load_str(yaml).expect("config should parse env-backed numeric string");
     assert_eq!(config.pipelines["test"].workers, Some(4));
+
+    let expanded = Config::expand_env_yaml_str(yaml).expect("env expansion should succeed");
+    let expanded_value: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(&expanded).expect("expanded YAML should parse");
+    assert_eq!(
+        expanded_value["pipelines"]["test"]["workers"].as_str(),
+        Some("4"),
+        "env substitution should produce string data, not YAML numbers"
+    );
+}
+
+#[test]
+fn issue_1855_env_strings_are_parsed_as_bools_by_typed_schema() {
+    let _env_lock = env_lock();
+    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_STRICT_PATH", "false");
+
+    let yaml = r#"
+input:
+  type: http
+  listen: 127.0.0.1:8080
+  http:
+    strict_path: ${LOGFWD_ISSUE_1855_STRICT_PATH}
+output:
+  type: stdout
+"#;
+
+    let config = Config::load_str(yaml).expect("config should parse env-backed bool");
+    let input = &config.pipelines["default"].inputs[0];
+    let strict_path = match &input.type_config {
+        logfwd_config::InputTypeConfig::Http(http) => {
+            http.http.as_ref().and_then(|config| config.strict_path)
+        }
+        _ => panic!("expected http input"),
+    };
+
+    assert_eq!(strict_path, Some(false));
 }
 
 #[test]
@@ -206,8 +242,8 @@ fn issue_1855_tagged_unquoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_TAGGED_UNQUOTED", "123");
 
-    // An unquoted env placeholder with a !str tag should NOT be coerced to a
-    // number — the explicit string tag means the user wants a string value.
+    // Env substitution already produces string data; the explicit string tag
+    // should preserve that behavior.
     let yaml = r#"
 input:
   type: file
@@ -250,7 +286,7 @@ output:
 }
 
 #[test]
-fn issue_1855_mixed_quoted_and_unquoted_env_uses_node_context() {
+fn issue_1855_mixed_env_uses_schema_for_types_and_strings_for_string_fields() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_MIXED", "4");
 
@@ -266,7 +302,7 @@ pipelines:
       - type: stdout
 "#;
 
-    let config = Config::load_str(yaml).expect("mixed env-backed scalars should parse");
+    let config = Config::load_str(yaml).expect("mixed env-backed values should parse");
 
     assert_eq!(config.pipelines["test"].workers, Some(4));
     assert_eq!(
@@ -296,7 +332,7 @@ output:
 }
 
 #[test]
-fn issue_1855_block_scalar_mixed_indentation_expands_without_marker_leak() {
+fn issue_1855_block_scalar_mixed_indentation_expands() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_BLOCK_FIELD", "message");
 
@@ -323,14 +359,10 @@ pipelines:
         transform.contains(r#""message""#),
         "unexpected transform: {transform}"
     );
-    assert!(
-        !transform.contains("__LOGFWD_QEP_"),
-        "placeholder marker leaked into transform: {transform}"
-    );
 }
 
 #[test]
-fn issue_1855_single_quoted_yaml_escape_survives_placeholder_marking() {
+fn issue_1855_single_quoted_yaml_escape_survives_env_expansion() {
     let yaml = r#"
 pipelines:
   test:

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -346,6 +346,28 @@ output:
 }
 
 #[test]
+fn env_bool_string_is_parsed_by_shared_tls_schema() {
+    let _env_lock = env_lock();
+    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_TLS_SKIP_VERIFY", "true");
+
+    let yaml = r#"
+input:
+  type: generator
+output:
+  type: otlp
+  endpoint: http://127.0.0.1:4318
+  tls:
+    insecure_skip_verify: ${LOGFWD_ISSUE_1855_TLS_SKIP_VERIFY}
+"#;
+
+    let config = Config::load_str(yaml).expect("config should parse env-backed TLS bool");
+    let output = &config.pipelines["default"].outputs[0];
+    let tls = output.tls.as_ref().expect("TLS config should be present");
+
+    assert!(tls.insecure_skip_verify);
+}
+
+#[test]
 fn quoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_QUOTED_PATH", "1234");

--- a/dev-docs/research/README.md
+++ b/dev-docs/research/README.md
@@ -21,6 +21,7 @@ Point-in-time investigations that informed architecture decisions.
 
 - [checkpoint-snapshot-design.md](checkpoint-snapshot-design.md)
 - [columnar-batch-builder.md](columnar-batch-builder.md)
+- [config-library-poc-2026-04-19.md](config-library-poc-2026-04-19.md)
 - [crate-restructure-plan.md](crate-restructure-plan.md)
 - [elasticsearch-retry-contract-2026-04-18.md](elasticsearch-retry-contract-2026-04-18.md)
 - [file-tailing-audit.md](file-tailing-audit.md)

--- a/dev-docs/research/config-library-poc-2026-04-19.md
+++ b/dev-docs/research/config-library-poc-2026-04-19.md
@@ -1,0 +1,109 @@
+# Config Library POC
+
+Date: 2026-04-19
+
+## Question
+
+Can we replace logfwd's hand-written YAML-aware environment expansion and
+config loading with a published Rust config library?
+
+## Current Semantics To Preserve
+
+- `${VAR}` expands inside YAML string values.
+- YAML-significant characters in env values remain data, not syntax.
+- Missing environment variables fail fast and name the missing variable.
+- Exact unquoted placeholders may coerce to YAML scalar types such as numbers,
+  booleans, or null.
+- Exact quoted placeholders stay strings.
+- YAML `!!str` / `!str` tags force string behavior.
+- Mapping keys can contain `${VAR}`.
+- Duplicate mapping keys created by env expansion are rejected.
+- Deserialization diagnostics include useful field paths.
+
+## POC Results
+
+The implementation-facing behavior is now covered by focused tests in
+`crates/logfwd-config/src/env.rs`.
+
+### `subst`
+
+`subst` with the `yaml` feature is the closest match for YAML-aware
+interpolation. It parses YAML, substitutes string values, and then
+deserializes. That avoids raw-text templating bugs where env values containing
+characters such as `#`, `:`, `{`, or `[` are reinterpreted as YAML syntax.
+
+It is not a drop-in replacement:
+
+- it substitutes string values, not mapping keys;
+- it cannot reject duplicate mapping keys created by key expansion, because key
+  expansion does not happen;
+- exact numeric placeholders remain strings and fail typed deserialization into
+  fields such as `usize`;
+- it currently depends on `serde_yaml 0.9.34+deprecated`, while logfwd already
+  uses `serde_yaml_ng`.
+
+Conclusion: useful reference behavior for safe value interpolation, but not
+enough to replace `Config::expand_env_yaml_str` or `Config::load_str`.
+
+### `figment`
+
+Figment supports layered configuration and environment overlays. The POC
+confirms `Env::prefixed("LOGFWD_").split("__")` can override nested typed
+fields such as `LOGFWD_PIPELINES__APP__WORKERS=9`.
+
+It does not solve `${VAR}` interpolation inside YAML values. Its YAML provider
+also depends on `serde_yaml`.
+
+Conclusion: viable shape for typed env overlays, but not a replacement for
+YAML-aware placeholder expansion.
+
+### `config`
+
+`config` supports layered configuration and environment overlays. The POC
+confirms `Environment::with_prefix("LOGFWD").prefix_separator("_").separator("__")`
+can override nested typed fields such as `LOGFWD_PIPELINES__APP__WORKERS=9`.
+
+It does not solve `${VAR}` interpolation inside YAML values. Unlike Figment, its
+YAML feature uses `yaml-rust2` rather than deprecated `serde_yaml`.
+
+Conclusion: best candidate if we want a general config library for layering and
+typed env overrides.
+
+### `varsubst`
+
+`varsubst` is a narrow string-substitution crate. With default features disabled,
+it supports brace-delimited `${VAR}` placeholders without `$VAR` short syntax
+and without backslash escape handling. That makes it a good fit for logfwd's
+documented placeholder language because regex anchors like `$` and Windows paths
+like `C:\logs\${FILE}` remain ordinary config data.
+
+It leaves missing variables unchanged instead of reporting them. The production
+wrapper handles that by running a second pass with all present environment
+variables masked out, then rejecting any remaining `${VAR}` placeholder. This
+keeps missing-variable failure policy in logfwd while delegating placeholder
+parsing and substitution to the crate.
+
+Conclusion: best candidate for the `${VAR}` string grammar, provided logfwd owns
+the missing-variable policy wrapper.
+
+## Recommendation
+
+Use `config` for config-source layering and typed env overrides. Keep the YAML
+AST interpolation pass, but use `varsubst` for the `${VAR}` string grammar
+inside that pass instead of hand-parsing placeholders.
+
+The production design should be:
+
+1. Read YAML from file or string.
+2. Run logfwd's YAML-aware `${VAR}` expansion over the parsed YAML AST, delegating
+   per-string placeholder substitution to `varsubst`.
+3. Feed the expanded YAML into `config` as the base source.
+4. Add an optional `LOGFWD_` environment overlay source using `__` as the nested
+   separator.
+5. Deserialize to `RawConfig`, preserving or replacing the current
+   `serde_path_to_error` diagnostics with an equally precise path-aware error.
+6. Run existing semantic validation.
+
+Do not replace the current interpolation with `subst` unless we intentionally
+drop key expansion, duplicate-key detection, exact-scalar coercion, and the
+current braces-only syntax.

--- a/dev-docs/research/config-library-poc-2026-04-19.md
+++ b/dev-docs/research/config-library-poc-2026-04-19.md
@@ -1,6 +1,8 @@
 # Config Library POC
 
-Date: 2026-04-19
+> **Status:** Active
+> **Date:** 2026-04-19
+> **Context:** Config-source layering and environment-substitution crate evaluation.
 
 ## Question
 

--- a/dev-docs/research/config-library-poc-2026-04-19.md
+++ b/dev-docs/research/config-library-poc-2026-04-19.md
@@ -14,10 +14,9 @@ config loading with a published Rust config library?
 - `${VAR}` expands inside YAML string values.
 - YAML-significant characters in env values remain data, not syntax.
 - Missing environment variables fail fast and name the missing variable.
-- Exact unquoted placeholders may coerce to YAML scalar types such as numbers,
-  booleans, or null.
-- Exact quoted placeholders stay strings.
-- YAML `!!str` / `!str` tags force string behavior.
+- Environment substitution always produces string data.
+- The typed Rust config schema parses env-backed strings into field types such as
+  numbers, booleans, and enums.
 - Mapping keys can contain `${VAR}`.
 - Duplicate mapping keys created by env expansion are rejected.
 - Deserialization diagnostics include useful field paths.
@@ -39,8 +38,8 @@ It is not a drop-in replacement:
 - it substitutes string values, not mapping keys;
 - it cannot reject duplicate mapping keys created by key expansion, because key
   expansion does not happen;
-- exact numeric placeholders remain strings and fail typed deserialization into
-  fields such as `usize`;
+- exact numeric placeholders remain strings, so typed coercion must happen in a
+  later config/schema layer;
 - it currently depends on `serde_yaml 0.9.34+deprecated`, while logfwd already
   uses `serde_yaml_ng`.
 
@@ -90,22 +89,23 @@ the missing-variable policy wrapper.
 
 ## Recommendation
 
-Use `config` for config-source layering and typed env overrides. Keep the YAML
-AST interpolation pass, but use `varsubst` for the `${VAR}` string grammar
-inside that pass instead of hand-parsing placeholders.
+Use `config` for schema-directed deserialization/coercion, and later for
+config-source layering and typed env overrides. Keep the YAML AST interpolation
+pass, but use `varsubst` for the `${VAR}` string grammar inside that pass
+instead of hand-parsing placeholders.
 
 The production design should be:
 
 1. Read YAML from file or string.
 2. Run logfwd's YAML-aware `${VAR}` expansion over the parsed YAML AST, delegating
-   per-string placeholder substitution to `varsubst`.
-3. Feed the expanded YAML into `config` as the base source.
-4. Add an optional `LOGFWD_` environment overlay source using `__` as the nested
+   per-string placeholder substitution to `varsubst`; env values remain strings.
+3. Convert the expanded YAML AST into a `config` source without reparsing YAML
+   text, so YAML-specific values like `.nan` still reach semantic validation.
+4. Deserialize to `RawConfig` through `config`, letting the typed Rust schema
+   parse env-backed strings into numeric, boolean, and enum fields.
+5. Add an optional `LOGFWD_` environment overlay source using `__` as the nested
    separator.
-5. Deserialize to `RawConfig`, preserving or replacing the current
-   `serde_path_to_error` diagnostics with an equally precise path-aware error.
 6. Run existing semantic validation.
 
 Do not replace the current interpolation with `subst` unless we intentionally
-drop key expansion, duplicate-key detection, exact-scalar coercion, and the
-current braces-only syntax.
+drop key expansion, duplicate-key detection, and the current braces-only syntax.


### PR DESCRIPTION
## Summary
- replace the hand-written `${VAR}` substitution scanner with a narrow `varsubst`-backed wrapper
- keep YAML AST expansion for structure safety, mapping-key expansion, duplicate-key detection, and effective-config output
- deserialize the expanded AST through `config` so env-backed strings are parsed by the Rust config schema instead of YAML scalar inference
- harden env lookup to use `std::env::var(name)` per referenced placeholder, preserving OS lookup semantics and reporting non-Unicode values explicitly
- preserve only the unterminated `${VAR` tail while still expanding completed placeholders before it
- document the simpler env-substitution rule and update the config-library research note

## Notes
- environment substitution now always produces string data; typed fields such as `usize`, `u64`, `u16`, and `bool` parse those strings through schema-level deserializers
- `$VAR` remains literal
- `${VAR:fallback}` is rejected rather than becoming a second config language
- `${VAR` is preserved literally; completed placeholders before that tail still expand
- regex `$` anchors, Windows-style backslashes, block scalars, mapping keys, and env values containing `${...}` text are covered by tests

## Tests
- `cargo test -p logfwd-config env::tests -- --nocapture`
- `cargo test -p logfwd-config -- --nocapture`
- `cargo clippy -p logfwd-config -- -D warnings`
- `cargo fmt --check`
- `just toml-check`
- `python3 scripts/docs/validate_operational_sections.py`
- tracked research metadata validation using `scripts/docs/validate_research_metadata.py`
- `npm run build` from `book`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parse config env var values through schema to enforce strict YAML type checking
> - Env variable substitution now produces string values that the typed schema then parses into the correct numeric/boolean type, rather than coercing YAML scalars directly. This allows `${ENV_VAR}` to supply numbers and booleans to typed fields.
> - Adds strict deserialization helpers in [`serde_helpers.rs`](https://github.com/strawgate/fastforward/pull/2308/files#diff-4774fe9a119cd730a0952cee564c6f88984f61cb1756660fd6cefe9afd5563a2): string fields now reject non-string YAML scalars, numeric/bool fields accept either native YAML scalars or string representations, and list/map fields enforce per-element string types.
> - Rewrites env expansion in [`env.rs`](https://github.com/strawgate/fastforward/pull/2308/files#diff-1e4ef9eba653ed8d412487f1a692a7f9d82d9db7247b1e9accfa3c22c2bdbfc6) to handle only braced `${VAR}` placeholders; bare `$VAR` is left literal, default syntax `${VAR:fallback}` is rejected, and unterminated `${VAR` tails are preserved while any preceding closed placeholders are still expanded.
> - Replaces `serde_path_to_error` with the `config` crate for deserialization, routing YAML through a YAML→`config::Value` conversion before schema deserialization. Duplicate keys produced by env expansion are now detected and rejected.
> - Behavioral Change: env-expanded values that previously resolved to non-string YAML scalars (e.g. bare integers or booleans) now always land as strings and are parsed by the schema; fields that previously accepted raw YAML integers/booleans where a string was expected now return a deserialization error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c394166.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->