### PR TITLE
fix: correct eBPF sensor event semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,6 +4523,7 @@ name = "sensor-ebpf"
 version = "0.1.0"
 dependencies = [
  "aya",
+ "libc",
  "sensor-ebpf-common",
 ]
 

--- a/crates/logfwd-ebpf-proto/sensor-ebpf/Cargo.toml
+++ b/crates/logfwd-ebpf-proto/sensor-ebpf/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 aya = { workspace = true }
+libc = { workspace = true }
 sensor-ebpf-common = { path = "sensor-ebpf-common", version = "0.1.0", features = ["std"] }
 
 [lints]

--- a/crates/logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-kern/src/main.rs
+++ b/crates/logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-kern/src/main.rs
@@ -176,6 +176,13 @@ pub fn sched_process_exit(ctx: TracePointContext) -> u32 {
 }
 
 fn try_process_exit(_ctx: &TracePointContext) -> Result<(), i64> {
+    let pid_tgid = bpf_get_current_pid_tgid();
+    let pid = pid_tgid as u32;
+    let tgid = (pid_tgid >> 32) as u32;
+    if pid != tgid {
+        return Ok(());
+    }
+
     let mut entry = match EVENTS.reserve::<ProcessExitEvent>(0) {
         Some(e) => e,
         None => return Ok(()),

--- a/crates/logfwd-ebpf-proto/sensor-ebpf/src/main.rs
+++ b/crates/logfwd-ebpf-proto/sensor-ebpf/src/main.rs
@@ -155,6 +155,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut stdout = std::io::stdout().lock();
     let start = Instant::now();
     let deadline = Duration::from_secs(duration_secs);
+    let monotonic_to_wall_offset_ns =
+        monotonic_now_ns().map(|mono_now_ns| wall_clock_ns().saturating_sub(mono_now_ns));
 
     let mut counts = EventCounts::default();
 
@@ -176,7 +178,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 continue;
             }
 
-            let now_wall = wall_clock_ns();
+            let event_wall = match monotonic_to_wall_offset_ns {
+                Some(offset_ns) => event_wall_clock_ns(header.timestamp_ns, offset_ns),
+                None => wall_clock_ns(),
+            };
             let comm = comm_str(&header.comm);
             let comm_esc = if json_mode {
                 json_escape(comm)
@@ -195,7 +200,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"exec","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","filename":"{}"}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -222,7 +227,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"exit","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","exit_code":{}}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -253,7 +258,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"file_open","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","flags":{},"filename":"{}"}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -282,7 +287,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"file_delete","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","flags":{},"pathname":"{}"}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -312,7 +317,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"file_rename","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","oldname":"{}","newname":"{}"}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -340,7 +345,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"setuid","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","target_uid":{}}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -367,7 +372,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"setgid","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","target_gid":{}}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -395,7 +400,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"module_load","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","taints":{},"module":"{}"}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -424,7 +429,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"ptrace","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","request":{},"request_name":"{}","target_pid":{}}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -454,7 +459,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"memfd_create","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","flags":{},"name":"{}"}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -478,13 +483,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // SAFETY: length checked >= size_of::<TcpConnectEvent>(); ring buffer is 8-byte aligned.
                     let ev = unsafe { &*(ptr.cast::<TcpConnectEvent>()) };
                     counts.tcp_connect += 1;
-                    let src = Ipv4Addr::from(ev.saddr.to_ne_bytes());
-                    let dst = Ipv4Addr::from(ev.daddr.to_ne_bytes());
+                    let src = format_addr(ev.saddr);
+                    let dst = format_addr(ev.daddr);
                     if json_mode {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"tcp_connect","tgid":{},"comm":"{}","src":"{}:{}","dst":"{}:{}"}}"#,
-                            now_wall, header.tgid, comm_esc, src, ev.sport, dst, ev.dport
+                            event_wall, header.tgid, comm_esc, src, ev.sport, dst, ev.dport
                         )?;
                     } else {
                         writeln!(
@@ -500,13 +505,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     // SAFETY: length checked >= size_of::<TcpAcceptEvent>(); ring buffer is 8-byte aligned.
                     let ev = unsafe { &*(ptr.cast::<TcpAcceptEvent>()) };
                     counts.tcp_accept += 1;
-                    let src = Ipv4Addr::from(ev.saddr.to_ne_bytes());
-                    let dst = Ipv4Addr::from(ev.daddr.to_ne_bytes());
+                    let src = format_addr(ev.saddr);
+                    let dst = format_addr(ev.daddr);
                     if json_mode {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"tcp_accept","tgid":{},"comm":"{}","src":"{}:{}","dst":"{}:{}"}}"#,
-                            now_wall, header.tgid, comm_esc, src, ev.sport, dst, ev.dport
+                            event_wall, header.tgid, comm_esc, src, ev.sport, dst, ev.dport
                         )?;
                     } else {
                         writeln!(
@@ -530,7 +535,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         Some(qt) => format!("{qt}"),
                         None => "?".to_string(),
                     };
-                    let dst = Ipv4Addr::from(ev.dst_addr.to_ne_bytes());
+                    let dst = format_addr(ev.dst_addr);
                     if json_mode {
                         // Emit null JSON values for undecoded fields.
                         let qname_json = match qname_opt.as_deref() {
@@ -544,7 +549,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             stdout,
                             r#"{{"ts":{},"kind":"dns_query","tgid":{},"pid":{},"uid":{},"gid":{},"cgroup":{},"comm":"{}","qname":{},"qtype":{},"tx_id":{},"dst":"{}:{}"}}"#,
-                            now_wall,
+                            event_wall,
                             header.tgid,
                             header.pid,
                             header.uid,
@@ -603,6 +608,30 @@ fn wall_clock_ns() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos() as u64
+}
+
+fn event_wall_clock_ns(mono_event_ns: u64, mono_to_wall_offset_ns: u64) -> u64 {
+    mono_event_ns.saturating_add(mono_to_wall_offset_ns)
+}
+
+fn monotonic_now_ns() -> Option<u64> {
+    let mut ts = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    // SAFETY: `ts` is a valid, writable pointer to a stack-allocated timespec.
+    let ret = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &raw mut ts) };
+    if ret == 0 {
+        let secs = u64::try_from(ts.tv_sec).ok()?;
+        let nanos = u64::try_from(ts.tv_nsec).ok()?;
+        Some(secs.saturating_mul(1_000_000_000).saturating_add(nanos))
+    } else {
+        None
+    }
+}
+
+fn format_addr(addr: u32) -> Ipv4Addr {
+    Ipv4Addr::from(addr.to_ne_bytes())
 }
 
 fn comm_str(comm: &[u8; COMM_SIZE]) -> &str {

--- a/crates/logfwd-io/src/platform_sensor.rs
+++ b/crates/logfwd-io/src/platform_sensor.rs
@@ -151,9 +151,8 @@ fn wall_clock_ns() -> u64 {
 
 /// Format an IPv4 address from a `__be32` u32.
 ///
-/// The kernel stores `saddr`/`daddr` as `__be32`: the raw bytes in memory are
-/// already in network order. `to_ne_bytes()` gives those raw bytes on any
-/// platform, and `Ipv4Addr::from([u8; 4])` interprets them in network order.
+/// The sensor reads network-order address bytes into a native `u32`, so native
+/// bytes recover the original IPv4 octets.
 fn format_addr(addr: u32) -> String {
     let ip = Ipv4Addr::from(addr.to_ne_bytes());
     ip.to_string()
@@ -831,5 +830,22 @@ impl InputSource for PlatformSensorInput {
             SensorState::Running { health, .. } => *health,
             SensorState::Poisoned => ComponentHealth::Failed,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_addr;
+
+    #[test]
+    fn format_addr_renders_network_order_ipv4() {
+        let addr = u32::from_ne_bytes([127, 0, 0, 1]);
+        assert_eq!(format_addr(addr), "127.0.0.1");
+    }
+
+    #[test]
+    fn format_addr_renders_multibyte_octets() {
+        let addr = u32::from_ne_bytes([192, 168, 1, 10]);
+        assert_eq!(format_addr(addr), "192.168.1.10");
     }
 }


### PR DESCRIPTION
## Summary

- Filter `sched_process_exit` to process leaders so ordinary non-leader thread exits do not emit process-exit events.
- Render eBPF IPv4 ring-buffer values from their raw/native byte sequence so copied `__be32` octets are preserved on little-endian hosts.
- Derive standalone JSON timestamps from the event header timestamp using a monotonic-to-wall offset computed once at startup, now using `clock_gettime(CLOCK_MONOTONIC)` and falling back to per-event wall clock if offset derivation fails.

## Verification

- `cargo test -p logfwd-io platform_sensor --lib` — passed, but 0 tests matched on this host because platform sensor tests are cfg-gated
- `cargo test -p logfwd-io` — passed: 604 passed, 14 ignored across lib/integration/state-machine tests
- `just fmt`
- `taplo check crates/logfwd-ebpf-proto/sensor-ebpf/Cargo.toml`
- `just ci` — passed locally before the CI-only raw-pointer lint fix: fmt check, encoder check, workspace guard, clippy `-D warnings`, taplo, nextest `1776 passed, 43 skipped`
- `cargo clippy -p sensor-ebpf --target x86_64-unknown-linux-gnu -- -D warnings` — passed after installing the Linux Rust target locally

## Not run / environment limits

- Privileged Linux eBPF load/attach validation was not run from this macOS worktree.
- `cargo clippy --workspace -- -D warnings` does not complete natively on macOS because Aya imports Linux netlink/BPF APIs not present in macOS `libc`; CI runs that workspace clippy on Linux.

## Issue disposition

- Addresses #1991 and #1993 portions of #2103.
- Adds the first #1990 filter for ordinary non-leader thread exits, but does not fully close #1990's true process-death semantics when a thread-group leader exits before sibling threads. That residual is now captured in #1990/#2103 and assigned to Codex Cloud research task https://chatgpt.com/codex/tasks/task_e_69e53f92d7dc832eaa924068658b3fc2.
- Does not change `openat` offsets for #2006; current constants still appear already ABI-correct.
- Leaves residual #2009 exit-code race proof/repro for follow-up because no kernel-versioned repro was available here.
- Does not include #2069 map pressure work or #2030 polling/platform-sensor improvements.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix eBPF sensor event semantics for process exits and event timestamps
> - Process exit events are now emitted only for thread-group leaders (`pid == tgid`); per-thread exits are skipped in `try_process_exit` in [sensor-ebpf-kern/src/main.rs](https://github.com/strawgate/fastforward/pull/2323/files#diff-db59d166304a2e5e48daf8ea39059f5be6f4a54879872948002572e70901c2d3).
> - Event timestamps now use the kernel-provided monotonic capture time translated to wall-clock time via a one-time offset computed at startup, with fallback to current wall-clock time.
> - IP address formatting for TCP connect/accept and DNS events is unified through a `format_addr` helper in [sensor-ebpf/src/main.rs](https://github.com/strawgate/fastforward/pull/2323/files#diff-c7f6f430cd7320e949d5a1d7a24e492ffe18d2964b3b212fb63ae8761cd8e2bd).
> - Behavioral Change: previously, exit events were emitted for every thread exit; now only the main thread (group leader) produces an exit event.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9a152e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->