### PR TITLE
fix(config): reject null/missing output type instead of silent Null sink

### DIFF
--- a/bench/scenarios/otlp-receiver.yaml
+++ b/bench/scenarios/otlp-receiver.yaml
@@ -2,6 +2,6 @@ input:
   type: otlp
   listen: 127.0.0.1:14318
 output:
-  type: null
+  type: "null"
 server:
   diagnostics: 127.0.0.1:9091

--- a/bench/scenarios/self-bench.yaml
+++ b/bench/scenarios/self-bench.yaml
@@ -3,6 +3,6 @@ input:
 transform: |
   SELECT * FROM logs WHERE level != 'DEBUG'
 output:
-  type: null
+  type: "null"
 server:
   diagnostics: 127.0.0.1:9090

--- a/bench/scenarios/self-ceiling.yaml
+++ b/bench/scenarios/self-ceiling.yaml
@@ -3,6 +3,6 @@ input:
 transform: |
   SELECT * FROM logs
 output:
-  type: null
+  type: "null"
 server:
   diagnostics: 127.0.0.1:9090

--- a/bench/scenarios/tcp-receiver.yaml
+++ b/bench/scenarios/tcp-receiver.yaml
@@ -2,6 +2,6 @@ input:
   type: tcp
   listen: 127.0.0.1:15140
 output:
-  type: null
+  type: "null"
 server:
   diagnostics: 127.0.0.1:9091

--- a/bench/scenarios/udp-receiver.yaml
+++ b/bench/scenarios/udp-receiver.yaml
@@ -2,6 +2,6 @@ input:
   type: udp
   listen: 127.0.0.1:15514
 output:
-  type: null
+  type: "null"
 server:
   diagnostics: 127.0.0.1:9091

--- a/crates/logfwd-config-wasm/src/lib.rs
+++ b/crates/logfwd-config-wasm/src/lib.rs
@@ -304,7 +304,7 @@ const OUTPUT_TEMPLATES: &[OutputTemplate] = &[
         id: "null",
         label: "null sink",
         description: "Discard all logs. Useful for benchmarking.",
-        snippet: "output:\n  type: null\n",
+        snippet: "output:\n  type: \"null\"\n",
         fields: &[],
     },
 ];

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -93,20 +93,20 @@ storage:
 
     #[test]
     fn input_source_metadata_flag_defaults_false_and_parses_true() {
-        let default_yaml = r"
+        let default_yaml = r#"
 input:
   type: file
   path: /var/log/pods/**/*.log
   format: cri
 
 output:
-  type: null
-";
+  type: "null"
+"#;
         let cfg = Config::load_str(default_yaml).expect("default source_metadata should parse");
         let pipe = &cfg.pipelines["default"];
         assert!(!pipe.inputs[0].source_metadata);
 
-        let enabled_yaml = r"
+        let enabled_yaml = r#"
 input:
   type: file
   path: /var/log/pods/**/*.log
@@ -114,8 +114,8 @@ input:
   source_metadata: true
 
 output:
-  type: null
-";
+  type: "null"
+"#;
         let cfg = Config::load_str(enabled_yaml).expect("source_metadata true should parse");
         let pipe = &cfg.pipelines["default"];
         assert!(pipe.inputs[0].source_metadata);
@@ -534,7 +534,7 @@ output:
         for (otype, extra) in [
             ("otlp", "endpoint: http://x:4317"),
             ("stdout", ""),
-            ("null", ""),
+            ("\"null\"", ""),
             ("elasticsearch", "endpoint: http://x"),
             ("loki", "endpoint: http://x"),
             ("arrow_ipc", "endpoint: http://x"),
@@ -1307,24 +1307,28 @@ output:
     }
 
     // -----------------------------------------------------------------------
-    // Bug #707: type: null YAML keyword collision
+    // Bug #707 / #2001: type: null YAML keyword collision
     // -----------------------------------------------------------------------
+    // Unquoted `type: null` is YAML's null value, not the string "null".
+    // Silently treating YAML null as the Null sink caused silent data loss
+    // (#2001). Users must quote the value: `type: "null"`.
 
     #[test]
-    fn type_null_works_in_simple_layout() {
-        // `type: null` in simple layout must parse as OutputType::Null.
+    fn unquoted_type_null_is_rejected_simple_layout() {
+        // Unquoted `type: null` is YAML null — must be rejected, not silently
+        // routed to the Null sink.
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: null\n";
-        let cfg = Config::load_str(yaml).expect("type: null simple layout");
-        assert_eq!(
-            cfg.pipelines["default"].outputs[0].output_type(),
-            OutputType::Null
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid output config"),
+            "unquoted type: null must be rejected: {msg}"
         );
     }
 
     #[test]
-    fn type_null_works_in_advanced_list_layout() {
-        // Before the fix, `type: null` in a YAML list deserialized as the YAML
-        // null scalar, causing serde to fail with a confusing untagged-enum error.
+    fn unquoted_type_null_is_rejected_advanced_list_layout() {
+        // Same as above but in the advanced pipelines layout.
         let yaml = r"
 pipelines:
   app:
@@ -1334,16 +1338,17 @@ pipelines:
     outputs:
       - type: null
 ";
-        let cfg = Config::load_str(yaml).expect("type: null in advanced list layout");
-        assert_eq!(
-            cfg.pipelines["app"].outputs[0].output_type(),
-            OutputType::Null
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid output config") || msg.contains("did not match"),
+            "unquoted type: null in list must be rejected: {msg}"
         );
     }
 
     #[test]
-    fn type_null_quoted_also_works() {
-        // `type: "null"` (quoted string) must continue to work.
+    fn quoted_type_null_creates_null_sink() {
+        // `type: "null"` (quoted string) creates the Null sink intentionally.
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: \"null\"\n";
         let cfg = Config::load_str(yaml).expect("type: \"null\" quoted");
         assert_eq!(
@@ -1382,6 +1387,19 @@ pipelines:
         assert!(
             msg.contains("invalid output config") && msg.contains("unknown variant ``"),
             "empty-string output type must fail clearly: {msg}"
+        );
+    }
+
+    #[test]
+    fn null_output_type_field_is_rejected() {
+        // `type: ~` (YAML null as type value) must not silently become the Null
+        // sink — that would cause silent data loss.
+        let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: ~\n";
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid output config"),
+            "null type field value must be rejected: {msg}"
         );
     }
 
@@ -1986,7 +2004,7 @@ pipelines:
         path: /tmp/test.log
         listen: 127.0.0.1:9999
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("file input must reject listen");
     }
@@ -2001,7 +2019,7 @@ pipelines:
         listen: 0.0.0.0:514
         path: /tmp/test.log
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("tcp input must reject path");
     }
@@ -2016,7 +2034,7 @@ pipelines:
         listen: 0.0.0.0:514
         max_open_files: 128
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("tcp input must reject max_open_files");
     }
@@ -2031,7 +2049,7 @@ pipelines:
         listen: 0.0.0.0:514
         adaptive_fast_polls_max: 4
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("tcp input must reject adaptive_fast_polls_max");
     }
@@ -2050,7 +2068,7 @@ pipelines:
           cert_file: /tmp/server.pem
           key_file: /tmp/server.key
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2073,7 +2091,7 @@ pipelines:
         tls:
           cert_file: /tmp/server.pem
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2097,7 +2115,7 @@ pipelines:
           key_file: /tmp/server.key
           require_client_auth: true
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2121,7 +2139,7 @@ pipelines:
           cert_file: /tmp/server.pem
           key_file: /tmp/server.key
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("udp input must reject tls");
     }
@@ -2136,7 +2154,7 @@ pipelines:
         listen: 0.0.0.0:514
         glob_rescan_interval_ms: 5000
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("tcp input must reject glob_rescan_interval_ms");
     }
@@ -2150,7 +2168,7 @@ pipelines:
       - type: generator
         path: /tmp/test.log
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("generator input must reject path");
     }
@@ -2178,7 +2196,7 @@ pipelines:
           sequence:
             field: seq
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let cfg = Config::load_str(yaml).expect("generator block should be valid");
         let gen_type = match &cfg.pipelines["test"].inputs[0].type_config {
@@ -2235,7 +2253,7 @@ pipelines:
       - type: generator
         listen: "1000"
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("generator input must reject listen");
     }
@@ -2253,7 +2271,7 @@ pipelines:
         generator:
           profile: record
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let _ = Config::load_str(yaml).expect_err("file input must reject generator block");
     }
@@ -2270,7 +2288,7 @@ pipelines:
           sequence:
             field: " "
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2293,7 +2311,7 @@ pipelines:
           sequence:
             field: seq
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2313,7 +2331,7 @@ pipelines:
         generator:
           batch_size: 0
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2334,7 +2352,7 @@ pipelines:
           attributes:
             "": run-123
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2356,7 +2374,7 @@ pipelines:
           attributes:
             ratio: .nan
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2376,7 +2394,7 @@ pipelines:
           profile: record
           event_created_unix_nano_field: " "
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2399,7 +2417,7 @@ pipelines:
             created: run-123
           event_created_unix_nano_field: created
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2422,7 +2440,7 @@ pipelines:
             field: seq
           event_created_unix_nano_field: seq
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2443,7 +2461,7 @@ pipelines:
           attributes:
             benchmark_id: run-123
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2464,7 +2482,7 @@ pipelines:
             start: "2023-06-01T12:00:00Z"
             step_ms: 5000
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let cfg = Config::load_str(yaml).expect("timestamp config should be valid");
         let gen_type = match &cfg.pipelines["test"].inputs[0].type_config {
@@ -2494,7 +2512,7 @@ pipelines:
             start: "now"
             step_ms: -100
     outputs:
-      - type: null
+      - type: "null"
 "#;
         Config::load_str(yaml).expect("timestamp start=now should be valid");
     }
@@ -2510,7 +2528,7 @@ pipelines:
           timestamp:
             step_ms: 0
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2530,7 +2548,7 @@ pipelines:
           timestamp:
             start: "not-a-date"
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2551,7 +2569,7 @@ pipelines:
           timestamp:
             start: "now"
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2572,7 +2590,7 @@ pipelines:
           timestamp:
             start: "2024-02-31T00:00:00Z"
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2592,7 +2610,7 @@ pipelines:
           timestamp:
             start: "2024-13-01T00:00:00Z"
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
@@ -2610,7 +2628,7 @@ pipelines:
       - type: arrow_ipc
         listen: 0.0.0.0:4317
     outputs:
-      - type: null
+      - type: "null"
 "#;
         Config::load_str(yaml).expect("arrow_ipc input should validate when listen is provided");
     }

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -156,14 +156,6 @@ impl<'de> Deserialize<'de> for OutputType {
                     E::unknown_variant(v, compat::supported_output_type_names_for_errors())
                 })
             }
-
-            fn visit_unit<E: serde::de::Error>(self) -> Result<OutputType, E> {
-                Ok(OutputType::Null)
-            }
-
-            fn visit_none<E: serde::de::Error>(self) -> Result<OutputType, E> {
-                Ok(OutputType::Null)
-            }
         }
 
         d.deserialize_any(V)

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -2207,7 +2207,7 @@ pipelines:
           response_code: 204
           response_body: '{"ok":true}'
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).expect_err("204 + response_body must fail validation");
         assert!(
@@ -2229,7 +2229,7 @@ pipelines:
         http:
           max_drained_bytes_per_poll: 0
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(yaml).expect_err("zero drain cap must fail validation");
         assert!(

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -992,7 +992,7 @@ pipelines:
       - name: out1
         type: stdout
       - name: out1
-        type: null
+        type: "null"
 "#;
 
     let output_err = Config::load_str(duplicate_output_yaml)

--- a/crates/logfwd-runtime/src/generated_cli.rs
+++ b/crates/logfwd-runtime/src/generated_cli.rs
@@ -189,7 +189,7 @@ pub fn render_devour_yaml(mode: DevourModeSpec, listen: &str, diagnostics_addr: 
     };
 
     format!(
-        "{input}output:\n  type: null\nserver:\n  diagnostics: {}\n",
+        "{input}output:\n  type: \"null\"\nserver:\n  diagnostics: {}\n",
         yaml_quote(diagnostics_addr),
     )
 }

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -1158,7 +1158,7 @@ input:
       field: seq
     event_created_unix_nano_field: event_created_unix_nano
 output:
-  type: null
+  type: "null"
 "#;
         let config = logfwd_config::Config::load_str(yaml).unwrap();
         let pipe_cfg = &config.pipelines["default"];
@@ -1530,7 +1530,7 @@ input:
       stream_id: emitter-0
 transform: "SELECT nonexistent_col FROM logs"
 output:
-  type: null
+  type: "null"
 "#;
         let config = logfwd_config::Config::load_str(&yaml).unwrap();
         let pipe_cfg = &config.pipelines["default"];

--- a/crates/logfwd/src/config_templates.rs
+++ b/crates/logfwd/src/config_templates.rs
@@ -113,7 +113,7 @@ pub(crate) const OUTPUT_TEMPLATES: &[OutputTemplate] = &[
         id: "null",
         label: "null sink (drop data)",
         description: "Discard all logs. Useful for benchmarking or dry runs.",
-        snippet: "output:\n  type: null\n",
+        snippet: "output:\n  type: \"null\"\n",
     },
 ];
 

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -2797,7 +2797,7 @@ input:
   listen: 127.0.0.1:4318
   format: raw
 output:
-  type: null
+  type: "null"
 "#;
         let config = logfwd_config::Config::load_str(yaml).expect("config should parse");
         let result = validate_pipelines_read_only(&config, None, |_name| {}, |_err| {});
@@ -2811,7 +2811,7 @@ input:
   type: linux_ebpf_sensor
   format: raw
 output:
-  type: null
+  type: "null"
 "#;
         let err = logfwd_config::Config::load_str(yaml)
             .expect_err("sensor format should fail config validation");
@@ -2830,7 +2830,7 @@ input:
   sensor:
     poll_interval_ms: 1000
 output:
-  type: null
+  type: "null"
 "#;
         let config = logfwd_config::Config::load_str(yaml).expect("config should parse");
         validate_pipelines_read_only(&config, None, |_name| {}, |_err| {})
@@ -2858,7 +2858,7 @@ output:
   type: otlp
   listen: 127.0.0.1:{port}
 output:
-  type: null
+  type: "null"
 "#
         )
         .expect("write config");
@@ -2894,7 +2894,7 @@ input:
   type: otlp
   listen: 127.0.0.1:4318
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT level AS x, msg AS x FROM logs
 "#;
@@ -2914,7 +2914,7 @@ input:
   type: otlp
   listen: 127.0.0.1:4318
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT level AS x, msg AS x FROM logs
 "#;
@@ -2937,7 +2937,7 @@ transform: |
 input:
   type: generator
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT missing_column FROM logs
 "#;
@@ -2960,7 +2960,7 @@ transform: |
 input:
   type: generator
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT Level FROM logs
 "#;
@@ -2983,7 +2983,7 @@ transform: |
 input:
   type: generator
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT method FROM logs
 "#;
@@ -3006,7 +3006,7 @@ transform: |
 input:
   type: generator
 output:
-  type: null
+  type: "null"
 enrichment:
   - type: static
     table_name: labels
@@ -3036,7 +3036,7 @@ input:
   generator:
     complexity: complex
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT bytes_in FROM logs
 "#;

--- a/crates/logfwd/tests/it/compliance_file.rs
+++ b/crates/logfwd/tests/it/compliance_file.rs
@@ -49,7 +49,7 @@ input:
   path: {}
   format: json
 output:
-  type: null
+  type: "null"
 ",
         log_path.display()
     )
@@ -141,7 +141,7 @@ input:
   format: json
   glob_rescan_interval_ms: 50
 output:
-  type: null
+  type: "null"
 "#,
         pattern
     )


### PR DESCRIPTION
## Summary
- Fixes #2001 -- null or missing output `type` field no longer silently defaults to the Null sink (which discards all data)
- Removed `visit_unit`/`visit_none` methods from the `OutputType` custom deserializer that returned `OutputType::Null` for YAML null values
- Users must now explicitly write `type: "null"` (quoted) to use the Null sink; unquoted `type: null` (YAML null) is rejected with a clear error
- Updated all YAML configs, tests, and templates across 15 files to use the quoted form

## Test plan
- [x] New test `null_output_type_field_is_rejected` verifies `type: ~` is rejected
- [x] New tests `unquoted_type_null_is_rejected_{simple,advanced}_layout` verify unquoted `type: null` is rejected
- [x] Existing test `quoted_type_null_creates_null_sink` (renamed) confirms `type: "null"` still works
- [x] `just lint` passes
- [x] `just test` passes (1827 tests, 0 failures)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject YAML null output type instead of silently creating a Null sink
> - Removes `visit_unit` and `visit_none` from `OutputType`'s deserializer in [types.rs](https://github.com/strawgate/fastforward/pull/2381/files#diff-62e3ac9382eb657aa94241b95339050d93e352844aef7d3a16f2bf66bb681a91), so `type: null` or `type: ~` now produces a deserialization error instead of silently mapping to `OutputType::Null`.
> - The explicit quoted string `type: "null"` remains the only valid way to configure the Null sink.
> - Updates all YAML fixtures, test snippets, CLI templates, and config wizards across the codebase to use `type: "null"` instead of `type: null`.
> - Behavioral Change: any existing config using unquoted `null` as the output type will now be rejected at parse time with an invalid config error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e351df.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->