### PR TITLE
fix: preserve OTLP receiver scalar semantics

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver/convert.rs
+++ b/crates/logfwd-io/src/otlp_receiver/convert.rs
@@ -61,8 +61,7 @@ pub(super) fn convert_request_to_batch(
                 } else {
                     (record.observed_time_unix_nano, "observed_time_unix_nano")
                 };
-                if let Some(ts) = convert_otlp_timestamp(ts_raw, ts_field)?
-                {
+                if let Some(ts) = convert_otlp_timestamp(ts_raw, ts_field)? {
                     builder.append_i64_value_by_idx(timestamp_idx, ts);
                 }
 

--- a/crates/logfwd-io/src/otlp_receiver/convert.rs
+++ b/crates/logfwd-io/src/otlp_receiver/convert.rs
@@ -61,16 +61,17 @@ pub(super) fn convert_request_to_batch(
                 } else {
                     record.observed_time_unix_nano
                 };
-                if let Ok(ts) = i64::try_from(ts_raw)
-                    && ts > 0
+                if let Some(ts) =
+                    convert_otlp_timestamp(ts_raw, "time_unix_nano/observed_time_unix_nano")?
                 {
                     builder.append_i64_value_by_idx(timestamp_idx, ts);
                 }
 
                 // observed_time_unix_nano — always written separately.
-                if let Ok(obs_ts) = i64::try_from(record.observed_time_unix_nano)
-                    && obs_ts > 0
-                {
+                if let Some(obs_ts) = convert_otlp_timestamp(
+                    record.observed_time_unix_nano,
+                    "observed_time_unix_nano",
+                )? {
                     builder.append_i64_value_by_idx(observed_ts_idx, obs_ts);
                 }
 
@@ -151,6 +152,18 @@ pub(super) fn convert_request_to_batch(
     builder
         .finish_batch_detached()
         .map_err(|e| InputError::Receiver(format!("structured OTLP batch build error: {e}")))
+}
+
+fn convert_otlp_timestamp(raw: u64, field_name: &str) -> Result<Option<i64>, InputError> {
+    if raw == 0 {
+        return Ok(None);
+    }
+    let converted = i64::try_from(raw).map_err(|_| {
+        InputError::Receiver(format!(
+            "invalid OTLP {field_name}: value {raw} exceeds signed 64-bit nanosecond range"
+        ))
+    })?;
+    Ok(Some(converted))
 }
 
 fn append_attribute_value(

--- a/crates/logfwd-io/src/otlp_receiver/convert.rs
+++ b/crates/logfwd-io/src/otlp_receiver/convert.rs
@@ -56,13 +56,12 @@ pub(super) fn convert_request_to_batch(
 
                 // timestamp: prefer time_unix_nano, fall back to
                 // observed_time_unix_nano when event time is unknown (#1690).
-                let ts_raw = if record.time_unix_nano > 0 {
-                    record.time_unix_nano
+                let (ts_raw, ts_field) = if record.time_unix_nano > 0 {
+                    (record.time_unix_nano, "time_unix_nano")
                 } else {
-                    record.observed_time_unix_nano
+                    (record.observed_time_unix_nano, "observed_time_unix_nano")
                 };
-                if let Some(ts) =
-                    convert_otlp_timestamp(ts_raw, "time_unix_nano/observed_time_unix_nano")?
+                if let Some(ts) = convert_otlp_timestamp(ts_raw, ts_field)?
                 {
                     builder.append_i64_value_by_idx(timestamp_idx, ts);
                 }

--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -173,7 +173,7 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
 
     for rl in resource_logs {
         // Collect resource attributes.
-        let mut resource_attrs: Vec<(String, String)> = Vec::new();
+        let mut resource_attrs: Vec<(String, &serde_json::Value)> = Vec::new();
         if let Some(attrs) = rl
             .get("resource")
             .and_then(|r| r.get("attributes"))
@@ -186,9 +186,7 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
                 let Some(value) = kv.get("value") else {
                     continue;
                 };
-                if let Some(value) = json_any_value_to_string(value)? {
-                    resource_attrs.push((format!("{resource_prefix}{key}"), value));
-                }
+                resource_attrs.push((format!("{resource_prefix}{key}"), value));
             }
         }
 
@@ -281,8 +279,9 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
                 }
 
                 for (key, value) in &resource_attrs {
-                    write_json_string_field(&mut out, key, value);
-                    out.push(b',');
+                    if write_json_any_value_field_from_json(&mut out, key, value)? {
+                        out.push(b',');
+                    }
                 }
 
                 // Write protocol fields BEFORE log record attributes so that

--- a/crates/logfwd-io/src/otlp_receiver/tests.rs
+++ b/crates/logfwd-io/src/otlp_receiver/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use arrow::array::{Array, BooleanArray, Int64Array, StringArray, StringViewArray};
+use arrow::array::{Array, BooleanArray, Float64Array, Int64Array, StringArray, StringViewArray};
 use arrow::datatypes::DataType;
 use logfwd_types::field_names;
 use opentelemetry_proto::tonic::{
@@ -1042,6 +1042,70 @@ fn json_path_structured_values_match_protobuf_shape() {
 }
 
 #[test]
+fn json_resource_scalar_attributes_preserve_supported_types() {
+    let batch = decode_otlp_json(
+        br#"{
+            "resourceLogs": [{
+                "resource": {
+                    "attributes": [
+                        { "key": "sampled", "value": { "boolValue": true } },
+                        { "key": "retries", "value": { "intValue": "7" } },
+                        { "key": "ratio", "value": { "doubleValue": 1.25 } },
+                        { "key": "service", "value": { "stringValue": "checkout" } },
+                        { "key": "payload", "value": { "bytesValue": "AQIDBA==" } }
+                    ]
+                },
+                "scopeLogs": [{
+                    "logRecords": [{ "body": { "stringValue": "ok" } }]
+                }]
+            }]
+        }"#,
+        field_names::DEFAULT_RESOURCE_PREFIX,
+    )
+    .expect("resource scalar attributes should decode");
+
+    let sampled = batch
+        .column_by_name("resource.attributes.sampled")
+        .expect("resource bool column must exist");
+    assert_eq!(sampled.data_type(), &DataType::Boolean);
+    let sampled = sampled
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .expect("resource bool should be BooleanArray");
+    assert!(sampled.value(0));
+
+    let retries = batch
+        .column_by_name("resource.attributes.retries")
+        .expect("resource int column must exist");
+    assert_eq!(retries.data_type(), &DataType::Int64);
+    let retries = retries
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .expect("resource int should be Int64Array");
+    assert_eq!(retries.value(0), 7);
+
+    let ratio = batch
+        .column_by_name("resource.attributes.ratio")
+        .expect("resource float column must exist");
+    assert_eq!(ratio.data_type(), &DataType::Float64);
+    let ratio = ratio
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .expect("resource float should be Float64Array");
+    assert_eq!(ratio.value(0), 1.25);
+
+    let service = batch
+        .column_by_name("resource.attributes.service")
+        .expect("resource string column must exist");
+    assert_eq!(string_value_at(service.as_ref(), 0), "checkout");
+
+    let payload = batch
+        .column_by_name("resource.attributes.payload")
+        .expect("resource bytes column must exist");
+    assert_eq!(string_value_at(payload.as_ref(), 0), "01020304");
+}
+
+#[test]
 fn handles_invalid_protobuf() {
     let result = decode_otlp_protobuf(b"not valid protobuf", field_names::DEFAULT_RESOURCE_PREFIX);
     assert!(result.is_err());
@@ -1912,5 +1976,37 @@ fn batch_path_uses_observed_time_when_event_time_is_zero() {
         ts_arr.value(0),
         OBSERVED_NS as i64,
         "batch path must use observed_time_unix_nano when time_unix_nano is 0"
+    );
+}
+
+#[test]
+fn batch_path_errors_on_overflowed_observed_timestamp() {
+    let request = ExportLogsServiceRequest {
+        resource_logs: vec![ResourceLogs {
+            scope_logs: vec![ScopeLogs {
+                log_records: vec![LogRecord {
+                    time_unix_nano: 0,
+                    observed_time_unix_nano: u64::MAX,
+                    body: Some(AnyValue {
+                        value: Some(Value::StringValue("overflow".into())),
+                    }),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    };
+
+    let err = convert_request_to_batch(&request, field_names::DEFAULT_RESOURCE_PREFIX)
+        .expect_err("timestamp overflow must fail deterministically");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("observed_time_unix_nano"),
+        "overflow diagnostic should name offending field: {msg}"
+    );
+    assert!(
+        msg.contains("exceeds signed 64-bit nanosecond range"),
+        "overflow diagnostic should explain range failure: {msg}"
     );
 }


### PR DESCRIPTION
## Summary

- Preserve typed scalar resource attributes in OTLP JSON decode instead of stringifying every resource attribute.
- Return a deterministic receiver error when protobuf OTLP timestamps exceed the signed 64-bit nanosecond range instead of silently omitting them.
- Add regressions for JSON resource scalar attributes and overflowed observed timestamps.

## Verification

- `cargo test -p logfwd-io otlp_receiver --lib` — 145 passed, 1 ignored
- `cargo test -p logfwd-io` — 606 passed, 14 ignored across lib/integration/state-machine tests
- `just fmt`
- `just ci` — passed: fmt check, encoder check, workspace guard, clippy `-D warnings`, taplo, nextest `1778 passed, 43 skipped`

## Notes

This is the receiver-side slice from #2027 only. Sink-side #1879/#1898 and stale #1909 disposition remain out of scope.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OTLP receiver to preserve scalar type semantics and validate timestamp overflow
> - Resource attributes in OTLP JSON input are now written with their native types (bool, integer, double, string, bytes) instead of being coerced to strings, using `write_json_any_value_field_from_json` in [`decode.rs`](https://github.com/strawgate/fastforward/pull/2322/files#diff-1104a97c31865187f0a65affb5b8e2440e9db24cacdb3f9c1d24db1595686898).
> - A new `convert_otlp_timestamp` helper in [`convert.rs`](https://github.com/strawgate/fastforward/pull/2322/files#diff-6a6c2f5983178bb5062936eae5ac67d23b68f59157031419375de85a09f9be85) validates u64-to-i64 conversion for both `time_unix_nano` and `observed_time_unix_nano`, returning a descriptive error on overflow instead of silently omitting the timestamp.
> - Behavioral Change: `convert_request_to_batch` now returns an error (rather than silently dropping values) when either timestamp field exceeds the signed 64-bit range.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f5a0d95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->