### PR TITLE
fix(docs): sync car.d with targetD in highway sim transitions

### DIFF
--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -222,7 +222,7 @@ export function createSimulation(overrides, scaleFn) {
         slots[i] = null;
         slots[nextSlot] = car;
         car.slot = nextSlot;
-        car.targetD = slotDArr[nextSlot];
+        car.d = car.targetD = slotDArr[nextSlot];
         car.speed = 3.5;
 
         // Mark as past gate when crossing the gate slot
@@ -232,7 +232,7 @@ export function createSimulation(overrides, scaleFn) {
       } else {
         // Can't advance — stopped
         car.speed = 0;
-        car.targetD = slotDArr[i];
+        car.d = car.targetD = slotDArr[i];
       }
 
       // Fade for exit (past gate) and cont (full length)
@@ -263,7 +263,7 @@ export function createSimulation(overrides, scaleFn) {
       hwySlots[lastHwy] = null;
       car.segment = 'exit';
       car.slot = 0;
-      car.targetD = exitSlotD[0];
+      car.d = car.targetD = exitSlotD[0];
       car.pastGate = false;
       exitSlots[0] = car;
       return;
@@ -274,7 +274,7 @@ export function createSimulation(overrides, scaleFn) {
       hwySlots[lastHwy] = null;
       car.segment = 'cont';
       car.slot = 0;
-      car.targetD = contSlotD[0];
+      car.d = car.targetD = contSlotD[0];
       contSlots[0] = car;
       return;
     }
@@ -293,7 +293,7 @@ export function createSimulation(overrides, scaleFn) {
       rampSlots[lastRamp] = null;
       car.segment = 'highway';
       car.slot = cfg.mergeSlot;
-      car.targetD = hwySlotD[cfg.mergeSlot];
+      car.d = car.targetD = hwySlotD[cfg.mergeSlot];
       hwySlots[cfg.mergeSlot] = car;
     } else {
       car.speed = 0;


### PR DESCRIPTION
## Summary

Fixes a bug from #2303 review feedback where `car.d` was never updated after initialization in the slot-based highway simulation. Only `car.targetD` was set during segment transitions and stopped-car branches, leaving `car.d` stale at the spawn-time value.

## Changes

5 lines in `highway-sim.mjs` — changed bare `car.targetD = ...` to `car.d = car.targetD = ...` at:
- `advanceSegment` stopped-car branch (line 235)
- `advanceSegment` forward-move branch (line 225)
- `tryHwyToExit` → exit transition (line 266)
- `tryHwyToExit` → cont transition (line 277)
- `tryRampMerge` → highway merge (line 296)

The two gate-stop paths (lines 202-203, 215-216) already used `car.d = car.targetD` on a separate line and were correct.

## Test plan

All 41 existing tests pass (`node --test book/src/components/__tests__/highway-sim.test.mjs`).

Relates to #2303

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync `car.d` with `car.targetD` during slot transitions in highway sim
> In [highway-sim.mjs](https://github.com/strawgate/fastforward/pull/2313/files#diff-3cd598b368f6c25e5fdb6d5543ce9386ecc712ab90450994da39111e7797fbf0), slot transition cases (advance, stop, exit, cont, merge) previously only updated `car.targetD`, leaving `car.d` out of sync until a later update. Now `car.d` is set alongside `car.targetD` at each transition point. Behavioral Change: `car.d` now jumps immediately to the target slot distance at the moment of reassignment rather than gradually converging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 159ca04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->