### PR TITLE
fix: support ff send fanout destinations

### DIFF
--- a/book/src/content/docs/configuration/outputs.mdx
+++ b/book/src/content/docs/configuration/outputs.mdx
@@ -140,5 +140,7 @@ outputs:
     format: console
 ```
 
+The same destination-only shape works with `ff send` for finite stdin workflows.
+
 </TabItem>
 </Tabs>

--- a/book/src/content/docs/quick-start.mdx
+++ b/book/src/content/docs/quick-start.mdx
@@ -103,7 +103,7 @@ FastForward exits when it reaches the end of a finite file. In production you'd 
 ### Send piped data
 
 For one-off command-line use, keep a destination-only config and pipe data into `ff`.
-`ff send` reads stdin, drains the configured output, and exits.
+`ff send` reads stdin, drains the configured output or outputs, and exits.
 
 ```yaml
 # destination.yaml

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -661,9 +661,17 @@ fn build_stdin_send_config_yaml(
             )));
         }
     }
-    if !mapping.contains_key(yaml_string("output")) {
+    let has_output = mapping.contains_key(yaml_string("output"));
+    let has_outputs = mapping.contains_key(yaml_string("outputs"));
+    if has_output && has_outputs {
         return Err(CliError::Config(
-            "`ff send` destination config must define top-level `output`".to_owned(),
+            "`ff send` destination config must define only one of top-level `output` or `outputs`"
+                .to_owned(),
+        ));
+    }
+    if !has_output && !has_outputs {
+        return Err(CliError::Config(
+            "`ff send` destination config must define top-level `output` or `outputs`".to_owned(),
         ));
     }
 
@@ -673,11 +681,49 @@ fn build_stdin_send_config_yaml(
         let format = format.as_config_format().to_string();
         input.insert(yaml_string("format"), yaml_string(&format));
     }
-    mapping.insert(yaml_string("input"), serde_yaml_ng::Value::Mapping(input));
 
     merge_send_resource_attrs(mapping, service, resources)?;
 
+    if has_outputs {
+        rewrite_send_config_with_outputs(mapping, input)?;
+    } else {
+        mapping.insert(yaml_string("input"), serde_yaml_ng::Value::Mapping(input));
+    }
+
     serde_yaml_ng::to_string(&value).map_err(|e| CliError::Config(e.to_string()))
+}
+
+fn rewrite_send_config_with_outputs(
+    mapping: &mut serde_yaml_ng::Mapping,
+    input: serde_yaml_ng::Mapping,
+) -> Result<(), CliError> {
+    let outputs = mapping.remove(yaml_string("outputs")).ok_or_else(|| {
+        CliError::Config("send destination config is missing top-level `outputs`".to_owned())
+    })?;
+
+    let mut pipeline = serde_yaml_ng::Mapping::new();
+    pipeline.insert(
+        yaml_string("inputs"),
+        serde_yaml_ng::Value::Sequence(vec![serde_yaml_ng::Value::Mapping(input)]),
+    );
+    pipeline.insert(yaml_string("outputs"), outputs);
+
+    for key in ["transform", "enrichment", "resource_attrs"] {
+        if let Some(value) = mapping.remove(yaml_string(key)) {
+            pipeline.insert(yaml_string(key), value);
+        }
+    }
+
+    let mut pipelines = serde_yaml_ng::Mapping::new();
+    pipelines.insert(
+        yaml_string("default"),
+        serde_yaml_ng::Value::Mapping(pipeline),
+    );
+    mapping.insert(
+        yaml_string("pipelines"),
+        serde_yaml_ng::Value::Mapping(pipelines),
+    );
+    Ok(())
 }
 
 fn merge_send_resource_attrs(
@@ -2270,6 +2316,46 @@ output:
     }
 
     #[test]
+    fn stdin_send_config_accepts_plural_outputs() {
+        let yaml = r"
+resource_attrs:
+  env: prod
+transform: |
+  SELECT * FROM logs
+outputs:
+  - type: stdout
+    format: json
+  - type: file
+    path: ./sent.ndjson
+";
+        let generated =
+            build_stdin_send_config_yaml(yaml, Some(SendFormat::Raw), Some("checkout"), &[])
+                .expect("send config should render");
+        let config =
+            logfwd_config::Config::load_str(&generated).expect("generated config should parse");
+        let pipeline = &config.pipelines["default"];
+
+        assert_eq!(
+            pipeline.inputs[0].input_type(),
+            logfwd_config::InputType::Stdin
+        );
+        assert_eq!(pipeline.inputs[0].format, Some(logfwd_config::Format::Raw));
+        assert_eq!(pipeline.outputs.len(), 2);
+        assert_eq!(
+            pipeline
+                .resource_attrs
+                .get("service.name")
+                .map(String::as_str),
+            Some("checkout")
+        );
+        assert_eq!(
+            pipeline.resource_attrs.get("env").map(String::as_str),
+            Some("prod")
+        );
+        assert_eq!(pipeline.transform.as_deref(), Some("SELECT * FROM logs\n"));
+    }
+
+    #[test]
     fn stdin_send_config_rejects_runtime_inputs() {
         for (field, yaml) in [
             (
@@ -2295,7 +2381,25 @@ output:
         let err = build_stdin_send_config_yaml("server: {}\n", None, None, &[])
             .expect_err("send config should require output");
         assert!(
-            err.to_string().contains("must define top-level `output`"),
+            err.to_string()
+                .contains("must define top-level `output` or `outputs`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn stdin_send_config_rejects_output_and_outputs_together() {
+        let yaml = r"
+output:
+  type: stdout
+outputs:
+  - type: stdout
+";
+        let err = build_stdin_send_config_yaml(yaml, None, None, &[])
+            .expect_err("send config should reject ambiguous destination output shape");
+        assert!(
+            err.to_string()
+                .contains("only one of top-level `output` or `outputs`"),
             "unexpected error: {err}"
         );
     }

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -697,9 +697,9 @@ fn rewrite_send_config_with_outputs(
     mapping: &mut serde_yaml_ng::Mapping,
     input: serde_yaml_ng::Mapping,
 ) -> Result<(), CliError> {
-    let outputs = mapping.remove(yaml_string("outputs")).ok_or_else(|| {
-        CliError::Config("send destination config is missing top-level `outputs`".to_owned())
-    })?;
+    let outputs = mapping
+        .remove(yaml_string("outputs"))
+        .expect("internal invariant violated: `ff send` rewrite requires top-level `outputs`");
 
     let mut pipeline = serde_yaml_ng::Mapping::new();
     pipeline.insert(
@@ -2322,6 +2322,11 @@ resource_attrs:
   env: prod
 transform: |
   SELECT * FROM logs
+enrichment:
+  - type: static
+    table_name: labels
+    labels:
+      env: dogfood
 outputs:
   - type: stdout
     format: json
@@ -2353,6 +2358,16 @@ outputs:
             Some("prod")
         );
         assert_eq!(pipeline.transform.as_deref(), Some("SELECT * FROM logs\n"));
+        match &pipeline.enrichment[..] {
+            [logfwd_config::EnrichmentConfig::Static(static_cfg)] => {
+                assert_eq!(static_cfg.table_name, "labels");
+                assert_eq!(
+                    static_cfg.labels.get("env").map(String::as_str),
+                    Some("dogfood")
+                );
+            }
+            other => panic!("expected one static enrichment config, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -685,7 +685,7 @@ fn build_stdin_send_config_yaml(
     merge_send_resource_attrs(mapping, service, resources)?;
 
     if has_outputs {
-        rewrite_send_config_with_outputs(mapping, input)?;
+        rewrite_send_config_with_outputs(mapping, input);
     } else {
         mapping.insert(yaml_string("input"), serde_yaml_ng::Value::Mapping(input));
     }
@@ -696,7 +696,7 @@ fn build_stdin_send_config_yaml(
 fn rewrite_send_config_with_outputs(
     mapping: &mut serde_yaml_ng::Mapping,
     input: serde_yaml_ng::Mapping,
-) -> Result<(), CliError> {
+) {
     let outputs = mapping
         .remove(yaml_string("outputs"))
         .expect("internal invariant violated: `ff send` rewrite requires top-level `outputs`");
@@ -723,7 +723,6 @@ fn rewrite_send_config_with_outputs(
         yaml_string("pipelines"),
         serde_yaml_ng::Value::Mapping(pipelines),
     );
-    Ok(())
 }
 
 fn merge_send_resource_attrs(


### PR DESCRIPTION
## Summary

- Allow destination-only `ff send` configs to use top-level `outputs:` as a fan-out destination shape.
- Lower `outputs:` destination configs into a generated one-pipeline config with stdin input, preserving top-level `transform`, `enrichment`, and `resource_attrs`.
- Document that destination-only `outputs:` works for finite stdin workflows.

## Dogfood finding

While dogfooding `cat logs | ff -c destination.yaml`, a destination config with fan-out outputs failed with:

```text
error: `ff send` destination config must define top-level `output`
```

That made the CLI feel inconsistent with the documented plural `outputs` shape.

## Validation

- `cargo fmt --check`
- `cargo test -p logfwd stdin_send_config`
- `cargo check -p logfwd-io -p logfwd-config -p logfwd-runtime -p logfwd`
- `just lint`
- end-to-end dogfood: piped JSON into `ff -c destination.yaml --format json` with destination `outputs:` fanning out to stdout and file


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support top-level `outputs` (plural) in `ff send` fanout destination configs
> - `ff send` previously only accepted a singular `output` key in destination-only configs; it now also accepts a top-level `outputs` key for fanout to multiple destinations.
> - When `outputs` is present, `build_stdin_send_config_yaml` delegates to a new `rewrite_send_config_with_outputs` helper that restructures the config into a `pipelines.default` shape, preserving `transform`, `enrichment`, and `resource_attrs`.
> - Returns an error if both `output` and `outputs` are present, or if neither is defined.
> - Documentation in `outputs.mdx` and `quick-start.mdx` is updated to reflect the expanded `ff send` behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b39cb01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->