### PR TITLE
bench: add OTLP projection decode gates

### DIFF
--- a/dev-docs/benchmarks/otlp/otlp_projection_decode_2026-04-19.md
+++ b/dev-docs/benchmarks/otlp/otlp_projection_decode_2026-04-19.md
@@ -1,0 +1,103 @@
+# OTLP Projection Decode Benchmarks
+
+> **Status:** Completed
+> **Date:** 2026-04-19
+> **Context:** Benchmark evidence for OTLP projected decode cutover gates.
+
+## Verdict
+
+Do not make `projected_fallback` the default yet.
+
+The projected decoder remains a strong performance candidate for primitive-heavy
+OTLP payloads, but this run does not satisfy the cutover gates from #2301:
+
+- `narrow-1k` and `attrs-heavy` pass the primitive detached-projection gate.
+- `trace-heavy` improves over prost, but misses the strict primitive gate.
+- `compression-relevant` passes the fallback gate.
+- `complex-anyvalue` fails the fallback gate by a wide margin because the
+  fallback wrapper pays projection-attempt cost before returning to prost.
+
+Recommendation: keep `prost` as the default, keep projected modes explicit, and
+optimize fallback classification before revisiting the default switch.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Date | 2026-04-19 |
+| Host | `Darwin Mac.ad.weaston.org 25.3.0 arm64` |
+| CPU | `Apple M4` |
+| Rust | `rustc 1.94.1 (e408947bf 2026-03-25)` |
+| Repo HEAD | `484b2d055e28050dd8dbde023bb62e28602c7e29` |
+| Benchmark command | `just bench-otlp-io otlp_input_decode_materialize` |
+| Criterion settings | benchmark default warm-up, `sample_size(10)` in `otlp_io.rs` |
+| Build note | First run spent 22m25s in release/LTO build before measurement. |
+| Plot note | `gnuplot` was unavailable; Criterion used the plotters backend. |
+
+## Gate Definitions
+
+| Gate | Formula |
+|---|---|
+| Primitive gate | `projected_detached_to_batch` median <= `0.80 * prost_reference_to_batch` median |
+| Complex/fallback gate | `projected_fallback_to_batch` median <= `1.05 * prost_reference_to_batch` median |
+
+Confidence interval note: pass/fail uses Criterion median point estimates.
+Tables also include median confidence intervals so marginal results can be
+reviewed before policy decisions.
+
+## Required Fixture Gates
+
+| Fixture | Bucket | Prost median | Candidate | Candidate median | Threshold | Ratio | Result |
+|---|---|---:|---|---:|---:|---:|---|
+| `narrow-1k` | primitive | 0.711 ms | `projected_detached_to_batch` | 0.418 ms | 0.569 ms | 0.588 | PASS |
+| `attrs-heavy` | primitive | 9.039 ms | `projected_detached_to_batch` | 4.013 ms | 7.231 ms | 0.444 | PASS |
+| `trace-heavy` | primitive | 9.459 ms | `projected_detached_to_batch` | 8.617 ms | 7.567 ms | 0.911 | FAIL |
+| `complex-anyvalue` | complex/fallback | 5.253 ms | `projected_fallback_to_batch` | 10.811 ms | 5.515 ms | 2.058 | FAIL |
+| `compression-relevant` | complex/fallback | 14.423 ms | `projected_fallback_to_batch` | 6.573 ms | 15.144 ms | 0.456 | PASS |
+
+## Required Variant Table
+
+| Fixture | Rows | Variant | Median | Median CI | ns/row |
+|---|---:|---|---:|---:|---:|
+| `narrow-1k` | 1,000 | `prost_reference_to_batch` | 0.711 ms | 0.710-0.719 ms | 711.0 |
+| `narrow-1k` | 1,000 | `projected_fallback_to_batch` | 0.362 ms | 0.361-0.367 ms | 361.6 |
+| `narrow-1k` | 1,000 | `projected_detached_to_batch` | 0.418 ms | 0.418-0.422 ms | 418.2 |
+| `narrow-1k` | 1,000 | `projected_view_to_batch` | 0.360 ms | 0.359-0.361 ms | 360.4 |
+| `attrs-heavy` | 2,000 | `prost_reference_to_batch` | 9.039 ms | 9.027-9.052 ms | 4519.3 |
+| `attrs-heavy` | 2,000 | `projected_fallback_to_batch` | 3.693 ms | 3.684-3.714 ms | 1846.3 |
+| `attrs-heavy` | 2,000 | `projected_detached_to_batch` | 4.013 ms | 3.994-4.026 ms | 2006.7 |
+| `attrs-heavy` | 2,000 | `projected_view_to_batch` | 3.721 ms | 3.705-3.750 ms | 1860.7 |
+| `trace-heavy` | 8,000 | `prost_reference_to_batch` | 9.459 ms | 9.432-9.470 ms | 1182.4 |
+| `trace-heavy` | 8,000 | `projected_fallback_to_batch` | 7.745 ms | 7.375-9.208 ms | 968.2 |
+| `trace-heavy` | 8,000 | `projected_detached_to_batch` | 8.617 ms | 8.514-8.655 ms | 1077.2 |
+| `trace-heavy` | 8,000 | `projected_view_to_batch` | 7.335 ms | 7.307-8.022 ms | 916.8 |
+| `complex-anyvalue` | 2,000 | `prost_reference_to_batch` | 5.253 ms | 5.219-5.315 ms | 2626.4 |
+| `complex-anyvalue` | 2,000 | `projected_fallback_to_batch` | 10.811 ms | 10.801-10.913 ms | 5405.5 |
+| `compression-relevant` | 5,000 | `prost_reference_to_batch` | 14.423 ms | 14.105-15.467 ms | 2884.6 |
+| `compression-relevant` | 5,000 | `projected_fallback_to_batch` | 6.573 ms | 6.410-6.804 ms | 1314.6 |
+| `compression-relevant` | 5,000 | `projected_detached_to_batch` | 7.741 ms | 7.555-9.094 ms | 1548.2 |
+| `compression-relevant` | 5,000 | `projected_view_to_batch` | 6.313 ms | 6.211-6.485 ms | 1262.6 |
+
+## Interpretation
+
+The projection path is clearly worthwhile for straightforward primitive shapes.
+`projected_view_to_batch` is usually fastest, and `projected_fallback_to_batch`
+also wins on primitive fixtures where no fallback is needed.
+
+The default-switch blocker is fallback cost. `complex-anyvalue` is valid OTLP
+that requires prost fallback; the current wrapper takes roughly 2.06x the prost
+median. That is too expensive for a default path unless fallback incidence is
+known to be negligible, which we have not proven.
+
+`trace-heavy` also misses the primitive detached gate. It still improves over
+prost and `projected_view_to_batch` is stronger, but the agreed gate names
+`projected_detached_to_batch`, so the gate should fail as written.
+
+## Next Work
+
+1. Optimize unsupported-but-valid fallback classification so complex `AnyValue`
+   payloads avoid a full failed projection attempt when possible.
+2. Decide whether the primitive gate should use detached projection, view
+   projection, or the production wrapper before encoding it as policy.
+3. Add the dedicated projected-decode fuzz and compatibility corpus work before
+   any default switch PR.

--- a/dev-docs/benchmarks/otlp/otlp_projection_decode_2026-04-19.summary.json
+++ b/dev-docs/benchmarks/otlp/otlp_projection_decode_2026-04-19.summary.json
@@ -1,0 +1,228 @@
+{
+  "artifact": "otlp_projection_decode_2026-04-19",
+  "status": "completed",
+  "date": "2026-04-19",
+  "repo": {
+    "head": "484b2d055e28050dd8dbde023bb62e28602c7e29",
+    "head_short": "484b2d055e28",
+    "branch": "codex/otlp-projection-bench-gates"
+  },
+  "environment": {
+    "host": "Darwin Mac.ad.weaston.org 25.3.0 arm64",
+    "cpu": "Apple M4",
+    "rustc": "rustc 1.94.1 (e408947bf 2026-03-25)",
+    "criterion_sample_size": 10,
+    "gnuplot": "unavailable; plotters backend used"
+  },
+  "command": "just bench-otlp-io otlp_input_decode_materialize",
+  "criterion_group": "otlp_input_decode_materialize",
+  "gate_definitions": {
+    "primitive": {
+      "candidate": "projected_detached_to_batch",
+      "baseline": "prost_reference_to_batch",
+      "operator": "<=",
+      "multiplier": 0.8
+    },
+    "complex_fallback": {
+      "candidate": "projected_fallback_to_batch",
+      "baseline": "prost_reference_to_batch",
+      "operator": "<=",
+      "multiplier": 1.05
+    }
+  },
+  "gate_summary": {
+    "primitive": {
+      "passed": 2,
+      "failed": 1
+    },
+    "complex_fallback": {
+      "passed": 1,
+      "failed": 1
+    },
+    "overall": "fail"
+  },
+  "recommendation": {
+    "decision": "defer_default_switch",
+    "summary": "Keep prost as the default. Projected decode is strong on primitive-heavy fixtures, but trace-heavy misses the strict primitive gate and complex-anyvalue fails the fallback gate."
+  },
+  "fixtures": [
+    {
+      "name": "narrow-1k",
+      "bucket": "primitive",
+      "rows": 1000,
+      "results": {
+        "prost_reference_to_batch": {
+          "median_ns": 710968.356299,
+          "ci_low_ns": 710005.843012,
+          "ci_high_ns": 719401.439258,
+          "ns_per_row": 710.968
+        },
+        "projected_fallback_to_batch": {
+          "median_ns": 361639.49504,
+          "ci_low_ns": 361231.861558,
+          "ci_high_ns": 366938.740079,
+          "ns_per_row": 361.639
+        },
+        "projected_detached_to_batch": {
+          "median_ns": 418210.824413,
+          "ci_low_ns": 417665.517019,
+          "ci_high_ns": 422019.706573,
+          "ns_per_row": 418.211
+        },
+        "projected_view_to_batch": {
+          "median_ns": 360373.791831,
+          "ci_low_ns": 359117.333992,
+          "ci_high_ns": 361233.692547,
+          "ns_per_row": 360.374
+        }
+      },
+      "gates": {
+        "primitive": {
+          "threshold_ns": 568774.685039,
+          "ratio": 0.588225,
+          "passed": true
+        }
+      }
+    },
+    {
+      "name": "attrs-heavy",
+      "bucket": "primitive",
+      "rows": 2000,
+      "results": {
+        "prost_reference_to_batch": {
+          "median_ns": 9038697.29,
+          "ci_low_ns": 9027115.291667,
+          "ci_high_ns": 9051954.574107,
+          "ns_per_row": 4519.349
+        },
+        "projected_fallback_to_batch": {
+          "median_ns": 3692592.316667,
+          "ci_low_ns": 3684347.8525,
+          "ci_high_ns": 3713742.142857,
+          "ns_per_row": 1846.296
+        },
+        "projected_detached_to_batch": {
+          "median_ns": 4013482.987578,
+          "ci_low_ns": 3994414.130435,
+          "ci_high_ns": 4026268.153986,
+          "ns_per_row": 2006.741
+        },
+        "projected_view_to_batch": {
+          "median_ns": 3721451.0,
+          "ci_low_ns": 3704844.375,
+          "ci_high_ns": 3749538.5,
+          "ns_per_row": 1860.726
+        }
+      },
+      "gates": {
+        "primitive": {
+          "threshold_ns": 7230957.832,
+          "ratio": 0.443911,
+          "passed": true
+        }
+      }
+    },
+    {
+      "name": "trace-heavy",
+      "bucket": "primitive",
+      "rows": 8000,
+      "results": {
+        "prost_reference_to_batch": {
+          "median_ns": 9458854.004167,
+          "ci_low_ns": 9431603.12625,
+          "ci_high_ns": 9470192.559524,
+          "ns_per_row": 1182.357
+        },
+        "projected_fallback_to_batch": {
+          "median_ns": 7745377.900463,
+          "ci_low_ns": 7375234.944444,
+          "ci_high_ns": 9207787.410417,
+          "ns_per_row": 968.172
+        },
+        "projected_detached_to_batch": {
+          "median_ns": 8617442.517045,
+          "ci_low_ns": 8514215.909091,
+          "ci_high_ns": 8654508.318182,
+          "ns_per_row": 1077.18
+        },
+        "projected_view_to_batch": {
+          "median_ns": 7334697.916667,
+          "ci_low_ns": 7307231.770833,
+          "ci_high_ns": 8021825.870833,
+          "ns_per_row": 916.837
+        }
+      },
+      "gates": {
+        "primitive": {
+          "threshold_ns": 7567083.203334,
+          "ratio": 0.910993,
+          "passed": false
+        }
+      }
+    },
+    {
+      "name": "complex-anyvalue",
+      "bucket": "complex_fallback",
+      "rows": 2000,
+      "results": {
+        "prost_reference_to_batch": {
+          "median_ns": 5252852.295635,
+          "ci_low_ns": 5218715.166667,
+          "ci_high_ns": 5314791.211111,
+          "ns_per_row": 2626.426
+        },
+        "projected_fallback_to_batch": {
+          "median_ns": 10811040.044444,
+          "ci_low_ns": 10801193.277778,
+          "ci_high_ns": 10912925.944444,
+          "ns_per_row": 5405.52
+        }
+      },
+      "gates": {
+        "complex_fallback": {
+          "threshold_ns": 5515494.910417,
+          "ratio": 2.058127,
+          "passed": false
+        }
+      }
+    },
+    {
+      "name": "compression-relevant",
+      "bucket": "complex_fallback",
+      "rows": 5000,
+      "results": {
+        "prost_reference_to_batch": {
+          "median_ns": 14423186.765306,
+          "ci_low_ns": 14105401.785714,
+          "ci_high_ns": 15466948.087302,
+          "ns_per_row": 2884.637
+        },
+        "projected_fallback_to_batch": {
+          "median_ns": 6572763.89881,
+          "ci_low_ns": 6409845.521259,
+          "ci_high_ns": 6804447.321429,
+          "ns_per_row": 1314.553
+        },
+        "projected_detached_to_batch": {
+          "median_ns": 7741169.263889,
+          "ci_low_ns": 7555495.118056,
+          "ci_high_ns": 9093607.642857,
+          "ns_per_row": 1548.234
+        },
+        "projected_view_to_batch": {
+          "median_ns": 6312866.492593,
+          "ci_low_ns": 6210626.85,
+          "ci_high_ns": 6485328.333333,
+          "ns_per_row": 1262.573
+        }
+      },
+      "gates": {
+        "complex_fallback": {
+          "threshold_ns": 15144346.103571,
+          "ratio": 0.455709,
+          "passed": true
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the committed OTLP projection decode benchmark artifacts requested by #2301:

- `dev-docs/benchmarks/otlp/otlp_projection_decode_2026-04-19.md`
- `dev-docs/benchmarks/otlp/otlp_projection_decode_2026-04-19.summary.json`

The report records Criterion medians, confidence intervals, per-row timings, and pass/fail gate calculations for the required fixture buckets and decode variants.

Closes #2301.

## Result

Recommendation is to keep `prost` as the default for now.

Gate summary:

| Gate bucket | Passed | Failed |
|---|---:|---:|
| Primitive | 2 | 1 |
| Complex/fallback | 1 | 1 |

Notable failures:

- `trace-heavy`: `projected_detached_to_batch` is faster than prost, but misses the strict `<= 0.80 * prost` primitive gate.
- `complex-anyvalue`: `projected_fallback_to_batch` is about 2.06x prost median because it pays projection-attempt cost before falling back.

## Validation

- `just bench-otlp-io otlp_input_decode_materialize`
- `jq empty dev-docs/benchmarks/otlp/otlp_projection_decode_2026-04-19.summary.json`
- `git diff --check`
- `python3 scripts/docs/validate_operational_sections.py`
- `python3 scripts/docs/report_stale_docs.py`
- `python3 scripts/docs/validate_root_doc_allowlist.py`

Note: `python3 scripts/docs/validate_research_metadata.py` fails in this local worktree because of pre-existing untracked `dev-docs/research/fanout-*` artifacts. Those files are not staged, committed, or included in this PR.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add OTLP projection decode benchmark report
> Adds a benchmark report and summary JSON for OTLP projection decode performance in [dev-docs/benchmarks/otlp/](https://github.com/strawgate/fastforward/pull/2347/files#diff-78e3b4425f5f2ea9f210622d122970b2fcbc356c9e1ebd980fe749af686bf90f). The report covers environment details, gate definitions, fixture gates, variant results, interpretation, and next steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7468fcd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->