### PR TITLE
fix: harden projected decoder pool

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver.rs
+++ b/crates/logfwd-io/src/otlp_receiver.rs
@@ -96,16 +96,32 @@ struct ReceiverPayload {
 
 #[cfg(any(feature = "otlp-research", test))]
 struct ProjectedDecoderPool {
-    decoders: Box<[Mutex<ProjectedOtlpDecoder>]>,
+    decoders: Box<[ProjectedDecoderShard]>,
     next_decoder: AtomicUsize,
+}
+
+/// One reusable projected decoder in the pool.
+///
+/// The decoder mutex protects reusable builder/scratch state. `is_available`
+/// lets selection skip a shard after lock poisoning is observed, avoiding
+/// intermittent reuse of a permanently poisoned decoder.
+#[cfg(any(feature = "otlp-research", test))]
+struct ProjectedDecoderShard {
+    /// Reusable projected decoder state for one shard.
+    decoder: Mutex<ProjectedOtlpDecoder>,
+    /// True while the shard may be selected by round-robin decode traffic.
+    is_available: AtomicBool,
 }
 
 #[cfg(any(feature = "otlp-research", test))]
 impl ProjectedDecoderPool {
     fn new(resource_prefix: &str, shard_count: usize) -> Self {
-        let shard_count = shard_count.max(1);
+        let shard_count = shard_count.clamp(1, MAX_PROJECTED_DECODER_SHARDS);
         let decoders = (0..shard_count)
-            .map(|_| Mutex::new(ProjectedOtlpDecoder::new(resource_prefix)))
+            .map(|_| ProjectedDecoderShard {
+                decoder: Mutex::new(ProjectedOtlpDecoder::new(resource_prefix)),
+                is_available: AtomicBool::new(true),
+            })
             .collect::<Vec<_>>()
             .into_boxed_slice();
         Self {
@@ -114,19 +130,34 @@ impl ProjectedDecoderPool {
         }
     }
 
-    fn next(&self) -> &Mutex<ProjectedOtlpDecoder> {
-        let index = self.next_decoder.fetch_add(1, Ordering::Relaxed) % self.decoders.len();
-        &self.decoders[index]
+    fn next(&self) -> Option<&ProjectedDecoderShard> {
+        let len = self.decoders.len();
+        let start_index = self.next_decoder.fetch_add(1, Ordering::Relaxed);
+        for offset in 0..len {
+            let index = start_index.wrapping_add(offset) % len;
+            let shard = &self.decoders[index];
+            if shard.is_available.load(Ordering::Acquire) {
+                return Some(shard);
+            }
+        }
+        None
     }
 
     #[cfg(test)]
-    fn first(&self) -> &Mutex<ProjectedOtlpDecoder> {
+    fn first(&self) -> &ProjectedDecoderShard {
         &self.decoders[0]
     }
 
-    #[cfg(test)]
     fn len(&self) -> usize {
         self.decoders.len()
+    }
+}
+
+#[cfg(any(feature = "otlp-research", test))]
+impl ProjectedDecoderShard {
+    /// Remove this shard from future selection after a poison/error boundary.
+    fn mark_unavailable(&self) {
+        self.is_available.store(false, Ordering::Release);
     }
 }
 

--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -563,7 +563,7 @@ mod tests {
         match err {
             InputError::Io(io_err) => {
                 assert_eq!(io_err.kind(), io::ErrorKind::InvalidData);
-                assert_eq!(io_err.to_string(), "payload too large");
+                assert!(io_err.to_string().contains("payload too large"));
             }
             other => panic!("expected InvalidData payload-too-large error, got {other:?}"),
         }
@@ -579,7 +579,7 @@ mod tests {
         match err {
             InputError::Io(io_err) => {
                 assert_eq!(io_err.kind(), io::ErrorKind::InvalidData);
-                assert_eq!(io_err.to_string(), "payload too large");
+                assert!(io_err.to_string().contains("payload too large"));
             }
             other => panic!("expected InvalidData payload-too-large error, got {other:?}"),
         }

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -321,12 +321,33 @@ fn decode_with_reusable_projected_decoder(
     let decoder_pool = state.projected_decoders.as_ref().ok_or_else(|| {
         ProjectedDecodeError::Internal("projected decoder pool not initialized".to_string())
     })?;
-    let mut decoder = decoder_pool.next().lock().map_err(|_| {
-        ProjectedDecodeError::Internal("projected decoder lock poisoned".to_string())
-    })?;
-    decoder
-        .try_decode_view_bytes(body)
-        .map_err(ProjectedDecodeError::Projection)
+    let mut saw_poisoned_shard = false;
+    for _ in 0..decoder_pool.len() {
+        let Some(shard) = decoder_pool.next() else {
+            break;
+        };
+        let mut decoder = match shard.decoder.lock() {
+            Ok(decoder) => decoder,
+            Err(_) => {
+                saw_poisoned_shard = true;
+                shard.mark_unavailable();
+                continue;
+            }
+        };
+        return decoder
+            .try_decode_view_bytes(body)
+            .map_err(ProjectedDecodeError::Projection);
+    }
+
+    if saw_poisoned_shard {
+        Err(ProjectedDecodeError::Internal(
+            "all projected decoder shards are poisoned or unavailable".to_string(),
+        ))
+    } else {
+        Err(ProjectedDecodeError::Internal(
+            "projected decoder pool has no available shards".to_string(),
+        ))
+    }
 }
 
 #[cfg(any(feature = "otlp-research", test))]
@@ -401,6 +422,7 @@ mod tests {
         let poison_result = catch_unwind(AssertUnwindSafe(|| {
             let _guard = decoder_pool
                 .first()
+                .decoder
                 .lock()
                 .expect("initial lock should succeed");
             panic!("poison projected decoder");
@@ -415,30 +437,80 @@ mod tests {
     }
 
     #[test]
+    fn projected_decoder_pool_caps_requested_shards() {
+        let pool = ProjectedDecoderPool::new(field_names::DEFAULT_RESOURCE_PREFIX, usize::MAX);
+        assert_eq!(pool.len(), super::super::MAX_PROJECTED_DECODER_SHARDS);
+    }
+
+    #[test]
     fn projected_decoder_pool_round_robins_shards() {
         let pool = ProjectedDecoderPool::new(field_names::DEFAULT_RESOURCE_PREFIX, 2);
-        let first = pool.next();
-        let second = pool.next();
-        let third = pool.next();
+        let first = pool.next().expect("first shard should be available");
+        let second = pool.next().expect("second shard should be available");
+        let third = pool.next().expect("first shard should be selected again");
 
         assert!(!std::ptr::eq(first, second));
         assert!(std::ptr::eq(first, third));
     }
 
     #[test]
-    fn projected_decoder_poison_is_internal_error() {
+    fn projected_decoder_pool_skips_unavailable_shards() {
+        let pool = ProjectedDecoderPool::new(field_names::DEFAULT_RESOURCE_PREFIX, 2);
+        let first = pool.next().expect("first shard should be available");
+        first.mark_unavailable();
+        let second = pool.next().expect("second shard should be available");
+        let third = pool.next().expect("second shard should remain available");
+
+        assert!(!std::ptr::eq(first, second));
+        assert!(std::ptr::eq(second, third));
+    }
+
+    #[test]
+    fn single_projected_decoder_poison_is_internal_error() {
         let state = projected_only_state(1024);
         poison_projected_decoder_lock(&state);
 
         match decode_otlp_protobuf_request_blocking(Vec::new(), &state) {
             Err(OtlpRequestDecodeError::Internal(msg)) => {
-                assert!(msg.contains("projected decoder lock poisoned"));
+                assert!(msg.contains("all projected decoder shards are poisoned"));
             }
             Err(OtlpRequestDecodeError::Payload(_)) => {
                 panic!("poisoned decoder lock must not be reported as a payload error");
             }
             Ok(_) => panic!("poisoned decoder lock must fail"),
         }
+    }
+
+    #[test]
+    fn projected_decoder_poisoned_shard_is_removed_from_rotation_without_failing_request() {
+        let (tx, _rx) = mpsc::sync_channel(1);
+        let state = OtlpServerState {
+            tx,
+            is_running: Arc::new(AtomicBool::new(true)),
+            health: Arc::new(AtomicU8::new(ComponentHealth::Healthy.as_repr())),
+            resource_prefix: field_names::DEFAULT_RESOURCE_PREFIX.to_string(),
+            protobuf_decode_mode: OtlpProtobufDecodeMode::ProjectedOnly,
+            protobuf_decode_permits: Arc::new(Semaphore::new(1)),
+            projected_decoders: Some(ProjectedDecoderPool::new(
+                field_names::DEFAULT_RESOURCE_PREFIX,
+                2,
+            )),
+            stats: None,
+            max_message_size_bytes: 1024,
+        };
+        poison_projected_decoder_lock(&state);
+
+        let first = decode_otlp_protobuf_request_blocking(Vec::new(), &state);
+        assert!(
+            first.is_ok(),
+            "request should retry against a healthy shard after disabling the poisoned shard"
+        );
+
+        let second = decode_otlp_protobuf_request_blocking(Vec::new(), &state);
+        assert!(
+            second.is_ok(),
+            "subsequent request should skip the poisoned shard"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Cap `ProjectedDecoderPool::new` internally so future call sites cannot allocate an unbounded shard count.
- Track decoder shard availability and disable a shard after its mutex is poisoned, so future projected-decode requests skip it instead of intermittently reusing a permanently poisoned lock.
- Relax compressed-payload expansion-limit tests to assert structured `InvalidData` behavior without coupling to the exact error string.

## Verification

- `cargo test -p logfwd-io otlp_receiver --features otlp-research -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -p logfwd-io --features otlp-research -- -D warnings`
- `git diff --check`
- `just ci`

## Notes

This follows up the projected decoder pool work from #2306 before we move into the benchmark/cutover-gate work in #2301.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden projected decoder pool by skipping poisoned shards during round-robin selection
> - Introduces `ProjectedDecoderShard` wrapping each decoder with an `AtomicBool is_available` flag; shards marked unavailable via `mark_unavailable()` are permanently excluded from selection.
> - `ProjectedDecoderPool.next()` now returns `Option<&ProjectedDecoderShard>`, skipping unavailable shards and returning `None` when all are exhausted.
> - `decode_with_reusable_projected_decoder` retries across shards on mutex poison, calling `mark_unavailable()` on the poisoned shard and continuing the loop rather than failing immediately.
> - Pool creation now clamps shard count to `[1, MAX_PROJECTED_DECODER_SHARDS]`.
> - Behavioral Change: callers of `decode_with_reusable_projected_decoder` now receive distinct Internal errors depending on whether shards were poisoned vs. no available shards exist from the start.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c76bee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->