### PR TITLE
test: codify null output config contract

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -1329,6 +1329,64 @@ pipelines:
         );
     }
 
+    #[test]
+    fn whole_output_null_is_rejected() {
+        let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput: null\n";
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("output is required when input is specified"),
+            "whole output null must not be treated as the null sink: {msg}"
+        );
+    }
+
+    #[test]
+    fn missing_output_type_is_rejected() {
+        let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput: {}\n";
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid output config") && msg.contains("missing field `type`"),
+            "missing output type must fail clearly: {msg}"
+        );
+    }
+
+    #[test]
+    fn empty_string_output_type_is_rejected() {
+        let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: \"\"\n";
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid output config") && msg.contains("unknown variant ``"),
+            "empty-string output type must fail clearly: {msg}"
+        );
+    }
+
+    #[test]
+    fn duplicate_pipeline_mapping_key_is_rejected() {
+        let yaml = r"
+pipelines:
+  app:
+    inputs:
+      - type: file
+        path: /tmp/a.log
+    outputs:
+      - type: stdout
+  app:
+    inputs:
+      - type: file
+        path: /tmp/b.log
+    outputs:
+      - type: stdout
+";
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("duplicate entry with key \"app\""),
+            "duplicate pipeline names must be rejected before validation: {msg}"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Bug #725: server.diagnostics address validated at config load time
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add regression coverage for the null-output config boundary from #2097.
- Preserve the existing intentional null sink forms: `type: null` and `type: "null"`.
- Codify that whole `output: null`, missing `output.type`, and empty-string output types are rejected.
- Add coverage showing duplicate pipeline mapping keys are rejected during YAML parsing.

Closes #2097.

## Validation

- `cargo test -p logfwd-config null --lib`
- `cargo test -p logfwd-config output_type --lib`
- `cargo test -p logfwd-config duplicate_pipeline_mapping_key_is_rejected --lib`
- `just lint`
- `just ci` (1815 passed, 43 skipped)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests to codify null output config contract in `logfwd-config`
> Adds four tests to [crates/logfwd-config/src/lib.rs](https://github.com/strawgate/fastforward/pull/2364/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150) that assert invalid output configurations are rejected with specific error messages:
> - Whole output set to YAML null is rejected with `'output is required when input is specified'`
> - Empty output object (missing `type`) is rejected with `'missing field \`type\`'`
> - Empty string output `type` is rejected with `'unknown variant'`
> - Duplicate pipeline mapping keys are rejected with `'duplicate entry with key'`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3058d3e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->