### PR TITLE
test: improve file compliance wait diagnostics

### DIFF
--- a/crates/logfwd/tests/it/compliance_file.rs
+++ b/crates/logfwd/tests/it/compliance_file.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use logfwd::pipeline::Pipeline;
 use logfwd_config::Config;
@@ -55,21 +55,77 @@ output:
     )
 }
 
-fn wait_for(predicate: impl Fn() -> bool, timeout: Duration) -> bool {
-    let start = std::time::Instant::now();
-    while start.elapsed() < timeout {
-        if predicate() {
-            return true;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-    predicate()
-}
-
 /// Keep a generous wait budget for file-compliance tests.
 /// Coverage and busy CI hosts can introduce significant scheduling jitter.
 fn wait_timeout() -> Duration {
     Duration::from_secs(90)
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LineWaitSnapshot {
+    expected: usize,
+    observed: u64,
+    elapsed: Duration,
+    timeout: Duration,
+    polls: u64,
+}
+
+fn observed_lines(metrics: &PipelineMetrics) -> u64 {
+    metrics.transform_in.lines_total.load(Ordering::Relaxed)
+}
+
+fn wait_for_line_count(
+    metrics: &PipelineMetrics,
+    expected: usize,
+    timeout: Duration,
+) -> Result<LineWaitSnapshot, LineWaitSnapshot> {
+    let started = Instant::now();
+    let mut polls = 0;
+    loop {
+        polls += 1;
+        let observed = observed_lines(metrics);
+        let snapshot = LineWaitSnapshot {
+            expected,
+            observed,
+            elapsed: started.elapsed(),
+            timeout,
+            polls,
+        };
+        if observed >= expected as u64 {
+            return Ok(snapshot);
+        }
+        if snapshot.elapsed >= timeout {
+            return Err(snapshot);
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn panic_line_wait_timeout(phase: &str, snapshot: LineWaitSnapshot) -> ! {
+    panic!(
+        "{phase}: timed out waiting for {} lines; observed={} elapsed_ms={} timeout_ms={} polls={}",
+        snapshot.expected,
+        snapshot.observed,
+        snapshot.elapsed.as_millis(),
+        snapshot.timeout.as_millis(),
+        snapshot.polls
+    );
+}
+
+fn wait_for_ready_lines(
+    shutdown: &CancellationToken,
+    metrics: &PipelineMetrics,
+    expected: usize,
+    timeout: Duration,
+    phase: &str,
+) -> LineWaitSnapshot {
+    match wait_for_line_count(metrics, expected, timeout) {
+        Ok(snapshot) => snapshot,
+        Err(snapshot) => {
+            shutdown.cancel();
+            panic_line_wait_timeout(phase, snapshot);
+        }
+    }
 }
 
 /// Build a pipeline config YAML for a glob input pattern.
@@ -120,16 +176,13 @@ fn wait_for_lines_and_cancel(
     metrics: &PipelineMetrics,
     expected: usize,
     timeout: Duration,
+    phase: &str,
 ) {
-    let reached = wait_for(
-        || metrics.transform_in.lines_total.load(Ordering::Relaxed) >= expected as u64,
-        timeout,
-    );
+    let result = wait_for_line_count(metrics, expected, timeout);
     shutdown.cancel();
-    assert!(
-        reached,
-        "timed out waiting for {expected} lines before shutdown"
-    );
+    if let Err(snapshot) = result {
+        panic_line_wait_timeout(phase, snapshot);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -156,13 +209,13 @@ fn compliance_file_rotate_create() {
     let (shutdown, metrics, handle) = run_pipeline_background(pipeline);
 
     // Wait for initial 5000 lines to be ingested before rotating.
-    if !wait_for(
-        || metrics.transform_in.lines_total.load(Ordering::Relaxed) >= 5000,
+    wait_for_ready_lines(
+        &shutdown,
+        &metrics,
+        5000,
         wait_timeout(),
-    ) {
-        shutdown.cancel();
-        panic!("timed out waiting for initial 5000 lines before create-style rotation");
-    }
+        "initial ingest before create-style rotation",
+    );
 
     // Simulate logrotate "create" style.
     fs::rename(&log_path, &rotated_path).unwrap();
@@ -173,7 +226,13 @@ fn compliance_file_rotate_create() {
     }
 
     // Poll until all 10000 lines are processed or 5s safety deadline.
-    wait_for_lines_and_cancel(&shutdown, &metrics, 10000, wait_timeout());
+    wait_for_lines_and_cancel(
+        &shutdown,
+        &metrics,
+        10000,
+        wait_timeout(),
+        "all lines after create-style rotation",
+    );
     let pipeline = handle.join().expect("pipeline thread panicked");
 
     let lines_in = pipeline
@@ -211,13 +270,13 @@ fn compliance_file_rotate_copytruncate() {
     let (shutdown, metrics, handle) = run_pipeline_background(pipeline);
 
     // Wait for initial 5000 lines to be ingested before rotating.
-    if !wait_for(
-        || metrics.transform_in.lines_total.load(Ordering::Relaxed) >= 5000,
+    wait_for_ready_lines(
+        &shutdown,
+        &metrics,
+        5000,
         wait_timeout(),
-    ) {
-        shutdown.cancel();
-        panic!("timed out waiting for initial 5000 lines before copytruncate rotation");
-    }
+        "initial ingest before copytruncate rotation",
+    );
 
     // Simulate logrotate "copytruncate" style.
     fs::copy(&log_path, &backup_path).unwrap();
@@ -234,7 +293,13 @@ fn compliance_file_rotate_copytruncate() {
     }
 
     // Poll until all 10000 lines are processed or 5s safety deadline.
-    wait_for_lines_and_cancel(&shutdown, &metrics, 10000, wait_timeout());
+    wait_for_lines_and_cancel(
+        &shutdown,
+        &metrics,
+        10000,
+        wait_timeout(),
+        "all lines after copytruncate rotation",
+    );
     let pipeline = handle.join().expect("pipeline thread panicked");
 
     let lines_in = pipeline
@@ -274,13 +339,13 @@ fn compliance_file_truncate() {
     let (shutdown, metrics, handle) = run_pipeline_background(pipeline);
 
     // Wait for initial 500 lines to be ingested before truncating.
-    if !wait_for(
-        || metrics.transform_in.lines_total.load(Ordering::Relaxed) >= 500,
+    wait_for_ready_lines(
+        &shutdown,
+        &metrics,
+        500,
         wait_timeout(),
-    ) {
-        shutdown.cancel();
-        panic!("timed out waiting for initial 500 lines before truncation");
-    }
+        "initial ingest before truncation",
+    );
 
     // Truncate the file in-place (same inode) and write new data.
     {
@@ -297,7 +362,13 @@ fn compliance_file_truncate() {
     }
 
     // Poll until >= 1000 lines processed or 5s safety deadline.
-    wait_for_lines_and_cancel(&shutdown, &metrics, 1000, wait_timeout());
+    wait_for_lines_and_cancel(
+        &shutdown,
+        &metrics,
+        1000,
+        wait_timeout(),
+        "all lines after truncation",
+    );
     let pipeline = handle.join().expect("pipeline thread panicked");
 
     let lines_in = pipeline
@@ -333,13 +404,13 @@ fn compliance_file_delete_recreate() {
     let (shutdown, metrics, handle) = run_pipeline_background(pipeline);
 
     // Wait for initial 1000 lines to be ingested before deleting.
-    if !wait_for(
-        || metrics.transform_in.lines_total.load(Ordering::Relaxed) >= 1000,
+    wait_for_ready_lines(
+        &shutdown,
+        &metrics,
+        1000,
         wait_timeout(),
-    ) {
-        shutdown.cancel();
-        panic!("timed out waiting for initial 1000 lines before delete/recreate");
-    }
+        "initial ingest before delete/recreate",
+    );
 
     // Delete the file.
     fs::remove_file(&log_path).unwrap();
@@ -354,7 +425,13 @@ fn compliance_file_delete_recreate() {
     }
 
     // Poll until >= 2000 lines processed or 5s safety deadline.
-    wait_for_lines_and_cancel(&shutdown, &metrics, 2000, wait_timeout());
+    wait_for_lines_and_cancel(
+        &shutdown,
+        &metrics,
+        2000,
+        wait_timeout(),
+        "all lines after delete/recreate",
+    );
     let pipeline = handle.join().expect("pipeline thread panicked");
 
     let lines_in = pipeline
@@ -394,13 +471,13 @@ fn compliance_file_grows_while_running() {
     let (shutdown, metrics, handle) = run_pipeline_background(pipeline);
 
     // Wait for the pipeline to start tailing before appending.
-    if !wait_for(
-        || metrics.transform_in.lines_total.load(Ordering::Relaxed) >= 100,
+    wait_for_ready_lines(
+        &shutdown,
+        &metrics,
+        100,
         wait_timeout(),
-    ) {
-        shutdown.cancel();
-        panic!("timed out waiting for initial 100 lines before continuous appends");
-    }
+        "initial ingest before continuous appends",
+    );
 
     // Append 100 lines every 50ms for 2 seconds (40 iterations).
     let log_path_clone = log_path.clone();
@@ -421,7 +498,13 @@ fn compliance_file_grows_while_running() {
     writer_handle.join().expect("writer thread panicked");
 
     // Poll until all 4100 lines are processed or 5s safety deadline.
-    wait_for_lines_and_cancel(&shutdown, &metrics, 4100, wait_timeout());
+    wait_for_lines_and_cancel(
+        &shutdown,
+        &metrics,
+        4100,
+        wait_timeout(),
+        "all lines after continuous appends",
+    );
     let pipeline = handle.join().expect("pipeline thread panicked");
 
     let lines_in = pipeline
@@ -454,14 +537,14 @@ fn compliance_glob_new_files() {
     let pipeline = build_pipeline(&yaml);
     let (shutdown, metrics, handle) = run_pipeline_background(pipeline);
 
-    // Wait for test1.log to be ingested.
-    if !wait_for(
-        || metrics.transform_in.lines_total.load(Ordering::Relaxed) >= 1000,
+    // Wait for test1.log to be ingested before creating test2.log.
+    wait_for_ready_lines(
+        &shutdown,
+        &metrics,
+        1000,
         wait_timeout(),
-    ) {
-        shutdown.cancel();
-        panic!("timed out waiting for first glob-discovered file before creating second file");
-    }
+        "first glob-discovered file before creating second file",
+    );
 
     // Create a second log file.
     let log2_path = dir.path().join("test2.log");
@@ -474,7 +557,13 @@ fn compliance_glob_new_files() {
     // Poll until both files are processed or 3s safety deadline.
     // glob_rescan_interval_ms is set to 50ms in glob_pipeline_yaml(), so the
     // new file is discovered quickly rather than waiting the default 5s.
-    wait_for_lines_and_cancel(&shutdown, &metrics, 2000, wait_timeout());
+    wait_for_lines_and_cancel(
+        &shutdown,
+        &metrics,
+        2000,
+        wait_timeout(),
+        "all lines after glob-discovered second file",
+    );
     let pipeline = handle.join().expect("pipeline thread panicked");
 
     let lines_in = pipeline
@@ -508,7 +597,13 @@ fn compliance_file_no_trailing_newline() {
 
     // Poll until all 4 lines are processed or 3s safety deadline.
     // The EndOfFile event flushes the partial line without a trailing newline.
-    wait_for_lines_and_cancel(&shutdown, &metrics, 4, wait_timeout());
+    wait_for_lines_and_cancel(
+        &shutdown,
+        &metrics,
+        4,
+        wait_timeout(),
+        "file without trailing newline",
+    );
     let pipeline = handle.join().expect("pipeline thread panicked");
 
     let lines_in = pipeline


### PR DESCRIPTION
## Summary

- Replace opaque file-compliance boolean waits with line-count wait snapshots that report phase, expected lines, observed lines, elapsed time, timeout, and poll count.
- Make pre-transition readiness gates explicit for create-style rotation, copytruncate, truncation, delete/recreate, continuous appends, and glob new-file discovery.
- Keep production file tailing/scanner behavior unchanged; this is harness diagnostics and determinism work only.

## Issue notes

Addresses #2325. The pending Codex Cloud task for this issue had no diff when this local implementation was prepared, so this PR supersedes the launched task unless it later produces materially better diagnostics.

## Verification

- `cargo fmt --check`
- `cargo test -p logfwd --test it compliance_file -- --nocapture` — passed: 6 passed, 1 ignored
- `for i in $(seq 1 5); do cargo test -p logfwd --test it compliance_file -- --nocapture || exit 1; done` — passed 5/5 repeats
- `just ci` — passed: fmt check, OTLP codegen check, workspace guard, clippy `-D warnings`, taplo, nextest `1783 passed, 43 skipped`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve file compliance test wait diagnostics with structured helpers
> - Replaces the generic `wait_for(predicate, timeout) -> bool` helper in [compliance_file.rs](https://github.com/strawgate/fastforward/pull/2337/files#diff-57a8a7db8ac690699d7e3db98e33828b79c8fd144e52db137cdd0e642e351ee8) with structured polling helpers that return a `LineWaitSnapshot` containing expected count, observed count, elapsed time, timeout, and poll count.
> - Adds `wait_for_line_count`, `wait_for_ready_lines`, and `wait_for_lines_and_cancel` helpers; timeout panics now include phase labels and metric-rich diagnostics instead of generic messages.
> - `wait_for_lines_and_cancel` gains a required `phase: &str` parameter; all call sites are updated with descriptive phase strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 895875d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->