### PR TITLE
feat: add stdin send cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,6 +2776,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "serde_json",
+ "serde_yaml_ng",
  "stats_alloc",
  "tempfile",
  "tikv-jemallocator",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ FastForward is a research and learning project exploring how far you can push a 
 
 The [documentation site](https://strawgate.github.io/fastforward/) has interactive guides that explain how each piece works — from SIMD parsing to backpressure to checkpoint ordering — with live simulations you can play with.
 
-> **Note:** The CLI is currently named `logfwd` and will be renamed to `ff` in a future release.
+> **Note:** The Cargo package is named `logfwd`; the installed CLI binary is `ff`.
 
 ## Try it
 
@@ -29,7 +29,7 @@ git clone https://github.com/strawgate/fastforward.git && cd fastforward
 cargo build --release -p logfwd
 
 # Generate some test data
-./target/release/logfwd generate-json 100000 logs.json
+./target/release/ff generate-json 100000 logs.json
 ```
 
 ```yaml
@@ -50,10 +50,23 @@ output:
 ```
 
 ```bash
-./target/release/logfwd run --config config.yaml
+./target/release/ff run --config config.yaml
 ```
 
 Only error records with slow durations make it through — everything else is filtered by the SQL transform.
+
+For one-off command-line sends, keep a destination-only config and pipe data into `ff`:
+
+```yaml
+# destination.yaml
+output:
+  type: otlp
+  endpoint: http://127.0.0.1:4318/v1/logs
+```
+
+```bash
+cat logs.json | ./target/release/ff send --config destination.yaml --format json --service checkout
+```
 
 ## What makes it interesting
 

--- a/book/src/content/docs/configuration/inputs.md
+++ b/book/src/content/docs/configuration/inputs.md
@@ -41,7 +41,7 @@ input:
 
 ```bash
 cat app.log | ff send --config destination.yaml --format json
-kubectl logs pod/app | ff send --config destination.yaml --format cri
+kubectl logs pod/app | LOGFWD_CONFIG=destination.yaml ff --format cri
 ```
 
 Use `file` input for daemon-style tailing. `stdin` is finite command input; it does not watch paths or discover rotated files.

--- a/book/src/content/docs/configuration/inputs.md
+++ b/book/src/content/docs/configuration/inputs.md
@@ -28,6 +28,24 @@ input:
 - `per_file_read_budget_bytes` (default: 262144): The maximum bytes to read from a single file during one polling iteration before yielding to other files.
 - `adaptive_fast_polls_max` (default: 8): Immediate repoll budget after a read-budget hit; set to `0` to disable adaptive fast repolls.
 
+## Stdin
+
+Read data from standard input, drain outputs, and exit when stdin closes.
+This input is intended for `ff send` and piped shell workflows.
+
+```yaml
+input:
+  type: stdin
+  format: auto     # auto | cri | json | raw
+```
+
+```bash
+cat app.log | ff send --config destination.yaml --format json
+kubectl logs pod/app | ff send --config destination.yaml --format cri
+```
+
+Use `file` input for daemon-style tailing. `stdin` is finite command input; it does not watch paths or discover rotated files.
+
 ## Generator
 
 Emit synthetic JSON log lines for benchmarking and pipeline testing. No external

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -6,6 +6,7 @@ description: "Complete YAML reference for all FastForward settings"
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 FastForward commands that operate on pipeline config (for example `run`, `validate`, `dry-run`, and `effective-config`) accept a YAML file via `--config <config.yaml>`.
+`ff send` accepts a destination-only config with top-level `output`, injects stdin as the input, drains the output, and exits.
 
 ## Overview
 
@@ -118,6 +119,19 @@ input:
   path: /var/log/pods/**/*.log
   format: cri
 ```
+
+### `stdin` input
+
+Read data from standard input. This input has no input-specific fields.
+It is primarily used by `ff send` for command-line piping.
+
+```yaml
+input:
+  type: stdin
+  format: auto
+```
+
+Supported formats: `auto`, `cri`, `json`, and `raw`.
 
 ### `generator` input
 
@@ -334,6 +348,7 @@ Behavior:
 | Value | Status | Description |
 |-------|--------|-------------|
 | `file` | Implemented | Tail files matching a glob pattern. |
+| `stdin` | Implemented | Read piped stdin until EOF, then drain outputs and exit. |
 | `generator` | Implemented | Emit synthetic JSON-like records from an in-process source. |
 | `udp` | Implemented | Receive log lines over UDP. |
 | `tcp` | Implemented | Accept log lines over TCP. |

--- a/book/src/content/docs/learn/index.mdx
+++ b/book/src/content/docs/learn/index.mdx
@@ -13,7 +13,7 @@ FastForward processes log data through four stages. Click any stage to explore i
 
 | Stage | What's inside |
 |-------|---------------|
-| [Inputs](/learn/inputs/) | 8 input types — file tailing, TCP, UDP, OTLP, HTTP, Arrow IPC, sensor, generator |
+| [Inputs](/learn/inputs/) | 9 input types — stdin, file tailing, TCP, UDP, OTLP, HTTP, Arrow IPC, sensor, generator |
 | [Scanner Deep Dive](/learn/scanner/) | SIMD structural indexing, field pushdown, zero-copy Arrow building |
 | [Columnar](/learn/columnar/) | Why Arrow columnar storage makes SQL fast |
 | [Backpressure in Action](/learn/backpressure/) | How bounded channels propagate pressure through the pipeline |

--- a/book/src/content/docs/learn/inputs.mdx
+++ b/book/src/content/docs/learn/inputs.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Inputs"
-description: "The 8 input types FastForward supports — from file tailing to Arrow-native sources"
+description: "The 9 input types FastForward supports — from stdin piping to Arrow-native sources"
 ---
 
-Sources produce raw bytes or Arrow batches independently and feed into a bounded pipeline channel. FastForward supports 8 input types across two modes:
+Sources produce raw bytes or Arrow batches independently and feed into a bounded pipeline channel. FastForward supports 9 input types across two modes:
 
-- **Raw bytes** — File, TCP, UDP, HTTP. The scanner parses these into Arrow RecordBatches.
+- **Raw bytes** — File, stdin, TCP, UDP, HTTP. The scanner parses these into Arrow RecordBatches.
 - **Arrow-native** — OTLP, Arrow IPC, Platform Sensor, Generator. These produce structured RecordBatches directly, bypassing the scanner entirely.
 
 ## File
@@ -17,6 +17,14 @@ Tail files matching glob patterns with position tracking across restarts. Detect
 **Internal stages:** Glob Discovery → File Watcher → Read Loop → Budget Control → EOF Detection
 
 See [Tailing](/learn/tailing/) for a detailed look at rotation, truncation, and crash recovery.
+
+## Stdin
+
+Read from standard input until EOF, then drain the pipeline and exit.
+
+**Key properties:** finite command input. Bounded reader channel. No checkpointing, glob discovery, or rotation handling.
+
+**Internal stages:** Stdin Reader → Bounded Channel → EOF Detection → Drain
 
 ## TCP
 

--- a/book/src/content/docs/quick-start.mdx
+++ b/book/src/content/docs/quick-start.mdx
@@ -120,7 +120,7 @@ Bare `ff` also enters send mode when stdin is piped, using the normal config
 search order. Set `LOGFWD_CONFIG` when you want an explicit destination config:
 
 ```bash
-cat logs.json | LOGFWD_CONFIG=destination.yaml ff
+cat logs.json | LOGFWD_CONFIG=destination.yaml ff --format json --service checkout
 ```
 
 ---

--- a/book/src/content/docs/quick-start.mdx
+++ b/book/src/content/docs/quick-start.mdx
@@ -11,7 +11,7 @@ import DataFlowAnimation from '../../components/DataFlowAnimation.astro';
 FastForward is a research project exploring how to build a fast log forwarder with Rust. This guide gets you from zero to a working pipeline in about 15 minutes.
 
 :::note
-The binary is currently named `logfwd` and will be renamed to `ff` in a future release. Docker images still reference `memagent` (the original image name).
+The Cargo package is named `logfwd`; the installed CLI binary is `ff`. Docker images still reference `memagent` (the original image name).
 :::
 
 ## Install
@@ -24,7 +24,7 @@ The binary is currently named `logfwd` and will be renamed to `ff` in a future r
     git clone https://github.com/strawgate/fastforward.git
     cd fastforward
     cargo build --release -p logfwd
-    sudo cp target/release/logfwd /usr/local/bin/
+    sudo cp target/release/ff /usr/local/bin/
     ```
   </TabItem>
   <TabItem label="Docker" icon="docker">
@@ -49,8 +49,8 @@ The binary is currently named `logfwd` and will be renamed to `ff` in a future r
 Verify it works:
 
 ```bash
-logfwd --version
-logfwd --help
+ff --version
+ff --help
 ```
 
 ---
@@ -60,7 +60,7 @@ logfwd --help
 Generate synthetic JSON log lines and print them to your terminal.
 
 ```bash
-logfwd generate-json 10000 logs.json
+ff generate-json 10000 logs.json
 ```
 
 This creates 10,000 JSON log lines with fields like `level`, `message`, `status`, `duration_ms`, and `service`.
@@ -78,16 +78,16 @@ output:
 ```
 
 ```bash
-logfwd run --config config.yaml
+ff run --config config.yaml
 ```
 
 You'll see colored output for every log line:
 
 ```
-logfwd v0.x.x (abc1234 2026-04-01, release)
+ff v0.x.x (abc1234 2026-04-01, release)
 
   ready: default
-logfwd running (1 pipeline(s))
+ff running (1 pipeline(s))
 
 10:30:00.000Z  INFO   request handled GET /api/v1/users/10000  duration_ms=1 request_id=... service=myapp status=200
 10:30:00.000Z  ERROR  request handled GET /health/10021  duration_ms=40 request_id=... service=myapp status=503
@@ -100,6 +100,29 @@ FastForward parsed every JSON line, detected field types automatically, built Ar
 FastForward exits when it reaches the end of a finite file. In production you'd point it at a log file being actively appended to, and it tails continuously.
 :::
 
+### Send piped data
+
+For one-off command-line use, keep a destination-only config and pipe data into `ff`.
+`ff send` reads stdin, drains the configured output, and exits.
+
+```yaml
+# destination.yaml
+output:
+  type: stdout
+  format: console
+```
+
+```bash
+cat logs.json | ff send --config destination.yaml --format json --service checkout
+```
+
+Bare `ff` also enters send mode when stdin is piped, using the normal config
+search order. Set `LOGFWD_CONFIG` when you want an explicit destination config:
+
+```bash
+cat logs.json | LOGFWD_CONFIG=destination.yaml ff
+```
+
 ---
 
 ## Stage 2: Filter with SQL
@@ -107,7 +130,7 @@ FastForward exits when it reaches the end of a finite file. In production you'd 
 Add a SQL transform to keep only what matters. Every batch of parsed records becomes a DataFusion SQL table named `logs`.
 
 ```bash
-logfwd generate-json 10000 logs.json    # regenerate — FastForward tracks file positions
+ff generate-json 10000 logs.json    # regenerate — FastForward tracks file positions
 ```
 
 ```yaml
@@ -128,7 +151,7 @@ output:
 ```
 
 ```bash
-logfwd run --config config.yaml
+ff run --config config.yaml
 ```
 
 Now you see only errors with slow durations. Only the columns from the `SELECT` appear — everything else was filtered before reaching the output. In production, this means you only ship the logs you care about.
@@ -148,7 +171,7 @@ FastForward sends OTLP protobuf to an OpenTelemetry Collector, Grafana Alloy, or
 Test locally with FastForward's built-in blackhole receiver:
 
 ```bash
-logfwd blackhole &
+ff blackhole &
 ```
 
 ```yaml
@@ -170,8 +193,8 @@ output:
 ```
 
 ```bash
-logfwd generate-json 10000 logs.json
-logfwd run --config config.yaml
+ff generate-json 10000 logs.json
+ff run --config config.yaml
 ```
 
 To ship to a real collector:
@@ -220,8 +243,8 @@ What's different from the earlier stages:
 ### Validate before deploying
 
 ```bash
-logfwd validate --config pipeline.yaml
-logfwd dry-run --config pipeline.yaml
+ff validate --config pipeline.yaml
+ff dry-run --config pipeline.yaml
 ```
 
 `validate` catches YAML errors. `dry-run` goes further and compiles the SQL against the Arrow schema, catching column name typos and type mismatches.

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -721,6 +721,7 @@ pipelines:
             ("otlp", "listen: 0.0.0.0:4317"),
             ("arrow_ipc", "listen: 0.0.0.0:4319"),
             ("http", "listen: 0.0.0.0:8080"),
+            ("stdin", ""),
             ("generator", ""),
             ("linux_ebpf_sensor", ""),
             ("macos_es_sensor", ""),
@@ -730,6 +731,51 @@ pipelines:
             let yaml = format!("input:\n  type: {itype}\n  {extra}\noutput:\n  type: stdout\n");
             Config::load_str(&yaml).unwrap_or_else(|e| panic!("failed for {itype}: {e}"));
         }
+    }
+
+    #[test]
+    fn stdin_input_accepts_supported_formats() {
+        for format in ["auto", "cri", "json", "raw"] {
+            let yaml =
+                format!("input:\n  type: stdin\n  format: {format}\noutput:\n  type: stdout\n");
+            let cfg = Config::load_str(&yaml)
+                .unwrap_or_else(|e| panic!("failed for stdin format {format}: {e}"));
+            let input = &cfg.pipelines["default"].inputs[0];
+            assert_eq!(input.input_type(), InputType::Stdin);
+        }
+    }
+
+    #[test]
+    fn stdin_input_rejects_unsupported_format() {
+        let yaml = r"
+input:
+  type: stdin
+  format: logfmt
+output:
+  type: stdout
+";
+        let err = Config::load_str(yaml).expect_err("stdin should reject unsupported format");
+        assert!(
+            err.to_string()
+                .contains("stdin input only supports format auto, cri, json, or raw"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn stdin_input_rejects_file_only_fields() {
+        let yaml = r"
+input:
+  type: stdin
+  path: /tmp/app.log
+output:
+  type: stdout
+";
+        let err = Config::load_str(yaml).expect_err("stdin should reject path");
+        assert!(
+            err.to_string().contains("unknown field `path`"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -44,6 +44,8 @@ pub enum InputType {
     Tcp,
     Otlp,
     Http,
+    /// Finite input read from process standard input.
+    Stdin,
     Generator,
     /// Linux eBPF sensor input.
     #[serde(rename = "linux_ebpf_sensor", alias = "linux_sensor_beta")]
@@ -77,6 +79,7 @@ impl fmt::Display for InputType {
             InputType::Tcp => f.write_str("tcp"),
             InputType::Otlp => f.write_str("otlp"),
             InputType::Http => f.write_str("http"),
+            InputType::Stdin => f.write_str("stdin"),
             InputType::Generator => f.write_str("generator"),
             InputType::LinuxEbpfSensor => f.write_str("linux_ebpf_sensor"),
             InputType::MacosEsSensor => f.write_str("macos_es_sensor"),
@@ -179,6 +182,13 @@ pub enum Format {
     Auto,
     Console,
     Text,
+}
+
+impl Format {
+    /// Returns whether this format can be decoded from stdin input.
+    pub fn is_stdin_compatible(&self) -> bool {
+        matches!(self, Self::Auto | Self::Cri | Self::Json | Self::Raw)
+    }
 }
 
 impl fmt::Display for Format {
@@ -522,6 +532,8 @@ pub enum InputTypeConfig {
     Tcp(TcpTypeConfig),
     Otlp(OtlpTypeConfig),
     Http(HttpTypeConfig),
+    /// Configuration for `type: stdin`.
+    Stdin(StdinTypeConfig),
     Generator(GeneratorTypeConfig),
     #[serde(rename = "linux_ebpf_sensor", alias = "linux_sensor_beta")]
     LinuxEbpfSensor(SensorTypeConfig),
@@ -551,6 +563,7 @@ impl InputTypeConfig {
             Self::Tcp(_) => InputType::Tcp,
             Self::Otlp(_) => InputType::Otlp,
             Self::Http(_) => InputType::Http,
+            Self::Stdin(_) => InputType::Stdin,
             Self::Generator(_) => InputType::Generator,
             Self::LinuxEbpfSensor(_) => InputType::LinuxEbpfSensor,
             Self::MacosEsSensor(_) => InputType::MacosEsSensor,
@@ -644,6 +657,14 @@ pub struct HttpTypeConfig {
     #[serde(default)]
     pub http: Option<HttpInputConfig>,
 }
+
+/// Configuration for stdin input.
+///
+/// Stdin input has no input-specific fields; unknown fields are rejected so
+/// file-tail options such as `path` do not silently apply to command input.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct StdinTypeConfig {}
 
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -321,6 +321,15 @@ impl Config {
                                 &h.listen,
                             )?;
                         }
+                        InputTypeConfig::Stdin(_) => {
+                            if let Some(fmt) = &input.format
+                                && !fmt.is_stdin_compatible()
+                            {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': stdin input only supports format auto, cri, json, or raw (got {fmt})"
+                                )));
+                            }
+                        }
                         InputTypeConfig::Generator(g) => {
                             if g.generator.as_ref().and_then(|cfg| cfg.batch_size) == Some(0) {
                                 return Err(ConfigError::Validation(format!(

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -393,6 +393,10 @@ impl InputSource for FramedInput {
         self.inner.health()
     }
 
+    fn is_finished(&self) -> bool {
+        self.inner.is_finished()
+    }
+
     fn apply_hints(&mut self, hints: &FilterHints) {
         self.inner.apply_hints(hints);
     }

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -1,5 +1,7 @@
-use std::io;
+use std::io::{self, Read};
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
 
 use arrow::record_batch::RecordBatch;
 use logfwd_types::diagnostics::ComponentHealth;
@@ -84,6 +86,14 @@ pub trait InputSource: Send {
     /// Coarse runtime health for readiness and diagnostics.
     fn health(&self) -> ComponentHealth;
 
+    /// Whether the source has reached a terminal end-of-input state.
+    ///
+    /// Long-running inputs return `false`. Finite inputs such as stdin return
+    /// `true` after emitting EOF so the runtime can drain and exit cleanly.
+    fn is_finished(&self) -> bool {
+        false
+    }
+
     /// Apply filter hints for predicate pushdown. Inputs that support
     /// pushdown use these to skip data early (e.g., XDP severity filtering).
     /// Default implementation ignores hints — correct but slower.
@@ -133,6 +143,138 @@ pub trait InputSource: Send {
     /// Used for checkpoint restore — the checkpoint stores fingerprint + offset.
     /// The input source finds the matching file by fingerprint, not path.
     fn set_offset_by_source(&mut self, _source_id: SourceId, _offset: u64) {}
+}
+
+enum StdinMessage {
+    Data(Vec<u8>),
+    EndOfFile,
+    Error(io::ErrorKind, String),
+}
+
+/// Finite stdin source for command-line ingestion.
+pub struct StdinInput {
+    name: String,
+    rx: mpsc::Receiver<StdinMessage>,
+    is_finished: bool,
+    pending_error: Option<(io::ErrorKind, String)>,
+}
+
+impl StdinInput {
+    /// Spawn a background reader that forwards stdin chunks to the poll loop.
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        const CHANNEL_BOUND: usize = 16;
+        const READ_BUF_SIZE: usize = 64 * 1024;
+
+        let name = name.into();
+        let (tx, rx) = mpsc::sync_channel(CHANNEL_BOUND);
+        let thread_tx = tx.clone();
+        if let Err(err) = thread::Builder::new()
+            .name("logfwd-stdin-reader".to_owned())
+            .spawn(move || {
+                let stdin = io::stdin();
+                let mut stdin = stdin.lock();
+                let mut buf = vec![0; READ_BUF_SIZE];
+                loop {
+                    match stdin.read(&mut buf) {
+                        Ok(0) => {
+                            let _ = thread_tx.send(StdinMessage::EndOfFile);
+                            break;
+                        }
+                        Ok(n) => {
+                            if thread_tx
+                                .send(StdinMessage::Data(buf[..n].to_vec()))
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+                        Err(err) => {
+                            let kind = err.kind();
+                            let message = err.to_string();
+                            let _ = thread_tx.send(StdinMessage::Error(kind, message));
+                            break;
+                        }
+                    }
+                }
+            })
+        {
+            let _ = tx.send(StdinMessage::Error(err.kind(), err.to_string()));
+        }
+
+        Self {
+            name,
+            rx,
+            is_finished: false,
+            pending_error: None,
+        }
+    }
+}
+
+impl InputSource for StdinInput {
+    fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+        const MAX_EVENTS_PER_POLL: usize = 16;
+
+        if self.is_finished {
+            return Ok(vec![]);
+        }
+        if let Some((kind, message)) = self.pending_error.take() {
+            self.is_finished = true;
+            return Err(io::Error::new(kind, message));
+        }
+
+        let mut events = Vec::new();
+        while events.len() < MAX_EVENTS_PER_POLL {
+            match self.rx.try_recv() {
+                Ok(StdinMessage::Data(bytes)) => {
+                    let accounted_bytes = bytes.len() as u64;
+                    events.push(InputEvent::Data {
+                        bytes,
+                        source_id: None,
+                        accounted_bytes,
+                    });
+                }
+                Ok(StdinMessage::EndOfFile) => {
+                    self.is_finished = true;
+                    events.push(InputEvent::EndOfFile { source_id: None });
+                    break;
+                }
+                Ok(StdinMessage::Error(kind, message)) => {
+                    if !events.is_empty() {
+                        self.pending_error = Some((kind, message));
+                        break;
+                    }
+                    self.is_finished = true;
+                    return Err(io::Error::new(kind, message));
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.is_finished = true;
+                    events.push(InputEvent::EndOfFile { source_id: None });
+                    break;
+                }
+            }
+        }
+
+        Ok(events)
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn health(&self) -> ComponentHealth {
+        if self.is_finished {
+            ComponentHealth::Stopped
+        } else {
+            ComponentHealth::Healthy
+        }
+    }
+
+    fn is_finished(&self) -> bool {
+        self.is_finished
+    }
 }
 
 /// An input source backed by a `FileTailer`.
@@ -229,5 +371,59 @@ impl InputSource for FileInput {
 
     fn get_adaptive_fast_polls_max(&self) -> u8 {
         self.tailer.get_adaptive_fast_polls_max()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stdin_from_messages(messages: Vec<StdinMessage>) -> StdinInput {
+        let (tx, rx) = mpsc::sync_channel(messages.len().max(1));
+        for message in messages {
+            tx.send(message).expect("send test stdin message");
+        }
+        drop(tx);
+        StdinInput {
+            name: "stdin".to_owned(),
+            rx,
+            is_finished: false,
+            pending_error: None,
+        }
+    }
+
+    #[test]
+    fn stdin_poll_defers_error_until_consumed_data_is_returned() {
+        let mut input = stdin_from_messages(vec![
+            StdinMessage::Data(b"first\n".to_vec()),
+            StdinMessage::Error(io::ErrorKind::BrokenPipe, "stdin failed".to_owned()),
+        ]);
+
+        let events = input.poll().expect("data should be returned before error");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], InputEvent::Data { .. }));
+        assert!(!input.is_finished());
+
+        let err = match input.poll() {
+            Ok(_) => panic!("pending read error should surface"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+        assert!(input.is_finished());
+    }
+
+    #[test]
+    fn stdin_poll_error_without_data_finishes_immediately() {
+        let mut input = stdin_from_messages(vec![StdinMessage::Error(
+            io::ErrorKind::UnexpectedEof,
+            "stdin failed".to_owned(),
+        )]);
+
+        let err = match input.poll() {
+            Ok(_) => panic!("read error should surface"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+        assert!(input.is_finished());
     }
 }

--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -418,6 +418,7 @@ fn input_label(i: &logfwd_config::InputConfig) -> String {
         InputTypeConfig::Udp(u) => format!("udp   {}", u.listen),
         InputTypeConfig::Otlp(o) => format!("otlp  {}", o.listen),
         InputTypeConfig::Http(h) => format!("http  {}", h.listen),
+        InputTypeConfig::Stdin(_) => "stdin".to_string(),
         InputTypeConfig::ArrowIpc(a) => format!("arrow_ipc  {}", a.listen),
         InputTypeConfig::Generator(_) => "generator".to_string(),
         InputTypeConfig::LinuxEbpfSensor(_) => "linux_ebpf_sensor".to_string(),

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -10,7 +10,7 @@ use logfwd_config::{
 use logfwd_diagnostics::diagnostics::ComponentStats;
 use logfwd_io::format::FormatDecoder;
 use logfwd_io::framed::FramedInput;
-use logfwd_io::input::{FileInput, InputSource};
+use logfwd_io::input::{FileInput, InputSource, StdinInput};
 use logfwd_io::tail::TailConfig;
 
 use super::InputState;
@@ -64,6 +64,17 @@ fn validate_input_format(name: &str, input_type: InputType, format: &Format) -> 
         InputType::Http if !matches!(format, Format::Json | Format::Raw) => {
             return Err(format!(
                 "input '{name}': format {:?} is not supported for {:?} inputs (expected json or raw)",
+                format, input_type
+            ));
+        }
+        InputType::Stdin
+            if !matches!(
+                format,
+                Format::Cri | Format::Auto | Format::Json | Format::Raw
+            ) =>
+        {
+            return Err(format!(
+                "input '{name}': format {:?} is not supported for {:?} inputs (expected cri, auto, json, or raw)",
                 format, input_type
             ));
         }
@@ -371,6 +382,12 @@ pub(super) fn build_input_state(
             }
             let source = logfwd_io::http_input::HttpInput::new_with_options(name, addr, options)
                 .map_err(|e| format!("input '{name}': failed to start HTTP input: {e}"))?;
+            (Box::new(source), format, 4 * 1024 * 1024)
+        }
+        InputTypeConfig::Stdin(_) => {
+            let format = cfg.format.clone().unwrap_or(Format::Auto);
+            validate_input_format(name, InputType::Stdin, &format)?;
+            let source = StdinInput::new(name);
             (Box::new(source), format, 4 * 1024 * 1024)
         }
         InputTypeConfig::Udp(u) => {
@@ -724,6 +741,30 @@ mod tests {
     fn http_input_accepts_json_and_raw_formats() {
         assert!(validate_input_format("http", InputType::Http, &Format::Json).is_ok());
         assert!(validate_input_format("http", InputType::Http, &Format::Raw).is_ok());
+    }
+
+    #[test]
+    fn stdin_input_accepts_line_or_raw_formats() {
+        for format in [Format::Auto, Format::Cri, Format::Json, Format::Raw] {
+            assert!(validate_input_format("stdin", InputType::Stdin, &format).is_ok());
+        }
+    }
+
+    #[test]
+    fn stdin_input_rejects_structured_formats() {
+        for format in [
+            Format::Logfmt,
+            Format::Syslog,
+            Format::Text,
+            Format::Console,
+        ] {
+            let err = validate_input_format("stdin", InputType::Stdin, &format)
+                .expect_err("stdin input must reject unsupported format");
+            assert!(
+                err.contains("expected cri, auto, json, or raw"),
+                "unexpected error: {err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -266,6 +266,23 @@ fn io_worker_loop(
             }
         }
 
+        if input.source.is_finished() {
+            if !input.buf.is_empty() {
+                metrics.inc_flush_by_timeout();
+                if !flush_buf(
+                    &mut input.buf,
+                    &*input.source,
+                    &tx,
+                    &metrics,
+                    &mut last_bp_warn,
+                    input_index,
+                ) {
+                    break;
+                }
+            }
+            break;
+        }
+
         let timeout_elapsed = buffered_since.is_some_and(|t| t.elapsed() >= batch_timeout);
         let flush_by_size = input.buf.len() >= safe_batch_target_bytes;
         let flush_by_timeout = !input.buf.is_empty() && timeout_elapsed;

--- a/crates/logfwd-runtime/src/pipeline/input_poll.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_poll.rs
@@ -153,6 +153,20 @@ pub(super) async fn async_input_poll_loop(
             }
         }
 
+        if input.source.is_finished() {
+            if !input.buf.is_empty() {
+                if let Some(msg) =
+                    scan_and_transform_for_send(&mut input, &mut transform, &metrics, input_index)
+                        .await
+                {
+                    if tx.send(msg).await.is_err() {
+                        break;
+                    }
+                }
+            }
+            break;
+        }
+
         let timeout_elapsed = buffered_since.is_some_and(|t| t.elapsed() >= batch_timeout);
         let should_send = should_flush_buffer(input.buf.len(), batch_target_bytes, timeout_elapsed);
         if should_send {

--- a/crates/logfwd/Cargo.toml
+++ b/crates/logfwd/Cargo.toml
@@ -43,6 +43,7 @@ logfwd-transform = { version = "0.1.0", path = "../logfwd-transform", optional =
 logfwd-types = { version = "0.1.0", path = "../logfwd-types" }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
+serde_yaml_ng = { workspace = true }
 tokio = { version = "1", features = [
     "rt-multi-thread",
     "macros",

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -7,6 +7,7 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 use std::env;
+use std::ffi::OsString;
 use std::io::{self, IsTerminal, Write};
 use std::sync::Arc;
 use std::time::Duration;
@@ -33,7 +34,7 @@ const LONG_VERSION: &str = concat!(
 const CLI_AFTER_HELP: &str = r"Examples:
   ff run --config config.yaml
   cat app.log | ff
-  kubectl logs pod/app | ff send --format json --service checkout
+  kubectl logs pod/app | ff --format json --service checkout
   ff validate --config config.yaml
   ff dry-run --config config.yaml
   ff effective-config --config config.yaml
@@ -463,7 +464,8 @@ fn main() {
 
 #[tokio::main]
 async fn main_inner() -> i32 {
-    let cli = match Cli::try_parse() {
+    let stdin_is_terminal = io::stdin().is_terminal();
+    let cli = match parse_cli_from(env::args_os(), stdin_is_terminal) {
         Ok(cli) => cli,
         Err(err) => {
             let code = match err.kind() {
@@ -477,7 +479,7 @@ async fn main_inner() -> i32 {
 
     let result = if let Some(command) = cli.command {
         run_command(command).await
-    } else if !io::stdin().is_terminal() {
+    } else if !stdin_is_terminal {
         run_command(Commands::Send(SendArgs::default())).await
     } else {
         if let Some(path) = discover_config() {
@@ -556,6 +558,43 @@ async fn run_command(command: Commands) -> Result<(), CliError> {
     }
 }
 
+fn parse_cli_from<I, T>(args: I, stdin_is_terminal: bool) -> Result<Cli, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString>,
+{
+    let args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+    match Cli::try_parse_from(args.clone()) {
+        Ok(cli) => Ok(cli),
+        Err(err) => {
+            if stdin_is_terminal || !should_retry_parse_as_send(err.kind()) {
+                return Err(err);
+            }
+            Cli::try_parse_from(rewrite_args_as_send(args))
+        }
+    }
+}
+
+fn should_retry_parse_as_send(kind: ErrorKind) -> bool {
+    matches!(
+        kind,
+        ErrorKind::UnknownArgument | ErrorKind::InvalidSubcommand
+    )
+}
+
+fn rewrite_args_as_send(args: Vec<OsString>) -> Vec<OsString> {
+    let mut rewritten = Vec::with_capacity(args.len() + 1);
+    if let Some((program, rest)) = args.split_first() {
+        rewritten.push(program.clone());
+        rewritten.push(OsString::from("send"));
+        rewritten.extend(rest.iter().cloned());
+    } else {
+        rewritten.push(OsString::from("ff"));
+        rewritten.push(OsString::from("send"));
+    }
+    rewritten
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -616,13 +655,13 @@ fn build_stdin_send_config_yaml(
     })?;
 
     for unsupported in ["input", "pipelines"] {
-        if mapping.contains_key(&yaml_string(unsupported)) {
+        if mapping.contains_key(yaml_string(unsupported)) {
             return Err(CliError::Config(format!(
                 "`ff send` expects a destination-only config; remove top-level `{unsupported}` or use `ff run`"
             )));
         }
     }
-    if !mapping.contains_key(&yaml_string("output")) {
+    if !mapping.contains_key(yaml_string("output")) {
         return Err(CliError::Config(
             "`ff send` destination config must define top-level `output`".to_owned(),
         ));
@@ -701,7 +740,7 @@ fn resolve_send_config_path(config_path: Option<&str>) -> Result<String, CliErro
             "no destination config file found (use `ff send --config <file>` or set LOGFWD_CONFIG)"
                 .to_owned(),
         ),
-        other => other,
+        CliError::Runtime(e) => CliError::Runtime(e),
     })
 }
 
@@ -2154,6 +2193,41 @@ mod cli_tests {
             }
             other => panic!("expected send command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn piped_bare_send_with_overrides_parses_successfully() {
+        let cli = parse_cli_from(
+            [
+                "ff",
+                "--config",
+                "dest.yaml",
+                "--format",
+                "raw",
+                "--service",
+                "checkout",
+                "--resource",
+                "deployment=blue",
+            ],
+            false,
+        )
+        .expect("parser should retry piped bare args as send command");
+        match cli.command.expect("command") {
+            Commands::Send(args) => {
+                assert_eq!(args.config.as_deref(), Some("dest.yaml"));
+                assert!(matches!(args.format, Some(SendFormat::Raw)));
+                assert_eq!(args.service.as_deref(), Some("checkout"));
+                assert_eq!(args.resource, ["deployment=blue"]);
+            }
+            other => panic!("expected send command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn interactive_bare_send_overrides_remain_invalid() {
+        let err = parse_cli_from(["ff", "--format", "raw"], true)
+            .expect_err("interactive top-level send args should stay invalid");
+        assert!(matches!(err.kind(), ErrorKind::UnknownArgument));
     }
 
     #[test]

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -32,6 +32,8 @@ const LONG_VERSION: &str = concat!(
 );
 const CLI_AFTER_HELP: &str = r"Examples:
   ff run --config config.yaml
+  cat app.log | ff
+  kubectl logs pod/app | ff send --format json --service checkout
   ff validate --config config.yaml
   ff dry-run --config config.yaml
   ff effective-config --config config.yaml
@@ -314,6 +316,48 @@ struct DevourArgs {
     diagnostics_addr: String,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SendFormat {
+    Auto,
+    Cri,
+    Json,
+    Raw,
+}
+
+impl SendFormat {
+    fn as_config_format(self) -> logfwd_config::Format {
+        match self {
+            Self::Auto => logfwd_config::Format::Auto,
+            Self::Cri => logfwd_config::Format::Cri,
+            Self::Json => logfwd_config::Format::Json,
+            Self::Raw => logfwd_config::Format::Raw,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Args, Default)]
+struct SendArgs {
+    #[arg(
+        short = 'c',
+        long = "config",
+        value_name = "FILE",
+        help = "Destination YAML config file"
+    )]
+    config: Option<String>,
+
+    /// Input format for stdin.
+    #[arg(long, value_enum)]
+    format: Option<SendFormat>,
+
+    /// Set `service.name` on emitted records.
+    #[arg(long)]
+    service: Option<String>,
+
+    /// Add or override a resource attribute, repeatable: --resource key=value.
+    #[arg(long, value_name = "KEY=VALUE")]
+    resource: Vec<String>,
+}
+
 #[derive(Debug, Parser)]
 #[command(
     name = "ff",
@@ -361,6 +405,8 @@ enum Commands {
         )]
         config: Option<String>,
     },
+    /// Read stdin, send it to the configured destination, drain, and exit.
+    Send(SendArgs),
     /// Blast generated data into a destination sink via the normal runtime pipeline.
     Blast(BlastArgs),
     /// Run a blackhole receiver via the normal runtime pipeline.
@@ -431,6 +477,8 @@ async fn main_inner() -> i32 {
 
     let result = if let Some(command) = cli.command {
         run_command(command).await
+    } else if !io::stdin().is_terminal() {
+        run_command(Commands::Send(SendArgs::default())).await
     } else {
         if let Some(path) = discover_config() {
             eprintln!(
@@ -490,6 +538,7 @@ async fn run_command(command: Commands) -> Result<(), CliError> {
             let config_path = resolve_config_path(config.as_deref())?;
             cmd_run(&config_path, false, true).await
         }
+        Commands::Send(args) => cmd_send(args).await,
         Commands::Blast(args) => cmd_blast(args).await,
         Commands::Devour(args) => cmd_devour(args).await,
         Commands::Blackhole { bind_addr } => cmd_blackhole(bind_addr.as_deref()).await,
@@ -528,6 +577,132 @@ async fn cmd_run(config_path: &str, validate_only: bool, dry_run: bool) -> Resul
     }
 
     run_pipelines(config, base_path, config_path, &config_yaml, None).await
+}
+
+async fn cmd_send(args: SendArgs) -> Result<(), CliError> {
+    if io::stdin().is_terminal() {
+        return Err(CliError::Config(
+            "stdin is interactive; pipe data into `ff` or use `ff run --config <file>` for daemon mode"
+                .to_owned(),
+        ));
+    }
+
+    let config_path = resolve_send_config_path(args.config.as_deref())?;
+    let config_yaml = std::fs::read_to_string(&config_path)
+        .map_err(|e| CliError::Config(format!("cannot read {config_path}: {e}")))?;
+    let runnable_yaml = build_stdin_send_config_yaml(
+        &config_yaml,
+        args.format,
+        args.service.as_deref(),
+        &args.resource,
+    )?;
+    let base_path = std::path::Path::new(&config_path).parent();
+    let config = logfwd_config::Config::load_str_with_base_path(&runnable_yaml, base_path)
+        .map_err(|e| CliError::Config(e.to_string()))?;
+
+    run_pipelines(config, base_path, &config_path, &runnable_yaml, None).await
+}
+
+fn build_stdin_send_config_yaml(
+    config_yaml: &str,
+    format: Option<SendFormat>,
+    service: Option<&str>,
+    resources: &[String],
+) -> Result<String, CliError> {
+    let mut value: serde_yaml_ng::Value =
+        serde_yaml_ng::from_str(config_yaml).map_err(|e| CliError::Config(e.to_string()))?;
+    let mapping = value.as_mapping_mut().ok_or_else(|| {
+        CliError::Config("send destination config must be a YAML mapping".to_owned())
+    })?;
+
+    for unsupported in ["input", "pipelines"] {
+        if mapping.contains_key(&yaml_string(unsupported)) {
+            return Err(CliError::Config(format!(
+                "`ff send` expects a destination-only config; remove top-level `{unsupported}` or use `ff run`"
+            )));
+        }
+    }
+    if !mapping.contains_key(&yaml_string("output")) {
+        return Err(CliError::Config(
+            "`ff send` destination config must define top-level `output`".to_owned(),
+        ));
+    }
+
+    let mut input = serde_yaml_ng::Mapping::new();
+    input.insert(yaml_string("type"), yaml_string("stdin"));
+    if let Some(format) = format {
+        let format = format.as_config_format().to_string();
+        input.insert(yaml_string("format"), yaml_string(&format));
+    }
+    mapping.insert(yaml_string("input"), serde_yaml_ng::Value::Mapping(input));
+
+    merge_send_resource_attrs(mapping, service, resources)?;
+
+    serde_yaml_ng::to_string(&value).map_err(|e| CliError::Config(e.to_string()))
+}
+
+fn merge_send_resource_attrs(
+    mapping: &mut serde_yaml_ng::Mapping,
+    service: Option<&str>,
+    resources: &[String],
+) -> Result<(), CliError> {
+    if service.is_none() && resources.is_empty() {
+        return Ok(());
+    }
+
+    let key = yaml_string("resource_attrs");
+    if !mapping.contains_key(&key) {
+        mapping.insert(
+            key.clone(),
+            serde_yaml_ng::Value::Mapping(serde_yaml_ng::Mapping::new()),
+        );
+    }
+    let attrs = mapping
+        .get_mut(&key)
+        .and_then(serde_yaml_ng::Value::as_mapping_mut)
+        .ok_or_else(|| {
+            CliError::Config(
+                "top-level `resource_attrs` must be a mapping when using send overrides".to_owned(),
+            )
+        })?;
+
+    if let Some(service) = service {
+        attrs.insert(yaml_string("service.name"), yaml_string(service));
+    }
+    for raw in resources {
+        let (name, value) = parse_key_value(raw, "--resource")?;
+        attrs.insert(yaml_string(name), yaml_string(value));
+    }
+
+    Ok(())
+}
+
+fn parse_key_value<'a>(raw: &'a str, flag: &str) -> Result<(&'a str, &'a str), CliError> {
+    let (name, value) = raw.split_once('=').ok_or_else(|| {
+        CliError::Config(format!("{flag} must be in KEY=VALUE form, got `{raw}`"))
+    })?;
+    let name = name.trim();
+    let value = value.trim();
+    if name.is_empty() {
+        return Err(CliError::Config(format!(
+            "{flag} key must not be empty, got `{raw}`"
+        )));
+    }
+    Ok((name, value))
+}
+
+fn yaml_string(value: &str) -> serde_yaml_ng::Value {
+    serde_yaml_ng::Value::String(value.to_owned())
+}
+
+fn resolve_send_config_path(config_path: Option<&str>) -> Result<String, CliError> {
+    resolve_config_path(config_path).map_err(|err| match err {
+        CliError::Config(_) => CliError::Config(
+            "no destination config file found (use `ff send --config <file>` or set LOGFWD_CONFIG)"
+                .to_owned(),
+        ),
+        other => other,
+    })
 }
 
 async fn cmd_blast(mut args: BlastArgs) -> Result<(), CliError> {
@@ -1575,7 +1750,7 @@ fn validate_pipeline_read_only(
                 .format
                 .clone()
                 .unwrap_or(match input_cfg.type_config {
-                    InputTypeConfig::File(_) => Format::Auto,
+                    InputTypeConfig::File(_) | InputTypeConfig::Stdin(_) => Format::Auto,
                     _ => Format::Json,
                 });
             validate_input_format_read_only(&input_name, input_cfg.input_type(), &format)?;
@@ -1619,6 +1794,7 @@ fn validate_input_format_read_only(
             format,
             Format::Cri | Format::Auto | Format::Json | Format::Raw
         ),
+        InputType::Stdin => format.is_stdin_compatible(),
         InputType::Generator | InputType::Otlp => matches!(format, Format::Json),
         InputType::Http => matches!(format, Format::Json | Format::Raw),
         InputType::Udp | InputType::Tcp => matches!(format, Format::Json | Format::Raw),
@@ -1952,6 +2128,127 @@ mod cli_tests {
             Commands::Blackhole { bind_addr } => assert!(bind_addr.is_none()),
             other => panic!("expected blackhole command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn send_command_with_overrides_parses_successfully() {
+        let cli = Cli::try_parse_from([
+            "ff",
+            "send",
+            "--config",
+            "dest.yaml",
+            "--format",
+            "json",
+            "--service",
+            "checkout",
+            "--resource",
+            "deployment=blue",
+        ])
+        .expect("parser should accept send command");
+        match cli.command.expect("command") {
+            Commands::Send(args) => {
+                assert_eq!(args.config.as_deref(), Some("dest.yaml"));
+                assert!(matches!(args.format, Some(SendFormat::Json)));
+                assert_eq!(args.service.as_deref(), Some("checkout"));
+                assert_eq!(args.resource, ["deployment=blue"]);
+            }
+            other => panic!("expected send command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stdin_send_config_injects_input_and_merges_resources() {
+        let yaml = r"
+resource_attrs:
+  env: prod
+output:
+  type: stdout
+";
+        let resource = vec![" deployment = blue ".to_owned()];
+        let generated =
+            build_stdin_send_config_yaml(yaml, Some(SendFormat::Json), Some("checkout"), &resource)
+                .expect("send config should render");
+        let config =
+            logfwd_config::Config::load_str(&generated).expect("generated config should parse");
+        let pipeline = &config.pipelines["default"];
+        let input = &pipeline.inputs[0];
+
+        assert_eq!(input.input_type(), logfwd_config::InputType::Stdin);
+        assert_eq!(input.format, Some(logfwd_config::Format::Json));
+        assert_eq!(
+            pipeline
+                .resource_attrs
+                .get("service.name")
+                .map(String::as_str),
+            Some("checkout")
+        );
+        assert_eq!(
+            pipeline
+                .resource_attrs
+                .get("deployment")
+                .map(String::as_str),
+            Some("blue")
+        );
+        assert_eq!(
+            pipeline.resource_attrs.get("env").map(String::as_str),
+            Some("prod")
+        );
+    }
+
+    #[test]
+    fn stdin_send_config_rejects_runtime_inputs() {
+        for (field, yaml) in [
+            (
+                "input",
+                "input:\n  type: file\n  path: /tmp/app.log\noutput:\n  type: stdout\n",
+            ),
+            (
+                "pipelines",
+                "pipelines:\n  default:\n    input:\n      type: file\n      path: /tmp/app.log\n    output:\n      type: stdout\n",
+            ),
+        ] {
+            let err = build_stdin_send_config_yaml(yaml, None, None, &[])
+                .expect_err("send config should reject runtime input shape");
+            assert!(
+                err.to_string().contains(field),
+                "error should mention {field}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn stdin_send_config_requires_destination_output() {
+        let err = build_stdin_send_config_yaml("server: {}\n", None, None, &[])
+            .expect_err("send config should require output");
+        assert!(
+            err.to_string().contains("must define top-level `output`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn stdin_send_config_rejects_malformed_resource_override() {
+        let err = build_stdin_send_config_yaml(
+            "output:\n  type: stdout\n",
+            None,
+            None,
+            &["deployment".to_owned()],
+        )
+        .expect_err("send config should reject malformed resource override");
+        assert!(
+            err.to_string().contains("--resource"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_input_format_read_only_accepts_stdin_auto() {
+        validate_input_format_read_only(
+            "stdin",
+            logfwd_config::InputType::Stdin,
+            &logfwd_config::Format::Auto,
+        )
+        .expect("stdin should accept auto format");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add finite `stdin` input support that drains and exits when stdin reaches EOF.
- Add `ff send` plus piped bare `ff` command mode for destination-only configs.
- Document stdin command mode and update CLI examples to use the `ff` binary.

## Validation

- `cargo fmt --check`
- `cargo check -p logfwd-io -p logfwd-config -p logfwd-runtime -p logfwd`
- `cargo test -p logfwd-config stdin`
- `cargo test -p logfwd-runtime stdin_input`
- `cargo test -p logfwd send_command_with_overrides_parses_successfully`
- `cargo test -p logfwd piped_bare_send_with_overrides_parses_successfully`
- `cargo test -p logfwd interactive_bare_send_overrides_remain_invalid`
- `cargo test -p logfwd stdin_send_config`
- `cargo test -p logfwd validate_input_format_read_only_accepts_stdin_auto`
- end-to-end `ff send` stdin smoke test via `cargo run -p logfwd -- send --config <tmp>/destination.yaml --format json`
- end-to-end piped bare `ff` smoke tests with `XDG_CONFIG_HOME=<tmp>` and `ff --format raw` / `ff --config <tmp>/destination.yaml --format json`
- `just lint`
- `just test` (1776 passed, 43 skipped; nextest reported 1 leaky test with zero exit)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ff send` subcommand to forward piped stdin data through configured destinations
> - Adds a new `send` subcommand to the `ff` CLI that reads from stdin, injects it as an input into a destination-only config, runs the pipeline, and exits on EOF.
> - Bare `ff` with piped stdin implicitly invokes `send`; unknown top-level args are reparsed as `send` args when stdin is a pipe.
> - Adds `StdinInput` in [logfwd-io](https://github.com/strawgate/fastforward/pull/2318/files#diff-83046fe79e778223879707c21b46ce7fb3a97d42c3703b9d794524e356dd45c2) as a finite input source that spawns a background thread, batches reads, and signals EOF to trigger pipeline drain and shutdown.
> - Extends config parsing and validation to support `type: stdin` inputs with compatible formats (auto, cri, json, raw).
> - Behavioral Change: pipelines with finite inputs (stdin) now flush buffered data and exit when EOF is reached rather than running indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 34f2616.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

