### PR TITLE
refactor: build output sinks from typed configs

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -2896,6 +2896,22 @@ format: json
     }
 
     #[test]
+    fn output_config_v2_from_legacy_preserves_elasticsearch_path_alias() {
+        let output = OutputConfig {
+            output_type: OutputType::Elasticsearch,
+            endpoint: Some("http://localhost:9200".to_string()),
+            path: Some("legacy-index".to_string()),
+            ..Default::default()
+        };
+
+        let v2 = OutputConfigV2::from(&output);
+        let OutputConfigV2::Elasticsearch(elasticsearch) = v2 else {
+            panic!("expected elasticsearch v2 output config");
+        };
+        assert_eq!(elasticsearch.index.as_deref(), Some("legacy-index"));
+    }
+
+    #[test]
     fn output_config_v2_variants_normalize_to_output_types() {
         let cases = [
             (

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -820,6 +820,96 @@ impl<'de> Deserialize<'de> for OutputConfig {
     }
 }
 
+// Compatibility conversion from the legacy flat shape. It carries the fields
+// each sink factory historically used and preserves previously ignored fields
+// as ignored while callers still pass `OutputConfig`.
+impl From<&OutputConfig> for OutputConfigV2 {
+    fn from(config: &OutputConfig) -> Self {
+        match config.output_type {
+            OutputType::Otlp => OutputConfigV2::Otlp(OtlpOutputConfig {
+                name: config.name.clone(),
+                endpoint: config.endpoint.clone(),
+                protocol: config.protocol.clone(),
+                compression: config.compression.clone(),
+                auth: config.auth.clone(),
+                tls: config.tls.clone(),
+                headers: config.headers.clone(),
+                retry_attempts: config.retry_attempts,
+                retry_initial_backoff_ms: config.retry_initial_backoff_ms,
+                retry_max_backoff_ms: config.retry_max_backoff_ms,
+                request_timeout_ms: config.request_timeout_ms,
+                batch_size: config.batch_size,
+                batch_timeout_ms: config.batch_timeout_ms,
+            }),
+            OutputType::Http => OutputConfigV2::Http(HttpOutputConfig {
+                name: config.name.clone(),
+                endpoint: config.endpoint.clone(),
+                compression: config.compression.clone(),
+                format: config.format.clone(),
+                auth: config.auth.clone(),
+            }),
+            OutputType::Elasticsearch => OutputConfigV2::Elasticsearch(ElasticsearchOutputConfig {
+                name: config.name.clone(),
+                endpoint: config.endpoint.clone(),
+                compression: config.compression.clone(),
+                request_mode: config.request_mode.clone(),
+                index: config.index.clone().or_else(|| config.path.clone()),
+                auth: config.auth.clone(),
+                tls: config.tls.clone(),
+                request_timeout_ms: config.request_timeout_ms,
+            }),
+            OutputType::Loki => OutputConfigV2::Loki(LokiOutputConfig {
+                name: config.name.clone(),
+                endpoint: config.endpoint.clone(),
+                auth: config.auth.clone(),
+                tenant_id: config.tenant_id.clone(),
+                static_labels: config.static_labels.clone(),
+                label_columns: config.label_columns.clone(),
+                tls: config.tls.clone(),
+                request_timeout_ms: config.request_timeout_ms,
+            }),
+            OutputType::Stdout => OutputConfigV2::Stdout(StdoutOutputConfig {
+                name: config.name.clone(),
+                format: config.format.clone(),
+            }),
+            OutputType::File => OutputConfigV2::File(FileOutputConfig {
+                name: config.name.clone(),
+                path: config.path.clone(),
+                format: config.format.clone(),
+            }),
+            OutputType::Parquet => OutputConfigV2::Parquet(ParquetOutputConfig {
+                name: config.name.clone(),
+                path: config.path.clone(),
+                compression: config.compression.clone(),
+                format: config.format.clone(),
+            }),
+            OutputType::Null => OutputConfigV2::Null(NullOutputConfig {
+                name: config.name.clone(),
+            }),
+            OutputType::Tcp => OutputConfigV2::Tcp(SocketOutputConfig {
+                name: config.name.clone(),
+                endpoint: config.endpoint.clone(),
+            }),
+            OutputType::Udp => OutputConfigV2::Udp(SocketOutputConfig {
+                name: config.name.clone(),
+                endpoint: config.endpoint.clone(),
+            }),
+            OutputType::ArrowIpc => OutputConfigV2::ArrowIpc(ArrowIpcOutputConfig {
+                name: config.name.clone(),
+                endpoint: config.endpoint.clone(),
+                compression: config.compression.clone(),
+                auth: config.auth.clone(),
+                host: config.host.clone(),
+                port: config.port,
+                write_legacy_ipc_format: config.write_legacy_ipc_format,
+                buffer_size_bytes: config.buffer_size_bytes,
+                batch_size: config.batch_size,
+                write_schema_on_connect: config.write_schema_on_connect,
+            }),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct OutputConfigV1 {

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use logfwd_config::{Format, OutputConfig, OutputType};
+use logfwd_config::{Format, OutputConfig, OutputConfigV2, OutputType, TlsClientConfig};
 use logfwd_types::diagnostics::ComponentStats;
 
 use crate::arrow_ipc_sink::ArrowIpcSinkFactory;
@@ -22,15 +22,14 @@ use crate::udp_sink::UdpSinkFactory;
 
 fn build_http_client_builder(
     name: &str,
-    cfg: &OutputConfig,
+    tls: Option<&TlsClientConfig>,
+    request_timeout_ms: Option<u64>,
 ) -> Result<reqwest::ClientBuilder, OutputError> {
     let mut client_builder = reqwest::Client::builder()
-        .timeout(Duration::from_millis(
-            cfg.request_timeout_ms.unwrap_or(30_000),
-        ))
+        .timeout(Duration::from_millis(request_timeout_ms.unwrap_or(30_000)))
         .pool_max_idle_per_host(64);
 
-    if let Some(tls) = &cfg.tls {
+    if let Some(tls) = tls {
         if tls.insecure_skip_verify {
             client_builder = client_builder.danger_accept_invalid_certs(true);
         }
@@ -92,10 +91,28 @@ pub fn build_sink_factory(
     base_path: Option<&Path>,
     stats: Arc<ComponentStats>,
 ) -> Result<Arc<dyn SinkFactory>, OutputError> {
-    let auth_headers = build_auth_headers(cfg.auth.as_ref());
+    if cfg.output_type == OutputType::File
+        && let Some(compression) = cfg.compression.as_deref()
+    {
+        return Err(OutputError::Construction(format!(
+            "output '{name}': file does not support '{compression}' compression"
+        )));
+    }
 
-    match cfg.output_type {
-        OutputType::Elasticsearch => {
+    let typed = OutputConfigV2::from(cfg);
+    build_sink_factory_v2(name, &typed, base_path, stats)
+}
+
+/// Build an `Arc<dyn SinkFactory>` from a typed output configuration.
+pub fn build_sink_factory_v2(
+    name: &str,
+    cfg: &OutputConfigV2,
+    base_path: Option<&Path>,
+    stats: Arc<ComponentStats>,
+) -> Result<Arc<dyn SinkFactory>, OutputError> {
+    match cfg {
+        OutputConfigV2::Elasticsearch(cfg) => {
+            let auth_headers = build_auth_headers(cfg.auth.as_ref());
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!(
                     "output '{name}': elasticsearch requires 'endpoint'"
@@ -104,7 +121,6 @@ pub fn build_sink_factory(
             let index = cfg
                 .index
                 .as_ref()
-                .or(cfg.path.as_ref())
                 .map_or("logs", String::as_str)
                 .to_string();
             let compress = match cfg.compression.as_deref() {
@@ -127,7 +143,7 @@ pub fn build_sink_factory(
                 auth_headers,
                 compress,
                 request_mode,
-                build_http_client_builder(name, cfg)?,
+                build_http_client_builder(name, cfg.tls.as_ref(), cfg.request_timeout_ms)?,
                 stats,
             )
             .map_err(|e| {
@@ -135,7 +151,8 @@ pub fn build_sink_factory(
             })?;
             Ok(Arc::new(factory))
         }
-        OutputType::Loki => {
+        OutputConfigV2::Loki(cfg) => {
+            let auth_headers = build_auth_headers(cfg.auth.as_ref());
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': loki requires 'endpoint'"))
             })?;
@@ -150,7 +167,7 @@ pub fn build_sink_factory(
                     .collect(),
                 cfg.label_columns.clone().unwrap_or_default(),
                 auth_headers,
-                build_http_client_builder(name, cfg)?,
+                build_http_client_builder(name, cfg.tls.as_ref(), cfg.request_timeout_ms)?,
                 stats,
             )
             .map_err(|e| {
@@ -158,7 +175,8 @@ pub fn build_sink_factory(
             })?;
             Ok(Arc::new(factory))
         }
-        OutputType::ArrowIpc => {
+        OutputConfigV2::ArrowIpc(cfg) => {
+            let auth_headers = build_auth_headers(cfg.auth.as_ref());
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': arrow_ipc requires 'endpoint'"))
             })?;
@@ -184,7 +202,8 @@ pub fn build_sink_factory(
             })?;
             Ok(Arc::new(factory))
         }
-        OutputType::Http => {
+        OutputConfigV2::Http(cfg) => {
+            let auth_headers = build_auth_headers(cfg.auth.as_ref());
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': http requires 'endpoint'"))
             })?;
@@ -210,14 +229,15 @@ pub fn build_sink_factory(
             })?;
             Ok(Arc::new(factory))
         }
-        OutputType::Udp => {
+        OutputConfigV2::Udp(cfg) => {
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': udp requires 'endpoint'"))
             })?;
             let factory = UdpSinkFactory::new(name.to_string(), endpoint.clone(), stats);
             Ok(Arc::new(factory))
         }
-        OutputType::Otlp => {
+        OutputConfigV2::Otlp(cfg) => {
+            let auth_headers = build_auth_headers(cfg.auth.as_ref());
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': OTLP requires 'endpoint'"))
             })?;
@@ -241,7 +261,8 @@ pub fn build_sink_factory(
                 }
             };
 
-            let client_builder = build_http_client_builder(name, cfg)?;
+            let client_builder =
+                build_http_client_builder(name, cfg.tls.as_ref(), cfg.request_timeout_ms)?;
 
             let mut all_headers = auth_headers;
             if let Some(cfg_headers) = &cfg.headers {
@@ -283,7 +304,7 @@ pub fn build_sink_factory(
             })?;
             Ok(Arc::new(factory))
         }
-        OutputType::Stdout => {
+        OutputConfigV2::Stdout(cfg) => {
             let fmt = match cfg.format.as_ref() {
                 Some(Format::Json) => StdoutFormat::Json,
                 Some(Format::Console) => StdoutFormat::Console,
@@ -302,15 +323,10 @@ pub fn build_sink_factory(
                 stats,
             )))
         }
-        OutputType::File => {
+        OutputConfigV2::File(cfg) => {
             let path = cfg.path.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': file requires 'path'"))
             })?;
-            if let Some(compression) = cfg.compression.as_deref() {
-                return Err(OutputError::Construction(format!(
-                    "output '{name}': file does not support '{compression}' compression"
-                )));
-            }
             let mut resolved_path = PathBuf::from(path);
             if resolved_path.is_relative()
                 && let Some(base) = base_path
@@ -337,7 +353,7 @@ pub fn build_sink_factory(
             })?;
             Ok(Arc::new(factory))
         }
-        OutputType::Tcp => {
+        OutputConfigV2::Tcp(cfg) => {
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': tcp requires 'endpoint'"))
             })?;
@@ -347,22 +363,24 @@ pub fn build_sink_factory(
                 stats,
             )))
         }
-        OutputType::Null => Ok(Arc::new(NullSinkFactory::new(name.to_string(), stats))),
+        OutputConfigV2::Null(_) => Ok(Arc::new(NullSinkFactory::new(name.to_string(), stats))),
+        OutputConfigV2::Parquet(_) => Err(OutputError::Construction(format!(
+            "output '{name}': type Parquet not yet supported"
+        ))),
         _ => Err(OutputError::Construction(format!(
-            "output '{name}': type {:?} not yet supported",
-            cfg.output_type
+            "output '{name}': unknown output type"
         ))),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::build_sink_factory;
+    use super::{build_sink_factory, build_sink_factory_v2};
     use std::collections::HashMap;
     use std::fs;
     use std::sync::Arc;
 
-    use logfwd_config::{OutputConfig, OutputType};
+    use logfwd_config::{OutputConfig, OutputConfigV2, OutputType, StdoutOutputConfig};
     use logfwd_types::diagnostics::ComponentStats;
 
     #[test]
@@ -378,6 +396,32 @@ mod tests {
         assert!(
             result.is_ok(),
             "arrow_ipc should accept explicit 'none' compression"
+        );
+    }
+
+    #[test]
+    fn build_sink_factory_v2_builds_from_typed_variant() {
+        let cfg = OutputConfigV2::Stdout(StdoutOutputConfig {
+            name: None,
+            format: None,
+        });
+
+        let result = build_sink_factory_v2("stdout", &cfg, None, Arc::new(ComponentStats::new()));
+        assert!(result.is_ok(), "typed stdout config should build a sink");
+    }
+
+    #[test]
+    fn build_sink_factory_preserves_legacy_ignored_fields() {
+        let cfg = OutputConfig {
+            output_type: OutputType::Stdout,
+            endpoint: Some("ignored.example:4318".to_string()),
+            ..Default::default()
+        };
+
+        let result = build_sink_factory("stdout", &cfg, None, Arc::new(ComponentStats::new()));
+        assert!(
+            result.is_ok(),
+            "compatibility wrapper should preserve legacy ignored fields"
         );
     }
 


### PR DESCRIPTION
## Summary
- add a compatibility conversion from legacy flat `OutputConfig` to typed `OutputConfigV2`
- refactor the output sink factory to build from typed output variants via `build_sink_factory_v2`
- keep the existing public `build_sink_factory` wrapper compatible with legacy ignored fields and file compression rejection
- add regression coverage for direct typed factory construction, legacy ignored fields, and the Elasticsearch `path` alias mapping

## Notes
This is a narrow #2299 follow-up: runtime/config loading can still pass the flat compatibility shape, but the factory internals now consume typed variants. The next slice can move validation and runtime ownership closer to `OutputConfigV2` without changing sink construction again.

## Verification
- `cargo fmt --check`
- `cargo test -p logfwd-output build_sink_factory --lib`
- `cargo test -p logfwd-config output_config -- --nocapture`
- `cargo test -p logfwd-config -p logfwd-output --lib`
- `cargo check -p logfwd-config -p logfwd-output -p logfwd-runtime -p logfwd`
- `cargo clippy -p logfwd-config -p logfwd-output -- -D warnings`
- `just lint`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor output sink construction to use typed `OutputConfigV2` configs
> - Introduces `build_sink_factory_v2` in [`factory.rs`](https://github.com/strawgate/fastforward/pull/2344/files#diff-38138875bb6a160b3328cc8507d27d322ae4c2f810e755490e66ce6088078fac) that builds sinks directly from typed `OutputConfigV2` variants, with variant-specific validation and error messages.
> - Updates `build_sink_factory` to convert legacy `OutputConfig` to `OutputConfigV2` via a new `From<&OutputConfig>` impl in [`types.rs`](https://github.com/strawgate/fastforward/pull/2344/files#diff-62e3ac9382eb657aa94241b95339050d93e352844aef7d3a16f2bf66bb681a91), then delegates to `build_sink_factory_v2`.
> - Refactors `build_http_client_builder` to accept `tls` and `request_timeout_ms` directly instead of a full `OutputConfig`, so TLS/timeout settings are applied per-variant.
> - Maps legacy Elasticsearch `path` field to `index` when `index` is unset during conversion.
> - Parquet outputs now return an explicit "not yet supported" error; file outputs with compression are rejected earlier than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5798c9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->