### PR TITLE
fix: harden OTLP protocol field validation

### DIFF
--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -306,6 +306,11 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
                     let parsed_flags = parse_protojson_i64(flags).ok_or_else(|| {
                         InputError::Receiver("invalid OTLP JSON flags: not a valid int64".into())
                     })?;
+                    if parsed_flags < 0 || parsed_flags > i64::from(u32::MAX) {
+                        return Err(InputError::Receiver(
+                            "invalid OTLP JSON flags: must be a uint32".into(),
+                        ));
+                    }
                     if parsed_flags > 0 {
                         write_json_key(&mut out, field_names::FLAGS);
                         write_i64_to_buf(&mut out, parsed_flags);

--- a/crates/logfwd-io/src/otlp_receiver/tests.rs
+++ b/crates/logfwd-io/src/otlp_receiver/tests.rs
@@ -845,6 +845,45 @@ fn invalid_json_flags_returns_error() {
 }
 
 #[test]
+fn negative_json_flags_returns_error() {
+    let result = decode_otlp_json(
+        br#"{
+            "resourceLogs": [{
+                "scopeLogs": [{
+                    "logRecords": [{
+                        "flags": -1
+                    }]
+                }]
+            }]
+        }"#,
+        field_names::DEFAULT_RESOURCE_PREFIX,
+    );
+
+    assert!(
+        result.is_err(),
+        "negative flags must fail because OTLP flags are uint32"
+    );
+}
+
+#[test]
+fn out_of_range_json_flags_returns_error() {
+    let result = decode_otlp_json(
+        br#"{
+            "resourceLogs": [{
+                "scopeLogs": [{
+                    "logRecords": [{
+                        "flags": 4294967296
+                    }]
+                }]
+            }]
+        }"#,
+        field_names::DEFAULT_RESOURCE_PREFIX,
+    );
+
+    assert!(result.is_err(), "flags above uint32::MAX must fail");
+}
+
+#[test]
 fn invalid_json_trace_id_returns_error() {
     let result = decode_otlp_json(
         br#"{

--- a/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
+++ b/crates/logfwd-output/src/generated/otlp_log_record_fast_v1.rs
@@ -47,7 +47,7 @@ pub(super) fn encode_row_as_log_record_fast_v1(
         if arr.is_null(row) {
             severity_num as u64
         } else {
-            u64::try_from(arr.value(row)).unwrap_or(severity_num as u64)
+            u64::try_from(arr.value(row)).unwrap_or(0)
         }
     } else {
         severity_num as u64

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -1322,7 +1322,7 @@ fn encode_row_as_log_record(
         if arr.is_null(row) {
             severity_num as u64
         } else {
-            u64::try_from(arr.value(row)).unwrap_or(severity_num as u64)
+            u64::try_from(arr.value(row)).unwrap_or(0)
         }
     } else {
         severity_num as u64
@@ -2707,6 +2707,39 @@ mod tests {
             lr.severity_number, 17,
             "null severity_number column must fall back to parsed level"
         );
+    }
+
+    #[test]
+    fn negative_severity_number_encodes_unspecified() {
+        use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+        use prost::Message;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("level", DataType::Utf8, true),
+            Field::new(field_names::SEVERITY_NUMBER, DataType::Int64, true),
+            Field::new("message", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![Some("ERROR")])),
+                Arc::new(Int64Array::from(vec![Some(-1)])),
+                Arc::new(StringArray::from(vec![Some("broken")])),
+            ],
+        )
+        .expect("valid batch");
+
+        let mut sink = make_sink();
+        sink.encode_batch(&batch, &make_metadata());
+
+        let request = ExportLogsServiceRequest::decode(sink.encoder_buf.as_slice())
+            .expect("prost must decode output");
+        let lr = &request.resource_logs[0].scope_logs[0].log_records[0];
+        assert_eq!(
+            lr.severity_number, 0,
+            "negative severity_number must not wrap or inherit level severity"
+        );
+        assert_eq!(lr.severity_text, "ERROR");
     }
 
     #[test]

--- a/scripts/generate_otlp_fast_encoder.py
+++ b/scripts/generate_otlp_fast_encoder.py
@@ -75,7 +75,7 @@ pub(super) fn encode_row_as_log_record_fast_v1(
         if arr.is_null(row) {{
             severity_num as u64
         }} else {{
-            u64::try_from(arr.value(row)).unwrap_or(severity_num as u64)
+            u64::try_from(arr.value(row)).unwrap_or(0)
         }}
     }} else {{
         severity_num as u64


### PR DESCRIPTION
## Summary

- Clamp explicit negative OTLP `severity_number` values to unspecified instead of falling back through the parsed level severity.
- Keep the generated fast OTLP encoder and generator template in sync with the handwritten sink behavior.
- Reject OTLP JSON `flags` values outside the `uint32` protocol range, including negative values and values above `u32::MAX`.
- Add regressions for negative severity numbers and invalid JSON flags.

Closes #2350.

## Validation

- `python3 scripts/generate_otlp_fast_encoder.py --check`
- `cargo test -p logfwd-output negative_severity_number_encodes_unspecified --lib`
- `cargo test -p logfwd-io json_flags_returns_error --lib`
- `just lint`
- `just ci` (1814 passed, 43 skipped)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OTLP protocol field validation for out-of-range `flags` and negative `severity_number`
> - JSON log records with `flags` outside the uint32 range (negative or > 4294967295) now return an `InputError` instead of being silently accepted or ignored, validated in [`decode.rs`](https://github.com/strawgate/fastforward/pull/2363/files#diff-1104a97c31865187f0a65affb5b8e2440e9db24cacdb3f9c1d24db1595686898).
> - Negative `severity_number` column values now encode as 0 (Unspecified) in the output OTLP `LogRecord` instead of falling back to the level-derived severity number, updated in [`otlp_sink.rs`](https://github.com/strawgate/fastforward/pull/2363/files#diff-56ca7e19db98793b4ef621c0d28a618a4c8af2bd492bc89cc8a21e845f25a43c) and the generated encoder.
> - The fast encoder generator [`generate_otlp_fast_encoder.py`](https://github.com/strawgate/fastforward/pull/2363/files#diff-b04ce9376babe3bbd36e33954166d44f45b4442d3d766cebaa1ebfca76fe2c52) is updated to match the new severity fallback behavior.
> - Behavioral Change: Previously invalid `flags` values were silently accepted; they now cause an error. Negative `severity_number` values previously inherited a parsed severity; they now encode as 0.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f14ab4d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->