### PR TITLE
fix: type output enum config fields

### DIFF
--- a/book/src/content/docs/configuration/outputs.mdx
+++ b/book/src/content/docs/configuration/outputs.mdx
@@ -34,7 +34,7 @@ POST newline-delimited JSON to any HTTP endpoint. Each Arrow RecordBatch is seri
 output:
   type: http
   endpoint: https://logging-service:9200
-  compression: zstd    # zstd | none
+  compression: zstd    # zstd | gzip | none
   auth:
     headers:
       X-API-Key: "${API_KEY}"

--- a/book/src/content/docs/configuration/outputs.mdx
+++ b/book/src/content/docs/configuration/outputs.mdx
@@ -43,7 +43,7 @@ output:
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `endpoint` | string | Yes | — | Full URL to POST logs to |
-| `compression` | string | No | none | `zstd` or `none` |
+| `compression` | enum | No | none | `zstd`, `gzip`, or `none`; invalid values are rejected while parsing config |
 | `auth` | object | No | — | Bearer token or custom headers |
 
 </TabItem>
@@ -88,8 +88,8 @@ Streaming mode is experimental and currently requires `compression: none`. Use `
 |-------|------|----------|---------|-------------|
 | `endpoint` | string | Yes | — | Elasticsearch URL |
 | `index` | string | No | `logs` | Target index name |
-| `compression` | string | No | none | `gzip` or `none` |
-| `request_mode` | string | No | `buffered` | `buffered` or experimental `streaming` (streaming currently requires `compression: none`) |
+| `compression` | enum | No | none | `gzip` or `none`; `zstd` is rejected for Elasticsearch by validation |
+| `request_mode` | enum | No | `buffered` | `buffered` or experimental `streaming`; invalid values are rejected while parsing config (streaming currently requires `compression: none`) |
 | `auth` | object | No | — | Bearer token or custom headers |
 
 Bulk payloads are split before they exceed `5242880` bytes (5 MiB). That limit is internal and is not a YAML field.

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -416,7 +416,7 @@ lands.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `endpoint` | string | Yes | Full URL, e.g. `http://ingest.example.com/logs`. |
-| `compression` | enum | No | Reserved for future use. Recognized values are `zstd`, `gzip`, and `none`; the HTTP output type is still rejected by validation until runtime support lands. |
+| `compression` | enum | No | Reserved for future use. Recognized values are `zstd`, `gzip`, and `none`; the HTTP output itself is still not yet supported. |
 
 ```yaml
 output:

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -396,8 +396,8 @@ Send log records as OTLP protobuf to an OpenTelemetry collector.
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `endpoint` | string | Yes | — | Full collector URL, e.g. `http://otel-collector:4317` (gRPC) or `http://otel-collector:4318/v1/logs` (HTTP). |
-| `protocol` | string | No | `http` | `http` or `grpc`. |
-| `compression` | string | No | none | `zstd`, `gzip`, or `none` for the request body. |
+| `protocol` | enum | No | `http` | `http` or `grpc`. Invalid values are rejected while parsing config. |
+| `compression` | enum | No | none | `zstd`, `gzip`, or `none` for the request body. Invalid values are rejected while parsing config. |
 
 ```yaml
 output:
@@ -416,7 +416,7 @@ lands.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `endpoint` | string | Yes | Full URL, e.g. `http://ingest.example.com/logs`. |
-| `compression` | string | No | Reserved for future use. |
+| `compression` | enum | No | Reserved for future use. Recognized values are `zstd`, `gzip`, and `none`; the HTTP output type is still rejected by validation until runtime support lands. |
 
 ```yaml
 output:
@@ -446,8 +446,8 @@ Ship to Elasticsearch via the Bulk API.
 |-------|------|----------|---------|-------------|
 | `endpoint` | string | Yes | — | Elasticsearch base URL. |
 | `index` | string | No | `logs` | Target index name. Must not be empty, and must not contain Elasticsearch-reserved characters or prefixes. |
-| `compression` | string | No | `none` | `gzip` or `none`. |
-| `request_mode` | string | No | `buffered` | `buffered` or `streaming`. `streaming` currently requires `compression: none`. |
+| `compression` | enum | No | `none` | `gzip` or `none`. `zstd` is rejected for Elasticsearch by validation. |
+| `request_mode` | enum | No | `buffered` | `buffered` or `streaming`. Invalid values are rejected while parsing config; `streaming` currently requires `compression: none`. |
 | `request_timeout_ms` | integer | No | `30000` | HTTP request timeout in milliseconds. Must be >= 1 when set. |
 | `tls` | object | No | — | Optional TLS client options (`ca_file`, `cert_file`, `key_file`, `insecure_skip_verify`) for HTTPS endpoints. |
 | `auth` | object | No | — | Optional bearer token or custom headers for HTTP auth. |

--- a/crates/logfwd-bench/src/es_throughput.rs
+++ b/crates/logfwd-bench/src/es_throughput.rs
@@ -49,6 +49,7 @@ fn request_mode_name(mode: ElasticsearchRequestMode) -> &'static str {
     match mode {
         ElasticsearchRequestMode::Buffered => "buffered",
         ElasticsearchRequestMode::Streaming => "streaming",
+        _ => "unknown",
     }
 }
 

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -24,16 +24,17 @@ pub use shared::{
     TlsServerConfig,
 };
 pub use types::{
-    ArrowIpcOutputConfig, ArrowIpcTypeConfig, AuthConfig, Config, ConfigError, CsvEnrichmentConfig,
-    ElasticsearchOutputConfig, EnrichmentConfig, FileOutputConfig, FileTypeConfig, Format,
-    GeneratorAttributeValueConfig, GeneratorComplexityConfig, GeneratorInputConfig,
-    GeneratorProfileConfig, GeneratorSequenceConfig, GeneratorTypeConfig, GeoDatabaseConfig,
-    GeoDatabaseFormat, HostInfoConfig, HostMetricsInputConfig, HttpInputConfig, HttpMethodConfig,
-    HttpOutputConfig, HttpTypeConfig, InputConfig, InputType, InputTypeConfig,
-    JournaldBackendConfig, JournaldInputConfig, JournaldTypeConfig, JsonlEnrichmentConfig,
-    K8sPathConfig, LokiOutputConfig, NullOutputConfig, OtlpOutputConfig,
-    OtlpProtobufDecodeModeConfig, OtlpTypeConfig, OutputConfig, OutputConfigV1, OutputConfigV2,
-    OutputType, ParquetOutputConfig, PipelineConfig, S3InputConfig, S3TypeConfig, SensorTypeConfig,
+    ArrowIpcOutputConfig, ArrowIpcTypeConfig, AuthConfig, CompressionFormat, Config, ConfigError,
+    CsvEnrichmentConfig, ElasticsearchOutputConfig, ElasticsearchRequestMode, EnrichmentConfig,
+    FileOutputConfig, FileTypeConfig, Format, GeneratorAttributeValueConfig,
+    GeneratorComplexityConfig, GeneratorInputConfig, GeneratorProfileConfig,
+    GeneratorSequenceConfig, GeneratorTypeConfig, GeoDatabaseConfig, GeoDatabaseFormat,
+    HostInfoConfig, HostMetricsInputConfig, HttpInputConfig, HttpMethodConfig, HttpOutputConfig,
+    HttpTypeConfig, InputConfig, InputType, InputTypeConfig, JournaldBackendConfig,
+    JournaldInputConfig, JournaldTypeConfig, JsonlEnrichmentConfig, K8sPathConfig,
+    LokiOutputConfig, NullOutputConfig, OtlpOutputConfig, OtlpProtobufDecodeModeConfig,
+    OtlpProtocol, OtlpTypeConfig, OutputConfig, OutputConfigV1, OutputConfigV2, OutputType,
+    ParquetOutputConfig, PipelineConfig, S3InputConfig, S3TypeConfig, SensorTypeConfig,
     ServerConfig, SocketOutputConfig, StaticEnrichmentConfig, StdoutOutputConfig, StorageConfig,
     TcpTypeConfig, UdpTypeConfig,
 };
@@ -1118,8 +1119,8 @@ output:
         let cfg = Config::load_str(yaml).expect("streaming request_mode should validate");
         let pipe = &cfg.pipelines["default"];
         assert_eq!(
-            pipe.outputs[0].validation_config().request_mode.as_deref(),
-            Some("streaming")
+            pipe.outputs[0].validation_config().request_mode,
+            Some(ElasticsearchRequestMode::Streaming)
         );
     }
 
@@ -1135,7 +1136,11 @@ output:
   request_mode: fancy
 ";
         let err = Config::load_str(yaml).expect_err("invalid request_mode should fail");
-        assert!(err.to_string().contains("request_mode"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("fancy") && msg.contains("buffered") && msg.contains("streaming"),
+            "expected request_mode enum rejection: {msg}"
+        );
     }
 
     #[test]
@@ -2988,6 +2993,33 @@ format: json
             err.to_string().contains("format"),
             "strict v2 otlp config should reject format, got: {err}"
         );
+    }
+
+    #[test]
+    fn output_config_v2_rejects_invalid_enum_values_at_parse_time() {
+        let cases = [
+            (
+                "type: otlp\nendpoint: http://localhost:4318/v1/logs\nprotocol: websocket\n",
+                "websocket",
+            ),
+            (
+                "type: otlp\nendpoint: http://localhost:4318/v1/logs\ncompression: lz4\n",
+                "lz4",
+            ),
+            (
+                "type: elasticsearch\nendpoint: http://localhost:9200\nrequest_mode: fancy\n",
+                "fancy",
+            ),
+        ];
+
+        for (yaml, bad_value) in cases {
+            let err = serde_yaml_ng::from_str::<OutputConfigV2>(yaml).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains(bad_value) && msg.contains("unknown variant"),
+                "expected enum parse rejection for {bad_value}: {msg}"
+            );
+        }
     }
 
     #[test]

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -3001,23 +3001,29 @@ format: json
             (
                 "type: otlp\nendpoint: http://localhost:4318/v1/logs\nprotocol: websocket\n",
                 "websocket",
+                &["http", "grpc"][..],
             ),
             (
                 "type: otlp\nendpoint: http://localhost:4318/v1/logs\ncompression: lz4\n",
                 "lz4",
+                &["gzip", "zstd", "none"][..],
             ),
             (
                 "type: elasticsearch\nendpoint: http://localhost:9200\nrequest_mode: fancy\n",
                 "fancy",
+                &["buffered", "streaming"][..],
             ),
         ];
 
-        for (yaml, bad_value) in cases {
+        for (yaml, bad_value, expected_variants) in cases {
             let err = serde_yaml_ng::from_str::<OutputConfigV2>(yaml).unwrap_err();
             let msg = err.to_string();
             assert!(
-                msg.contains(bad_value) && msg.contains("unknown variant"),
-                "expected enum parse rejection for {bad_value}: {msg}"
+                msg.contains(bad_value)
+                    && expected_variants
+                        .iter()
+                        .all(|variant| msg.contains(variant)),
+                "expected enum parse rejection mentioning {bad_value} and valid variants {expected_variants:?}: {msg}"
             );
         }
     }

--- a/crates/logfwd-config/src/serde_helpers.rs
+++ b/crates/logfwd-config/src/serde_helpers.rs
@@ -1,5 +1,8 @@
 use serde::Deserialize;
-use serde::de::{Error as DeError, MapAccess, SeqAccess, Unexpected, value::MapAccessDeserializer};
+use serde::de::{
+    Error as DeError, IntoDeserializer, MapAccess, SeqAccess, Unexpected,
+    value::{MapAccessDeserializer, UnitDeserializer},
+};
 use std::fmt;
 use std::marker::PhantomData;
 use std::num::NonZeroU64;
@@ -35,6 +38,69 @@ where
             Ok(items)
         }
 
+        fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            T::deserialize(value.into_deserializer()).map(|item| vec![item])
+        }
+
+        fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            T::deserialize(value.into_deserializer()).map(|item| vec![item])
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            T::deserialize(value.into_deserializer()).map(|item| vec![item])
+        }
+
+        fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            T::deserialize(value.into_deserializer()).map(|item| vec![item])
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            T::deserialize(value.into_deserializer()).map(|item| vec![item])
+        }
+
+        fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            T::deserialize(value.into_deserializer()).map(|item| vec![item])
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            T::deserialize(UnitDeserializer::<E>::new()).map(|item| vec![item])
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: DeError,
+        {
+            self.visit_unit()
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            T::deserialize(deserializer).map(|item| vec![item])
+        }
+
         fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
         where
             A: MapAccess<'de>,
@@ -46,6 +112,94 @@ where
     deserializer.deserialize_any(OneOrManyVisitor {
         marker: PhantomData,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct StringValues {
+        #[serde(deserialize_with = "deserialize_one_or_many")]
+        values: Vec<String>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct NumberValues {
+        #[serde(deserialize_with = "deserialize_one_or_many")]
+        values: Vec<u64>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct BoolValues {
+        #[serde(deserialize_with = "deserialize_one_or_many")]
+        values: Vec<bool>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct OptionalValues {
+        #[serde(deserialize_with = "deserialize_one_or_many")]
+        values: Vec<Option<String>>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct NamedValue {
+        name: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct MapValues {
+        #[serde(deserialize_with = "deserialize_one_or_many")]
+        values: Vec<NamedValue>,
+    }
+
+    #[test]
+    fn deserialize_one_or_many_accepts_scalar_string() {
+        let parsed: StringValues = serde_yaml_ng::from_str("values: alpha\n").unwrap();
+
+        assert_eq!(parsed.values, vec!["alpha"]);
+    }
+
+    #[test]
+    fn deserialize_one_or_many_accepts_scalar_number() {
+        let parsed: NumberValues = serde_yaml_ng::from_str("values: 42\n").unwrap();
+
+        assert_eq!(parsed.values, vec![42]);
+    }
+
+    #[test]
+    fn deserialize_one_or_many_accepts_scalar_bool() {
+        let parsed: BoolValues = serde_yaml_ng::from_str("values: true\n").unwrap();
+
+        assert_eq!(parsed.values, vec![true]);
+    }
+
+    #[test]
+    fn deserialize_one_or_many_accepts_scalar_null_when_item_type_accepts_it() {
+        let parsed: OptionalValues = serde_yaml_ng::from_str("values: null\n").unwrap();
+
+        assert_eq!(parsed.values, vec![None]);
+    }
+
+    #[test]
+    fn deserialize_one_or_many_accepts_sequence() {
+        let parsed: StringValues =
+            serde_yaml_ng::from_str("values:\n  - alpha\n  - beta\n").unwrap();
+
+        assert_eq!(parsed.values, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn deserialize_one_or_many_accepts_single_map() {
+        let parsed: MapValues = serde_yaml_ng::from_str("values:\n  name: alpha\n").unwrap();
+
+        assert_eq!(
+            parsed.values,
+            vec![NamedValue {
+                name: "alpha".to_owned()
+            }]
+        );
+    }
 }
 
 /// Deserializes an optional numeric or boolean field from a strict YAML scalar.

--- a/crates/logfwd-config/src/serde_helpers.rs
+++ b/crates/logfwd-config/src/serde_helpers.rs
@@ -10,16 +10,16 @@ where
     T: Deserialize<'de>,
     D: serde::Deserializer<'de>,
 {
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum OneOrMany<T> {
-        Many(Vec<T>),
-        One(T),
-    }
-
-    match OneOrMany::deserialize(deserializer)? {
-        OneOrMany::Many(v) => Ok(v),
-        OneOrMany::One(v) => Ok(vec![v]),
+    let value = serde_yaml_ng::Value::deserialize(deserializer)?;
+    match value {
+        serde_yaml_ng::Value::Sequence(items) => items
+            .into_iter()
+            .map(T::deserialize)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(D::Error::custom),
+        other => T::deserialize(other)
+            .map(|item| vec![item])
+            .map_err(D::Error::custom),
     }
 }
 

--- a/crates/logfwd-config/src/serde_helpers.rs
+++ b/crates/logfwd-config/src/serde_helpers.rs
@@ -21,7 +21,7 @@ where
         type Value = Vec<T>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("a mapping or a sequence of mappings")
+            formatter.write_str("a value or a sequence of values")
         }
 
         fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>

--- a/crates/logfwd-config/src/serde_helpers.rs
+++ b/crates/logfwd-config/src/serde_helpers.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use serde::de::{Error as DeError, Unexpected};
+use serde::de::{Error as DeError, MapAccess, SeqAccess, Unexpected, value::MapAccessDeserializer};
 use std::fmt;
 use std::marker::PhantomData;
 use std::num::NonZeroU64;
@@ -10,17 +10,42 @@ where
     T: Deserialize<'de>,
     D: serde::Deserializer<'de>,
 {
-    let value = serde_yaml_ng::Value::deserialize(deserializer)?;
-    match value {
-        serde_yaml_ng::Value::Sequence(items) => items
-            .into_iter()
-            .map(T::deserialize)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(D::Error::custom),
-        other => T::deserialize(other)
-            .map(|item| vec![item])
-            .map_err(D::Error::custom),
+    struct OneOrManyVisitor<T> {
+        marker: PhantomData<T>,
     }
+
+    impl<'de, T> serde::de::Visitor<'de> for OneOrManyVisitor<T>
+    where
+        T: Deserialize<'de>,
+    {
+        type Value = Vec<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a mapping or a sequence of mappings")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let mut items = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+            while let Some(item) = seq.next_element()? {
+                items.push(item);
+            }
+            Ok(items)
+        }
+
+        fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+        where
+            A: MapAccess<'de>,
+        {
+            T::deserialize(MapAccessDeserializer::new(map)).map(|item| vec![item])
+        }
+    }
+
+    deserializer.deserialize_any(OneOrManyVisitor {
+        marker: PhantomData,
+    })
 }
 
 /// Deserializes an optional numeric or boolean field from a strict YAML scalar.

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -175,8 +175,11 @@ impl<'de> Deserialize<'de> for OutputType {
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum CompressionFormat {
+    /// Do not compress request bodies.
     None,
+    /// Compress request bodies with gzip.
     Gzip,
+    /// Compress request bodies with zstd.
     Zstd,
 }
 
@@ -195,7 +198,9 @@ impl fmt::Display for CompressionFormat {
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum OtlpProtocol {
+    /// Send OTLP data over HTTP.
     Http,
+    /// Send OTLP data over gRPC.
     Grpc,
 }
 
@@ -213,7 +218,9 @@ impl fmt::Display for OtlpProtocol {
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum ElasticsearchRequestMode {
+    /// Build the Elasticsearch bulk request body in memory before sending.
     Buffered,
+    /// Stream Elasticsearch bulk request body chunks while sending.
     Streaming,
 }
 

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -862,9 +862,9 @@ pub struct OutputConfig {
 }
 
 /// Deserializes an output config by trying V2 (typed) first, falling back to V1
-/// (legacy flat). Uses a visitor to consume the map from the original
-/// deserializer, preserving YAML source locations for error messages instead of
-/// round-tripping through an intermediate `serde_yaml_ng::Value`.
+/// (legacy flat). The source map is consumed into owned YAML value pairs so it
+/// can be replayed for each schema attempt, then both parse errors are reported
+/// together when neither schema matches.
 fn deserialize_output_with_fallback<'de, D, T>(
     deserializer: D,
     from_v2: impl FnOnce(OutputConfigV2) -> T,

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -173,6 +173,7 @@ impl<'de> Deserialize<'de> for OutputType {
 /// Request-body compression configured for output sinks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum CompressionFormat {
     None,
     Gzip,
@@ -192,6 +193,7 @@ impl fmt::Display for CompressionFormat {
 /// OTLP transport protocol configured for OTLP outputs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum OtlpProtocol {
     Http,
     Grpc,
@@ -209,6 +211,7 @@ impl fmt::Display for OtlpProtocol {
 /// Elasticsearch bulk request construction mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ElasticsearchRequestMode {
     Buffered,
     Streaming,

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -170,6 +170,59 @@ impl<'de> Deserialize<'de> for OutputType {
     }
 }
 
+/// Request-body compression configured for output sinks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CompressionFormat {
+    None,
+    Gzip,
+    Zstd,
+}
+
+impl fmt::Display for CompressionFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompressionFormat::None => f.write_str("none"),
+            CompressionFormat::Gzip => f.write_str("gzip"),
+            CompressionFormat::Zstd => f.write_str("zstd"),
+        }
+    }
+}
+
+/// OTLP transport protocol configured for OTLP outputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OtlpProtocol {
+    Http,
+    Grpc,
+}
+
+impl fmt::Display for OtlpProtocol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OtlpProtocol::Http => f.write_str("http"),
+            OtlpProtocol::Grpc => f.write_str("grpc"),
+        }
+    }
+}
+
+/// Elasticsearch bulk request construction mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ElasticsearchRequestMode {
+    Buffered,
+    Streaming,
+}
+
+impl fmt::Display for ElasticsearchRequestMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ElasticsearchRequestMode::Buffered => f.write_str("buffered"),
+            ElasticsearchRequestMode::Streaming => f.write_str("streaming"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
@@ -767,9 +820,9 @@ pub struct OutputConfig {
     pub name: Option<String>,
     pub output_type: OutputType,
     pub endpoint: Option<String>,
-    pub protocol: Option<String>,
-    pub compression: Option<String>,
-    pub request_mode: Option<String>,
+    pub protocol: Option<OtlpProtocol>,
+    pub compression: Option<CompressionFormat>,
+    pub request_mode: Option<ElasticsearchRequestMode>,
     pub format: Option<Format>,
     pub path: Option<String>,
     pub index: Option<String>,
@@ -835,8 +888,8 @@ impl From<&OutputConfig> for OutputConfigV2 {
             OutputType::Otlp => OutputConfigV2::Otlp(OtlpOutputConfig {
                 name: config.name.clone(),
                 endpoint: config.endpoint.clone(),
-                protocol: config.protocol.clone(),
-                compression: config.compression.clone(),
+                protocol: config.protocol,
+                compression: config.compression,
                 auth: config.auth.clone(),
                 tls: config.tls.clone(),
                 headers: config.headers.clone(),
@@ -850,15 +903,15 @@ impl From<&OutputConfig> for OutputConfigV2 {
             OutputType::Http => OutputConfigV2::Http(HttpOutputConfig {
                 name: config.name.clone(),
                 endpoint: config.endpoint.clone(),
-                compression: config.compression.clone(),
+                compression: config.compression,
                 format: config.format.clone(),
                 auth: config.auth.clone(),
             }),
             OutputType::Elasticsearch => OutputConfigV2::Elasticsearch(ElasticsearchOutputConfig {
                 name: config.name.clone(),
                 endpoint: config.endpoint.clone(),
-                compression: config.compression.clone(),
-                request_mode: config.request_mode.clone(),
+                compression: config.compression,
+                request_mode: config.request_mode,
                 index: config.index.clone().or_else(|| config.path.clone()),
                 auth: config.auth.clone(),
                 tls: config.tls.clone(),
@@ -886,7 +939,7 @@ impl From<&OutputConfig> for OutputConfigV2 {
             OutputType::Parquet => OutputConfigV2::Parquet(ParquetOutputConfig {
                 name: config.name.clone(),
                 path: config.path.clone(),
-                compression: config.compression.clone(),
+                compression: config.compression,
                 format: config.format.clone(),
             }),
             OutputType::Null => OutputConfigV2::Null(NullOutputConfig {
@@ -903,7 +956,7 @@ impl From<&OutputConfig> for OutputConfigV2 {
             OutputType::ArrowIpc => OutputConfigV2::ArrowIpc(ArrowIpcOutputConfig {
                 name: config.name.clone(),
                 endpoint: config.endpoint.clone(),
-                compression: config.compression.clone(),
+                compression: config.compression,
                 auth: config.auth.clone(),
                 host: config.host.clone(),
                 port: config.port,
@@ -925,12 +978,12 @@ pub struct OutputConfigV1 {
     pub output_type: OutputType,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub endpoint: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub protocol: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub compression: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub request_mode: Option<String>,
+    #[serde(default)]
+    pub protocol: Option<OtlpProtocol>,
+    #[serde(default)]
+    pub compression: Option<CompressionFormat>,
+    #[serde(default)]
+    pub request_mode: Option<ElasticsearchRequestMode>,
     pub format: Option<Format>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub path: Option<String>,
@@ -1184,10 +1237,10 @@ pub struct OtlpOutputConfig {
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub endpoint: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub protocol: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub compression: Option<String>,
+    #[serde(default)]
+    pub protocol: Option<OtlpProtocol>,
+    #[serde(default)]
+    pub compression: Option<CompressionFormat>,
     #[serde(default)]
     pub auth: Option<AuthConfig>,
     #[serde(default)]
@@ -1240,8 +1293,8 @@ pub struct HttpOutputConfig {
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub endpoint: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub compression: Option<String>,
+    #[serde(default)]
+    pub compression: Option<CompressionFormat>,
     pub format: Option<Format>,
     #[serde(default)]
     pub auth: Option<AuthConfig>,
@@ -1268,10 +1321,10 @@ pub struct ElasticsearchOutputConfig {
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub endpoint: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub compression: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub request_mode: Option<String>,
+    #[serde(default)]
+    pub compression: Option<CompressionFormat>,
+    #[serde(default)]
+    pub request_mode: Option<ElasticsearchRequestMode>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub index: Option<String>,
     #[serde(default)]
@@ -1393,8 +1446,8 @@ pub struct ParquetOutputConfig {
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub path: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub compression: Option<String>,
+    #[serde(default)]
+    pub compression: Option<CompressionFormat>,
     pub format: Option<Format>,
 }
 
@@ -1455,8 +1508,8 @@ pub struct ArrowIpcOutputConfig {
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub endpoint: Option<String>,
-    #[serde(default, deserialize_with = "deserialize_option_strict_string")]
-    pub compression: Option<String>,
+    #[serde(default)]
+    pub compression: Option<CompressionFormat>,
     #[serde(default)]
     pub auth: Option<AuthConfig>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -861,24 +861,72 @@ pub struct OutputConfig {
     pub write_schema_on_connect: Option<bool>,
 }
 
+/// Deserializes an output config by trying V2 (typed) first, falling back to V1
+/// (legacy flat). Uses a visitor to consume the map from the original
+/// deserializer, preserving YAML source locations for error messages instead of
+/// round-tripping through an intermediate `serde_yaml_ng::Value`.
+fn deserialize_output_with_fallback<'de, D, T>(
+    deserializer: D,
+    from_v2: impl FnOnce(OutputConfigV2) -> T,
+    from_v1: impl FnOnce(OutputConfigV1) -> T,
+) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::value::MapDeserializer;
+
+    struct OutputMapVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for OutputMapVisitor {
+        type Value = Vec<(serde_yaml_ng::Value, serde_yaml_ng::Value)>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("an output configuration mapping")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut entries = Vec::with_capacity(map.size_hint().unwrap_or(0));
+            while let Some(entry) =
+                map.next_entry::<serde_yaml_ng::Value, serde_yaml_ng::Value>()?
+            {
+                entries.push(entry);
+            }
+            Ok(entries)
+        }
+    }
+
+    let entries: Vec<(serde_yaml_ng::Value, serde_yaml_ng::Value)> =
+        deserializer.deserialize_map(OutputMapVisitor)?;
+
+    // Try the V2 typed schema first via a replayed map deserializer.
+    let v2_error = {
+        let de = MapDeserializer::new(entries.clone().into_iter());
+        match OutputConfigV2::deserialize(de) {
+            Ok(v2) => return Ok(from_v2(v2)),
+            Err(error) => error,
+        }
+    };
+
+    // Fall back to the V1 flat schema.
+    let de = MapDeserializer::new(entries.into_iter());
+    OutputConfigV1::deserialize(de)
+        .map(from_v1)
+        .map_err(|v1_error| {
+            serde::de::Error::custom(format!(
+                "invalid output config; v2 parse error: {v2_error}; legacy parse error: {v1_error}"
+            ))
+        })
+}
+
 impl<'de> Deserialize<'de> for OutputConfig {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        let value = serde_yaml_ng::Value::deserialize(deserializer)?;
-        let v2_error = match OutputConfigV2::deserialize(value.clone()) {
-            Ok(v2) => return Ok(v2.into()),
-            Err(error) => error,
-        };
-
-        OutputConfigV1::deserialize(value)
-            .map(OutputConfig::from)
-            .map_err(|v1_error| {
-                serde::de::Error::custom(format!(
-                    "invalid output config; v2 parse error: {v2_error}; legacy parse error: {v1_error}"
-                ))
-            })
+        deserialize_output_with_fallback(deserializer, OutputConfig::from, OutputConfig::from)
     }
 }
 
@@ -1216,20 +1264,11 @@ impl<'de> Deserialize<'de> for OutputConfigEntry {
     where
         D: serde::Deserializer<'de>,
     {
-        let value = serde_yaml_ng::Value::deserialize(deserializer)?;
-        let v2_error = match OutputConfigV2::deserialize(value.clone()) {
-            Ok(config) => return Ok(OutputConfigEntry::from(config)),
-            Err(error) => error,
-        };
-
-        OutputConfigV1::deserialize(value)
-            .map(OutputConfig::from)
-            .map(OutputConfigEntry::from)
-            .map_err(|v1_error| {
-                serde::de::Error::custom(format!(
-                    "invalid output config; v2 parse error: {v2_error}; legacy parse error: {v1_error}"
-                ))
-            })
+        deserialize_output_with_fallback(
+            deserializer,
+            OutputConfigEntry::from,
+            |v1: OutputConfigV1| OutputConfigEntry::from(OutputConfig::from(v1)),
+        )
     }
 }
 

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1,7 +1,7 @@
 use crate::types::{
-    Config, ConfigError, EnrichmentConfig, Format, GeneratorAttributeValueConfig,
-    GeneratorProfileConfig, InputType, InputTypeConfig, JournaldBackendConfig, OutputType,
-    PIPELINE_WORKERS_MAX,
+    CompressionFormat, Config, ConfigError, ElasticsearchRequestMode, EnrichmentConfig, Format,
+    GeneratorAttributeValueConfig, GeneratorProfileConfig, InputType, InputTypeConfig,
+    JournaldBackendConfig, OutputType, PIPELINE_WORKERS_MAX,
 };
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
@@ -713,15 +713,10 @@ impl Config {
                                         "pipeline '{name}' output '{label}': elasticsearch index '{idx}' {reason}"
                                     )));
                                 }
-                                if let Some(mode) = output.request_mode.as_deref()
-                                    && !matches!(mode, "buffered" | "streaming")
-                                {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' output '{label}': elasticsearch request_mode must be 'buffered' or 'streaming'"
-                                    )));
-                                }
-                                if output.request_mode.as_deref() == Some("streaming")
-                                    && output.compression.as_deref() == Some("gzip")
+                                if matches!(
+                                    output.request_mode,
+                                    Some(ElasticsearchRequestMode::Streaming)
+                                ) && matches!(output.compression, Some(CompressionFormat::Gzip))
                                 {
                                     return Err(ConfigError::Validation(format!(
                                         "pipeline '{name}' output '{label}': elasticsearch request_mode 'streaming' does not support gzip compression yet"
@@ -805,8 +800,8 @@ impl Config {
                         )));
                     }
                     if output.output_type == OutputType::ArrowIpc
-                        && let Some(c) = output.compression.as_deref()
-                        && !matches!(c, "zstd" | "none")
+                        && let Some(c) = output.compression
+                        && !matches!(c, CompressionFormat::Zstd | CompressionFormat::None)
                     {
                         return Err(ConfigError::Validation(format!(
                             "pipeline '{name}' output '{label}': arrow_ipc output only supports 'zstd' or 'none' compression, not '{c}'"
@@ -875,28 +870,20 @@ impl Config {
                             "pipeline '{name}' output '{label}': 'protocol' is only supported for otlp outputs"
                         )));
                     }
-                    // Validate OTLP protocol value (#1876).
-                    if output.output_type == OutputType::Otlp
-                        && let Some(p) = output.protocol.as_deref()
-                        && !matches!(p, "http" | "grpc")
-                    {
-                        return Err(ConfigError::Validation(format!(
-                            "pipeline '{name}' output '{label}': otlp protocol must be 'http' or 'grpc', got '{p}'"
-                        )));
-                    }
-                    // Validate compression values per output type (#1876).
-                    if let Some(c) = output.compression.as_deref() {
+                    // Validate compression values per output type.
+                    if let Some(c) = output.compression {
                         match output.output_type {
-                            OutputType::Otlp if !matches!(c, "zstd" | "gzip" | "none") => {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' output '{label}': otlp compression must be 'zstd', 'gzip', or 'none', got '{c}'"
-                                )));
-                            }
-                            OutputType::Elasticsearch if !matches!(c, "gzip" | "none") => {
+                            OutputType::Elasticsearch
+                                if !matches!(
+                                    c,
+                                    CompressionFormat::Gzip | CompressionFormat::None
+                                ) =>
+                            {
                                 return Err(ConfigError::Validation(format!(
                                     "pipeline '{name}' output '{label}': elasticsearch compression must be 'gzip' or 'none', got '{c}'"
                                 )));
                             }
+                            // OTLP accepts every `CompressionFormat` variant.
                             // ArrowIpc allows zstd/none and is validated above.
                             // Other types either reject compression entirely or accept any.
                             _ => {}
@@ -2340,7 +2327,7 @@ mod validate_otlp_protocol_compression_tests {
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("protocol") && msg.contains("websocket"),
+            msg.contains("websocket") && msg.contains("http") && msg.contains("grpc"),
             "expected protocol rejection for 'websocket': {msg}"
         );
     }
@@ -2363,7 +2350,7 @@ mod validate_otlp_protocol_compression_tests {
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("compression") && msg.contains("lz4"),
+            msg.contains("lz4") && msg.contains("zstd") && msg.contains("gzip"),
             "expected compression rejection for 'lz4': {msg}"
         );
     }

--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use arrow::ipc::reader::StreamReader;
 use arrow::record_batch::RecordBatch;
 
+pub use logfwd_config::ElasticsearchRequestMode;
 use logfwd_types::diagnostics::ComponentStats;
 use logfwd_types::field_names;
 use tokio::sync::mpsc;
@@ -35,12 +36,6 @@ pub(crate) struct ElasticsearchConfig {
     /// Precomputed `{"index":{"_index":"<name>"}}\n` bytes — avoids a `format!`
     /// allocation on every `serialize_batch` call.
     action_bytes: Box<[u8]>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ElasticsearchRequestMode {
-    Buffered,
-    Streaming,
 }
 
 /// Async Elasticsearch sink using reqwest.

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -131,7 +131,7 @@ pub fn build_sink_factory_v2(
                 Some(CompressionFormat::None) | None => false,
                 Some(other) => {
                     return Err(OutputError::Construction(format!(
-                        "output '{name}': elasticsearch does not support '{other}' compression (use 'gzip' or omit)"
+                        "output '{name}': elasticsearch does not support '{other}' compression (use 'gzip', 'none', or omit)"
                     )));
                 }
             };
@@ -139,6 +139,11 @@ pub fn build_sink_factory_v2(
                 Some(ElasticsearchRequestMode::Streaming) => ElasticsearchRequestMode::Streaming,
                 Some(ElasticsearchRequestMode::Buffered) | None => {
                     ElasticsearchRequestMode::Buffered
+                }
+                Some(other) => {
+                    return Err(OutputError::Construction(format!(
+                        "output '{name}': unsupported elasticsearch request_mode '{other}' (use 'buffered', 'streaming', or omit)"
+                    )));
                 }
             };
             let factory = ElasticsearchSinkFactory::new_with_client(
@@ -215,6 +220,11 @@ pub fn build_sink_factory_v2(
                 Some(CompressionFormat::Zstd) => Compression::Zstd,
                 Some(CompressionFormat::Gzip) => Compression::Gzip,
                 Some(CompressionFormat::None) | None => Compression::None,
+                Some(other) => {
+                    return Err(OutputError::Construction(format!(
+                        "output '{name}': unknown HTTP compression '{other}' (expected 'zstd', 'gzip', or 'none')"
+                    )));
+                }
             };
             let factory = JsonLinesSinkFactory::new(
                 name.to_string(),
@@ -243,11 +253,21 @@ pub fn build_sink_factory_v2(
             let protocol = match cfg.protocol {
                 Some(OtlpProtocol::Grpc) => OtlpProtocol::Grpc,
                 Some(OtlpProtocol::Http) | None => OtlpProtocol::Http,
+                Some(other) => {
+                    return Err(OutputError::Construction(format!(
+                        "output '{name}': unsupported OTLP protocol '{other}' (use 'http', 'grpc', or omit)"
+                    )));
+                }
             };
             let compression = match cfg.compression {
                 Some(CompressionFormat::Zstd) => Compression::Zstd,
                 Some(CompressionFormat::Gzip) => Compression::Gzip,
                 Some(CompressionFormat::None) | None => Compression::None,
+                Some(other) => {
+                    return Err(OutputError::Construction(format!(
+                        "output '{name}': unknown OTLP compression '{other}' (expected 'zstd', 'gzip', or 'none')"
+                    )));
+                }
             };
 
             let client_builder =

--- a/crates/logfwd-output/src/factory.rs
+++ b/crates/logfwd-output/src/factory.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 #[cfg(test)]
 use logfwd_config::OutputConfig;
-use logfwd_config::{Format, OutputConfigV2, TlsClientConfig};
+use logfwd_config::{CompressionFormat, Format, OtlpProtocol, OutputConfigV2, TlsClientConfig};
 use logfwd_types::diagnostics::ComponentStats;
 
 use crate::arrow_ipc_sink::ArrowIpcSinkFactory;
@@ -16,7 +16,7 @@ use crate::json_lines::JsonLinesSinkFactory;
 use crate::loki::LokiSinkFactory;
 use crate::metadata::Compression;
 use crate::null::NullSinkFactory;
-use crate::otlp_sink::{OtlpProtocol, OtlpSinkFactory};
+use crate::otlp_sink::OtlpSinkFactory;
 use crate::sink::SinkFactory;
 use crate::stdout::{StdoutFormat, StdoutSinkFactory};
 use crate::tcp_sink::TcpSinkFactory;
@@ -95,7 +95,7 @@ pub(crate) fn build_sink_factory(
     stats: Arc<ComponentStats>,
 ) -> Result<Arc<dyn SinkFactory>, OutputError> {
     if cfg.output_type == logfwd_config::OutputType::File
-        && let Some(compression) = cfg.compression.as_deref()
+        && let Some(compression) = cfg.compression
     {
         return Err(OutputError::Construction(format!(
             "output '{name}': file does not support '{compression}' compression"
@@ -126,18 +126,20 @@ pub fn build_sink_factory_v2(
                 .as_ref()
                 .map_or("logs", String::as_str)
                 .to_string();
-            let compress = match cfg.compression.as_deref() {
-                Some("gzip") => true,
-                Some("none") | None => false,
+            let compress = match cfg.compression {
+                Some(CompressionFormat::Gzip) => true,
+                Some(CompressionFormat::None) | None => false,
                 Some(other) => {
                     return Err(OutputError::Construction(format!(
                         "output '{name}': elasticsearch does not support '{other}' compression (use 'gzip' or omit)"
                     )));
                 }
             };
-            let request_mode = match cfg.request_mode.as_deref() {
-                Some("streaming") => ElasticsearchRequestMode::Streaming,
-                _ => ElasticsearchRequestMode::Buffered,
+            let request_mode = match cfg.request_mode {
+                Some(ElasticsearchRequestMode::Streaming) => ElasticsearchRequestMode::Streaming,
+                Some(ElasticsearchRequestMode::Buffered) | None => {
+                    ElasticsearchRequestMode::Buffered
+                }
             };
             let factory = ElasticsearchSinkFactory::new_with_client(
                 name.to_string(),
@@ -183,15 +185,14 @@ pub fn build_sink_factory_v2(
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': arrow_ipc requires 'endpoint'"))
             })?;
-            let compression = match cfg.compression.as_deref() {
-                Some("zstd") => Compression::Zstd,
-                Some("none") => Compression::None,
+            let compression = match cfg.compression {
+                Some(CompressionFormat::Zstd) => Compression::Zstd,
+                Some(CompressionFormat::None) | None => Compression::None,
                 Some(other) => {
                     return Err(OutputError::Construction(format!(
                         "output '{name}': arrow_ipc does not support '{other}' compression (use 'zstd', 'none', or omit)"
                     )));
                 }
-                None => Compression::None,
             };
             let factory = ArrowIpcSinkFactory::new(
                 name.to_string(),
@@ -210,15 +211,10 @@ pub fn build_sink_factory_v2(
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': http requires 'endpoint'"))
             })?;
-            let compression = match cfg.compression.as_deref() {
-                Some("zstd") => Compression::Zstd,
-                Some("gzip") => Compression::Gzip,
-                Some("none") | None => Compression::None,
-                Some(other) => {
-                    return Err(OutputError::Construction(format!(
-                        "output '{name}': unknown HTTP compression '{other}' (expected 'zstd', 'gzip', or 'none')"
-                    )));
-                }
+            let compression = match cfg.compression {
+                Some(CompressionFormat::Zstd) => Compression::Zstd,
+                Some(CompressionFormat::Gzip) => Compression::Gzip,
+                Some(CompressionFormat::None) | None => Compression::None,
             };
             let factory = JsonLinesSinkFactory::new(
                 name.to_string(),
@@ -244,24 +240,14 @@ pub fn build_sink_factory_v2(
             let endpoint = cfg.endpoint.as_ref().ok_or_else(|| {
                 OutputError::Construction(format!("output '{name}': OTLP requires 'endpoint'"))
             })?;
-            let protocol = match cfg.protocol.as_deref() {
-                Some("grpc") => OtlpProtocol::Grpc,
-                Some("http") | None => OtlpProtocol::Http,
-                Some(other) => {
-                    return Err(OutputError::Construction(format!(
-                        "output '{name}': unknown OTLP protocol '{other}' (expected 'http' or 'grpc')"
-                    )));
-                }
+            let protocol = match cfg.protocol {
+                Some(OtlpProtocol::Grpc) => OtlpProtocol::Grpc,
+                Some(OtlpProtocol::Http) | None => OtlpProtocol::Http,
             };
-            let compression = match cfg.compression.as_deref() {
-                Some("zstd") => Compression::Zstd,
-                Some("gzip") => Compression::Gzip,
-                Some("none") | None => Compression::None,
-                Some(other) => {
-                    return Err(OutputError::Construction(format!(
-                        "output '{name}': unknown OTLP compression '{other}' (expected 'zstd', 'gzip', or 'none')"
-                    )));
-                }
+            let compression = match cfg.compression {
+                Some(CompressionFormat::Zstd) => Compression::Zstd,
+                Some(CompressionFormat::Gzip) => Compression::Gzip,
+                Some(CompressionFormat::None) | None => Compression::None,
             };
 
             let client_builder =
@@ -383,7 +369,9 @@ mod tests {
     use std::fs;
     use std::sync::Arc;
 
-    use logfwd_config::{OutputConfig, OutputConfigV2, OutputType, StdoutOutputConfig};
+    use logfwd_config::{
+        CompressionFormat, OutputConfig, OutputConfigV2, OutputType, StdoutOutputConfig,
+    };
     use logfwd_types::diagnostics::ComponentStats;
 
     #[test]
@@ -391,7 +379,7 @@ mod tests {
         let cfg = OutputConfig {
             output_type: OutputType::ArrowIpc,
             endpoint: Some("http://localhost:4318/v1/logs".to_string()),
-            compression: Some("none".to_string()),
+            compression: Some(CompressionFormat::None),
             ..Default::default()
         };
 

--- a/crates/logfwd-output/src/lib.rs
+++ b/crates/logfwd-output/src/lib.rs
@@ -30,6 +30,7 @@ pub use error::OutputError;
 pub use factory::build_sink_factory_v2;
 pub use file_sink::{FileSink, FileSinkFactory};
 pub use json_lines::{JsonLinesSink, JsonLinesSinkFactory};
+pub use logfwd_config::OtlpProtocol;
 pub use loki::{LokiSink, LokiSinkFactory};
 pub use metadata::{BatchMetadata, Compression};
 pub use null::{NullSink, NullSinkFactory};
@@ -39,7 +40,7 @@ pub use otap_sink::{
     decode_batch_status_generated_fast, encode_batch_arrow_records,
     encode_batch_arrow_records_generated_fast,
 };
-pub use otlp_sink::{OtlpProtocol, OtlpSink, OtlpSinkFactory};
+pub use otlp_sink::{OtlpSink, OtlpSinkFactory};
 pub use sink::{
     AsyncFanoutFactory, AsyncFanoutSink, OnceAsyncFactory, SendResult, Sink, SinkFactory,
 };

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -540,6 +540,12 @@ impl OtlpSink {
         let content_type = match self.protocol {
             OtlpProtocol::Grpc => "application/grpc",
             OtlpProtocol::Http => "application/x-protobuf",
+            other => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unsupported OTLP protocol '{other}'"),
+                ));
+            }
         };
 
         // For gRPC, prepend the 5-byte length-prefixed frame header required by the

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -16,6 +16,7 @@ use flate2::Compression as GzipLevel;
 use flate2::write::GzEncoder;
 
 use logfwd_arrow::conflict_schema::normalize_conflict_columns;
+use logfwd_config::OtlpProtocol;
 use logfwd_core::otlp::{
     self, Severity, bytes_field_size, encode_bytes_field, encode_fixed32, encode_fixed64,
     encode_tag, encode_varint, encode_varint_field, hex_decode, parse_severity,
@@ -46,14 +47,6 @@ const DEFAULT_GRPC_MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 // ---------------------------------------------------------------------------
 // OtlpSink
 // ---------------------------------------------------------------------------
-
-/// OTLP transport protocol.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum OtlpProtocol {
-    Grpc,
-    Http,
-}
 
 /// Sends OTLP protobuf LogRecords over gRPC or HTTP.
 pub struct OtlpSink {

--- a/crates/logfwd-output/src/tests.rs
+++ b/crates/logfwd-output/src/tests.rs
@@ -5,7 +5,7 @@ use arrow::datatypes::DataType;
 use arrow::datatypes::{Field, Schema};
 use arrow::record_batch::RecordBatch;
 use logfwd_config::OutputType;
-use logfwd_config::{Format, OutputConfig};
+use logfwd_config::{CompressionFormat, Format, OtlpProtocol, OutputConfig};
 use logfwd_types::diagnostics::ComponentStats;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -357,7 +357,7 @@ fn test_build_sink_factory_file_rejects_compression() {
         name: Some("capture".to_string()),
         output_type: OutputType::File,
         path: Some("/tmp/capture.ndjson".to_string()),
-        compression: Some("zstd".to_string()),
+        compression: Some(CompressionFormat::Zstd),
         ..Default::default()
     };
 
@@ -377,8 +377,8 @@ fn test_build_sink_factory_otlp_accepts_gzip() {
         name: Some("otel".to_string()),
         output_type: OutputType::Otlp,
         endpoint: Some("http://localhost:4318".to_string()),
-        protocol: Some("http".to_string()),
-        compression: Some("gzip".to_string()),
+        protocol: Some(OtlpProtocol::Http),
+        compression: Some(CompressionFormat::Gzip),
         ..Default::default()
     };
     build_sink_factory("otel", &cfg, None, Arc::new(ComponentStats::new()))
@@ -391,7 +391,7 @@ fn test_build_sink_factory_http_supported() {
         name: Some("http-ok".to_string()),
         output_type: OutputType::Http,
         endpoint: Some("http://localhost:9200".to_string()),
-        compression: Some("gzip".to_string()),
+        compression: Some(CompressionFormat::Gzip),
         ..Default::default()
     };
     let result = build_sink_factory("http-ok", &cfg, None, Arc::new(ComponentStats::new()));
@@ -404,7 +404,7 @@ fn test_build_sink_factory_elasticsearch_rejects_unknown_compression() {
         name: Some("es".to_string()),
         output_type: OutputType::Elasticsearch,
         endpoint: Some("http://localhost:9200".to_string()),
-        compression: Some("zstd".to_string()),
+        compression: Some(CompressionFormat::Zstd),
         ..Default::default()
     };
     let err = match build_sink_factory("es", &cfg, None, Arc::new(ComponentStats::new())) {

--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -587,8 +587,7 @@ fn build_meter_provider(
         let interval_secs = config
             .server
             .metrics_interval_secs
-            .map(|v| v.get())
-            .unwrap_or(60);
+            .map_or(60, logfwd_config::PositiveSecs::get);
 
         let otlp_exporter = opentelemetry_otlp::MetricExporter::builder()
             .with_http()

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -114,7 +114,10 @@ impl Pipeline {
                                 }
                             };
 
-                        if let Some(interval_secs) = geo_cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = geo_cfg
+                            .refresh_interval
+                            .map(logfwd_config::PositiveSecs::get)
+                        {
                             let reloadable = Arc::new(
                                 crate::transform::enrichment::ReloadableGeoDb::new(initial_db),
                             );
@@ -221,7 +224,9 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) =
+                            cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
+                        {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -273,7 +278,9 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) =
+                            cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
+                        {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -338,7 +345,9 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) =
+                            cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
+                        {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -4,9 +4,9 @@ use std::time::Duration;
 
 use opentelemetry::metrics::Meter;
 
+use logfwd_config::{CompressionFormat, Format, InputTypeConfig, OutputConfigV2, PipelineConfig};
 #[cfg(feature = "datafusion")]
 use logfwd_config::{EnrichmentConfig, GeoDatabaseFormat};
-use logfwd_config::{Format, InputTypeConfig, OutputConfigV2, PipelineConfig};
 use logfwd_diagnostics::diagnostics::PipelineMetrics;
 use logfwd_io::checkpoint::{
     CheckpointStore, FileCheckpointStore, SourceCheckpoint, default_data_dir,
@@ -557,7 +557,7 @@ impl Pipeline {
             build_output_factory_from_config(
                 0,
                 output_cfg.typed(),
-                output_cfg.compression.as_deref(),
+                output_cfg.compression,
                 base_path,
                 &mut metrics,
             )?
@@ -567,7 +567,7 @@ impl Pipeline {
                 factories.push(build_output_factory_from_config(
                     i,
                     output_cfg.typed(),
-                    output_cfg.compression.as_deref(),
+                    output_cfg.compression,
                     base_path,
                     &mut metrics,
                 )?);
@@ -640,7 +640,7 @@ impl Pipeline {
 fn build_output_factory_from_config(
     index: usize,
     output_cfg: &OutputConfigV2,
-    legacy_file_compression: Option<&str>,
+    legacy_file_compression: Option<CompressionFormat>,
     base_path: Option<&Path>,
     metrics: &mut PipelineMetrics,
 ) -> Result<Arc<dyn SinkFactory>, String> {
@@ -682,7 +682,8 @@ fn should_open_checkpoint_store(checkpoint_dir: &Path, has_explicit_data_dir: bo
 mod tests {
     use super::*;
     use logfwd_config::{
-        InputConfig, InputTypeConfig, OutputConfig, OutputConfigV2, OutputType, StdoutOutputConfig,
+        CompressionFormat, InputConfig, InputTypeConfig, OutputConfig, OutputConfigV2, OutputType,
+        StdoutOutputConfig,
     };
 
     fn minimal_input(path: String) -> InputConfig {
@@ -754,7 +755,7 @@ mod tests {
             OutputConfig {
                 output_type: OutputType::File,
                 path: Some(dir.path().join("out.log").display().to_string()),
-                compression: Some("gzip".to_string()),
+                compression: Some(CompressionFormat::Gzip),
                 ..Default::default()
             }
             .into(),

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -511,7 +511,7 @@ pub(super) fn build_input_state(
                         .sensor
                         .as_ref()
                         .and_then(|c| c.poll_interval_ms)
-                        .map(|v| v.get()),
+                        .map(logfwd_config::PositiveMillis::get),
                 };
 
                 let source = PlatformSensorInput::new(name, sensor_cfg).map_err(|e| {
@@ -637,7 +637,9 @@ pub(super) fn build_input_state(
                     s3_cfg.max_concurrent_objects,
                     s3_cfg.visibility_timeout_secs,
                     compression_override,
-                    s3_cfg.poll_interval_ms.map(|v| v.get()),
+                    s3_cfg
+                        .poll_interval_ms
+                        .map(logfwd_config::PositiveMillis::get),
                 )
                 .map_err(|e| format!("input '{name}': {e}"))?;
 

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -155,10 +155,10 @@ pub(super) fn build_input_state(
             let format = cfg.format.clone().unwrap_or(Format::Auto);
             let mut tail_config = TailConfig {
                 start_from_end: false,
-                poll_interval_ms: f
-                    .poll_interval_ms
-                    .map(|v| v.get())
-                    .unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
+                poll_interval_ms: f.poll_interval_ms.map_or(
+                    DEFAULT_FILE_POLL_INTERVAL_MS,
+                    logfwd_config::PositiveMillis::get,
+                ),
                 read_buf_size: f.read_buf_size.unwrap_or(DEFAULT_READ_BUF_SIZE),
                 per_file_read_budget_bytes: f
                     .per_file_read_budget_bytes
@@ -709,14 +709,14 @@ pub(super) fn build_input_state(
 fn build_host_metrics_config(
     cfg: Option<&HostMetricsInputConfig>,
 ) -> logfwd_io::host_metrics::HostMetricsConfig {
-    let poll_interval_ms = cfg
-        .and_then(|c| c.poll_interval_ms)
-        .map(|v| v.get())
-        .unwrap_or(DEFAULT_SENSOR_POLL_INTERVAL_MS);
-    let control_reload_interval_ms = cfg
-        .and_then(|c| c.control_reload_interval_ms)
-        .map(|v| v.get())
-        .unwrap_or(DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS);
+    let poll_interval_ms = cfg.and_then(|c| c.poll_interval_ms).map_or(
+        DEFAULT_SENSOR_POLL_INTERVAL_MS,
+        logfwd_config::PositiveMillis::get,
+    );
+    let control_reload_interval_ms = cfg.and_then(|c| c.control_reload_interval_ms).map_or(
+        DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS,
+        logfwd_config::PositiveMillis::get,
+    );
     logfwd_io::host_metrics::HostMetricsConfig {
         poll_interval: std::time::Duration::from_millis(poll_interval_ms),
         control_path: cfg.and_then(|c| c.control_path.clone()).map(PathBuf::from),

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -843,7 +843,9 @@ mod tests {
     use std::time::Instant;
 
     use arrow::record_batch::RecordBatch;
-    use logfwd_config::{Format, OutputConfig, OutputConfigV2, OutputType};
+    use logfwd_config::{
+        CompressionFormat, Format, OtlpProtocol, OutputConfig, OutputConfigV2, OutputType,
+    };
     use logfwd_core::scan_config::ScanConfig;
     use logfwd_diagnostics::diagnostics::ComponentStats;
     use logfwd_output::{
@@ -901,8 +903,8 @@ mod tests {
             name: Some("otel".to_string()),
             output_type: OutputType::Otlp,
             endpoint: Some("http://localhost:4318".to_string()),
-            protocol: Some("http".to_string()),
-            compression: Some("zstd".to_string()),
+            protocol: Some(OtlpProtocol::Http),
+            compression: Some(CompressionFormat::Zstd),
             ..Default::default()
         };
         let typed = OutputConfigV2::from(&cfg);


### PR DESCRIPTION
## Summary

- Add config-owned typed enums for output `compression`, OTLP `protocol`, and Elasticsearch `request_mode`.
- Apply those enum types across legacy `OutputConfig` and typed `OutputConfigV2` output structs, then update output factory/runtime call sites to match on enums instead of strings.
- Preserve parse-time enum errors through direct one-or-many deserialization and keep per-output semantic validation for unsupported combinations.
- Add `#[non_exhaustive]` to the public config enums, update downstream matches, and refresh configuration docs.
- Carry small runtime clippy cleanups required by current `main` after the PositiveMillis/PositiveSecs merge.

Closes #2355.

## Tests

- `cargo fmt --check`
- `cargo check -p logfwd-config -p logfwd-output -p logfwd-runtime -p logfwd-bench`
- `cargo test -p logfwd-config --lib`
- `cargo test -p logfwd-output build_sink_factory --lib`
- `cargo test -p logfwd-runtime pipeline::build --lib`
- `cargo clippy -p logfwd-config -p logfwd-output -p logfwd-runtime -p logfwd-bench -- -D warnings`
- `cargo clippy --workspace -- -D warnings` attempted locally, but macOS cannot compile Linux eBPF/aya dependencies; the CI failure it exposed was fixed.
- `git diff --check`
- `just ci` (`1827` passed, `43` skipped)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace string fields with typed enums for output config compression, protocol, and request_mode
> - Introduces `CompressionFormat`, `OtlpProtocol`, and `ElasticsearchRequestMode` enums in [types.rs](https://github.com/strawgate/fastforward/pull/2371/files#diff-62e3ac9382eb657aa94241b95339050d93e352844aef7d3a16f2bf66bb681a91), replacing `Option<String>` fields across all output config structs.
> - Invalid enum values (e.g. unknown compression formats, unsupported protocols) are now rejected at parse time with error messages listing the bad value and valid variants.
> - Validation logic in [validate.rs](https://github.com/strawgate/fastforward/pull/2371/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) and [factory.rs](https://github.com/strawgate/fastforward/pull/2371/files#diff-38138875bb6a160b3328cc8507d27d322ae4c2f810e755490e66ce6088078fac) is updated to match on enum variants instead of string comparisons.
> - `OtlpProtocol` is consolidated to originate from `logfwd-config`; the duplicate local definitions in [otlp_sink.rs](https://github.com/strawgate/fastforward/pull/2371/files#diff-56ca7e19db98793b4ef621c0d28a618a4c8af2bd492bc89cc8a21e845f25a43c) and [elasticsearch.rs](https://github.com/strawgate/fastforward/pull/2371/files#diff-b9095bc7efeb6ecbe346137059311c896d924d2c2f753a727aa4781e16486def) are removed.
> - Behavioral Change: error messages for unsupported protocol/compression/request_mode values have changed wording; previously invalid strings could pass parsing and fail later, now they fail at deserialization.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df3a0a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->