### PR TITLE
fix: preserve UDP sender source identity

### DIFF
--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -751,7 +751,10 @@ mod tests {
 
         // Distinctness: different addresses yield different ids.
         let id_b = source_id_for_sender(addr_b);
-        assert_ne!(id_a1, id_b, "different IPv6 addresses must produce different ids");
+        assert_ne!(
+            id_a1, id_b,
+            "different IPv6 addresses must produce different ids"
+        );
     }
 }
 

--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -2,11 +2,12 @@
 //! per received datagram (or batch of datagrams).
 
 use std::io;
-use std::net::UdpSocket;
+use std::net::{SocketAddr, UdpSocket};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use logfwd_types::diagnostics::ComponentHealth;
+use logfwd_types::pipeline::SourceId;
 use socket2::{Domain, Protocol, Socket, Type};
 
 use crate::input::{InputEvent, InputSource};
@@ -34,6 +35,32 @@ const MAX_EMIT_BYTES_PER_POLL: usize = 1024 * 1024;
 #[inline]
 const fn should_stop_udp_drain(datagrams_read: usize, emitted_bytes: usize) -> bool {
     datagrams_read >= MAX_DATAGRAMS_PER_POLL || emitted_bytes >= MAX_EMIT_BYTES_PER_POLL
+}
+
+/// Derive a stable sender-scoped source id for UDP datagrams.
+///
+/// Domain-separated from other source-id families (file fingerprints, TCP
+/// connection sequence ids, etc.) so maps keyed by SourceId are less likely to
+/// collide across transport types.
+fn source_id_for_sender(addr: SocketAddr) -> SourceId {
+    let mut h = xxhash_rust::xxh64::Xxh64::new(0);
+    h.update(b"udp:");
+    match addr {
+        SocketAddr::V4(v4) => {
+            h.update(&[4u8]);
+            h.update(&v4.ip().octets());
+            h.update(&v4.port().to_le_bytes());
+        }
+        SocketAddr::V6(v6) => {
+            h.update(&[6u8]);
+            h.update(&v6.ip().octets());
+            h.update(&v6.port().to_le_bytes());
+            h.update(&v6.flowinfo().to_le_bytes());
+            h.update(&v6.scope_id().to_le_bytes());
+        }
+    }
+    let digest = h.digest();
+    SourceId(if digest == 0 { 1 } else { digest })
 }
 
 #[derive(Debug, Clone)]
@@ -76,7 +103,7 @@ impl UdpInput {
         options: UdpInputOptions,
         stats: Arc<logfwd_types::diagnostics::ComponentStats>,
     ) -> io::Result<Self> {
-        let parsed_addr: std::net::SocketAddr = addr.parse().map_err(io::Error::other)?;
+        let parsed_addr: SocketAddr = addr.parse().map_err(io::Error::other)?;
         let domain = if parsed_addr.is_ipv4() {
             Domain::IPV4
         } else {
@@ -123,7 +150,7 @@ impl UdpInput {
     }
 
     /// Returns the local address this socket is bound to.
-    pub fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.socket.local_addr()
     }
 
@@ -152,31 +179,32 @@ impl InputSource for UdpInput {
         let mut under_pressure = false;
         let mut datagrams_read = 0usize;
 
-        // Accumulate into a single byte buffer; avoid per-datagram Vec alloc.
-        // We re-use `self.buf` for recv and build the output in a separate vec
-        // only when data actually arrives.
-        let mut total: Option<Vec<u8>> = None;
-        let mut source_bytes: u64 = 0;
+        // Emit one event per datagram to preserve sender attribution.
+        let mut events: Vec<InputEvent> = Vec::new();
+        let mut emitted_bytes_total = 0usize;
 
         // Drain all available datagrams in one poll cycle.
         loop {
-            // `recv` is cheaper than `recv_from` — we don't need the source addr.
-            match self.socket.recv(&mut self.buf) {
-                Ok(n) => {
+            match self.socket.recv_from(&mut self.buf) {
+                Ok((n, sender)) => {
                     datagrams_read = datagrams_read.saturating_add(1);
                     if n > 0 {
-                        source_bytes = source_bytes.saturating_add(n as u64);
+                        let mut bytes = Vec::with_capacity(n.saturating_add(1));
                         let data = &self.buf[..n];
-                        let out = total.get_or_insert_with(|| Vec::with_capacity(4096));
-                        out.extend_from_slice(data);
+                        bytes.extend_from_slice(data);
                         // Ensure newline termination so the scanner always sees
                         // complete lines, even if the sender omitted a trailing LF.
                         if !data.ends_with(b"\n") {
-                            out.push(b'\n');
+                            bytes.push(b'\n');
                         }
+                        emitted_bytes_total = emitted_bytes_total.saturating_add(bytes.len());
+                        events.push(InputEvent::Data {
+                            bytes,
+                            source_id: Some(source_id_for_sender(sender)),
+                            accounted_bytes: n as u64,
+                        });
                     }
-                    let emitted_bytes = total.as_ref().map_or(0, Vec::len);
-                    if should_stop_udp_drain(datagrams_read, emitted_bytes) {
+                    if should_stop_udp_drain(datagrams_read, emitted_bytes_total) {
                         under_pressure = true;
                         break;
                     }
@@ -214,17 +242,7 @@ impl InputSource for UdpInput {
             },
         );
 
-        match total {
-            Some(bytes) => {
-                let accounted_bytes = source_bytes;
-                Ok(vec![InputEvent::Data {
-                    bytes,
-                    source_id: None,
-                    accounted_bytes,
-                }])
-            }
-            None => Ok(Vec::new()),
-        }
+        Ok(events)
     }
 
     fn name(&self) -> &str {
@@ -260,12 +278,15 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
 
         let events = input.poll().unwrap();
-        assert_eq!(events.len(), 1);
-        if let InputEvent::Data { bytes, .. } = &events[0] {
-            let text = String::from_utf8_lossy(bytes);
-            assert!(text.contains("hello world"), "got: {text}");
-            assert!(text.contains("second line"), "got: {text}");
+        assert_eq!(events.len(), 2);
+        let mut text = String::new();
+        for event in &events {
+            if let InputEvent::Data { bytes, .. } = event {
+                text.push_str(&String::from_utf8_lossy(bytes));
+            }
         }
+        assert!(text.contains("hello world"), "got: {text}");
+        assert!(text.contains("second line"), "got: {text}");
     }
 
     #[test]
@@ -578,7 +599,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(75));
 
         let first = input.poll().unwrap();
-        assert_eq!(first.len(), 1);
+        assert_eq!(first.len(), MAX_DATAGRAMS_PER_POLL);
         let first_lines = first
             .iter()
             .filter_map(|event| match event {
@@ -613,6 +634,103 @@ mod tests {
         for i in 0..total {
             assert!(text.contains(&format!("pkt-{i}\n")), "missing pkt-{i}");
         }
+    }
+
+    #[test]
+    fn source_id_is_present_for_received_datagrams() {
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
+        let addr = input.local_addr().unwrap();
+        let sender = StdSocket::bind("127.0.0.1:0").unwrap();
+
+        sender.send_to(b"hello\n", addr).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let events = input.poll().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            InputEvent::Data {
+                source_id: Some(_), ..
+            } => {}
+            _ => panic!("expected UDP data to carry a source_id"),
+        }
+    }
+
+    #[test]
+    fn source_id_is_stable_per_sender_socket() {
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
+        let addr = input.local_addr().unwrap();
+        let sender = StdSocket::bind("127.0.0.1:0").unwrap();
+
+        sender.send_to(b"first\n", addr).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        let first_events = input.poll().unwrap();
+        let first = match &first_events[0] {
+            InputEvent::Data {
+                source_id: Some(id),
+                ..
+            } => *id,
+            _ => panic!("expected source_id on first poll"),
+        };
+
+        sender.send_to(b"second\n", addr).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        let second_events = input.poll().unwrap();
+        let second = match &second_events[0] {
+            InputEvent::Data {
+                source_id: Some(id),
+                ..
+            } => *id,
+            _ => panic!("expected source_id on second poll"),
+        };
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn source_ids_differ_for_distinct_senders() {
+        let mut input = UdpInput::new(
+            "test",
+            "127.0.0.1:0",
+            Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
+        let addr = input.local_addr().unwrap();
+        let sender_a = StdSocket::bind("127.0.0.1:0").unwrap();
+        let sender_b = StdSocket::bind("127.0.0.1:0").unwrap();
+
+        sender_a.send_to(b"a\n", addr).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        let event_a = input.poll().unwrap();
+        let source_a = match &event_a[0] {
+            InputEvent::Data {
+                source_id: Some(id),
+                ..
+            } => *id,
+            _ => panic!("expected source_id for sender_a"),
+        };
+
+        sender_b.send_to(b"b\n", addr).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        let event_b = input.poll().unwrap();
+        let source_b = match &event_b[0] {
+            InputEvent::Data {
+                source_id: Some(id),
+                ..
+            } => *id,
+            _ => panic!("expected source_id for sender_b"),
+        };
+
+        assert_ne!(source_a, source_b);
     }
 }
 

--- a/crates/logfwd-io/src/udp_input.rs
+++ b/crates/logfwd-io/src/udp_input.rs
@@ -55,7 +55,6 @@ fn source_id_for_sender(addr: SocketAddr) -> SourceId {
             h.update(&[6u8]);
             h.update(&v6.ip().octets());
             h.update(&v6.port().to_le_bytes());
-            h.update(&v6.flowinfo().to_le_bytes());
             h.update(&v6.scope_id().to_le_bytes());
         }
     }
@@ -180,7 +179,7 @@ impl InputSource for UdpInput {
         let mut datagrams_read = 0usize;
 
         // Emit one event per datagram to preserve sender attribution.
-        let mut events: Vec<InputEvent> = Vec::new();
+        let mut events: Vec<InputEvent> = Vec::with_capacity(MAX_DATAGRAMS_PER_POLL);
         let mut emitted_bytes_total = 0usize;
 
         // Drain all available datagrams in one poll cycle.
@@ -731,6 +730,28 @@ mod tests {
         };
 
         assert_ne!(source_a, source_b);
+    }
+
+    #[test]
+    fn source_id_ipv6_stable_and_distinct() {
+        use std::net::{Ipv6Addr, SocketAddrV6};
+
+        let addr_a = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 5000, 0, 0));
+        let addr_b = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1),
+            5000,
+            0,
+            0,
+        ));
+
+        // Stability: same address yields the same id across calls.
+        let id_a1 = source_id_for_sender(addr_a);
+        let id_a2 = source_id_for_sender(addr_a);
+        assert_eq!(id_a1, id_a2, "IPv6 source id must be stable");
+
+        // Distinctness: different addresses yield different ids.
+        let id_b = source_id_for_sender(addr_b);
+        assert_ne!(id_a1, id_b, "different IPv6 addresses must produce different ids");
     }
 }
 

--- a/dev-docs/ADAPTER_CONTRACT.md
+++ b/dev-docs/ADAPTER_CONTRACT.md
@@ -177,6 +177,10 @@ The file path is:
 - Remainders, CRI aggregation state, and checkpoint math are keyed by source.
 - Bytes from one source must never complete or corrupt a partial line from a
   different source.
+- UDP datagrams must preserve sender-scoped source identity at the input-event
+  boundary (`recv_from` sender -> `InputEvent::Data.source_id`) so framing
+  state is isolated by sender instead of co-mingling all datagrams under
+  `None`.
 
 ### Newline-boundary checkpoint rules
 


### PR DESCRIPTION
## Summary

Implements #1714 with the low-discretion Option A contract: UDP now derives a stable sender-scoped `SourceId` from `recv_from()` peer addresses and attaches it to `InputEvent::Data.source_id` without injecting raw sender metadata into payload bytes.

Changes:
- Switch UDP receive from `recv()` to `recv_from()`.
- Derive a domain-separated, non-zero `SourceId` from sender IP/port.
- Emit one input event per datagram so downstream `FramedInput` can isolate per-sender remainder state.
- Document the UDP sender identity contract in `dev-docs/ADAPTER_CONTRACT.md`.

Fixes #1714.

## Verification

- `just fmt`
- `cargo test -p logfwd-io udp_input -- --nocapture`
- `cargo clippy -p logfwd-io -- -D warnings`
- `cargo test -p logfwd-io framed::tests::two_sources_interleaved_no_cross_contamination -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve UDP sender source identity in `UdpInput` by emitting one event per datagram
> - Replaces the shared accumulation buffer in `UdpInput.poll` with `recv_from`, emitting one `InputEvent::Data` per datagram, each with a sender-scoped `source_id` computed via xxhash64 of the sender address.
> - Adds `source_id_for_sender` in [udp_input.rs](https://github.com/strawgate/fastforward/pull/2310/files#diff-5f62a002b097adca156d69f60bf79b37835bcae9ae8c75fab88b66079b81a204) to produce a stable, domain-separated hash for IPv4/IPv6 senders, guarding against a 0 digest.
> - Documents the new rule in [ADAPTER_CONTRACT.md](https://github.com/strawgate/fastforward/pull/2310/files#diff-a8fd95c1bdb4125a19cebace3395d30eac66de7eee3f4721796e01d26f06ffbc) requiring UDP inputs to map `recv_from` sender to `InputEvent::Data.source_id`.
> - Behavioral Change: `poll` now returns one event per datagram instead of a single aggregated event; `source_id` is always set (previously `None`), and `accounted_bytes` reflects per-datagram size.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 109ef75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->