### PR TITLE
fix: repair source metadata post-merge tests

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -1127,7 +1127,7 @@ output:
         let pipeline = cfg.pipelines.values().next().unwrap();
         let input = &pipeline.inputs[0];
         match &input.type_config {
-            crate::InputTypeConfig::LinuxEbpfSensor(s) => {
+            InputTypeConfig::LinuxEbpfSensor(s) => {
                 let sensor = s.sensor.as_ref().unwrap();
                 assert_eq!(
                     sensor.include_event_types.as_ref().unwrap(),

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -2750,7 +2750,7 @@ pipelines:
           cert_file: /tmp/server.crt
           key_file: /tmp/server.key
     outputs:
-      - type: null
+      - type: "null"
 "#;
         Config::load_str(yaml).expect("tcp tls cert+key should validate");
     }
@@ -2766,7 +2766,7 @@ pipelines:
         tls:
           cert_file: /tmp/server.crt
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(partial).unwrap_err().to_string();
         assert!(
@@ -2785,7 +2785,7 @@ pipelines:
           key_file: /tmp/server.key
           client_ca_file: /tmp/ca.crt
     outputs:
-      - type: null
+      - type: "null"
 "#;
         let err = Config::load_str(mtls).unwrap_err().to_string();
         assert!(

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -1166,7 +1166,7 @@ mod tests {
             name: Some("tcp-in".to_string()),
             format: Some(Format::Json),
             sql: None,
-            source_metadata: false,
+            source_metadata: SourceMetadataStyle::None,
             type_config: InputTypeConfig::Tcp(logfwd_config::TcpTypeConfig {
                 listen: "127.0.0.1:0".to_string(),
                 tls: Some(logfwd_config::TlsInputConfig {


### PR DESCRIPTION
## Summary
- update post-merge config test fixtures to quote the `"null"` output type now that bare YAML null is rejected
- replace a stale boolean `source_metadata` test initializer with `SourceMetadataStyle::None`
- remove an unnecessary `crate::` qualification that clippy flags after the validator refactor

## Verification
- `cargo test -p logfwd-config tcp_tls_ -- --nocapture`
- `cargo test -p logfwd-runtime source_metadata -- --nocapture`
- `just lint`
- `just test`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix post-merge test failures in source metadata and TLS config tests
> - Fixes a match arm path in [lib.rs](https://github.com/strawgate/fastforward/pull/2392/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150) by removing the redundant `crate::` prefix from `InputTypeConfig::LinuxEbpfSensor`.
> - Updates embedded YAML in [validate.rs](https://github.com/strawgate/fastforward/pull/2392/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) TLS tests to use `"null"` (quoted string) instead of bare `null` for the output type field.
> - Updates [input_build.rs](https://github.com/strawgate/fastforward/pull/2392/files#diff-ca354d25bc72dec0d7f48518cd76a40d5bfab0a1f22f56449adbd8e2a81ffc4f) to use `SourceMetadataStyle::None` instead of `false` for the `source_metadata` field, reflecting a type change post-merge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f6fd09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->