### PR TITLE
fix: validate file output path usability

### DIFF
--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -494,7 +494,7 @@ Write records to a file.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `path` | string | Yes | Destination file path. |
+| `path` | string | Yes | Destination file path. Parent directory must already exist and be writable. |
 | `format` | string | No | `json` for NDJSON output, or `text` to write raw lines. |
 
 ```yaml

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1378,7 +1378,7 @@ fn validate_file_output_path_writable(
             parent.display()
         )));
     }
-    if parent_meta.permissions().readonly() {
+    if !resolved.exists() && parent_meta.permissions().readonly() {
         return Err(ConfigError::Validation(format!(
             "pipeline '{pipeline_name}' output '{output_label}': file output parent '{}' is read-only",
             parent.display()

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1300,6 +1300,8 @@ impl Config {
                             )));
                         }
                     }
+
+                    validate_file_output_path_writable(name, &out_label, out_path, base_path)?;
                 }
 
                 Ok(())
@@ -1349,6 +1351,62 @@ fn normalize_path_key_for_compare(path: &Path) -> std::path::PathBuf {
     {
         normalized
     }
+}
+
+fn validate_file_output_path_writable(
+    pipeline_name: &str,
+    output_label: &str,
+    output_path: &str,
+    base_path: Option<&Path>,
+) -> Result<(), ConfigError> {
+    let resolved = path_for_config_compare(output_path, base_path);
+    let parent = match resolved.parent() {
+        Some(parent) if parent.as_os_str().is_empty() => Path::new("."),
+        Some(parent) => parent,
+        None => Path::new("."),
+    };
+
+    let parent_meta = parent.metadata().map_err(|e| {
+        ConfigError::Validation(format!(
+            "pipeline '{pipeline_name}' output '{output_label}': file output parent directory '{}' is not usable: {e}",
+            parent.display()
+        ))
+    })?;
+    if !parent_meta.is_dir() {
+        return Err(ConfigError::Validation(format!(
+            "pipeline '{pipeline_name}' output '{output_label}': file output parent '{}' is not a directory",
+            parent.display()
+        )));
+    }
+    if parent_meta.permissions().readonly() {
+        return Err(ConfigError::Validation(format!(
+            "pipeline '{pipeline_name}' output '{output_label}': file output parent '{}' is read-only",
+            parent.display()
+        )));
+    }
+
+    if resolved.exists() {
+        let md = resolved.metadata().map_err(|e| {
+            ConfigError::Validation(format!(
+                "pipeline '{pipeline_name}' output '{output_label}': failed to inspect file output path '{}': {e}",
+                resolved.display()
+            ))
+        })?;
+        if md.is_dir() {
+            return Err(ConfigError::Validation(format!(
+                "pipeline '{pipeline_name}' output '{output_label}': file output path '{}' is a directory",
+                resolved.display()
+            )));
+        }
+        if md.permissions().readonly() {
+            return Err(ConfigError::Validation(format!(
+                "pipeline '{pipeline_name}' output '{output_label}': file output path '{}' is read-only",
+                resolved.display()
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn path_for_config_compare(path: &str, base_path: Option<&Path>) -> std::path::PathBuf {

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -737,6 +737,7 @@ pipelines:
     fs::remove_dir_all(&dir).expect("temp dir cleanup should succeed");
 }
 
+#[cfg(unix)]
 #[test]
 fn issue_2035_reject_file_output_when_parent_directory_is_read_only() {
     let dir = unique_temp_dir("readonly-parent");
@@ -770,6 +771,47 @@ pipelines:
     );
 
     fs::set_permissions(&dir, original_perms).expect("permissions reset should succeed");
+    fs::remove_dir_all(&dir).expect("temp dir cleanup should succeed");
+}
+
+#[test]
+fn issue_2035_reject_file_output_when_existing_file_is_read_only() {
+    let dir = unique_temp_dir("readonly-file");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let out_path = dir.join("out.ndjson");
+    fs::write(&out_path, b"existing content").expect("output file should be written");
+
+    let mut readonly_perms = fs::metadata(&out_path)
+        .expect("file metadata should be readable")
+        .permissions();
+    readonly_perms.set_readonly(true);
+    fs::set_permissions(&out_path, readonly_perms).expect("setting read-only should succeed");
+
+    let yaml = format!(
+        r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+    outputs:
+      - type: file
+        path: {}
+"#,
+        out_path.display()
+    );
+
+    let err = Config::load_str(&yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("file output path") && err.contains("read-only"),
+        "unexpected error: {err}"
+    );
+
+    // Reset permissions so cleanup can remove the file.
+    let mut writable_perms = fs::metadata(&out_path)
+        .expect("file metadata should be readable")
+        .permissions();
+    writable_perms.set_readonly(false);
+    fs::set_permissions(&out_path, writable_perms).expect("permissions reset should succeed");
     fs::remove_dir_all(&dir).expect("temp dir cleanup should succeed");
 }
 

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -1,6 +1,9 @@
 use logfwd_config::Config;
 use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -30,6 +33,14 @@ impl Drop for EnvVarGuard {
 
 fn env_lock() -> MutexGuard<'static, ()> {
     ENV_LOCK.lock().expect("env lock should not be poisoned")
+}
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("logfwd-{prefix}-{nanos}-{}", std::process::id()))
 }
 
 #[test]
@@ -646,6 +657,170 @@ pipelines:
         output_err.contains("duplicate output name 'out1'"),
         "unexpected error: {output_err}"
     );
+}
+
+#[test]
+fn issue_2035_reject_file_output_when_parent_directory_missing() {
+    let missing_parent = unique_temp_dir("missing-parent").join("child");
+    let out_path = missing_parent.join("out.ndjson");
+    let yaml = format!(
+        r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+    outputs:
+      - type: file
+        path: {}
+"#,
+        out_path.display()
+    );
+
+    let err = Config::load_str(&yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("file output parent directory") && err.contains("is not usable"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn issue_2035_reject_relative_file_output_when_base_parent_directory_missing() {
+    let base = unique_temp_dir("relative-base");
+    fs::create_dir_all(&base).expect("base dir should be created");
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+    outputs:
+      - type: file
+        path: missing/out.ndjson
+"#;
+
+    let err = Config::load_str_with_base_path(yaml, Some(&base))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("file output parent directory") && err.contains("is not usable"),
+        "unexpected error: {err}"
+    );
+
+    fs::remove_dir_all(&base).expect("base dir cleanup should succeed");
+}
+
+#[test]
+fn issue_2035_reject_file_output_when_parent_path_is_file() {
+    let dir = unique_temp_dir("parent-file");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let parent_file = dir.join("not-a-dir");
+    fs::write(&parent_file, b"not a directory").expect("parent file should be written");
+    let out_path = parent_file.join("out.ndjson");
+    let yaml = format!(
+        r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+    outputs:
+      - type: file
+        path: {}
+"#,
+        out_path.display()
+    );
+
+    let err = Config::load_str(&yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("file output parent") && err.contains("is not a directory"),
+        "unexpected error: {err}"
+    );
+
+    fs::remove_dir_all(&dir).expect("temp dir cleanup should succeed");
+}
+
+#[test]
+fn issue_2035_reject_file_output_when_parent_directory_is_read_only() {
+    let dir = unique_temp_dir("readonly-parent");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let original_perms = fs::metadata(&dir)
+        .expect("temp dir metadata should be readable")
+        .permissions();
+    let mut readonly_perms = original_perms.clone();
+    readonly_perms.set_readonly(true);
+    fs::set_permissions(&dir, readonly_perms)
+        .expect("setting read-only permissions should succeed");
+
+    let out_path = dir.join("out.ndjson");
+    let yaml = format!(
+        r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+    outputs:
+      - type: file
+        path: {}
+"#,
+        out_path.display()
+    );
+
+    let err = Config::load_str(&yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("file output parent") && err.contains("read-only"),
+        "unexpected error: {err}"
+    );
+
+    fs::set_permissions(&dir, original_perms).expect("permissions reset should succeed");
+    fs::remove_dir_all(&dir).expect("temp dir cleanup should succeed");
+}
+
+#[test]
+fn issue_2035_reject_file_output_when_existing_path_is_directory() {
+    let dir = unique_temp_dir("output-is-dir");
+    let out_path = dir.join("capture.ndjson");
+    fs::create_dir_all(&out_path).expect("output directory should be created");
+    let yaml = format!(
+        r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+    outputs:
+      - type: file
+        path: {}
+"#,
+        out_path.display()
+    );
+
+    let err = Config::load_str(&yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("file output path") && err.contains("is a directory"),
+        "unexpected error: {err}"
+    );
+
+    fs::remove_dir_all(&dir).expect("temp dir cleanup should succeed");
+}
+
+#[test]
+fn issue_2035_accept_file_output_when_parent_directory_is_writable() {
+    let dir = unique_temp_dir("writable-parent");
+    fs::create_dir_all(&dir).expect("temp dir should be created");
+    let out_path = dir.join("out.ndjson");
+    let yaml = format!(
+        r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+    outputs:
+      - type: file
+        path: {}
+"#,
+        out_path.display()
+    );
+
+    Config::load_str(&yaml).expect("writable output parent should validate");
+
+    fs::remove_dir_all(&dir).expect("temp dir cleanup should succeed");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes the #2035 slice of #2097 by validating file output path usability at config validation time instead of letting file sinks fail later during startup/runtime.

Changes:
- Reject file/parquet outputs whose parent directory is missing, not a directory, or read-only.
- Reject existing output paths that are directories or read-only files.
- Preserve existing higher-priority feedback-loop diagnostics before filesystem usability checks.
- Document that file output parent directories must already exist and be writable.
- Add portable regression coverage for missing parents, relative paths with base paths, parent-as-file, read-only parents, directory output paths, and writable parents.

Fixes #2035.
Part of #2097.

## Verification

- `just fmt`
- `cargo test -p logfwd-config --test validation_gaps issue_2035 -- --nocapture`
- `cargo clippy -p logfwd-config -- -D warnings`
- `cargo test -p logfwd-config --test validation_gaps -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate file output path writability at config load time
> - Adds `validate_file_output_path_writable` in [validate.rs](https://github.com/strawgate/fastforward/pull/2311/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) to check file output paths during config validation, producing specific errors for missing parent directories, non-directory parents, read-only parents, directory output paths, and read-only existing files.
> - Updates documentation in [reference.mdx](https://github.com/strawgate/fastforward/pull/2311/files#diff-6a69bd5c38c92acca3dd194d75d77551f1b8f6b98890da7e56f2c9cbe564aac4) to clarify that the parent directory must exist and be writable.
> - Behavioral Change: Configs with file outputs that previously loaded without error will now fail validation if the parent directory does not exist, is not a directory, or is read-only, or if the output path itself is a directory or read-only file.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cbd6eea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->