### PR TITLE
fix: correct OTLP sink protocol fields

### DIFF
--- a/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
+++ b/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
@@ -83,11 +83,8 @@ pub(super) fn encode_row_as_log_record_fast_v1(
     }
 
     if let Some((_, arr)) = columns.flags_col
-        && !arr.is_null(row) {
-            let raw = arr.value(row);
-            if let Ok(flags) = u32::try_from(raw) {
-                encode_fixed32(buf, otlp::LOG_RECORD_FLAGS, flags);
-            }
+        && let Some(flags) = arr.value_u32(row) {
+            encode_fixed32(buf, otlp::LOG_RECORD_FLAGS, flags);
         }
 
     if let Some((_, arr)) = columns.trace_id_col.as_ref()

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -9,7 +9,7 @@ use arrow::array::{
     Array, AsArray, BinaryArray, LargeBinaryArray, LargeStringArray, PrimitiveArray, StringArray,
     StringViewArray,
 };
-use arrow::datatypes::{DataType, Float64Type, Int64Type, UInt64Type};
+use arrow::datatypes::{DataType, Float64Type, Int64Type, UInt32Type, UInt64Type};
 use arrow::record_batch::RecordBatch;
 use arrow::util::display::array_value_to_string;
 use flate2::Compression as GzipLevel;
@@ -88,6 +88,28 @@ type ScopeKey<'a> = (Option<&'a str>, Option<&'a str>);
 
 /// Per-group state: resource key + scope key + byte-range spans of encoded log records.
 type ResourceGroup<'a> = (ResourceKey<'a>, ScopeKey<'a>, Vec<(usize, usize)>);
+
+#[derive(Clone, Copy)]
+enum FlagsArray<'a> {
+    Int64(&'a PrimitiveArray<Int64Type>),
+    UInt32(&'a PrimitiveArray<UInt32Type>),
+    UInt64(&'a PrimitiveArray<UInt64Type>),
+}
+
+impl FlagsArray<'_> {
+    #[inline]
+    fn value_u32(self, row: usize) -> Option<u32> {
+        match self {
+            FlagsArray::Int64(arr) => (!arr.is_null(row))
+                .then(|| arr.value(row))
+                .and_then(|raw| u32::try_from(raw).ok()),
+            FlagsArray::UInt32(arr) => (!arr.is_null(row)).then(|| arr.value(row)),
+            FlagsArray::UInt64(arr) => (!arr.is_null(row))
+                .then(|| arr.value(row))
+                .and_then(|raw| u32::try_from(raw).ok()),
+        }
+    }
+}
 
 impl OtlpSink {
     #[allow(clippy::too_many_arguments)]
@@ -588,48 +610,10 @@ impl OtlpSink {
                 let status = response.status();
 
                 if status.is_success() {
-                    // For gRPC, check grpc-status header — HTTP 200 can carry a
-                    // gRPC error in headers (trailers-only responses). (#1097)
-                    //
-                    // Note: reqwest does not surface HTTP/2 trailers from the
-                    // trailers frame, only from the initial HEADERS frame. This
-                    // catches trailers-only responses (the common error path for
-                    // OTLP collectors) but not normal headers→data→trailers flow.
                     if self.protocol == OtlpProtocol::Grpc
-                        && let Some(grpc_status) = response.headers().get("grpc-status")
+                        && let Some(send_result) = classify_grpc_status_headers(response.headers())
                     {
-                        let code = grpc_status
-                            .to_str()
-                            .unwrap_or("unknown")
-                            .trim()
-                            .parse::<u32>()
-                            .unwrap_or(2); // default to UNKNOWN
-                        if code != 0 {
-                            let msg = response
-                                .headers()
-                                .get("grpc-message")
-                                .and_then(|v| v.to_str().ok())
-                                .unwrap_or("")
-                                .to_string();
-                            // Classify gRPC status codes per gRPC spec:
-                            // Retryable: CANCELLED(1), DEADLINE_EXCEEDED(4),
-                            //   RESOURCE_EXHAUSTED(8), ABORTED(10), UNAVAILABLE(14)
-                            // Permanent: all others (INVALID_ARGUMENT, NOT_FOUND, etc.)
-                            return Ok(match code {
-                                1 | 4 | 10 | 14 => super::sink::SendResult::IoError(
-                                    io::Error::other(format!("gRPC error {code}: {msg}")),
-                                ),
-                                8 => {
-                                    // RESOURCE_EXHAUSTED → treat like 429
-                                    super::sink::SendResult::RetryAfter(Duration::from_secs(
-                                        DEFAULT_RETRY_AFTER_SECS,
-                                    ))
-                                }
-                                _ => super::sink::SendResult::Rejected(format!(
-                                    "gRPC error {code}: {msg}"
-                                )),
-                            });
-                        }
+                        return Ok(send_result);
                     }
                     self.stats.inc_lines(batch_rows);
                     self.stats.inc_bytes(self.encoder_buf.len() as u64);
@@ -661,6 +645,44 @@ impl OtlpSink {
             Err(e) => Err(io::Error::other(e.to_string())),
         }
     }
+}
+
+/// Classify gRPC application status from response headers.
+///
+/// OTLP/gRPC uses HTTP 200 for transport-level success and reports application errors
+/// in `grpc-status`/`grpc-message`.
+///
+/// Behavior:
+/// - Header-only or trailers-only responses where `grpc-status` is exposed in the initial
+///   header map are classified and returned.
+/// - Normal responses that send `grpc-status` only in the trailing headers are currently
+///   treated as transport success because reqwest does not expose HTTP/2 trailing headers
+///   via the response header map used here.
+fn classify_grpc_status_headers(
+    headers: &reqwest::header::HeaderMap,
+) -> Option<super::sink::SendResult> {
+    let grpc_status = headers.get("grpc-status")?;
+    let code = grpc_status
+        .to_str()
+        .unwrap_or("unknown")
+        .trim()
+        .parse::<u32>()
+        .unwrap_or(2); // default to UNKNOWN
+    if code == 0 {
+        return None;
+    }
+    let msg = headers
+        .get("grpc-message")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    Some(match code {
+        1 | 4 | 10 | 14 => {
+            super::sink::SendResult::IoError(io::Error::other(format!("gRPC error {code}: {msg}")))
+        }
+        8 => super::sink::SendResult::RetryAfter(Duration::from_secs(DEFAULT_RETRY_AFTER_SECS)),
+        _ => super::sink::SendResult::Rejected(format!("gRPC error {code}: {msg}")),
+    })
 }
 
 impl super::sink::Sink for OtlpSink {
@@ -898,7 +920,7 @@ struct BatchColumns<'a> {
     /// Downcast array for the `span_id` column (16 hex chars → 8-byte OTLP field 10).
     span_id_col: Option<(usize, OtlpStrCol<'a>)>,
     /// Downcast array for the `flags` / `trace_flags` column (uint32, OTLP field 8).
-    flags_col: Option<(usize, &'a PrimitiveArray<Int64Type>)>,
+    flags_col: Option<(usize, FlagsArray<'a>)>,
     /// Severity number column (Int64, OTLP severity_number).
     severity_num_col: Option<(usize, &'a PrimitiveArray<Int64Type>)>,
     /// Observed timestamp column (Int64, nanoseconds).
@@ -931,7 +953,7 @@ fn resolve_batch_columns<'a>(batch: &'a RecordBatch, message_field: &str) -> Bat
     let mut body_col: Option<(usize, OtlpStrCol<'_>)> = None;
     let mut trace_id_col: Option<(usize, OtlpStrCol<'_>)> = None;
     let mut span_id_col: Option<(usize, OtlpStrCol<'_>)> = None;
-    let mut flags_col: Option<(usize, &PrimitiveArray<Int64Type>)> = None;
+    let mut flags_col: Option<(usize, FlagsArray<'_>)> = None;
     // Column indices to exclude from attributes.
     let mut excluded = vec![false; schema.fields().len()];
 
@@ -990,11 +1012,19 @@ fn resolve_batch_columns<'a>(batch: &'a RecordBatch, message_field: &str) -> Bat
                 name,
                 field_names::TRACE_FLAGS,
                 field_names::TRACE_FLAGS_VARIANTS,
-            ) && flags_col.is_none()
-                && matches!(field.data_type(), DataType::Int64) =>
+            ) && flags_col.is_none() =>
             {
-                flags_col = Some((idx, batch.column(idx).as_primitive::<Int64Type>()));
-                excluded[idx] = true;
+                let col = batch.column(idx);
+                let resolved = match field.data_type() {
+                    DataType::Int64 => Some(FlagsArray::Int64(col.as_primitive::<Int64Type>())),
+                    DataType::UInt32 => Some(FlagsArray::UInt32(col.as_primitive::<UInt32Type>())),
+                    DataType::UInt64 => Some(FlagsArray::UInt64(col.as_primitive::<UInt64Type>())),
+                    _ => None,
+                };
+                if let Some(flags_arr) = resolved {
+                    flags_col = Some((idx, flags_arr));
+                    excluded[idx] = true;
+                }
             }
             name if name == message_field
                 || field_names::matches_any(
@@ -1341,12 +1371,9 @@ fn encode_row_as_log_record(
     // Clamp to u32 range: negative or >u32::MAX values are invalid per the
     // W3C Trace Context spec (only 8 bits are defined). (#1121)
     if let Some((_, arr)) = columns.flags_col
-        && !arr.is_null(row)
+        && let Some(flags) = arr.value_u32(row)
     {
-        let raw = arr.value(row);
-        if let Ok(flags) = u32::try_from(raw) {
-            encode_fixed32(buf, otlp::LOG_RECORD_FLAGS, flags);
-        }
+        encode_fixed32(buf, otlp::LOG_RECORD_FLAGS, flags);
     }
 
     // LogRecord.trace_id (bytes, 16 bytes) — hex-decoded from 32-char string column
@@ -1649,6 +1676,9 @@ fn write_grpc_frame(buf: &mut Vec<u8>, payload: &[u8], compressed: bool) -> io::
     buf.extend_from_slice(payload);
     Ok(())
 }
+
+#[cfg(test)]
+mod otlp_sink_correctness_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -1368,7 +1368,7 @@ fn encode_row_as_log_record(
     }
 
     // LogRecord.flags (fixed32) — W3C trace flags.
-    // Clamp to u32 range: negative or >u32::MAX values are invalid per the
+    // Filter to u32 range: negative or >u32::MAX values are invalid per the
     // W3C Trace Context spec (only 8 bits are defined). (#1121)
     if let Some((_, arr)) = columns.flags_col
         && let Some(flags) = arr.value_u32(row)

--- a/crates/logfwd-output/src/otlp_sink/otlp_sink_correctness_tests.rs
+++ b/crates/logfwd-output/src/otlp_sink/otlp_sink_correctness_tests.rs
@@ -81,3 +81,23 @@ fn encode_unsigned_flags_as_field_8() {
         "UInt64",
     );
 }
+
+#[test]
+fn encode_flags_uint64_out_of_range_silently_dropped() {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "flags",
+        DataType::UInt64,
+        true,
+    )]));
+    let arr = UInt64Array::from(vec![u64::from(u32::MAX) + 1]);
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(arr)]).expect("flags batch");
+
+    let mut sink = make_sink();
+    sink.encode_batch(&batch, &make_metadata());
+
+    // field 8, wire type 5 tag = 0x45 — must NOT appear when value > u32::MAX
+    assert!(
+        !contains_bytes(&sink.encoder_buf, &[0x45u8]),
+        "flags field 8 must not be encoded for out-of-range UInt64 value"
+    );
+}

--- a/crates/logfwd-output/src/otlp_sink/otlp_sink_correctness_tests.rs
+++ b/crates/logfwd-output/src/otlp_sink/otlp_sink_correctness_tests.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use arrow::array::{Array, UInt32Array, UInt64Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::record_batch::RecordBatch;
+use reqwest::header::{HeaderMap, HeaderValue};
+
+use super::*;
+
+fn make_sink() -> OtlpSink {
+    OtlpSink::new(
+        "test".into(),
+        "http://localhost:4318".into(),
+        OtlpProtocol::Http,
+        Compression::None,
+        vec![],
+        reqwest::Client::new(),
+        Arc::new(ComponentStats::new()),
+    )
+    .expect("sink")
+}
+
+fn make_metadata() -> BatchMetadata {
+    BatchMetadata {
+        resource_attrs: Arc::default(),
+        observed_time_ns: 1_000_000_000,
+    }
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+#[test]
+fn grpc_status_headers_are_classified() {
+    let mut retryable = HeaderMap::new();
+    retryable.insert("grpc-status", HeaderValue::from_static("14"));
+    retryable.insert("grpc-message", HeaderValue::from_static("unavailable"));
+    assert!(
+        matches!(
+            classify_grpc_status_headers(&retryable),
+            Some(crate::sink::SendResult::IoError(_))
+        ),
+        "grpc-status 14 should map to retryable IoError",
+    );
+
+    let mut success = HeaderMap::new();
+    success.insert("grpc-status", HeaderValue::from_static("0"));
+    assert!(classify_grpc_status_headers(&success).is_none());
+    assert!(classify_grpc_status_headers(&HeaderMap::new()).is_none());
+}
+
+fn assert_flags_column_encodes_as_field_8(
+    data_type: DataType,
+    arr: Arc<dyn Array>,
+    type_name: &str,
+) {
+    let schema = Arc::new(Schema::new(vec![Field::new("flags", data_type, true)]));
+    let batch = RecordBatch::try_new(schema, vec![arr]).expect("flags batch");
+
+    let mut sink = make_sink();
+    sink.encode_batch(&batch, &make_metadata());
+
+    let expected = [0x45u8, 0x01, 0x00, 0x00, 0x00];
+    assert!(
+        contains_bytes(&sink.encoder_buf, &expected),
+        "flags field 8 not found in encoded output for {type_name}"
+    );
+}
+
+#[test]
+fn encode_unsigned_flags_as_field_8() {
+    assert_flags_column_encodes_as_field_8(
+        DataType::UInt32,
+        Arc::new(UInt32Array::from(vec![1u32])),
+        "UInt32",
+    );
+    assert_flags_column_encodes_as_field_8(
+        DataType::UInt64,
+        Arc::new(UInt64Array::from(vec![1u64])),
+        "UInt64",
+    );
+}

--- a/scripts/generate_otlp_fast_encoder.py
+++ b/scripts/generate_otlp_fast_encoder.py
@@ -111,11 +111,8 @@ pub(super) fn encode_row_as_log_record_fast_v1(
     }}
 
     if let Some((_, arr)) = columns.flags_col
-        && !arr.is_null(row) {{
-            let raw = arr.value(row);
-            if let Ok(flags) = u32::try_from(raw) {{
-                encode_fixed32(buf, otlp::LOG_RECORD_FLAGS, flags);
-            }}
+        && let Some(flags) = arr.value_u32(row) {{
+            encode_fixed32(buf, otlp::LOG_RECORD_FLAGS, flags);
         }}
 
     if let Some((_, arr)) = columns.trace_id_col.as_ref()


### PR DESCRIPTION
## Summary

- Accept `UInt32` and compatible `UInt64` trace flag columns as OTLP `LogRecord.flags`, alongside the existing `Int64` path.
- Factor gRPC `grpc-status` header classification into a focused helper with tests for non-zero status, status zero, and missing status.
- Update the OTLP fast encoder generator so the generated path matches the handwritten encoder behavior.

## Issue notes

Addresses the sink side of #2027:

- #1879: `UInt32`/compatible `UInt64` flags now encode as OTLP field 8 instead of falling back to attributes.
- #1898: gRPC status handling is explicit for header-only/trailers-only responses visible through reqwest headers. True trailing HTTP/2 trailers remain a documented transport limitation because reqwest does not expose them through this response path.

## Verification

- `cargo test -p logfwd-output otlp --lib` — passed: 57 passed, 221 filtered out
- `just fmt`
- `python3 scripts/generate_otlp_fast_encoder.py --check` — via `just ci`
- `just ci` — passed: fmt check, OTLP codegen check, workspace guard, clippy `-D warnings`, taplo, nextest `1788 passed, 43 skipped`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OTLP sink to handle UInt32 and UInt64 Arrow columns for log record flags
> - Introduces a `FlagsArray` enum in [`otlp_sink.rs`](https://github.com/strawgate/fastforward/pull/2334/files#diff-56ca7e19db98793b4ef621c0d28a618a4c8af2bd492bc89cc8a21e845f25a43c) with variants for `Int64`, `UInt32`, and `UInt64`, replacing the previous `Int64`-only handling of the flags column.
> - Updates `resolve_batch_columns` to recognize `UInt32` and `UInt64` data types when resolving the flags/trace_flags column, and updates per-row encoding to use `FlagsArray::value_u32`.
> - Adds a `classify_grpc_status_headers` helper to centralize gRPC status/header parsing in `send_payload`, mapping status codes to `SendResult` variants.
> - Updates the code generation template in [`generate_otlp_fast_encoder.py`](https://github.com/strawgate/fastforward/pull/2334/files#diff-b04ce9376babe3bbd36e33954166d44f45b4442d3d766cebaa1ebfca76fe2c52) to match the new flags encoding approach.
> - Adds tests for gRPC status header classification and unsigned flags column encoding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f12247.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->