### PR TITLE
fix: replace redundant closures with PositiveMillis/PositiveSecs method refs

### DIFF
--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -587,8 +587,7 @@ fn build_meter_provider(
         let interval_secs = config
             .server
             .metrics_interval_secs
-            .map(logfwd_config::PositiveSecs::get)
-            .unwrap_or(60);
+            .map_or(60, logfwd_config::PositiveSecs::get);
 
         let otlp_exporter = opentelemetry_otlp::MetricExporter::builder()
             .with_http()

--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -587,7 +587,7 @@ fn build_meter_provider(
         let interval_secs = config
             .server
             .metrics_interval_secs
-            .map(|v| v.get())
+            .map(logfwd_config::PositiveSecs::get)
             .unwrap_or(60);
 
         let otlp_exporter = opentelemetry_otlp::MetricExporter::builder()

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -114,7 +114,10 @@ impl Pipeline {
                                 }
                             };
 
-                        if let Some(interval_secs) = geo_cfg.refresh_interval.map(logfwd_config::PositiveSecs::get) {
+                        if let Some(interval_secs) = geo_cfg
+                            .refresh_interval
+                            .map(logfwd_config::PositiveSecs::get)
+                        {
                             let reloadable = Arc::new(
                                 crate::transform::enrichment::ReloadableGeoDb::new(initial_db),
                             );
@@ -221,7 +224,9 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(logfwd_config::PositiveSecs::get) {
+                        if let Some(interval_secs) =
+                            cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
+                        {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -273,7 +278,9 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(logfwd_config::PositiveSecs::get) {
+                        if let Some(interval_secs) =
+                            cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
+                        {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -338,7 +345,9 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(logfwd_config::PositiveSecs::get) {
+                        if let Some(interval_secs) =
+                            cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
+                        {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -114,7 +114,7 @@ impl Pipeline {
                                 }
                             };
 
-                        if let Some(interval_secs) = geo_cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = geo_cfg.refresh_interval.map(logfwd_config::PositiveSecs::get) {
                             let reloadable = Arc::new(
                                 crate::transform::enrichment::ReloadableGeoDb::new(initial_db),
                             );
@@ -221,7 +221,7 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = cfg.refresh_interval.map(logfwd_config::PositiveSecs::get) {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -273,7 +273,7 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = cfg.refresh_interval.map(logfwd_config::PositiveSecs::get) {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -338,7 +338,7 @@ impl Pipeline {
                         table
                             .reload()
                             .map_err(|e| format!("enrichment '{}': {e}", cfg.table_name))?;
-                        if let Some(interval_secs) = cfg.refresh_interval.map(|s| s.get()) {
+                        if let Some(interval_secs) = cfg.refresh_interval.map(logfwd_config::PositiveSecs::get) {
                             let t = Arc::clone(&table);
                             let name = cfg.table_name.clone();
                             if let Ok(handle) = tokio::runtime::Handle::try_current() {

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -637,7 +637,9 @@ pub(super) fn build_input_state(
                     s3_cfg.max_concurrent_objects,
                     s3_cfg.visibility_timeout_secs,
                     compression_override,
-                    s3_cfg.poll_interval_ms.map(logfwd_config::PositiveMillis::get),
+                    s3_cfg
+                        .poll_interval_ms
+                        .map(logfwd_config::PositiveMillis::get),
                 )
                 .map_err(|e| format!("input '{name}': {e}"))?;
 

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -155,10 +155,10 @@ pub(super) fn build_input_state(
             let format = cfg.format.clone().unwrap_or(Format::Auto);
             let mut tail_config = TailConfig {
                 start_from_end: false,
-                poll_interval_ms: f
-                    .poll_interval_ms
-                    .map(logfwd_config::PositiveMillis::get)
-                    .unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
+                poll_interval_ms: f.poll_interval_ms.map_or(
+                    DEFAULT_FILE_POLL_INTERVAL_MS,
+                    logfwd_config::PositiveMillis::get,
+                ),
                 read_buf_size: f.read_buf_size.unwrap_or(DEFAULT_READ_BUF_SIZE),
                 per_file_read_budget_bytes: f
                     .per_file_read_budget_bytes
@@ -711,14 +711,14 @@ pub(super) fn build_input_state(
 fn build_host_metrics_config(
     cfg: Option<&HostMetricsInputConfig>,
 ) -> logfwd_io::host_metrics::HostMetricsConfig {
-    let poll_interval_ms = cfg
-        .and_then(|c| c.poll_interval_ms)
-        .map(logfwd_config::PositiveMillis::get)
-        .unwrap_or(DEFAULT_SENSOR_POLL_INTERVAL_MS);
-    let control_reload_interval_ms = cfg
-        .and_then(|c| c.control_reload_interval_ms)
-        .map(logfwd_config::PositiveMillis::get)
-        .unwrap_or(DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS);
+    let poll_interval_ms = cfg.and_then(|c| c.poll_interval_ms).map_or(
+        DEFAULT_SENSOR_POLL_INTERVAL_MS,
+        logfwd_config::PositiveMillis::get,
+    );
+    let control_reload_interval_ms = cfg.and_then(|c| c.control_reload_interval_ms).map_or(
+        DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS,
+        logfwd_config::PositiveMillis::get,
+    );
     logfwd_io::host_metrics::HostMetricsConfig {
         poll_interval: std::time::Duration::from_millis(poll_interval_ms),
         control_path: cfg.and_then(|c| c.control_path.clone()).map(PathBuf::from),

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -157,7 +157,7 @@ pub(super) fn build_input_state(
                 start_from_end: false,
                 poll_interval_ms: f
                     .poll_interval_ms
-                    .map(|v| v.get())
+                    .map(logfwd_config::PositiveMillis::get)
                     .unwrap_or(DEFAULT_FILE_POLL_INTERVAL_MS),
                 read_buf_size: f.read_buf_size.unwrap_or(DEFAULT_READ_BUF_SIZE),
                 per_file_read_budget_bytes: f
@@ -511,7 +511,7 @@ pub(super) fn build_input_state(
                         .sensor
                         .as_ref()
                         .and_then(|c| c.poll_interval_ms)
-                        .map(|v| v.get()),
+                        .map(logfwd_config::PositiveMillis::get),
                 };
 
                 let source = PlatformSensorInput::new(name, sensor_cfg).map_err(|e| {
@@ -637,7 +637,7 @@ pub(super) fn build_input_state(
                     s3_cfg.max_concurrent_objects,
                     s3_cfg.visibility_timeout_secs,
                     compression_override,
-                    s3_cfg.poll_interval_ms.map(|v| v.get()),
+                    s3_cfg.poll_interval_ms.map(logfwd_config::PositiveMillis::get),
                 )
                 .map_err(|e| format!("input '{name}': {e}"))?;
 
@@ -711,11 +711,11 @@ fn build_host_metrics_config(
 ) -> logfwd_io::host_metrics::HostMetricsConfig {
     let poll_interval_ms = cfg
         .and_then(|c| c.poll_interval_ms)
-        .map(|v| v.get())
+        .map(logfwd_config::PositiveMillis::get)
         .unwrap_or(DEFAULT_SENSOR_POLL_INTERVAL_MS);
     let control_reload_interval_ms = cfg
         .and_then(|c| c.control_reload_interval_ms)
-        .map(|v| v.get())
+        .map(logfwd_config::PositiveMillis::get)
         .unwrap_or(DEFAULT_SENSOR_CONTROL_RELOAD_INTERVAL_MS);
     logfwd_io::host_metrics::HostMetricsConfig {
         poll_interval: std::time::Duration::from_millis(poll_interval_ms),


### PR DESCRIPTION
Fixes 10 clippy redundant_closure_for_method_calls errors in logfwd-runtime introduced by the PositiveMillis/PositiveSecs newtypes merge.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace redundant closures with `PositiveMillis`/`PositiveSecs` method references
> Replaces `.map(|v| v.get())` closures with direct method references (e.g. `map(logfwd_config::PositiveSecs::get)`) across [bootstrap.rs](https://github.com/strawgate/fastforward/pull/2377/files#diff-851a18d1d09b862e055016804787b7d10ede93b9fda47be883bab270fb223c68), [build.rs](https://github.com/strawgate/fastforward/pull/2377/files#diff-9066bdb853d1e2fff1f2d2ad02a5eb7c17a2b62826ba724bbb990487b851ae83), and [input_build.rs](https://github.com/strawgate/fastforward/pull/2377/files#diff-ca354d25bc72dec0d7f48518cd76a40d5bfab0a1f22f56449adbd8e2a81ffc4f). No logic, defaults, or control flow are changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 883715c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->