### PR TITLE
refactor: store pipeline outputs as typed configs

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -80,9 +80,9 @@ storage:
         ));
         assert_eq!(pipe.inputs[0].format, Some(Format::Cri));
         assert!(pipe.transform.as_ref().unwrap().contains("SELECT"));
-        assert_eq!(pipe.outputs[0].output_type, OutputType::Otlp);
+        assert_eq!(pipe.outputs[0].output_type(), OutputType::Otlp);
         assert_eq!(
-            pipe.outputs[0].endpoint.as_deref(),
+            pipe.outputs[0].validation_config().endpoint.as_deref(),
             Some("http://otel-collector:4317")
         );
         assert_eq!(cfg.server.diagnostics.as_deref(), Some("0.0.0.0:9090"));
@@ -160,8 +160,8 @@ server:
             InputTypeConfig::Udp(u) if u.listen == "0.0.0.0:514"
         ));
         assert_eq!(pipe.outputs.len(), 2);
-        assert_eq!(pipe.outputs[0].output_type, OutputType::Otlp);
-        assert_eq!(pipe.outputs[1].output_type, OutputType::Stdout);
+        assert_eq!(pipe.outputs[0].output_type(), OutputType::Otlp);
+        assert_eq!(pipe.outputs[1].output_type(), OutputType::Stdout);
     }
 
     #[test]
@@ -180,7 +180,7 @@ output:
         let cfg = Config::load_str(yaml).expect("env var substitution");
         let pipe = &cfg.pipelines["default"];
         assert_eq!(
-            pipe.outputs[0].endpoint.as_deref(),
+            pipe.outputs[0].validation_config().endpoint.as_deref(),
             Some("http://my-collector:4317")
         );
         // SAFETY: this test is not run concurrently with other tests that
@@ -211,7 +211,7 @@ output:
         assert_eq!(cfg.pipelines.len(), 1);
         let pipe = &cfg.pipelines["default"];
         assert_eq!(pipe.inputs[0].input_type(), InputType::File);
-        assert_eq!(pipe.outputs[0].output_type, OutputType::Stdout);
+        assert_eq!(pipe.outputs[0].output_type(), OutputType::Stdout);
         let _ = fs::remove_file(&path);
     }
 
@@ -626,7 +626,7 @@ pipelines:
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: file\n  path: /tmp/out.ndjson\n";
         let cfg = Config::load_str(yaml).unwrap();
         assert_eq!(
-            cfg.pipelines["default"].outputs[0].output_type,
+            cfg.pipelines["default"].outputs[0].output_type(),
             OutputType::File
         );
     }
@@ -1013,7 +1013,8 @@ output:
 "#;
         let cfg = Config::load_str(yaml).expect("auth bearer_token");
         let pipe = &cfg.pipelines["default"];
-        let auth = pipe.outputs[0].auth.as_ref().expect("auth present");
+        let output = pipe.outputs[0].validation_config();
+        let auth = output.auth.as_ref().expect("auth present");
         assert_eq!(auth.bearer_token.as_deref(), Some("my-secret-token"));
         assert!(auth.headers.is_empty());
     }
@@ -1034,7 +1035,8 @@ output:
 "#;
         let cfg = Config::load_str(yaml).expect("auth custom headers");
         let pipe = &cfg.pipelines["default"];
-        let auth = pipe.outputs[0].auth.as_ref().expect("auth present");
+        let output = pipe.outputs[0].validation_config();
+        let auth = output.auth.as_ref().expect("auth present");
         assert_eq!(auth.bearer_token, None);
         assert_eq!(
             auth.headers.get("X-API-Key").map(String::as_str),
@@ -1062,7 +1064,8 @@ output:
 "#;
         let cfg = Config::load_str(yaml).expect("auth env var bearer");
         let pipe = &cfg.pipelines["default"];
-        let auth = pipe.outputs[0].auth.as_ref().expect("auth present");
+        let output = pipe.outputs[0].validation_config();
+        let auth = output.auth.as_ref().expect("auth present");
         assert_eq!(auth.bearer_token.as_deref(), Some("env-bearer-token"));
         // SAFETY: this test is not run concurrently with other tests that
         // depend on the same environment variable.
@@ -1081,7 +1084,7 @@ output:
 ";
         let cfg = Config::load_str(yaml).expect("no auth");
         let pipe = &cfg.pipelines["default"];
-        assert!(pipe.outputs[0].auth.is_none());
+        assert!(pipe.outputs[0].validation_config().auth.is_none());
     }
 
     #[test]
@@ -1097,7 +1100,10 @@ output:
 ";
         let cfg = Config::load_str(yaml).expect("streaming request_mode should validate");
         let pipe = &cfg.pipelines["default"];
-        assert_eq!(pipe.outputs[0].request_mode.as_deref(), Some("streaming"));
+        assert_eq!(
+            pipe.outputs[0].validation_config().request_mode.as_deref(),
+            Some("streaming")
+        );
     }
 
     #[test]
@@ -1293,7 +1299,7 @@ output:
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: null\n";
         let cfg = Config::load_str(yaml).expect("type: null simple layout");
         assert_eq!(
-            cfg.pipelines["default"].outputs[0].output_type,
+            cfg.pipelines["default"].outputs[0].output_type(),
             OutputType::Null
         );
     }
@@ -1313,7 +1319,7 @@ pipelines:
 ";
         let cfg = Config::load_str(yaml).expect("type: null in advanced list layout");
         assert_eq!(
-            cfg.pipelines["app"].outputs[0].output_type,
+            cfg.pipelines["app"].outputs[0].output_type(),
             OutputType::Null
         );
     }
@@ -1324,7 +1330,7 @@ pipelines:
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: \"null\"\n";
         let cfg = Config::load_str(yaml).expect("type: \"null\" quoted");
         assert_eq!(
-            cfg.pipelines["default"].outputs[0].output_type,
+            cfg.pipelines["default"].outputs[0].output_type(),
             OutputType::Null
         );
     }

--- a/crates/logfwd-config/src/load.rs
+++ b/crates/logfwd-config/src/load.rs
@@ -3,8 +3,8 @@ use crate::serde_helpers::{
     deserialize_option_strict_string, deserialize_string_map_strict_values,
 };
 use crate::types::{
-    Config, ConfigError, EnrichmentConfig, InputConfig, OutputConfig, PipelineConfig, ServerConfig,
-    StorageConfig,
+    Config, ConfigError, EnrichmentConfig, InputConfig, OutputConfigEntry, PipelineConfig,
+    ServerConfig, StorageConfig,
 };
 use config as config_rs;
 use serde::Deserialize;
@@ -19,7 +19,7 @@ struct RawConfig {
     input: Option<InputConfig>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     transform: Option<String>,
-    output: Option<OutputConfig>,
+    output: Option<OutputConfigEntry>,
     #[serde(default)]
     enrichment: Vec<EnrichmentConfig>,
     #[serde(default, deserialize_with = "deserialize_string_map_strict_values")]

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -1060,6 +1060,123 @@ impl From<OutputConfigV2> for OutputConfig {
     }
 }
 
+impl OutputConfigV2 {
+    /// Return the optional user-provided output name for this typed output.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            OutputConfigV2::Otlp(config) => config.name.as_deref(),
+            OutputConfigV2::Http(config) => config.name.as_deref(),
+            OutputConfigV2::Elasticsearch(config) => config.name.as_deref(),
+            OutputConfigV2::Loki(config) => config.name.as_deref(),
+            OutputConfigV2::Stdout(config) => config.name.as_deref(),
+            OutputConfigV2::File(config) => config.name.as_deref(),
+            OutputConfigV2::Parquet(config) => config.name.as_deref(),
+            OutputConfigV2::Null(config) => config.name.as_deref(),
+            OutputConfigV2::Tcp(config) => config.name.as_deref(),
+            OutputConfigV2::Udp(config) => config.name.as_deref(),
+            OutputConfigV2::ArrowIpc(config) => config.name.as_deref(),
+        }
+    }
+
+    /// Return the flat output type tag corresponding to this typed variant.
+    pub fn output_type(&self) -> OutputType {
+        match self {
+            OutputConfigV2::Otlp(_) => OutputType::Otlp,
+            OutputConfigV2::Http(_) => OutputType::Http,
+            OutputConfigV2::Elasticsearch(_) => OutputType::Elasticsearch,
+            OutputConfigV2::Loki(_) => OutputType::Loki,
+            OutputConfigV2::Stdout(_) => OutputType::Stdout,
+            OutputConfigV2::File(_) => OutputType::File,
+            OutputConfigV2::Parquet(_) => OutputType::Parquet,
+            OutputConfigV2::Null(_) => OutputType::Null,
+            OutputConfigV2::Tcp(_) => OutputType::Tcp,
+            OutputConfigV2::Udp(_) => OutputType::Udp,
+            OutputConfigV2::ArrowIpc(_) => OutputType::ArrowIpc,
+        }
+    }
+}
+
+/// Pipeline output entry stored in the config model.
+///
+/// New YAML is represented as a typed `OutputConfigV2`. Legacy flat output
+/// YAML is accepted at the deserialization edge. A flat compatibility view is
+/// retained so existing callers that access `PipelineConfig.outputs` fields can
+/// continue reading the normalized `OutputConfig` shape while new runtime code
+/// uses the typed variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputConfigEntry {
+    config: OutputConfigV2,
+    flat: OutputConfig,
+}
+
+impl OutputConfigEntry {
+    /// Return the typed output configuration used by new internal consumers.
+    pub fn typed(&self) -> &OutputConfigV2 {
+        &self.config
+    }
+
+    /// Return the optional user-provided output name from the typed config.
+    pub fn name(&self) -> Option<&str> {
+        self.config.name()
+    }
+
+    /// Return the flat output type tag for diagnostics and compatibility code.
+    pub fn output_type(&self) -> OutputType {
+        self.config.output_type()
+    }
+
+    /// Return a flat validation view, preserving legacy fields when present.
+    pub(crate) fn validation_config(&self) -> OutputConfig {
+        self.flat.clone()
+    }
+}
+
+impl From<OutputConfigV2> for OutputConfigEntry {
+    fn from(config: OutputConfigV2) -> Self {
+        let flat = OutputConfig::from(config.clone());
+        Self { config, flat }
+    }
+}
+
+impl From<OutputConfig> for OutputConfigEntry {
+    fn from(config: OutputConfig) -> Self {
+        Self {
+            config: OutputConfigV2::from(&config),
+            flat: config,
+        }
+    }
+}
+
+impl std::ops::Deref for OutputConfigEntry {
+    type Target = OutputConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.flat
+    }
+}
+
+impl<'de> Deserialize<'de> for OutputConfigEntry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_yaml_ng::Value::deserialize(deserializer)?;
+        let v2_error = match OutputConfigV2::deserialize(value.clone()) {
+            Ok(config) => return Ok(OutputConfigEntry::from(config)),
+            Err(error) => error,
+        };
+
+        OutputConfigV1::deserialize(value)
+            .map(OutputConfig::from)
+            .map(OutputConfigEntry::from)
+            .map_err(|v1_error| {
+                serde::de::Error::custom(format!(
+                    "invalid output config; v2 parse error: {v2_error}; legacy parse error: {v1_error}"
+                ))
+            })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct OtlpOutputConfig {
@@ -1244,6 +1361,11 @@ impl StdoutOutputConfig {
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
+/// File output configuration for the typed V2 schema.
+///
+/// File compression is intentionally not part of the typed schema. Legacy flat
+/// configs may still carry `compression`; compatibility code preserves that
+/// field in the flat view so it can reject the unsupported option explicitly.
 pub struct FileOutputConfig {
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub name: Option<String>,
@@ -1531,8 +1653,9 @@ pub struct PipelineConfig {
     pub inputs: Vec<InputConfig>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub transform: Option<String>,
+    /// Typed output configurations accepted from V2 or legacy output YAML.
     #[serde(default, deserialize_with = "deserialize_one_or_many")]
-    pub outputs: Vec<OutputConfig>,
+    pub outputs: Vec<OutputConfigEntry>,
     #[serde(default)]
     pub enrichment: Vec<EnrichmentConfig>,
     #[serde(default, deserialize_with = "deserialize_string_map_strict_values")]

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -132,7 +132,7 @@ impl Config {
 
                 let mut seen_output_names: HashSet<&str> = HashSet::new();
                 for (i, output) in pipe.outputs.iter().enumerate() {
-                    if let Some(output_name) = output.name.as_deref()
+                    if let Some(output_name) = output.name()
                         && !seen_output_names.insert(output_name)
                     {
                         return Err(ConfigError::Validation(format!(
@@ -712,6 +712,7 @@ impl Config {
                 }
 
                 for (i, output) in pipe.outputs.iter().enumerate() {
+                    let output = output.validation_config();
                     let label = output
                         .name
                         .as_deref()
@@ -1250,6 +1251,7 @@ impl Config {
                 }
 
                 for (j, output) in pipe.outputs.iter().enumerate() {
+                    let output = output.validation_config();
                     let out_label = output
                         .name
                         .as_deref()

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -2,7 +2,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
-use logfwd_config::{Format, OutputConfig, OutputConfigV2, OutputType, TlsClientConfig};
+#[cfg(test)]
+use logfwd_config::OutputConfig;
+use logfwd_config::{Format, OutputConfigV2, TlsClientConfig};
 use logfwd_types::diagnostics::ComponentStats;
 
 use crate::arrow_ipc_sink::ArrowIpcSinkFactory;
@@ -85,13 +87,14 @@ fn read_tls_file(name: &str, field: &str, path: &str) -> Result<Vec<u8>, OutputE
 ///
 /// Returns a factory that creates a fresh sink per worker. Most sink types
 /// support multiple workers; the factory can be called repeatedly.
-pub fn build_sink_factory(
+#[cfg(test)]
+pub(crate) fn build_sink_factory(
     name: &str,
     cfg: &OutputConfig,
     base_path: Option<&Path>,
     stats: Arc<ComponentStats>,
 ) -> Result<Arc<dyn SinkFactory>, OutputError> {
-    if cfg.output_type == OutputType::File
+    if cfg.output_type == logfwd_config::OutputType::File
         && let Some(compression) = cfg.compression.as_deref()
     {
         return Err(OutputError::Construction(format!(

--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -27,7 +27,7 @@ mod loki;
 pub use arrow_ipc_sink::{ArrowIpcSinkFactory, deserialize_ipc, serialize_ipc};
 pub use elasticsearch::{ElasticsearchRequestMode, ElasticsearchSink, ElasticsearchSinkFactory};
 pub use error::OutputError;
-pub use factory::build_sink_factory;
+pub use factory::build_sink_factory_v2;
 pub use file_sink::{FileSink, FileSinkFactory};
 pub use json_lines::{JsonLinesSink, JsonLinesSinkFactory};
 pub use loki::{LokiSink, LokiSinkFactory};

--- a/crates/logfwd-output/src/tests.rs
+++ b/crates/logfwd-output/src/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::factory::build_sink_factory;
 use arrow::array::{Float64Array, Int64Array, StringArray};
 use arrow::datatypes::DataType;
 use arrow::datatypes::{Field, Schema};

--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -278,7 +278,7 @@ pub async fn run_pipelines(
                 "     {}out{}  {}",
                 dim(use_color),
                 reset(use_color),
-                output_label(output)
+                output_label(output.typed())
             );
         }
     }
@@ -430,22 +430,42 @@ fn input_label(i: &logfwd_config::InputConfig) -> String {
     }
 }
 
-fn output_label(o: &logfwd_config::OutputConfig) -> String {
-    use logfwd_config::OutputType;
-    match o.output_type {
-        OutputType::Otlp => format!("otlp  {}", o.endpoint.as_deref().unwrap_or("")),
-        OutputType::Http => format!("http  {}", o.endpoint.as_deref().unwrap_or("")),
-        OutputType::Elasticsearch => {
-            format!("elasticsearch  {}", o.endpoint.as_deref().unwrap_or(""))
+fn output_label(o: &logfwd_config::OutputConfigV2) -> String {
+    use logfwd_config::OutputConfigV2;
+    match o {
+        OutputConfigV2::Otlp(config) => {
+            format!("otlp  {}", config.endpoint.as_deref().unwrap_or(""))
         }
-        OutputType::Loki => format!("loki  {}", o.endpoint.as_deref().unwrap_or("")),
-        OutputType::Tcp => format!("tcp   {}", o.endpoint.as_deref().unwrap_or("")),
-        OutputType::Udp => format!("udp   {}", o.endpoint.as_deref().unwrap_or("")),
-        OutputType::File => format!("file  {}", o.path.as_deref().unwrap_or("")),
-        OutputType::Parquet => format!("parquet  {}", o.path.as_deref().unwrap_or("")),
-        OutputType::Stdout => "stdout".to_string(),
-        OutputType::Null => "null".to_string(),
-        _ => "unknown".to_string(),
+        OutputConfigV2::Http(config) => {
+            format!("http  {}", config.endpoint.as_deref().unwrap_or(""))
+        }
+        OutputConfigV2::Elasticsearch(config) => {
+            format!(
+                "elasticsearch  {}",
+                config.endpoint.as_deref().unwrap_or("")
+            )
+        }
+        OutputConfigV2::Loki(config) => {
+            format!("loki  {}", config.endpoint.as_deref().unwrap_or(""))
+        }
+        OutputConfigV2::Tcp(config) => {
+            format!("tcp   {}", config.endpoint.as_deref().unwrap_or(""))
+        }
+        OutputConfigV2::Udp(config) => {
+            format!("udp   {}", config.endpoint.as_deref().unwrap_or(""))
+        }
+        OutputConfigV2::File(config) => {
+            format!("file  {}", config.path.as_deref().unwrap_or(""))
+        }
+        OutputConfigV2::Parquet(config) => {
+            format!("parquet  {}", config.path.as_deref().unwrap_or(""))
+        }
+        OutputConfigV2::Stdout(_) => "stdout".to_string(),
+        OutputConfigV2::Null(_) => "null".to_string(),
+        OutputConfigV2::ArrowIpc(config) => {
+            format!("arrow_ipc  {}", config.endpoint.as_deref().unwrap_or(""))
+        }
+        _ => o.output_type().to_string(),
     }
 }
 

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -6,12 +6,12 @@ use opentelemetry::metrics::Meter;
 
 #[cfg(feature = "datafusion")]
 use logfwd_config::{EnrichmentConfig, GeoDatabaseFormat};
-use logfwd_config::{Format, InputTypeConfig, PipelineConfig};
+use logfwd_config::{Format, InputTypeConfig, OutputConfigV2, PipelineConfig};
 use logfwd_diagnostics::diagnostics::PipelineMetrics;
 use logfwd_io::checkpoint::{
     CheckpointStore, FileCheckpointStore, SourceCheckpoint, default_data_dir,
 };
-use logfwd_output::{AsyncFanoutFactory, SinkFactory, build_sink_factory};
+use logfwd_output::{AsyncFanoutFactory, SinkFactory, build_sink_factory_v2};
 use logfwd_types::field_names;
 use logfwd_types::pipeline::{PipelineMachine, SourceId};
 use logfwd_types::source_metadata::SourceMetadataPlan;
@@ -563,27 +563,23 @@ impl Pipeline {
         // Build output sink factory → pool.
         let factory: Arc<dyn SinkFactory> = if config.outputs.len() == 1 {
             let output_cfg = &config.outputs[0];
-            let output_name = output_cfg
-                .name
-                .clone()
-                .unwrap_or_else(|| "output_0".to_string());
-            let output_type_str = format!("{:?}", output_cfg.output_type).to_lowercase();
-            let output_stats = metrics.add_output(&output_name, &output_type_str);
-            build_sink_factory(&output_name, output_cfg, base_path, output_stats)
-                .map_err(|e| e.to_string())?
+            build_output_factory_from_config(
+                0,
+                output_cfg.typed(),
+                output_cfg.compression.as_deref(),
+                base_path,
+                &mut metrics,
+            )?
         } else {
             let mut factories: Vec<Arc<dyn SinkFactory>> = Vec::new();
             for (i, output_cfg) in config.outputs.iter().enumerate() {
-                let output_name = output_cfg
-                    .name
-                    .clone()
-                    .unwrap_or_else(|| format!("output_{i}"));
-                let output_type_str = format!("{:?}", output_cfg.output_type).to_lowercase();
-                let output_stats = metrics.add_output(&output_name, &output_type_str);
-                factories.push(
-                    build_sink_factory(&output_name, output_cfg, base_path, output_stats)
-                        .map_err(|e| e.to_string())?,
-                );
+                factories.push(build_output_factory_from_config(
+                    i,
+                    output_cfg.typed(),
+                    output_cfg.compression.as_deref(),
+                    base_path,
+                    &mut metrics,
+                )?);
             }
             let fanout_name = name.to_string();
             Arc::new(AsyncFanoutFactory::new(fanout_name, factories))
@@ -657,6 +653,31 @@ impl Pipeline {
     }
 }
 
+fn build_output_factory_from_config(
+    index: usize,
+    output_cfg: &OutputConfigV2,
+    legacy_file_compression: Option<&str>,
+    base_path: Option<&Path>,
+    metrics: &mut PipelineMetrics,
+) -> Result<Arc<dyn SinkFactory>, String> {
+    let output_name = output_cfg
+        .name()
+        .map_or_else(|| format!("output_{index}"), str::to_owned);
+    let output_type_str = output_cfg.output_type().to_string();
+    let output_stats = metrics.add_output(&output_name, &output_type_str);
+
+    if matches!(output_cfg, OutputConfigV2::File(_))
+        && let Some(compression) = legacy_file_compression
+    {
+        return Err(format!(
+            "output '{output_name}': file does not support '{compression}' compression"
+        ));
+    }
+
+    build_sink_factory_v2(&output_name, output_cfg, base_path, output_stats)
+        .map_err(|e| e.to_string())
+}
+
 fn should_open_checkpoint_store(checkpoint_dir: &Path, has_explicit_data_dir: bool) -> bool {
     if has_explicit_data_dir {
         return true;
@@ -676,7 +697,9 @@ fn should_open_checkpoint_store(checkpoint_dir: &Path, has_explicit_data_dir: bo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use logfwd_config::{InputConfig, InputTypeConfig, OutputConfig, OutputType};
+    use logfwd_config::{
+        InputConfig, InputTypeConfig, OutputConfig, OutputConfigV2, OutputType, StdoutOutputConfig,
+    };
 
     fn minimal_input(path: String) -> InputConfig {
         InputConfig {
@@ -706,7 +729,7 @@ mod tests {
     fn minimal_config(path: String) -> PipelineConfig {
         PipelineConfig {
             inputs: vec![minimal_input(path)],
-            outputs: vec![minimal_output()],
+            outputs: vec![minimal_output().into()],
             transform: None,
             enrichment: vec![],
             resource_attrs: std::collections::HashMap::new(),
@@ -718,6 +741,51 @@ mod tests {
     }
 
     #[test]
+    fn from_config_accepts_native_typed_output_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        std::fs::write(&log_path, b"{\"msg\":\"hello\"}\n").unwrap();
+
+        let mut config = minimal_config(log_path.display().to_string());
+        config.outputs = vec![
+            OutputConfigV2::Stdout(StdoutOutputConfig {
+                name: Some("typed_stdout".to_string()),
+                format: None,
+            })
+            .into(),
+        ];
+
+        Pipeline::from_config("default", &config, &logfwd_test_utils::test_meter(), None)
+            .expect("native typed output entry should build");
+    }
+
+    #[test]
+    fn from_config_preserves_legacy_output_factory_rejections() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        std::fs::write(&log_path, b"{\"msg\":\"hello\"}\n").unwrap();
+
+        let mut config = minimal_config(log_path.display().to_string());
+        config.outputs = vec![
+            OutputConfig {
+                output_type: OutputType::File,
+                path: Some(dir.path().join("out.log").display().to_string()),
+                compression: Some("gzip".to_string()),
+                ..Default::default()
+            }
+            .into(),
+        ];
+
+        let err = Pipeline::from_config("default", &config, &logfwd_test_utils::test_meter(), None)
+            .err()
+            .expect("legacy file compression should still be rejected");
+        assert!(
+            err.contains("file does not support 'gzip' compression"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn from_config_uses_explicit_data_dir_for_checkpoint_store() {
         let dir = tempfile::tempdir().expect("tempdir");
         let log_path = dir.path().join("in.log");
@@ -726,7 +794,7 @@ mod tests {
         let cfg = PipelineConfig {
             inputs: vec![minimal_input(log_path.to_string_lossy().into_owned())],
             transform: None,
-            outputs: vec![minimal_output()],
+            outputs: vec![minimal_output().into()],
             enrichment: Vec::new(),
             resource_attrs: Default::default(),
             workers: None,
@@ -762,7 +830,7 @@ mod tests {
         let cfg = PipelineConfig {
             inputs: vec![minimal_input(log_path.to_string_lossy().into_owned())],
             transform: None,
-            outputs: vec![minimal_output()],
+            outputs: vec![minimal_output().into()],
             enrichment: Vec::new(),
             resource_attrs: Default::default(),
             workers: None,

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -48,7 +48,7 @@ use logfwd_io::tail::ByteOffset;
 #[cfg(feature = "turmoil")]
 use logfwd_output::SinkFactory;
 #[cfg(test)]
-use logfwd_output::build_sink_factory;
+use logfwd_output::build_sink_factory_v2;
 use logfwd_output::{BatchMetadata, OnceAsyncFactory};
 use logfwd_types::pipeline::{PipelineMachine, Running, SourceId};
 use logfwd_types::source_metadata::SourceMetadataPlan;
@@ -843,7 +843,7 @@ mod tests {
     use std::time::Instant;
 
     use arrow::record_batch::RecordBatch;
-    use logfwd_config::{Format, OutputConfig, OutputType};
+    use logfwd_config::{Format, OutputConfig, OutputConfigV2, OutputType};
     use logfwd_core::scan_config::ScanConfig;
     use logfwd_diagnostics::diagnostics::ComponentStats;
     use logfwd_output::{
@@ -887,8 +887,9 @@ mod tests {
             format: Some(Format::Json),
             ..Default::default()
         };
+        let typed = OutputConfigV2::from(&cfg);
         let factory =
-            build_sink_factory("test", &cfg, None, Arc::new(ComponentStats::new())).unwrap();
+            build_sink_factory_v2("test", &typed, None, Arc::new(ComponentStats::new())).unwrap();
         assert_eq!(factory.name(), "test");
         let sink = factory.create().expect("create should succeed");
         assert_eq!(sink.name(), "test");
@@ -904,8 +905,9 @@ mod tests {
             compression: Some("zstd".to_string()),
             ..Default::default()
         };
+        let typed = OutputConfigV2::from(&cfg);
         let factory =
-            build_sink_factory("otel", &cfg, None, Arc::new(ComponentStats::new())).unwrap();
+            build_sink_factory_v2("otel", &typed, None, Arc::new(ComponentStats::new())).unwrap();
         assert_eq!(factory.name(), "otel");
     }
 
@@ -916,7 +918,8 @@ mod tests {
             output_type: OutputType::Otlp,
             ..Default::default()
         };
-        let result = build_sink_factory("bad", &cfg, None, Arc::new(ComponentStats::new()));
+        let typed = OutputConfigV2::from(&cfg);
+        let result = build_sink_factory_v2("bad", &typed, None, Arc::new(ComponentStats::new()));
         assert!(result.is_err());
         let err = result.err().unwrap();
         assert!(err.to_string().contains("endpoint"), "got: {err}");


### PR DESCRIPTION
## Summary
- change `PipelineConfig.outputs` to store typed output entries instead of flat `OutputConfig`
- add `OutputConfigEntry` so config loading accepts strict V2 output YAML or legacy flat output YAML
- retain a flat `OutputConfig` compatibility view so existing `pipe.outputs[i].endpoint` / `tls` style callers keep compiling
- route runtime output construction through `build_sink_factory_v2` for every output entry
- keep legacy file-compression rejection in the typed factory by preserving the field during legacy-to-typed normalization
- keep migration shims out of the user-facing crate-root API where possible

## Why
This moves outputs past the factory-boundary adapter from #2344: loaded configs now carry typed output variants internally, and legacy flat output syntax is isolated at the deserialization/validation edge without weakening legacy behavior for programmatically constructed configs.

## Verification
- `cargo fmt --check && git diff --check`
- `cargo check -p logfwd-config -p logfwd-runtime -p logfwd-output -p logfwd`
- `cargo test -p logfwd-config`
- `cargo test -p logfwd-runtime pipeline::build --lib`
- `cargo test -p logfwd-output build_sink_factory --lib`
- `cargo clippy -p logfwd-config -p logfwd-output -p logfwd-runtime -- -D warnings`
- `just lint`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Store pipeline outputs as typed `OutputConfigEntry` with legacy flat compatibility
> - Introduces `OutputConfigEntry` in [types.rs](https://github.com/strawgate/fastforward/pull/2346/files#diff-62e3ac9382eb657aa94241b95339050d93e352844aef7d3a16f2bf66bb681a91) that wraps a typed `OutputConfigV2` alongside a flat `OutputConfig` clone, exposing both `typed()` and `validation_config()` accessors.
> - Custom `Deserialize` impl tries the new typed V2 schema first, falling back to legacy V1/flat format, so existing configs continue to work without changes.
> - `PipelineConfig.outputs` changes from `Vec<OutputConfig>` to `Vec<OutputConfigEntry>`; a `Deref<Target = OutputConfig>` impl keeps most legacy field access compiling.
> - Pipeline construction in [build.rs](https://github.com/strawgate/fastforward/pull/2346/files#diff-9066bdb853d1e2fff1f2d2ad02a5eb7c17a2b62826ba724bbb990487b851ae83) and startup labeling in [bootstrap.rs](https://github.com/strawgate/fastforward/pull/2346/files#diff-851a18d1d09b862e055016804787b7d10ede93b9fda47be883bab270fb223c68) now operate on the typed variant.
> - `build_sink_factory` is demoted to `#[cfg(test)] pub(crate)`; the public re-export from [lib.rs](https://github.com/strawgate/fastforward/pull/2346/files#diff-00ddb9f7cbde401078d0410c694ec7302918c0a95336aabc22305c3084e799c9) now points to `build_sink_factory_v2`.
> - Behavioral Change: callers that previously imported `build_sink_factory` from `logfwd-output` must switch to `build_sink_factory_v2`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 26a5c68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
