### PR TITLE
refactor(docs): clean up highway sim — segment map, drop car.d, moveCar, const/let

### DIFF
--- a/book/src/components/HighwayBackpressure.astro
+++ b/book/src/components/HighwayBackpressure.astro
@@ -163,37 +163,37 @@
 import { createSimulation } from './highway-sim.mjs';
 
 (function() {
-  var carsG = document.getElementById('hw-cars');
-  var statusEl = document.getElementById('hw-status');
-  var pipelineLabel = document.getElementById('hw-pipeline-label');
-  var slider = document.getElementById('hw-green');
-  var sliderDetail = document.getElementById('hw-slider-detail');
-  var lRed = document.getElementById('hw-l-red');
-  var lGreen = document.getElementById('hw-l-green');
-  var lightG = document.getElementById('hw-light');
-  var lightHousing = document.getElementById('hw-light-housing');
-  var stopLine = document.getElementById('hw-stop-line');
-  var sTput = document.getElementById('hw-s-tput');
-  var sQueue = document.getElementById('hw-s-queue');
-  var sStall = document.getElementById('hw-s-stall');
+  const carsG = document.getElementById('hw-cars');
+  const statusEl = document.getElementById('hw-status');
+  const pipelineLabel = document.getElementById('hw-pipeline-label');
+  const slider = document.getElementById('hw-green');
+  const sliderDetail = document.getElementById('hw-slider-detail');
+  const lRed = document.getElementById('hw-l-red');
+  const lGreen = document.getElementById('hw-l-green');
+  const lightG = document.getElementById('hw-light');
+  const lightHousing = document.getElementById('hw-light-housing');
+  const stopLine = document.getElementById('hw-stop-line');
+  const sTput = document.getElementById('hw-s-tput');
+  const sQueue = document.getElementById('hw-s-queue');
+  const sStall = document.getElementById('hw-s-stall');
 
   // Measure SVG paths
-  var pathRamp = document.getElementById('hw-path-ramp');
-  var pathHwy = document.getElementById('hw-path-hwy');
-  var pathExit = document.getElementById('hw-path-exit');
-  var pathCont = document.getElementById('hw-path-cont');
+  const pathRamp = document.getElementById('hw-path-ramp');
+  const pathHwy = document.getElementById('hw-path-hwy');
+  const pathExit = document.getElementById('hw-path-exit');
+  const pathCont = document.getElementById('hw-path-cont');
   if (!carsG || !slider || !pathRamp || !pathHwy || !pathExit || !pathCont) return;
 
-  var lenRamp = pathRamp.getTotalLength();
-  var lenHwy = pathHwy.getTotalLength();
-  var lenExit = pathExit.getTotalLength();
-  var lenCont = pathCont.getTotalLength();
+  const lenRamp = pathRamp.getTotalLength();
+  const lenHwy = pathHwy.getTotalLength();
+  const lenExit = pathExit.getTotalLength();
+  const lenCont = pathCont.getTotalLength();
 
-  var SIM_FRAMES = 10; // sim advances every 10 render frames (250ms at 25ms/frame)
-  var CAR_W = 20, CAR_H = 10;
+  const SIM_FRAMES = 10; // sim advances every 10 render frames (250ms at 25ms/frame)
+  const CAR_W = 20, CAR_H = 10;
 
   // Create simulation with measured path lengths
-  var sim = createSimulation({
+  const sim = createSimulation({
     lenRamp: lenRamp,
     lenHwy: lenHwy,
     lenExit: lenExit,
@@ -205,59 +205,59 @@ import { createSimulation } from './highway-sim.mjs';
   sim.setCycleStart(Date.now());
 
   // Gate position for traffic light rendering
-  var gateD = sim.getSlotD('exit', sim.cfg.gateSlot);
+  const gateD = sim.getSlotD('exit', sim.cfg.gateSlot);
 
   // ---- Position traffic light on exit ramp ----
   (function() {
-    var p = pathExit.getPointAtLength(gateD);
-    var p2 = pathExit.getPointAtLength(Math.min(gateD + 3, lenExit));
-    var angle = Math.atan2(p2.y - p.y, p2.x - p.x);
-    var perpAngle = angle - Math.PI / 2;
-    var cosP = Math.cos(perpAngle);
-    var sinP = Math.sin(perpAngle);
+    const p = pathExit.getPointAtLength(gateD);
+    const p2 = pathExit.getPointAtLength(Math.min(gateD + 3, lenExit));
+    const angle = Math.atan2(p2.y - p.y, p2.x - p.x);
+    const perpAngle = angle - Math.PI / 2;
+    const cosP = Math.cos(perpAngle);
+    const sinP = Math.sin(perpAngle);
 
     stopLine.setAttribute('x1', String((p.x + cosP * 14).toFixed(1)));
     stopLine.setAttribute('y1', String((p.y + sinP * 14).toFixed(1)));
     stopLine.setAttribute('x2', String((p.x - cosP * 14).toFixed(1)));
     stopLine.setAttribute('y2', String((p.y - sinP * 14).toFixed(1)));
 
-    var ox = p.x + cosP * 30;
-    var oy = p.y + sinP * 30;
+    const ox = p.x + cosP * 30;
+    const oy = p.y + sinP * 30;
     lightHousing.setAttribute('transform', 'translate(' + ox.toFixed(1) + ',' + oy.toFixed(1) + ')');
 
     lightG.style.display = '';
   })();
 
-  var TICK_MS = 25;
-  var LERP_RATE = 0.25; // visual interpolation speed per frame
+  const TICK_MS = 25;
+  const LERP_RATE = 0.25; // visual interpolation speed per frame
 
   // Segment → SVG path mapping
-  var pathMap = { ramp: pathRamp, highway: pathHwy, exit: pathExit, cont: pathCont };
-  var lenMap = { ramp: lenRamp, highway: lenHwy, exit: lenExit, cont: lenCont };
+  const pathMap = { ramp: pathRamp, highway: pathHwy, exit: pathExit, cont: pathCont };
+  const lenMap = { ramp: lenRamp, highway: lenHwy, exit: lenExit, cont: lenCont };
 
   function posAt(segment, d) {
-    var path = pathMap[segment];
-    var len = lenMap[segment];
+    const path = pathMap[segment];
+    const len = lenMap[segment];
     return path.getPointAtLength(Math.min(Math.max(0, d), len));
   }
   function angleAt(segment, d) {
-    var len = lenMap[segment];
-    var p1 = posAt(segment, d);
-    var p2 = posAt(segment, Math.min(d + 2, len));
+    const len = lenMap[segment];
+    const p1 = posAt(segment, d);
+    const p2 = posAt(segment, Math.min(d + 2, len));
     if (Math.abs(p2.x - p1.x) < 0.01 && Math.abs(p2.y - p1.y) < 0.01) return 0;
     return Math.atan2(p2.y - p1.y, p2.x - p1.x) * 180 / Math.PI;
   }
 
   // ---- DOM car management ----
-  var carEls = {};
-  var visualD = {}; // per-car visual interpolation state
+  const carEls = {};
+  const visualD = {}; // per-car visual interpolation state
 
   function createCarEl(car) {
-    var w = CAR_W * car.scale;
-    var h = CAR_H * car.scale;
-    var s = car.scale;
-    var g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
-    var body = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    let w = CAR_W * car.scale;
+    let h = CAR_H * car.scale;
+    const s = car.scale;
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    const body = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
 
     if (car.shape === 'truck') {
       w = CAR_W * s * 1.3;
@@ -293,8 +293,8 @@ import { createSimulation } from './highway-sim.mjs';
     g.appendChild(body);
 
     // Accent stripe
-    var stripe = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
-    var stripeW = car.shape === 'truck' ? 3 * s : 2.5 * s;
+    const stripe = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    const stripeW = car.shape === 'truck' ? 3 * s : 2.5 * s;
     stripe.setAttribute('x', String(w / 2 - stripeW - 1.5 * s));
     stripe.setAttribute('y', String(-h / 2 + 1.5 * s));
     stripe.setAttribute('width', String(stripeW));
@@ -304,7 +304,7 @@ import { createSimulation } from './highway-sim.mjs';
     g.appendChild(stripe);
 
     if (car.shape === 'truck' || car.shape === 'van') {
-      var s2 = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+      const s2 = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
       s2.setAttribute('x', String(-w / 2 + 2 * s));
       s2.setAttribute('y', String(-h / 2 + 1.5 * s));
       s2.setAttribute('width', String(2 * s));
@@ -320,7 +320,7 @@ import { createSimulation } from './highway-sim.mjs';
   }
 
   function removeCarEl(id) {
-    var el = carEls[id];
+    const el = carEls[id];
     if (el && el.g.parentNode) {
       el.g.parentNode.removeChild(el.g);
       delete carEls[id];
@@ -330,25 +330,25 @@ import { createSimulation } from './highway-sim.mjs';
   }
 
   function updateCarEl(car) {
-    var el = carEls[car.id];
+    const el = carEls[car.id];
     if (!el) return;
-    var seg = car.segment;
-    var len = lenMap[seg];
+    const seg = car.segment;
+    const len = lenMap[seg];
 
     // Lerp visualD toward car.targetD for smooth motion
-    var vd = visualD[car.id];
+    let vd = visualD[car.id];
     if (vd == null) vd = car.targetD;
     vd += (car.targetD - vd) * LERP_RATE;
     // Snap when very close to avoid endless micro-drifting
     if (Math.abs(car.targetD - vd) < 0.5) vd = car.targetD;
     visualD[car.id] = vd;
 
-    var d = Math.min(Math.max(0, vd), len);
-    var p = posAt(seg, d);
-    var a = angleAt(seg, d);
+    const d = Math.min(Math.max(0, vd), len);
+    const p = posAt(seg, d);
+    const a = angleAt(seg, d);
     el.g.setAttribute('transform', 'translate(' + p.x.toFixed(1) + ',' + p.y.toFixed(1) + ') rotate(' + a.toFixed(1) + ')');
 
-    var fill;
+    let fill;
     if (car.color === 'stop') fill = 'var(--hw-car-stop)';
     else if (car.color === 'slow') fill = 'var(--hw-car-slow)';
     else fill = 'var(--hw-car-flow)';
@@ -360,25 +360,25 @@ import { createSimulation } from './highway-sim.mjs';
   // ---- Main render loop ----
   // Sim ticks every SIM_FRAMES render frames to keep car speed natural.
   // Render frames interpolate visual positions for smoothness.
-  var lastStatus = '';
-  var timer = null;
-  var frameCount = 0;
-  var lastFrame = null; // most recent sim.tick() result
+  let lastStatus = '';
+  let timer = null;
+  let frameCount = 0;
+  let lastFrame = null; // most recent sim.tick() result
 
   // Track which segment each car was on last frame (for transition detection)
-  var lastSegment = {};
+  const lastSegment = {};
 
   function tick() {
-    var now = Date.now();
+    const now = Date.now();
     frameCount++;
 
     // Advance simulation every SIM_FRAMES render frames
     if (frameCount % SIM_FRAMES === 0 || !lastFrame) {
       lastFrame = sim.tick(now);
 
-      var allCars = lastFrame.cars;
-      for (var c = 0; c < allCars.length; c++) {
-        var car = allCars[c];
+      const allCars = lastFrame.cars;
+      for (let c = 0; c < allCars.length; c++) {
+        const car = allCars[c];
         if (!carEls[car.id]) createCarEl(car);
         // Reset visualD on segment transition
         if (lastSegment[car.id] && lastSegment[car.id] !== car.segment) {
@@ -386,7 +386,7 @@ import { createSimulation } from './highway-sim.mjs';
         }
         lastSegment[car.id] = car.segment;
       }
-      for (var r = 0; r < lastFrame.removedIds.length; r++) {
+      for (let r = 0; r < lastFrame.removedIds.length; r++) {
         removeCarEl(lastFrame.removedIds[r]);
       }
 
@@ -416,12 +416,12 @@ import { createSimulation } from './highway-sim.mjs';
       }
 
       // Status label
-      var msg = lastFrame.status.msg;
+      const msg = lastFrame.status.msg;
       if (msg !== lastStatus) {
         if (statusEl) statusEl.textContent = msg;
         if (pipelineLabel) {
           pipelineLabel.textContent = msg.toUpperCase();
-          var fill = lastFrame.status.level === 'blocked' ? 'var(--hw-car-stop)' : lastFrame.status.level === 'congested' ? 'var(--hw-car-slow)' : 'var(--hw-muted)';
+          const fill = lastFrame.status.level === 'blocked' ? 'var(--hw-car-stop)' : lastFrame.status.level === 'congested' ? 'var(--hw-car-slow)' : 'var(--hw-muted)';
           pipelineLabel.setAttribute('fill', fill);
         }
         lastStatus = msg;
@@ -430,7 +430,7 @@ import { createSimulation } from './highway-sim.mjs';
 
     // Always: update visual positions (smooth interpolation every render frame)
     if (lastFrame) {
-      for (var u = 0; u < lastFrame.cars.length; u++) {
+      for (let u = 0; u < lastFrame.cars.length; u++) {
         updateCarEl(lastFrame.cars[u]);
       }
     }
@@ -438,7 +438,7 @@ import { createSimulation } from './highway-sim.mjs';
 
   // ---- Slider events ----
   function onSliderInput() {
-    var v = parseInt(slider.value, 10);
+    const v = parseInt(slider.value, 10);
     sim.setGreenPct(v);
     if (sliderDetail) sliderDetail.textContent = 'Green ' + v + '% \u00B7 Red ' + (100 - v) + '%';
   }
@@ -461,16 +461,16 @@ import { createSimulation } from './highway-sim.mjs';
   if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
     sim.setLastSpawn(Date.now());
     seedCars();
-    var initial = sim.getCars();
-    for (var i = 0; i < initial.length; i++) {
+    const initial = sim.getCars();
+    for (let i = 0; i < initial.length; i++) {
       createCarEl(initial[i]);
       updateCarEl(initial[i]);
     }
     timer = setInterval(tick, TICK_MS);
   } else {
     seedCars();
-    var staticCars = sim.getCars();
-    for (var j = 0; j < staticCars.length; j++) {
+    const staticCars = sim.getCars();
+    for (let j = 0; j < staticCars.length; j++) {
       createCarEl(staticCars[j]);
       updateCarEl(staticCars[j]);
     }

--- a/book/src/components/__tests__/highway-sim.test.mjs
+++ b/book/src/components/__tests__/highway-sim.test.mjs
@@ -542,13 +542,12 @@ describe('slot positions', function () {
     assert.equal(car.targetD, expected);
   });
 
-  it('keeps legacy d synchronized with targetD after slot movement', function () {
+  it('targetD tracks slot position after movement', function () {
     var sim = createSimulation({ greenPct: 100, spawnMs: 99999 }, fixedScale(1));
     sim.exitAuto();
     var car = sim.addCar('highway', 1);
     sim.tick(1000);
-    assert.equal(car.d, car.targetD);
-    assert.equal(car.d, sim.getSlotD('highway', 2));
+    assert.equal(car.targetD, sim.getSlotD('highway', 2));
   });
 
   it('keeps a car stopped at the last slot when it cannot advance', function () {

--- a/book/src/components/highway-sim.mjs
+++ b/book/src/components/highway-sim.mjs
@@ -12,7 +12,7 @@
  *   cont:    cars continue east past the fork (always flowing, fade out)
  */
 
-export var DEFAULTS = {
+export const DEFAULTS = {
   slotsHwy: 15,
   slotsRamp: 5,
   slotsExit: 6,
@@ -30,79 +30,100 @@ export var DEFAULTS = {
   scaleMin: 0.8,
   scaleMax: 1.15,
   spawnBlockedThreshold: 8,
-  // Segment d-lengths for rendering (used to compute slot positions)
   lenHwy: 530,
   lenRamp: 180,
   lenExit: 210,
   lenCont: 215,
 };
 
-var SHAPES = ['sedan', 'truck', 'compact', 'van'];
-var SHAPE_W = { sedan: 1, truck: 1.3, compact: 0.8, van: 1 };
+const SHAPES = ['sedan', 'truck', 'compact', 'van'];
+const SHAPE_W = { sedan: 1, truck: 1.3, compact: 0.8, van: 1 };
 
 export function fixedScale(s) {
   return function () { return s; };
 }
 
 export function createSimulation(overrides, scaleFn) {
-  var cfg = {};
-  var k;
-  for (k in DEFAULTS) cfg[k] = DEFAULTS[k];
-  if (overrides) for (k in overrides) cfg[k] = overrides[k];
+  const cfg = {};
+  for (const k in DEFAULTS) cfg[k] = DEFAULTS[k];
+  if (overrides) for (const k in overrides) cfg[k] = overrides[k];
 
-  var getScale = scaleFn || function () {
+  const getScale = scaleFn || function () {
     return cfg.scaleMin + Math.random() * (cfg.scaleMax - cfg.scaleMin);
   };
 
-  // Compute slot d-positions for each segment
+  // Compute evenly-spaced slot positions along a segment
   function slotPositions(count, segLen) {
-    var positions = [];
-    var spacing = count > 1 ? segLen / (count - 1) : 0;
-    for (var i = 0; i < count; i++) {
+    const positions = [];
+    const spacing = count > 1 ? segLen / (count - 1) : 0;
+    for (let i = 0; i < count; i++) {
       positions.push(i * spacing);
     }
     return positions;
   }
 
-  var hwySlotD = slotPositions(cfg.slotsHwy, cfg.lenHwy);
-  var rampSlotD = slotPositions(cfg.slotsRamp, cfg.lenRamp);
-  var exitSlotD = slotPositions(cfg.slotsExit, cfg.lenExit);
-  var contSlotD = slotPositions(cfg.slotsCont, cfg.lenCont);
+  // ---- Segment map — single source of truth per segment ----
+  const segs = {
+    highway: {
+      slots: new Array(cfg.slotsHwy).fill(null),
+      slotD: slotPositions(cfg.slotsHwy, cfg.lenHwy),
+      len: cfg.lenHwy,
+      hasGate: false, fadePastGate: false, fadeFullLen: false,
+    },
+    ramp: {
+      slots: new Array(cfg.slotsRamp).fill(null),
+      slotD: slotPositions(cfg.slotsRamp, cfg.lenRamp),
+      len: cfg.lenRamp,
+      hasGate: false, fadePastGate: false, fadeFullLen: false,
+    },
+    exit: {
+      slots: new Array(cfg.slotsExit).fill(null),
+      slotD: slotPositions(cfg.slotsExit, cfg.lenExit),
+      len: cfg.lenExit,
+      hasGate: true, fadePastGate: true, fadeFullLen: false,
+    },
+    cont: {
+      slots: new Array(cfg.slotsCont).fill(null),
+      slotD: slotPositions(cfg.slotsCont, cfg.lenCont),
+      len: cfg.lenCont,
+      hasGate: false, fadePastGate: false, fadeFullLen: true,
+    },
+  };
 
-  // Slot arrays — null means empty, otherwise holds a car object
-  var hwySlots = new Array(cfg.slotsHwy).fill(null);
-  var rampSlots = new Array(cfg.slotsRamp).fill(null);
-  var exitSlots = new Array(cfg.slotsExit).fill(null);
-  var contSlots = new Array(cfg.slotsCont).fill(null);
+  let nextId = 0;
+  let lightIsGreen = true;
+  let greenPct = cfg.greenPct;
+  let cycleStart = 0;
+  let lastSpawn = -Infinity;
+  let spawnSrc = 0;
 
-  var nextId = 0;
-  var lightIsGreen = true;
-  var greenPct = cfg.greenPct;
-  var cycleStart = 0;
-  var lastSpawn = -Infinity;
-  var spawnSrc = 0;
+  let autoMode = true;
+  let autoVal = greenPct;
+  let autoDir = -1;
 
-  var autoMode = true;
-  var autoVal = greenPct;
-  var autoDir = -1;
-
-  var deliveries = [];
-  var stalledFrames = 0;
-  var totalFrames = 0;
-  var spawnBlockedTicks = 0;
+  const deliveries = [];
+  let stalledFrames = 0;
+  let totalFrames = 0;
+  let spawnBlockedTicks = 0;
 
   // ---- helpers ----
 
+  function moveCar(car, segment, slotIdx) {
+    const s = segs[segment];
+    car.segment = segment;
+    car.slot = slotIdx;
+    car.targetD = s.slotD[slotIdx];
+  }
+
   function makeCar(segment, slotIdx, scale) {
-    var s = scale != null ? scale : getScale();
-    var shape = SHAPES[nextId % SHAPES.length];
-    var shapeMul = SHAPE_W[shape] || 1;
-    var slotD = getSlotD(segment, slotIdx);
+    const s = scale != null ? scale : getScale();
+    const shape = SHAPES[nextId % SHAPES.length];
+    const shapeMul = SHAPE_W[shape] || 1;
+    const slotD = segs[segment].slotD[slotIdx] || 0;
     return {
       id: nextId++,
       segment: segment,
       slot: slotIdx,
-      d: slotD,
       targetD: slotD,
       speed: 0,
       scale: s,
@@ -114,47 +135,25 @@ export function createSimulation(overrides, scaleFn) {
     };
   }
 
-  function getSlotD(segment, slotIdx) {
-    if (segment === 'highway') return hwySlotD[slotIdx] || 0;
-    if (segment === 'ramp') return rampSlotD[slotIdx] || 0;
-    if (segment === 'exit') return exitSlotD[slotIdx] || 0;
-    if (segment === 'cont') return contSlotD[slotIdx] || 0;
-    return 0;
-  }
-
-  function getSlots(segment) {
-    if (segment === 'highway') return hwySlots;
-    if (segment === 'ramp') return rampSlots;
-    if (segment === 'exit') return exitSlots;
-    if (segment === 'cont') return contSlots;
-    return null;
-  }
-
-  function getSegLen(segment) {
-    if (segment === 'highway') return cfg.lenHwy;
-    if (segment === 'ramp') return cfg.lenRamp;
-    if (segment === 'exit') return cfg.lenExit;
-    if (segment === 'cont') return cfg.lenCont;
-    return 0;
-  }
-
   function allCars() {
-    var result = [];
-    var segments = [hwySlots, rampSlots, exitSlots, contSlots];
-    for (var s = 0; s < segments.length; s++) {
-      for (var i = 0; i < segments[s].length; i++) {
-        if (segments[s][i]) result.push(segments[s][i]);
+    const result = [];
+    const segNames = ['highway', 'ramp', 'exit', 'cont'];
+    for (let s = 0; s < segNames.length; s++) {
+      const slots = segs[segNames[s]].slots;
+      for (let i = 0; i < slots.length; i++) {
+        if (slots[i]) result.push(slots[i]);
       }
     }
     return result;
   }
 
   function totalCars() {
-    var count = 0;
-    var segments = [hwySlots, rampSlots, exitSlots, contSlots];
-    for (var s = 0; s < segments.length; s++) {
-      for (var i = 0; i < segments[s].length; i++) {
-        if (segments[s][i]) count++;
+    let count = 0;
+    const segNames = ['highway', 'ramp', 'exit', 'cont'];
+    for (let s = 0; s < segNames.length; s++) {
+      const slots = segs[segNames[s]].slots;
+      for (let i = 0; i < slots.length; i++) {
+        if (slots[i]) count++;
       }
     }
     return count;
@@ -171,7 +170,7 @@ export function createSimulation(overrides, scaleFn) {
   function tickLight(now) {
     if (greenPct >= 100) { lightIsGreen = true; return; }
     if (greenPct <= 0) { lightIsGreen = false; return; }
-    var elapsed = (now - cycleStart) % cfg.cycleTotal;
+    const elapsed = (now - cycleStart) % cfg.cycleTotal;
     lightIsGreen = elapsed < cfg.cycleTotal * greenPct / 100;
   }
 
@@ -185,35 +184,30 @@ export function createSimulation(overrides, scaleFn) {
 
   // ---- segment advancement ----
 
-  function advanceSegment(slots, slotDArr, segLen, opts) {
-    opts = opts || {};
-    // Process from the end (highest slot) to start, so each car
-    // sees the already-advanced state of the car ahead.
-    for (var i = slots.length - 1; i >= 0; i--) {
-      var car = slots[i];
+  function advanceSegment(seg) {
+    const { slots, slotD, len, hasGate, fadePastGate, fadeFullLen } = seg;
+
+    for (let i = slots.length - 1; i >= 0; i--) {
+      const car = slots[i];
       if (!car) continue;
 
       // Gate check — exit segment only
-      if (opts.hasGate && !lightIsGreen && !car.pastGate) {
+      if (hasGate && !lightIsGreen && !car.pastGate) {
         if (i >= cfg.gateSlot) {
-          // Car is at or past the gate slot but hasn't been marked past gate
-          // (placed here manually or reached gate during red) — stop
           car.speed = 0;
-          car.targetD = slotDArr[i];
-          car.d = car.targetD;
+          moveCar(car, car.segment, i);
           car.color = carColor(car);
           continue;
         }
       }
 
       // Try to advance to next slot
-      var nextSlot = i + 1;
+      const nextSlot = i + 1;
       if (nextSlot < slots.length && slots[nextSlot] === null) {
         // Gate blocking: can't advance past gateSlot if light is red
-        if (opts.hasGate && !lightIsGreen && !car.pastGate && nextSlot > cfg.gateSlot) {
+        if (hasGate && !lightIsGreen && !car.pastGate && nextSlot > cfg.gateSlot) {
           car.speed = 0;
-          car.targetD = slotDArr[i];
-          car.d = car.targetD;
+          moveCar(car, car.segment, i);
           car.color = carColor(car);
           continue;
         }
@@ -221,32 +215,30 @@ export function createSimulation(overrides, scaleFn) {
         // Move forward
         slots[i] = null;
         slots[nextSlot] = car;
-        car.slot = nextSlot;
-        car.targetD = slotDArr[nextSlot];
+        moveCar(car, car.segment, nextSlot);
         car.speed = 3.5;
 
         // Mark as past gate when crossing the gate slot
-        if (opts.hasGate && nextSlot > cfg.gateSlot) {
+        if (hasGate && nextSlot > cfg.gateSlot) {
           car.pastGate = true;
         }
       } else {
         // Can't advance — stopped
         car.speed = 0;
-        car.targetD = slotDArr[i];
+        moveCar(car, car.segment, i);
       }
 
       // Fade for exit (past gate) and cont (full length)
-      if (opts.fadePastGate && car.pastGate) {
-        var gatePos = slotDArr[cfg.gateSlot] || 0;
-        var fadeLen = segLen - gatePos;
+      if (fadePastGate && car.pastGate) {
+        const gatePos = slotD[cfg.gateSlot] || 0;
+        const fadeLen = len - gatePos;
         car.opacity = fadeLen > 0 ? Math.max(0, 1 - (car.targetD - gatePos) / fadeLen) : 0;
-      } else if (opts.fadeFullLen) {
-        car.opacity = segLen > 0 ? Math.max(0, 1 - car.targetD / segLen) : 0;
+      } else if (fadeFullLen) {
+        car.opacity = len > 0 ? Math.max(0, 1 - car.targetD / len) : 0;
       } else {
         car.opacity = 1;
       }
 
-      car.d = car.targetD;
       car.color = carColor(car);
     }
   }
@@ -254,28 +246,25 @@ export function createSimulation(overrides, scaleFn) {
   // ---- transitions ----
 
   function tryHwyToExit() {
-    var lastHwy = cfg.slotsHwy - 1;
-    var car = hwySlots[lastHwy];
+    const hwy = segs.highway;
+    const lastHwy = hwy.slots.length - 1;
+    const car = hwy.slots[lastHwy];
     if (!car) return;
 
     // Prefer exit ramp
-    if (exitSlots[0] === null) {
-      hwySlots[lastHwy] = null;
-      car.segment = 'exit';
-      car.slot = 0;
-      car.targetD = exitSlotD[0];
+    if (segs.exit.slots[0] === null) {
+      hwy.slots[lastHwy] = null;
+      moveCar(car, 'exit', 0);
       car.pastGate = false;
-      exitSlots[0] = car;
+      segs.exit.slots[0] = car;
       return;
     }
 
     // Continuation (only when light is green — prevents bypass during red)
-    if (lightIsGreen && contSlots[0] === null) {
-      hwySlots[lastHwy] = null;
-      car.segment = 'cont';
-      car.slot = 0;
-      car.targetD = contSlotD[0];
-      contSlots[0] = car;
+    if (lightIsGreen && segs.cont.slots[0] === null) {
+      hwy.slots[lastHwy] = null;
+      moveCar(car, 'cont', 0);
+      segs.cont.slots[0] = car;
       return;
     }
 
@@ -284,17 +273,17 @@ export function createSimulation(overrides, scaleFn) {
   }
 
   function tryRampMerge() {
-    var lastRamp = cfg.slotsRamp - 1;
-    var car = rampSlots[lastRamp];
+    const ramp = segs.ramp;
+    const hwy = segs.highway;
+    const lastRamp = ramp.slots.length - 1;
+    const car = ramp.slots[lastRamp];
     if (!car) return;
 
     // Merge into highway at mergeSlot if empty
-    if (hwySlots[cfg.mergeSlot] === null) {
-      rampSlots[lastRamp] = null;
-      car.segment = 'highway';
-      car.slot = cfg.mergeSlot;
-      car.targetD = hwySlotD[cfg.mergeSlot];
-      hwySlots[cfg.mergeSlot] = car;
+    if (hwy.slots[cfg.mergeSlot] === null) {
+      ramp.slots[lastRamp] = null;
+      moveCar(car, 'highway', cfg.mergeSlot);
+      hwy.slots[cfg.mergeSlot] = car;
     } else {
       car.speed = 0;
     }
@@ -306,26 +295,26 @@ export function createSimulation(overrides, scaleFn) {
     if (totalCars() >= cfg.maxCars) return { kind: 'capped' };
     if (now - lastSpawn < cfg.spawnMs) return { kind: 'cooldown' };
 
-    var spawned = false;
+    let spawned = false;
 
     // Alternate preferred source
-    var src = spawnSrc;
+    const src = spawnSrc;
     spawnSrc = 1 - spawnSrc;
 
     if (src === 0) {
-      if (hwySlots[0] === null) {
-        hwySlots[0] = makeCar('highway', 0);
+      if (segs.highway.slots[0] === null) {
+        segs.highway.slots[0] = makeCar('highway', 0);
         spawned = true;
-      } else if (rampSlots[0] === null) {
-        rampSlots[0] = makeCar('ramp', 0);
+      } else if (segs.ramp.slots[0] === null) {
+        segs.ramp.slots[0] = makeCar('ramp', 0);
         spawned = true;
       }
     } else {
-      if (rampSlots[0] === null) {
-        rampSlots[0] = makeCar('ramp', 0);
+      if (segs.ramp.slots[0] === null) {
+        segs.ramp.slots[0] = makeCar('ramp', 0);
         spawned = true;
-      } else if (hwySlots[0] === null) {
-        hwySlots[0] = makeCar('highway', 0);
+      } else if (segs.highway.slots[0] === null) {
+        segs.highway.slots[0] = makeCar('highway', 0);
         spawned = true;
       }
     }
@@ -342,12 +331,13 @@ export function createSimulation(overrides, scaleFn) {
   // ---- removal ----
 
   function removeDelivered(now) {
-    var removedIds = [];
+    const removedIds = [];
 
     // Exit: remove cars at last slot (delivered) or fully faded
-    var lastExit = cfg.slotsExit - 1;
-    for (var i = lastExit; i >= 0; i--) {
-      var ec = exitSlots[i];
+    const exitSlots = segs.exit.slots;
+    const lastExit = exitSlots.length - 1;
+    for (let i = lastExit; i >= 0; i--) {
+      const ec = exitSlots[i];
       if (!ec) continue;
       if (i === lastExit || ec.opacity <= 0.01) {
         removedIds.push(ec.id);
@@ -357,9 +347,10 @@ export function createSimulation(overrides, scaleFn) {
     }
 
     // Cont: remove cars at last slot or fully faded
-    var lastCont = cfg.slotsCont - 1;
-    for (var j = lastCont; j >= 0; j--) {
-      var cc = contSlots[j];
+    const contSlots = segs.cont.slots;
+    const lastCont = contSlots.length - 1;
+    for (let j = lastCont; j >= 0; j--) {
+      const cc = contSlots[j];
       if (!cc) continue;
       if (j === lastCont || cc.opacity <= 0.01) {
         removedIds.push(cc.id);
@@ -378,20 +369,20 @@ export function createSimulation(overrides, scaleFn) {
     tickLight(now);
 
     // 1. Remove delivered
-    var removedIds = removeDelivered(now);
+    const removedIds = removeDelivered(now);
 
     // 2. Advance continuation (downstream first — frees slots)
-    advanceSegment(contSlots, contSlotD, cfg.lenCont, { fadeFullLen: true });
+    advanceSegment(segs.cont);
 
     // 3. Highway → exit/cont transition (before exit advancement,
     //    so a full exit causes overflow to cont)
     tryHwyToExit();
 
     // 4. Advance exit
-    advanceSegment(exitSlots, exitSlotD, cfg.lenExit, { hasGate: true, fadePastGate: true });
+    advanceSegment(segs.exit);
 
     // 5. Advance highway
-    advanceSegment(hwySlots, hwySlotD, cfg.lenHwy);
+    advanceSegment(segs.highway);
 
     // 6. Try transition again (after highway advancement freed the lead car)
     tryHwyToExit();
@@ -400,13 +391,13 @@ export function createSimulation(overrides, scaleFn) {
     tryRampMerge();
 
     // 8. Advance ramp
-    advanceSegment(rampSlots, rampSlotD, cfg.lenRamp);
+    advanceSegment(segs.ramp);
 
     // 9. Try merge again
     tryRampMerge();
 
     // 10. Spawn
-    var spawn = trySpawn(now);
+    const spawn = trySpawn(now);
     if (spawn.kind === 'blocked') {
       spawnBlockedTicks++;
     } else if (spawn.kind !== 'cooldown') {
@@ -414,20 +405,20 @@ export function createSimulation(overrides, scaleFn) {
     }
 
     // Stats
-    var cutoff = now - 5000;
+    const cutoff = now - 5000;
     while (deliveries.length > 0 && deliveries[0] < cutoff) deliveries.shift();
-    var throughput = Math.round(deliveries.length * 12);
+    const throughput = Math.round(deliveries.length * 12);
 
-    var all = allCars();
-    var stalledCount = 0;
-    for (var s = 0; s < all.length; s++) {
+    const all = allCars();
+    let stalledCount = 0;
+    for (let s = 0; s < all.length; s++) {
       if (all[s].speed < 0.15 && all[s].segment !== 'cont') stalledCount++;
     }
     if (stalledCount > 0) stalledFrames++;
 
-    var stallPct = totalFrames > 0 ? Math.round(stalledFrames / totalFrames * 100) : 0;
+    const stallPct = totalFrames > 0 ? Math.round(stalledFrames / totalFrames * 100) : 0;
 
-    var status;
+    let status;
     if (spawnBlockedTicks >= cfg.spawnBlockedThreshold) {
       status = { level: 'blocked', msg: 'Traffic backed up to the on-ramp \u2014 no new cars can enter' };
     } else if (stalledCount > 3) {
@@ -461,27 +452,31 @@ export function createSimulation(overrides, scaleFn) {
     setCycleStart: function (t) { cycleStart = t; },
     setLastSpawn: function (t) { lastSpawn = t; },
     addCar: function (segment, slotIdx, speed, scale) {
-      var slots = getSlots(segment);
-      if (!slots) {
+      const seg = segs[segment];
+      if (!seg) {
         throw new Error('unknown segment ' + segment);
       }
-      if (slotIdx < 0 || slotIdx >= slots.length) {
+      if (slotIdx < 0 || slotIdx >= seg.slots.length) {
         throw new Error('invalid slot ' + slotIdx + ' for segment ' + segment);
       }
-      if (slots[slotIdx] !== null) {
+      if (seg.slots[slotIdx] !== null) {
         throw new Error('slot ' + slotIdx + ' on ' + segment + ' is occupied');
       }
-      var car = makeCar(segment, slotIdx, scale);
+      const car = makeCar(segment, slotIdx, scale);
       if (speed != null) car.speed = speed;
-      slots[slotIdx] = car;
+      seg.slots[slotIdx] = car;
       return car;
     },
     getSlots: function (segment) {
-      var slots = getSlots(segment);
-      if (!slots) throw new Error('unknown segment ' + segment);
-      return slots.slice();
+      const seg = segs[segment];
+      if (!seg) throw new Error('unknown segment ' + segment);
+      return seg.slots.slice();
     },
-    getSlotD: getSlotD,
+    getSlotD: function (segment, slotIdx) {
+      const seg = segs[segment];
+      if (!seg) return 0;
+      return seg.slotD[slotIdx] || 0;
+    },
     cfg: cfg,
   };
 }


### PR DESCRIPTION
## Summary

Structural refactor of the slot-based highway simulation with **no behavior changes**. All 41 tests pass, Astro build succeeds.

## What changed

| Refactor | Before | After | Why |
|---|---|---|---|
| **Segment map** | 4 parallel arrays per segment (`hwySlots`, `hwySlotD`, `cfg.lenHwy`, ...) + 3 if-chains (`getSlots`, `getSlotD`, `getSegLen`) | Single `segs` object bundles `slots`, `slotD`, `len`, and options per segment | Eliminates data scatter and if-chains. `advanceSegment(segs.exit)` instead of `advanceSegment(exitSlots, exitSlotD, cfg.lenExit, {hasGate:true, fadePastGate:true})` |
| **Drop `car.d`** | `car.d` and `car.targetD` both exist, must always be kept in sync | Only `car.targetD` in sim, `visualD` in renderer | Eliminates the entire class of forgot-to-sync bugs (#2303 review feedback, #2313) |
| **`moveCar()` helper** | Position/segment/slot mutations copy-pasted in 5+ places | Single `moveCar(car, segment, slotIdx)` function | One place to update if car fields change |
| **`var` → `const`/`let`** | ES5 `var` throughout `.mjs` and Astro script | Modern `const`/`let` | Would have caught the CAR_W hoisting bug as a TDZ ReferenceError at dev time |

## Test plan

- All 41 tests pass: `node --test book/src/components/__tests__/highway-sim.test.mjs`
- Astro build succeeds: `cd book && npx astro build`
- Net -6 lines

Relates to #2303, #2313

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor highway sim to use a unified `segs` map and remove `car.d` property
> - Introduces a centralized `segs` map in `createSimulation` ([highway-sim.mjs](https://github.com/strawgate/fastforward/pull/2314/files#diff-3cd598b368f6c25e5fdb6d5543ce9386ecc712ab90450994da39111e7797fbf0)) that holds slots, slot positions, length, and flags (gate, fade) per segment, replacing scattered helper functions.
> - Extracts a `moveCar` helper that updates a car's segment, slot, and `targetD` from `segs`, removing all manual `car.d` assignments.
> - Converts `var` declarations to `const`/`let` throughout [highway-sim.mjs](https://github.com/strawgate/fastforward/pull/2314/files#diff-3cd598b368f6c25e5fdb6d5543ce9386ecc712ab90450994da39111e7797fbf0) and [HighwayBackpressure.astro](https://github.com/strawgate/fastforward/pull/2314/files#diff-47399e83c747483e8e2291c0d77604fec3da890d28b1c54ef22a4f09b7b1350c).
> - Behavioral Change: `car.d` is no longer present on car objects; only `targetD` reflects slot position. The test in [highway-sim.test.mjs](https://github.com/strawgate/fastforward/pull/2314/files#diff-305098f088c7d333294d731ee3f0d26fcd6097737d87c90f9564eab29be7784d) is updated to drop the `car.d` assertion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8a3d8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->