### PR TITLE
fix: promote tail fingerprints without changing source ids

### DIFF
--- a/crates/logfwd-io/src/tail/discovery.rs
+++ b/crates/logfwd-io/src/tail/discovery.rs
@@ -137,8 +137,13 @@ impl FileDiscovery {
                     .file
                     .metadata()
                     .is_ok_and(|meta| has_metadata_indicating_deletion(&meta));
+                let previous_identity = FileIdentity {
+                    device: tailed.identity.device,
+                    inode: tailed.identity.inode,
+                    fingerprint: tailed.comparison_fingerprint,
+                };
                 should_rotate_file(
-                    &tailed.identity,
+                    &previous_identity,
                     &current_identity,
                     is_previous_handle_deleted,
                     tailed.fingerprint_len,
@@ -317,6 +322,7 @@ mod tests {
                     inode: 222,
                     fingerprint: 333,
                 },
+                comparison_fingerprint: 333,
                 fingerprint_len: 1024,
                 offset: 7,
                 path: path.clone(),
@@ -366,6 +372,68 @@ mod tests {
         assert!(
             !appended_text.contains("old replaced content"),
             "historical content must remain skipped"
+        );
+    }
+
+    #[test]
+    fn detect_changes_uses_promoted_fingerprint_window_after_short_file_grows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("promoted.log");
+        fs::write(&path, b"LINE-00000000\n").unwrap();
+
+        let mut reader = FileReader {
+            config: TailConfig {
+                start_from_end: false,
+                fingerprint_bytes: 32,
+                poll_interval_ms: 10,
+                glob_rescan_interval_ms: 0,
+                ..Default::default()
+            },
+            ..test_reader()
+        };
+        reader.open_file_at(&path, false).unwrap();
+        assert!(matches!(
+            reader.read_new_data(&path).expect("initial read"),
+            super::super::reader::ReadResult::Data(_)
+        ));
+
+        {
+            let mut f = fs::OpenOptions::new().append(true).open(&path).unwrap();
+            f.write_all(b"LINE-00000001\nLINE-00000002\n").unwrap();
+        }
+        assert!(matches!(
+            reader.read_new_data(&path).expect("growth read"),
+            super::super::reader::ReadResult::Data(_)
+        ));
+
+        let tailed = reader.files.get(&path).expect("tailed file");
+        assert_eq!(tailed.fingerprint_len, 32);
+        let source_id = tailed.identity.source_id();
+
+        fs::write(&path, b"LINE-00000000\nrewritten-after-promoted-window\n").unwrap();
+
+        let (watcher, rx) = test_watcher();
+        let discovery = FileDiscovery {
+            watcher,
+            watched_dirs: HashSet::new(),
+            glob_patterns: Vec::new(),
+            watch_paths: vec![path.clone()],
+            fs_events: rx,
+            last_glob_rescan: Instant::now(),
+        };
+
+        let mut events = Vec::new();
+        let had_error = discovery.detect_changes(&mut reader, &mut events);
+        assert!(!had_error, "detect_changes should succeed");
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                TailEvent::Rotated {
+                    path: event_path,
+                    source_id: event_source_id,
+                } if event_path == &path && *event_source_id == Some(source_id)
+            )),
+            "rewrite preserving the original short prefix should still rotate after fingerprint promotion"
         );
     }
 
@@ -479,6 +547,7 @@ mod tests {
         reader.files.insert(
             path.clone(),
             TailedFile {
+                comparison_fingerprint: stale_identity.fingerprint,
                 identity: stale_identity,
                 fingerprint_len: 1024,
                 file,

--- a/crates/logfwd-io/src/tail/identity.rs
+++ b/crates/logfwd-io/src/tail/identity.rs
@@ -68,6 +68,8 @@ fn metadata_device_inode(_meta: &std::fs::Metadata) -> (u64, u64) {
 }
 
 /// Compute the fingerprint of a file: xxhash64 of the first N bytes.
+///
+/// Preserves the caller's current file cursor position.
 pub(super) fn compute_fingerprint(file: &mut File, max_bytes: usize) -> io::Result<u64> {
     let pos = file.stream_position()?;
     file.seek(SeekFrom::Start(0))?;

--- a/crates/logfwd-io/src/tail/reader.rs
+++ b/crates/logfwd-io/src/tail/reader.rs
@@ -13,6 +13,7 @@ use super::tailer::{TailConfig, TailEvent};
 /// State tracked per tailed file.
 pub(super) struct TailedFile {
     pub(super) identity: FileIdentity,
+    pub(super) comparison_fingerprint: u64,
     pub(super) fingerprint_len: u64,
     pub(super) file: File,
     pub(super) offset: u64,
@@ -23,6 +24,7 @@ pub(super) struct TailedFile {
 /// Saved state for a file evicted from the open-file LRU cache.
 pub(super) struct EvictedFile {
     pub(super) identity: FileIdentity,
+    pub(super) comparison_fingerprint: u64,
     pub(super) fingerprint_len: u64,
     pub(super) offset: u64,
     pub(super) path: PathBuf,
@@ -78,18 +80,18 @@ fn evicted_matches_open_file(
     }
 
     if evicted.fingerprint_len == 0 {
-        return Ok(evicted.identity.fingerprint == current_identity.fingerprint);
+        return Ok(evicted.comparison_fingerprint == current_identity.fingerprint);
     }
 
     if evicted.fingerprint_len < fingerprint_bytes as u64 {
         let current_prefix = compute_fingerprint(file, evicted.fingerprint_len as usize)?;
-        if evicted.identity.fingerprint != current_prefix {
+        if evicted.comparison_fingerprint != current_prefix {
             return Ok(false);
         }
         return Ok(evicted.offset <= evicted.fingerprint_len || file_size < evicted.offset);
     }
 
-    Ok(evicted.identity.fingerprint == current_identity.fingerprint)
+    Ok(evicted.comparison_fingerprint == current_identity.fingerprint)
 }
 
 /// Owns the open file descriptors, read buffer, and byte-level I/O.
@@ -140,6 +142,7 @@ impl FileReader {
         });
 
         let mut stored_identity = identity.clone();
+        let mut stored_comparison_fingerprint = identity.fingerprint;
         let mut stored_fingerprint_len = fingerprint_len;
         let offset = if let Some(evicted) = evicted {
             if evicted_matches_open_file(
@@ -150,6 +153,7 @@ impl FileReader {
                 self.config.fingerprint_bytes,
             )? {
                 stored_identity = evicted.identity.clone();
+                stored_comparison_fingerprint = evicted.comparison_fingerprint;
                 stored_fingerprint_len = evicted.fingerprint_len;
                 if evicted.offset > file_size {
                     tracing::warn!(
@@ -186,6 +190,7 @@ impl FileReader {
             path.to_path_buf(),
             TailedFile {
                 identity: stored_identity,
+                comparison_fingerprint: stored_comparison_fingerprint,
                 fingerprint_len: stored_fingerprint_len,
                 file,
                 offset,
@@ -253,13 +258,16 @@ impl FileReader {
 
         tailed.last_read = Instant::now();
 
-        if tailed.identity.fingerprint == 0 {
-            let current_pos = tailed.file.stream_position()?;
-            tailed.file.seek(SeekFrom::Start(0))?;
+        if fingerprint_bytes > 0
+            && tailed.fingerprint_len < fingerprint_bytes as u64
+            && current_size > tailed.fingerprint_len
+        {
             let new_fp = compute_fingerprint(&mut tailed.file, fingerprint_bytes)?;
-            tailed.file.seek(SeekFrom::Start(current_pos))?;
             if new_fp != 0 {
-                tailed.identity.fingerprint = new_fp;
+                if tailed.identity.fingerprint == 0 {
+                    tailed.identity.fingerprint = new_fp;
+                }
+                tailed.comparison_fingerprint = new_fp;
                 tailed.fingerprint_len =
                     observed_fingerprint_len(new_fp, current_size, fingerprint_bytes);
             }
@@ -420,6 +428,7 @@ impl FileReader {
                         path.clone(),
                         EvictedFile {
                             identity: tailed.identity,
+                            comparison_fingerprint: tailed.comparison_fingerprint,
                             fingerprint_len: tailed.fingerprint_len,
                             offset: tailed.offset,
                             path,
@@ -586,6 +595,7 @@ mod tests {
                     inode: 2,
                     fingerprint: 0,
                 },
+                comparison_fingerprint: 0,
                 fingerprint_len: 0,
                 offset: 7,
                 path: path.clone(),
@@ -617,6 +627,7 @@ mod tests {
                     inode: 2,
                     fingerprint: 123,
                 },
+                comparison_fingerprint: 123,
                 fingerprint_len: 3,
                 offset: 4,
                 path: path.clone(),
@@ -652,6 +663,7 @@ mod tests {
                     inode: 2,
                     fingerprint: 123,
                 },
+                comparison_fingerprint: 123,
                 fingerprint_len: 3,
                 offset: 2,
                 path: path.clone(),
@@ -687,6 +699,7 @@ mod tests {
                     inode: 2,
                     fingerprint: 123,
                 },
+                comparison_fingerprint: 123,
                 fingerprint_len: 3,
                 offset: 2,
                 path: path.clone(),
@@ -929,6 +942,7 @@ mod tests {
         reader.evicted_offsets.insert(
             path.clone(),
             EvictedFile {
+                comparison_fingerprint: identity.fingerprint,
                 identity,
                 fingerprint_len: 3,
                 offset: 999,
@@ -967,6 +981,7 @@ mod tests {
         reader.evicted_offsets.insert(
             path.clone(),
             EvictedFile {
+                comparison_fingerprint: identity.fingerprint,
                 identity,
                 fingerprint_len: 6,
                 offset: 10,
@@ -1011,6 +1026,7 @@ mod tests {
                     inode: 999,
                     fingerprint: 999,
                 },
+                comparison_fingerprint: 999,
                 fingerprint_len: 6,
                 offset: 5,
                 path: path.clone(),
@@ -1039,7 +1055,7 @@ mod tests {
     }
 
     #[test]
-    fn read_new_data_keeps_nonzero_source_fingerprint_stable_while_file_grows() {
+    fn read_new_data_promotes_partial_fingerprint_window_while_file_grows() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("fingerprint-growth.log");
         fs::write(&path, b"LINE-00000000\n").unwrap();
@@ -1056,6 +1072,8 @@ mod tests {
         let got = reader.read_new_data(&path).unwrap();
         assert!(matches!(got, ReadResult::Data(_)));
         let first_fingerprint = reader.files.get(&path).unwrap().identity.fingerprint;
+        let first_comparison_fingerprint = reader.files.get(&path).unwrap().comparison_fingerprint;
+        let first_fingerprint_len = reader.files.get(&path).unwrap().fingerprint_len;
 
         let mut f = OpenOptions::new().append(true).open(&path).unwrap();
         f.write_all(b"LINE-00000001\nLINE-00000002\n").unwrap();
@@ -1064,10 +1082,19 @@ mod tests {
         let got = reader.read_new_data(&path).unwrap();
         assert!(matches!(got, ReadResult::Data(_)));
 
-        let updated = reader.files.get(&path).unwrap().identity.fingerprint;
+        let updated = reader.files.get(&path).unwrap();
+        assert_eq!(first_fingerprint_len, 14);
         assert_eq!(
-            updated, first_fingerprint,
-            "source identity must remain stable while the same file grows"
+            updated.fingerprint_len, 32,
+            "fingerprint window should promote once enough bytes are observable"
+        );
+        assert_eq!(
+            updated.identity.fingerprint, first_fingerprint,
+            "source identity should remain stable while the same file grows"
+        );
+        assert_ne!(
+            updated.comparison_fingerprint, first_comparison_fingerprint,
+            "comparison fingerprint should cover the larger observed prefix"
         );
     }
 
@@ -1106,6 +1133,7 @@ mod tests {
                     inode: 2,
                     fingerprint: 3,
                 },
+                comparison_fingerprint: 3,
                 fingerprint_len: 3,
                 file,
                 offset: 0,
@@ -1136,6 +1164,7 @@ mod tests {
                     inode: 2,
                     fingerprint: 3,
                 },
+                comparison_fingerprint: 3,
                 fingerprint_len: 3,
                 file,
                 offset: 0,
@@ -1173,6 +1202,7 @@ mod tests {
                     inode: 2,
                     fingerprint: 3,
                 },
+                comparison_fingerprint: 3,
                 fingerprint_len: 3,
                 offset: 7,
                 path: PathBuf::from("other.log"),

--- a/crates/logfwd-io/src/tail/reader.rs
+++ b/crates/logfwd-io/src/tail/reader.rs
@@ -218,6 +218,7 @@ impl FileReader {
             tailed.eof_state.on_data();
             tailed.file.seek(SeekFrom::Start(0))?;
             tailed.identity.fingerprint = compute_fingerprint(&mut tailed.file, fingerprint_bytes)?;
+            tailed.comparison_fingerprint = tailed.identity.fingerprint;
             tailed.fingerprint_len = observed_fingerprint_len(
                 tailed.identity.fingerprint,
                 current_size,
@@ -1058,7 +1059,8 @@ mod tests {
     fn read_new_data_promotes_partial_fingerprint_window_while_file_grows() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("fingerprint-growth.log");
-        fs::write(&path, b"LINE-00000000\n").unwrap();
+        let initial = b"LINE-00000000\n";
+        fs::write(&path, initial).unwrap();
 
         let mut reader = FileReader {
             config: TailConfig {
@@ -1083,9 +1085,9 @@ mod tests {
         assert!(matches!(got, ReadResult::Data(_)));
 
         let updated = reader.files.get(&path).unwrap();
-        assert_eq!(first_fingerprint_len, 14);
+        assert_eq!(first_fingerprint_len, initial.len() as u64);
         assert_eq!(
-            updated.fingerprint_len, 32,
+            updated.fingerprint_len, reader.config.fingerprint_bytes as u64,
             "fingerprint window should promote once enough bytes are observable"
         );
         assert_eq!(
@@ -1095,6 +1097,46 @@ mod tests {
         assert_ne!(
             updated.comparison_fingerprint, first_comparison_fingerprint,
             "comparison fingerprint should cover the larger observed prefix"
+        );
+    }
+
+    #[test]
+    fn truncation_refreshes_comparison_fingerprint() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("truncate-refresh.log");
+        let original = b"original-long-enough-for-window-and-offset";
+        let rewritten = b"rewritten-full-window";
+        fs::write(&path, original).unwrap();
+
+        let mut reader = FileReader {
+            config: TailConfig {
+                fingerprint_bytes: 16,
+                ..TailConfig::default()
+            },
+            ..test_reader()
+        };
+        reader.open_file_at(&path, false).unwrap();
+        let got = reader.read_new_data(&path).unwrap();
+        assert!(matches!(got, ReadResult::Data(_)));
+        assert!(original.len() > rewritten.len());
+        let before = reader.files.get(&path).unwrap().comparison_fingerprint;
+
+        fs::write(&path, rewritten).unwrap();
+        let got = reader.read_new_data(&path).unwrap();
+        assert!(matches!(got, ReadResult::TruncatedThenData(_)));
+
+        let tailed = reader.files.get(&path).unwrap();
+        assert_ne!(
+            tailed.comparison_fingerprint, before,
+            "truncated content should refresh the comparison fingerprint"
+        );
+        assert_eq!(
+            tailed.comparison_fingerprint, tailed.identity.fingerprint,
+            "truncation refresh should keep comparison and identity fingerprints aligned"
+        );
+        assert_eq!(
+            tailed.fingerprint_len, reader.config.fingerprint_bytes as u64,
+            "full-window truncation should not rely on later promotion"
         );
     }
 

--- a/crates/logfwd-io/src/tail/reader.rs
+++ b/crates/logfwd-io/src/tail/reader.rs
@@ -12,7 +12,9 @@ use super::tailer::{TailConfig, TailEvent};
 
 /// State tracked per tailed file.
 pub(super) struct TailedFile {
+    /// Stable identity used to derive the source id.
     pub(super) identity: FileIdentity,
+    /// Fingerprint used for rotation and eviction comparisons; promoted as the file grows.
     pub(super) comparison_fingerprint: u64,
     pub(super) fingerprint_len: u64,
     pub(super) file: File,


### PR DESCRIPTION
## Summary

- Promote the tailer comparison fingerprint as short files grow, so later rewrite detection is not stuck on the original short prefix.
- Keep the stable source identity separate from the promoted comparison fingerprint so partial-line and checkpoint state remain source-stable while a file grows.
- Add a discovery regression for prefix-preserving rewrites after fingerprint promotion.

## Validation

- `cargo test -p logfwd-io partial`
- `cargo test -p logfwd-io detect_changes_uses_promoted_fingerprint_window_after_short_file_grows`
- `just ci`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tail rotation detection to use promoted comparison fingerprints instead of source identity fingerprints
> - Adds a `comparison_fingerprint` field to `TailedFile` and `EvictedFile` in [reader.rs](https://github.com/strawgate/fastforward/pull/2319/files#diff-701e74383f2411e1c8fb8925978e0bc89708df4670396fc94b8b7e3a9776808d) that is separate from the stable identity fingerprint and promotes as the file grows.
> - Rotation detection in [discovery.rs](https://github.com/strawgate/fastforward/pull/2319/files#diff-e6374467660d2f8894a1bb3e26e8c44f44b1a1246eedcd154ff2e9e4b5a8e26b) now compares against `comparison_fingerprint` rather than the raw identity fingerprint, fixing false negatives when a file is rewritten within the promoted window.
> - Evicted-file restore matching in `evicted_matches_open_file` also switches to `comparison_fingerprint`, and eviction persists this value so it can be restored on reopen.
> - On truncation, `comparison_fingerprint` is refreshed to match the new identity fingerprint; on growth past the configured window, it is promoted to the full-window fingerprint while the identity fingerprint remains stable.
> - Behavioral Change: files that were previously not detected as rotated (because the short initial fingerprint matched a rewritten file's prefix) will now correctly emit rotation events once the fingerprint window has been promoted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 380eccf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->