### PR TITLE
fix: allow print_stdout lint in source_metadata_profile bench binary

### DIFF
--- a/crates/logfwd-bench/src/bin/source_metadata_profile.rs
+++ b/crates/logfwd-bench/src/bin/source_metadata_profile.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 //! Quick source metadata attachment timing/allocation profile.
 //!
 //! Run:


### PR DESCRIPTION
## Summary
- Add missing `#![allow(clippy::print_stdout, clippy::print_stderr)]` to `source_metadata_profile` bench binary
- All other bench binaries in `crates/logfwd-bench/src/bin/` already have this attribute; this was the only one missing
- Fixes clippy failure when running `just lint` (which uses `-D warnings`)

## Test plan
- [x] `cargo clippy -p logfwd-bench --bins -- -D warnings` passes
- [x] `just lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow `print_stdout` and `print_stderr` Clippy lints in `source_metadata_profile` bench binary
> Adds crate-level `#![allow(...)]` attributes for `clippy::print_stdout` and `clippy::print_stderr` in [source_metadata_profile.rs](https://github.com/strawgate/fastforward/pull/2403/files#diff-201ad867466b4f3d5560911ea0fe48fc1ee5397b56ac153172698a36b122bc6d) to suppress lint errors in the benchmarking binary where printing to stdout/stderr is intentional.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cc1109.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->