### PR TITLE
fix: satisfy clippy get-method lints

### DIFF
--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -11,6 +11,8 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+use logfwd_config::PositiveSecs;
+
 use crate::pipeline::Pipeline;
 
 /// Error returned while constructing or running the runtime orchestration shell.
@@ -587,8 +589,7 @@ fn build_meter_provider(
         let interval_secs = config
             .server
             .metrics_interval_secs
-            .map(|v| v.get())
-            .unwrap_or(60);
+            .map_or(60, PositiveSecs::get);
 
         let otlp_exporter = opentelemetry_otlp::MetricExporter::builder()
             .with_http()

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -6,7 +6,7 @@ use opentelemetry::metrics::Meter;
 
 #[cfg(feature = "datafusion")]
 use logfwd_config::{EnrichmentConfig, GeoDatabaseFormat};
-use logfwd_config::{Format, InputTypeConfig, OutputConfigV2, PipelineConfig};
+use logfwd_config::{Format, InputTypeConfig, OutputConfigV2, PipelineConfig, PositiveSecs};
 use logfwd_diagnostics::diagnostics::PipelineMetrics;
 use logfwd_io::checkpoint::{
     CheckpointStore, FileCheckpointStore, SourceCheckpoint, default_data_dir,
@@ -114,7 +114,8 @@ impl Pipeline {
                                 }
                             };
 
-                        if let Some(interval_secs) = geo_cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = geo_cfg.refresh_interval.map(PositiveSecs::get)
+                        {
                             let reloadable = Arc::new(
                                 crate::transform::enrichment::ReloadableGeoDb::new(initial_db),
                             );
@@ -221,7 +222,7 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = cfg.refresh_interval.map(PositiveSecs::get) {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -273,7 +274,7 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = cfg.refresh_interval.map(PositiveSecs::get) {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -338,7 +339,7 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = cfg.refresh_interval.map(PositiveSecs::get) {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -6,7 +6,7 @@ use bytes::BytesMut;
 use logfwd_config::{
     Format, GeneratorAttributeValueConfig, GeneratorComplexityConfig, GeneratorProfileConfig,
     HostMetricsInputConfig, HttpMethodConfig, InputConfig, InputType, InputTypeConfig,
-    OtlpProtobufDecodeModeConfig,
+    OtlpProtobufDecodeModeConfig, PositiveMillis,
 };
 use logfwd_diagnostics::diagnostics::ComponentStats;
 use logfwd_io::format::FormatDecoder;
@@ -157,8 +157,7 @@ pub(super) fn build_input_state(
                 start_from_end: false,
                 poll_interval_ms: f
                     .poll_interval_ms
-                    .map(|v| v.get())
-                    .unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
+                    .map_or(DEFAULT_FILE_POLL_INTERVAL_MS, PositiveMillis::get),
                 read_buf_size: f.read_buf_size.unwrap_or(DEFAULT_READ_BUF_SIZE),
                 per_file_read_budget_bytes: f
                     .per_file_read_budget_bytes
@@ -511,7 +510,7 @@ pub(super) fn build_input_state(
                         .sensor
                         .as_ref()
                         .and_then(|c| c.poll_interval_ms)
-                        .map(|v| v.get()),
+                        .map(PositiveMillis::get),
                 };
 
                 let source = PlatformSensorInput::new(name, sensor_cfg).map_err(|e| {
@@ -637,7 +636,7 @@ pub(super) fn build_input_state(
                     s3_cfg.max_concurrent_objects,
                     s3_cfg.visibility_timeout_secs,
                     compression_override,
-                    s3_cfg.poll_interval_ms.map(|v| v.get()),
+                    s3_cfg.poll_interval_ms.map(PositiveMillis::get),
                 )
                 .map_err(|e| format!("input '{name}': {e}"))?;
 
@@ -711,12 +710,11 @@ fn build_host_metrics_config(
 ) -> logfwd_io::host_metrics::HostMetricsConfig {
     let poll_interval_ms = cfg
         .and_then(|c| c.poll_interval_ms)
-        .map(|v| v.get())
-        .unwrap_or(DEFAULT_SENSOR_POLL_INTERVAL_MS);
-    let control_reload_interval_ms = cfg
-        .and_then(|c| c.control_reload_interval_ms)
-        .map(|v| v.get())
-        .unwrap_or(DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS);
+        .map_or(DEFAULT_SENSOR_POLL_INTERVAL_MS, PositiveMillis::get);
+    let control_reload_interval_ms = cfg.and_then(|c| c.control_reload_interval_ms).map_or(
+        DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS,
+        PositiveMillis::get,
+    );
     logfwd_io::host_metrics::HostMetricsConfig {
         poll_interval: std::time::Duration::from_millis(poll_interval_ms),
         control_path: cfg.and_then(|c| c.control_path.clone()).map(PathBuf::from),


### PR DESCRIPTION
## Summary

Fixes the shared runtime Clippy failures currently blocking multiple PRs after the CI Rust/Clippy version started denying `redundant_closure_for_method_calls` and `map_unwrap_or`.

- Replaces `map(|x| x.get())` calls on duration newtypes with `PositiveMillis::get` and `PositiveSecs::get` method references.
- Replaces `map(...).unwrap_or(...)` on optional duration fields with `map_or(...)`.
- Covers both runtime pipeline builders and the runtime bootstrap metrics interval path.
- Keeps behavior unchanged: all default values and configured interval conversions are the same.

## Why

Open PRs including #2370, #2373, and #2367 were failing the `Lint` job in shared `logfwd-runtime` code rather than in their own changed lines. Landing this first should let those branches re-run or update cleanly.

## Validation

- `just clippy`
- `cargo clippy -p logfwd-runtime -- -D warnings`
- `cargo fmt --check`
- `git diff --check`

Notes:
- Local `just lint` cannot complete on this machine because `python3` is 3.9.6 and `scripts/generate_otlp_projection.py` now uses Python `match` syntax.
- Local `cargo clippy --workspace -- -D warnings` cannot complete on macOS because the Linux eBPF `aya` dependency expects Linux-only libc symbols. GitHub CI runs the workspace lint on Linux and is the authoritative check for that target.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clippy `get-method` lints by using `map_or` with newtype `get` method references
> Replaces `.map(|v| v.get()).unwrap_or(default)` patterns with `.map_or(default, Type::get)` across `bootstrap.rs`, `pipeline/build.rs`, and `pipeline/input_build.rs`. Affects `PositiveSecs` and `PositiveMillis` unwrapping for interval config fields. No behavioral changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d8cc42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->