### PR TITLE
refactor: add typed output config parser

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -22,15 +22,18 @@ pub use shared::{
     TlsServerConfig,
 };
 pub use types::{
-    ArrowIpcTypeConfig, AuthConfig, Config, ConfigError, CsvEnrichmentConfig, EnrichmentConfig,
-    FileTypeConfig, Format, GeneratorAttributeValueConfig, GeneratorComplexityConfig,
-    GeneratorInputConfig, GeneratorProfileConfig, GeneratorSequenceConfig, GeneratorTypeConfig,
-    GeoDatabaseConfig, GeoDatabaseFormat, HostInfoConfig, HostMetricsInputConfig, HttpInputConfig,
-    HttpMethodConfig, HttpTypeConfig, InputConfig, InputType, InputTypeConfig,
+    ArrowIpcOutputConfig, ArrowIpcTypeConfig, AuthConfig, Config, ConfigError, CsvEnrichmentConfig,
+    ElasticsearchOutputConfig, EnrichmentConfig, FileOutputConfig, FileTypeConfig, Format,
+    GeneratorAttributeValueConfig, GeneratorComplexityConfig, GeneratorInputConfig,
+    GeneratorProfileConfig, GeneratorSequenceConfig, GeneratorTypeConfig, GeoDatabaseConfig,
+    GeoDatabaseFormat, HostInfoConfig, HostMetricsInputConfig, HttpInputConfig, HttpMethodConfig,
+    HttpOutputConfig, HttpTypeConfig, InputConfig, InputType, InputTypeConfig,
     JournaldBackendConfig, JournaldInputConfig, JournaldTypeConfig, JsonlEnrichmentConfig,
-    K8sPathConfig, OtlpProtobufDecodeModeConfig, OtlpTypeConfig, OutputConfig, OutputType,
-    PipelineConfig, S3InputConfig, S3TypeConfig, SensorTypeConfig, ServerConfig,
-    StaticEnrichmentConfig, StorageConfig, TcpTypeConfig, UdpTypeConfig,
+    K8sPathConfig, LokiOutputConfig, NullOutputConfig, OtlpOutputConfig,
+    OtlpProtobufDecodeModeConfig, OtlpTypeConfig, OutputConfig, OutputConfigV1, OutputConfigV2,
+    OutputType, ParquetOutputConfig, PipelineConfig, S3InputConfig, S3TypeConfig, SensorTypeConfig,
+    ServerConfig, SocketOutputConfig, StaticEnrichmentConfig, StdoutOutputConfig, StorageConfig,
+    TcpTypeConfig, UdpTypeConfig,
 };
 pub use validate::validate_host_port;
 
@@ -2858,6 +2861,150 @@ pipelines:
         compression: none
 "#;
         Config::load_str(yaml).expect("arrow_ipc output should accept none compression");
+    }
+
+    #[test]
+    fn output_config_v2_rejects_irrelevant_variant_fields() {
+        let yaml = r"
+type: otlp
+endpoint: http://localhost:4318/v1/logs
+format: json
+";
+
+        let err = serde_yaml_ng::from_str::<OutputConfigV2>(yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("format"),
+            "strict v2 otlp config should reject format, got: {err}"
+        );
+    }
+
+    #[test]
+    fn output_config_legacy_fallback_preserves_existing_flat_shape() {
+        let yaml = r"
+type: otlp
+endpoint: http://localhost:4318/v1/logs
+format: json
+";
+
+        let output = serde_yaml_ng::from_str::<OutputConfig>(yaml).unwrap();
+        assert_eq!(output.output_type, OutputType::Otlp);
+        assert_eq!(
+            output.endpoint.as_deref(),
+            Some("http://localhost:4318/v1/logs")
+        );
+        assert_eq!(output.format, Some(Format::Json));
+    }
+
+    #[test]
+    fn output_config_v2_variants_normalize_to_output_types() {
+        let cases = [
+            (
+                "type: otlp\nendpoint: http://localhost:4318/v1/logs\n",
+                OutputType::Otlp,
+            ),
+            (
+                "type: http\nendpoint: http://localhost:8080/ingest\n",
+                OutputType::Http,
+            ),
+            (
+                "type: elasticsearch\nendpoint: http://localhost:9200\nindex: logs\n",
+                OutputType::Elasticsearch,
+            ),
+            (
+                "type: loki\nendpoint: http://localhost:3100/loki/api/v1/push\n",
+                OutputType::Loki,
+            ),
+            ("type: stdout\nformat: json\n", OutputType::Stdout),
+            ("type: file\npath: /tmp/ff.log\n", OutputType::File),
+            (
+                "type: parquet\npath: /tmp/ff.parquet\n",
+                OutputType::Parquet,
+            ),
+            ("type: \"null\"\n", OutputType::Null),
+            ("type: tcp\nendpoint: 127.0.0.1:9000\n", OutputType::Tcp),
+            ("type: udp\nendpoint: 127.0.0.1:9001\n", OutputType::Udp),
+            (
+                "type: arrow_ipc\nendpoint: http://localhost:4317\n",
+                OutputType::ArrowIpc,
+            ),
+        ];
+
+        for (yaml, expected_type) in cases {
+            let v2 = serde_yaml_ng::from_str::<OutputConfigV2>(yaml).unwrap();
+            assert_eq!(OutputConfig::from(v2).output_type, expected_type);
+        }
+    }
+
+    #[test]
+    fn example_outputs_parse_as_v2_and_normalize_equivalently() {
+        use serde::Deserialize;
+        use serde_yaml_ng::Value;
+
+        let examples_dir =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/use-cases");
+        let mut checked = 0usize;
+
+        for entry in fs::read_dir(&examples_dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("yaml") {
+                continue;
+            }
+
+            let yaml = fs::read_to_string(&path).unwrap();
+            let value: Value = serde_yaml_ng::from_str(&yaml)
+                .unwrap_or_else(|err| panic!("{} should parse as YAML: {err}", path.display()));
+            for output_value in collect_output_values(&value) {
+                let v2 = OutputConfigV2::deserialize(output_value.clone()).unwrap_or_else(|err| {
+                    panic!("{} output should parse as v2: {err}", path.display())
+                });
+                let compat =
+                    OutputConfig::deserialize(output_value.clone()).unwrap_or_else(|err| {
+                        panic!(
+                            "{} output should parse through compatibility layer: {err}",
+                            path.display()
+                        )
+                    });
+                assert_eq!(OutputConfig::from(v2), compat, "{}", path.display());
+                checked += 1;
+            }
+        }
+
+        assert!(checked > 0, "expected example configs to contain outputs");
+    }
+
+    fn collect_output_values(value: &serde_yaml_ng::Value) -> Vec<serde_yaml_ng::Value> {
+        let Some(root) = value.as_mapping() else {
+            return Vec::new();
+        };
+        let mut outputs = Vec::new();
+
+        if let Some(output) = root.get(serde_yaml_ng::Value::String("output".to_string())) {
+            outputs.push(output.clone());
+        }
+
+        if let Some(pipelines) = root
+            .get(serde_yaml_ng::Value::String("pipelines".to_string()))
+            .and_then(serde_yaml_ng::Value::as_mapping)
+        {
+            for pipeline in pipelines.values() {
+                let Some(pipeline) = pipeline.as_mapping() else {
+                    continue;
+                };
+                if let Some(output_value) =
+                    pipeline.get(serde_yaml_ng::Value::String("outputs".to_string()))
+                {
+                    match output_value {
+                        serde_yaml_ng::Value::Sequence(values) => {
+                            outputs.extend(values.iter().cloned());
+                        }
+                        value => outputs.push(value.clone()),
+                    }
+                }
+            }
+        }
+
+        outputs
     }
 
     #[test]

--- a/crates/logfwd-config/src/shared.rs
+++ b/crates/logfwd-config/src/shared.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 ///
 /// Used by HTTP, OTLP, Elasticsearch, Loki, and other output sinks that
 /// establish TLS connections to a remote endpoint.
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct TlsClientConfig {
     /// Path to CA certificate file for server verification.

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -14,7 +14,7 @@ use std::fmt;
 pub(crate) const PIPELINE_WORKERS_MAX: usize = 1024;
 
 /// Authentication configuration for output HTTP sinks.
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AuthConfig {
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
@@ -756,9 +756,73 @@ pub struct S3InputConfig {
     pub poll_interval_ms: Option<u64>,
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct OutputConfig {
+    pub name: Option<String>,
+    pub output_type: OutputType,
+    pub endpoint: Option<String>,
+    pub protocol: Option<String>,
+    pub compression: Option<String>,
+    pub request_mode: Option<String>,
+    pub format: Option<Format>,
+    pub path: Option<String>,
+    pub index: Option<String>,
+    pub auth: Option<AuthConfig>,
+    pub tenant_id: Option<String>,
+    pub static_labels: Option<HashMap<String, String>>,
+    pub label_columns: Option<Vec<String>>,
+    /// Client TLS configuration for outbound connections.
+    pub tls: Option<TlsClientConfig>,
+    /// Custom HTTP headers to include in requests.
+    pub headers: Option<HashMap<String, String>>,
+    /// Number of retry attempts for transient errors.
+    pub retry_attempts: Option<u32>,
+    /// Initial backoff delay for retries.
+    pub retry_initial_backoff_ms: Option<u64>,
+    /// Maximum backoff delay for retries.
+    pub retry_max_backoff_ms: Option<u64>,
+    /// Timeout for each HTTP request.
+    pub request_timeout_ms: Option<u64>,
+    /// Maximum number of log records to send per batch.
+    pub batch_size: Option<usize>,
+    /// Maximum time to wait before sending a batch.
+    pub batch_timeout_ms: Option<u64>,
+    /// Host for socket-based IPC.
+    pub host: Option<String>,
+    /// Port for socket-based IPC.
+    pub port: Option<u16>,
+    /// Write the legacy IPC format (default: false).
+    pub write_legacy_ipc_format: Option<bool>,
+    /// Buffer size for the IPC writer in bytes.
+    pub buffer_size_bytes: Option<usize>,
+    /// Whether to write the schema immediately upon connection.
+    pub write_schema_on_connect: Option<bool>,
+}
+
+impl<'de> Deserialize<'de> for OutputConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_yaml_ng::Value::deserialize(deserializer)?;
+        let v2_error = match OutputConfigV2::deserialize(value.clone()) {
+            Ok(v2) => return Ok(v2.into()),
+            Err(error) => error,
+        };
+
+        OutputConfigV1::deserialize(value)
+            .map(OutputConfig::from)
+            .map_err(|v1_error| {
+                serde::de::Error::custom(format!(
+                    "invalid output config; v2 parse error: {v2_error}; legacy parse error: {v1_error}"
+                ))
+            })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct OutputConfigV1 {
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub name: Option<String>,
     #[serde(rename = "type")]
@@ -830,6 +894,384 @@ pub struct OutputConfig {
     /// Whether to write the schema immediately upon connection.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub write_schema_on_connect: Option<bool>,
+}
+
+impl From<OutputConfigV1> for OutputConfig {
+    fn from(config: OutputConfigV1) -> Self {
+        OutputConfig {
+            name: config.name,
+            output_type: config.output_type,
+            endpoint: config.endpoint,
+            protocol: config.protocol,
+            compression: config.compression,
+            request_mode: config.request_mode,
+            format: config.format,
+            path: config.path,
+            index: config.index,
+            auth: config.auth,
+            tenant_id: config.tenant_id,
+            static_labels: config.static_labels,
+            label_columns: config.label_columns,
+            tls: config.tls,
+            headers: config.headers,
+            retry_attempts: config.retry_attempts,
+            retry_initial_backoff_ms: config.retry_initial_backoff_ms,
+            retry_max_backoff_ms: config.retry_max_backoff_ms,
+            request_timeout_ms: config.request_timeout_ms,
+            batch_size: config.batch_size,
+            batch_timeout_ms: config.batch_timeout_ms,
+            host: config.host,
+            port: config.port,
+            write_legacy_ipc_format: config.write_legacy_ipc_format,
+            buffer_size_bytes: config.buffer_size_bytes,
+            write_schema_on_connect: config.write_schema_on_connect,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OutputConfigV2 {
+    Otlp(OtlpOutputConfig),
+    Http(HttpOutputConfig),
+    Elasticsearch(ElasticsearchOutputConfig),
+    Loki(LokiOutputConfig),
+    Stdout(StdoutOutputConfig),
+    File(FileOutputConfig),
+    Parquet(ParquetOutputConfig),
+    Null(NullOutputConfig),
+    Tcp(SocketOutputConfig),
+    Udp(SocketOutputConfig),
+    ArrowIpc(ArrowIpcOutputConfig),
+}
+
+impl From<OutputConfigV2> for OutputConfig {
+    fn from(config: OutputConfigV2) -> Self {
+        match config {
+            OutputConfigV2::Otlp(config) => config.into_output_config(),
+            OutputConfigV2::Http(config) => config.into_output_config(),
+            OutputConfigV2::Elasticsearch(config) => config.into_output_config(),
+            OutputConfigV2::Loki(config) => config.into_output_config(),
+            OutputConfigV2::Stdout(config) => config.into_output_config(),
+            OutputConfigV2::File(config) => config.into_output_config(),
+            OutputConfigV2::Parquet(config) => config.into_output_config(),
+            OutputConfigV2::Null(config) => config.into_output_config(),
+            OutputConfigV2::Tcp(config) => config.into_output_config(OutputType::Tcp),
+            OutputConfigV2::Udp(config) => config.into_output_config(OutputType::Udp),
+            OutputConfigV2::ArrowIpc(config) => config.into_output_config(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct OtlpOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub endpoint: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub protocol: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub compression: Option<String>,
+    #[serde(default)]
+    pub auth: Option<AuthConfig>,
+    #[serde(default)]
+    pub tls: Option<TlsClientConfig>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_string_map_strict_values"
+    )]
+    pub headers: Option<HashMap<String, String>>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub retry_attempts: Option<u32>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub retry_initial_backoff_ms: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub retry_max_backoff_ms: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub request_timeout_ms: Option<u64>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub batch_size: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub batch_timeout_ms: Option<u64>,
+}
+
+impl OtlpOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::Otlp,
+            endpoint: self.endpoint,
+            protocol: self.protocol,
+            compression: self.compression,
+            auth: self.auth,
+            tls: self.tls,
+            headers: self.headers,
+            retry_attempts: self.retry_attempts,
+            retry_initial_backoff_ms: self.retry_initial_backoff_ms,
+            retry_max_backoff_ms: self.retry_max_backoff_ms,
+            request_timeout_ms: self.request_timeout_ms,
+            batch_size: self.batch_size,
+            batch_timeout_ms: self.batch_timeout_ms,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct HttpOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub endpoint: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub compression: Option<String>,
+    pub format: Option<Format>,
+    #[serde(default)]
+    pub auth: Option<AuthConfig>,
+}
+
+impl HttpOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::Http,
+            endpoint: self.endpoint,
+            compression: self.compression,
+            format: self.format,
+            auth: self.auth,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ElasticsearchOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub endpoint: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub compression: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub request_mode: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub index: Option<String>,
+    #[serde(default)]
+    pub auth: Option<AuthConfig>,
+    #[serde(default)]
+    pub tls: Option<TlsClientConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub request_timeout_ms: Option<u64>,
+}
+
+impl ElasticsearchOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::Elasticsearch,
+            endpoint: self.endpoint,
+            compression: self.compression,
+            request_mode: self.request_mode,
+            index: self.index,
+            auth: self.auth,
+            tls: self.tls,
+            request_timeout_ms: self.request_timeout_ms,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct LokiOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub auth: Option<AuthConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub tenant_id: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_option_string_map_strict_values"
+    )]
+    pub static_labels: Option<HashMap<String, String>>,
+    #[serde(default, deserialize_with = "deserialize_option_vec_strict_string")]
+    pub label_columns: Option<Vec<String>>,
+    #[serde(default)]
+    pub tls: Option<TlsClientConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub request_timeout_ms: Option<u64>,
+}
+
+impl LokiOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::Loki,
+            endpoint: self.endpoint,
+            auth: self.auth,
+            tenant_id: self.tenant_id,
+            static_labels: self.static_labels,
+            label_columns: self.label_columns,
+            tls: self.tls,
+            request_timeout_ms: self.request_timeout_ms,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct StdoutOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    pub format: Option<Format>,
+}
+
+impl StdoutOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::Stdout,
+            format: self.format,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct FileOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub path: Option<String>,
+    pub format: Option<Format>,
+}
+
+impl FileOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::File,
+            path: self.path,
+            format: self.format,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ParquetOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub path: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub compression: Option<String>,
+    pub format: Option<Format>,
+}
+
+impl ParquetOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::Parquet,
+            path: self.path,
+            compression: self.compression,
+            format: self.format,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct NullOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+}
+
+impl NullOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::Null,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct SocketOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub endpoint: Option<String>,
+}
+
+impl SocketOutputConfig {
+    fn into_output_config(self, output_type: OutputType) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type,
+            endpoint: self.endpoint,
+            ..OutputConfig::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ArrowIpcOutputConfig {
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub endpoint: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub compression: Option<String>,
+    #[serde(default)]
+    pub auth: Option<AuthConfig>,
+    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
+    pub host: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub port: Option<u16>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub write_legacy_ipc_format: Option<bool>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub buffer_size_bytes: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub batch_size: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
+    pub write_schema_on_connect: Option<bool>,
+}
+
+impl ArrowIpcOutputConfig {
+    fn into_output_config(self) -> OutputConfig {
+        OutputConfig {
+            name: self.name,
+            output_type: OutputType::ArrowIpc,
+            endpoint: self.endpoint,
+            compression: self.compression,
+            auth: self.auth,
+            host: self.host,
+            port: self.port,
+            write_legacy_ipc_format: self.write_legacy_ipc_format,
+            buffer_size_bytes: self.buffer_size_bytes,
+            batch_size: self.batch_size,
+            write_schema_on_connect: self.write_schema_on_connect,
+            ..OutputConfig::default()
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]


### PR DESCRIPTION
## Summary

- Introduce `OutputConfigV2` as a tagged enum with strict per-output variant structs for all current output types.
- Keep the existing public `OutputConfig` shape as the normalized compatibility form, with deserialization trying V2 first and falling back to `OutputConfigV1` for legacy flat-field shapes.
- Add regression coverage for strict V2 rejection, legacy fallback preservation, all V2 variant tags, and example config V2 normalization equivalence.

## Scope notes

This is the first #2299 slice. Runtime and output factory code intentionally continue to consume the normalized `OutputConfig` struct in this PR, so there is no user-visible config behavior change.

## Validation

- `cargo test -p logfwd-config`
- `cargo check -p logfwd-config -p logfwd-output -p logfwd-runtime -p logfwd`
- `cargo clippy -p logfwd-config -- -D warnings`
- `cargo test -p logfwd-output build_sink_factory --lib`
- `just lint`

## Notes

- `cargo clippy -p logfwd-config --tests -- -D warnings` still fails on existing unrelated test lint debt (`needless_raw_string_hashes`, `undocumented_unsafe_blocks`, `permissions_set_readonly_false`, and a few existing lib-test style lints). The new test additions avoid the raw-string hash issue.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed v2 output config parser with per-sink strict field validation to `OutputConfig`
> - Introduces `OutputConfigV2`, a serde tagged enum with variants for each sink type (otlp, http, elasticsearch, loki, stdout, file, parquet, null, tcp, udp, arrow_ipc), each accepting only fields relevant to that sink.
> - `OutputConfig` deserialization now tries v2 first; on failure it falls back to `OutputConfigV1` (the existing flat shape), normalizing both to the same `OutputConfig` struct.
> - `OutputConfigV1` is extracted as an explicit struct with `deny_unknown_fields` so legacy configs are still validated strictly during fallback.
> - Behavioral Change: deserializing a v2 config with irrelevant fields (e.g. `format` on an `otlp` output) now returns an error; previously the flat parser would silently accept extra fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 174508e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->