### PR TITLE
fix(config): reject stray null output fields

### DIFF
--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -546,6 +546,18 @@ Write records to Parquet files.
 |-------|------|----------|-------------|
 | `path` | string | Yes | Destination file path. |
 
+### `null` output
+
+Drop records intentionally for tests and benchmark baselines. The type value must
+be quoted as a YAML string; unquoted `type: null` is YAML's null value and is
+rejected. Null outputs do not accept sink-specific fields such as `endpoint`,
+`format`, `auth`, `tls`, retry, or batch controls.
+
+```yaml
+output:
+  type: "null"
+```
+
 ---
 
 ## Output types

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -1127,7 +1127,7 @@ output:
         let pipeline = cfg.pipelines.values().next().unwrap();
         let input = &pipeline.inputs[0];
         match &input.type_config {
-            crate::InputTypeConfig::LinuxEbpfSensor(s) => {
+            InputTypeConfig::LinuxEbpfSensor(s) => {
                 let sensor = s.sensor.as_ref().unwrap();
                 assert_eq!(
                     sensor.include_event_types.as_ref().unwrap(),
@@ -1474,6 +1474,17 @@ output:
         assert!(
             msg.contains("invalid output config"),
             "unquoted type: null must be rejected: {msg}"
+        );
+    }
+
+    #[test]
+    fn empty_output_type_with_endpoint_is_rejected() {
+        let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type:\n  endpoint: https://collector:4318\n";
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid output config"),
+            "empty output type with endpoint must be rejected before it can become the null sink: {msg}"
         );
     }
 

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     CompressionFormat, Config, ConfigError, ElasticsearchRequestMode, EnrichmentConfig, Format,
     GeneratorAttributeValueConfig, GeneratorProfileConfig, InputType, InputTypeConfig,
-    JournaldBackendConfig, OutputType, PIPELINE_WORKERS_MAX,
+    JournaldBackendConfig, OutputConfig, OutputType, PIPELINE_WORKERS_MAX,
 };
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
@@ -20,6 +20,82 @@ fn validation_message(error: ConfigError) -> String {
         ConfigError::Io(error) => error.to_string(),
         ConfigError::Yaml(error) => error.to_string(),
     }
+}
+
+fn null_output_unsupported_field(output: &OutputConfig) -> Option<&'static str> {
+    if output.endpoint.is_some() {
+        return Some("endpoint");
+    }
+    if output.protocol.is_some() {
+        return Some("protocol");
+    }
+    if output.compression.is_some() {
+        return Some("compression");
+    }
+    if output.request_mode.is_some() {
+        return Some("request_mode");
+    }
+    if output.format.is_some() {
+        return Some("format");
+    }
+    if output.path.is_some() {
+        return Some("path");
+    }
+    if output.index.is_some() {
+        return Some("index");
+    }
+    if output.auth.is_some() {
+        return Some("auth");
+    }
+    if output.tenant_id.is_some() {
+        return Some("tenant_id");
+    }
+    if output.static_labels.is_some() {
+        return Some("static_labels");
+    }
+    if output.label_columns.is_some() {
+        return Some("label_columns");
+    }
+    if output.tls.is_some() {
+        return Some("tls");
+    }
+    if output.headers.is_some() {
+        return Some("headers");
+    }
+    if output.retry_attempts.is_some() {
+        return Some("retry_attempts");
+    }
+    if output.retry_initial_backoff_ms.is_some() {
+        return Some("retry_initial_backoff_ms");
+    }
+    if output.retry_max_backoff_ms.is_some() {
+        return Some("retry_max_backoff_ms");
+    }
+    if output.request_timeout_ms.is_some() {
+        return Some("request_timeout_ms");
+    }
+    if output.batch_size.is_some() {
+        return Some("batch_size");
+    }
+    if output.batch_timeout_ms.is_some() {
+        return Some("batch_timeout_ms");
+    }
+    if output.host.is_some() {
+        return Some("host");
+    }
+    if output.port.is_some() {
+        return Some("port");
+    }
+    if output.write_legacy_ipc_format.is_some() {
+        return Some("write_legacy_ipc_format");
+    }
+    if output.buffer_size_bytes.is_some() {
+        return Some("buffer_size_bytes");
+    }
+    if output.write_schema_on_connect.is_some() {
+        return Some("write_schema_on_connect");
+    }
+    None
 }
 
 impl Config {
@@ -817,7 +893,13 @@ impl Config {
                                 )));
                             }
                         }
-                        OutputType::Null => {}
+                        OutputType::Null => {
+                            if let Some(field) = null_output_unsupported_field(&output) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' output '{label}': null output does not support '{field}'; remove the field"
+                                )));
+                            }
+                        }
                         OutputType::Tcp | OutputType::Udp => {
                             if output.endpoint.is_none() {
                                 return Err(ConfigError::Validation(format!(
@@ -2750,7 +2832,7 @@ pipelines:
           cert_file: /tmp/server.crt
           key_file: /tmp/server.key
     outputs:
-      - type: null
+      - type: "null"
 "#;
         Config::load_str(yaml).expect("tcp tls cert+key should validate");
     }
@@ -2766,7 +2848,7 @@ pipelines:
         tls:
           cert_file: /tmp/server.crt
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(partial).unwrap_err().to_string();
         assert!(
@@ -2785,7 +2867,7 @@ pipelines:
           key_file: /tmp/server.key
           client_ca_file: /tmp/ca.crt
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(mtls).unwrap_err().to_string();
         assert!(

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -1005,6 +1005,46 @@ pipelines:
 }
 
 #[test]
+fn issue_2349_reject_null_output_endpoint() {
+    let yaml = r#"
+input:
+  type: file
+  path: /tmp/x.log
+output:
+  type: "null"
+  endpoint: https://collector:4318
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("pipeline 'default' output '#0'")
+            && err.contains("null output does not support 'endpoint'"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn issue_2349_reject_named_null_output_format() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+    outputs:
+      - name: discard
+        type: "null"
+        format: json
+"#;
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("pipeline 'test' output 'discard'")
+            && err.contains("null output does not support 'format'"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn issue_2035_reject_file_output_when_parent_directory_missing() {
     let missing_parent = unique_temp_dir("missing-parent").join("child");
     let out_path = missing_parent.join("out.ndjson");


### PR DESCRIPTION
## Summary

- reject sink-specific fields on explicit `type: "null"` outputs during validation with pipeline/output label context
- keep empty/YAML-null output type values rejected before they can become the null sink
- document that the null output type must be quoted and accepts no sink-specific fields

Fixes #2349.

## Verification

- `cargo test -p logfwd-config`
- `cargo test -p logfwd-config issue_2349 -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p logfwd-config -- -D warnings`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject stray fields on null output configs during validation
> - Adds a validation step in [`validate.rs`](https://github.com/strawgate/fastforward/pull/2391/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) that rejects `null` output configs containing sink-specific fields such as `endpoint`, `format`, `auth`, `tls`, retry, or batch controls, emitting a clear error naming the unsupported field.
> - Adds integration tests in [`validation_gaps.rs`](https://github.com/strawgate/fastforward/pull/2391/files#diff-6bc9e43bdf082760e44e77d151467e82e205fbfc86529a0f5296d0eff82e2c95) covering both default and named pipeline cases.
> - Updates existing tests to quote the null output type as `"null"` (YAML string) instead of the bare unquoted keyword.
> - Documents the `null` output type and its restrictions in the config reference.
> - Behavioral Change: configs with `type: null` (or bare `null`) that also set any transport or sink field now fail to load instead of silently ignoring those fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf13285.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->