### PR TITLE
feat(lints): must_use discipline + dylint #[hot_path] no-alloc lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,6 +2898,7 @@ dependencies = [
  "arrow",
  "bytes",
  "logfwd-core",
+ "logfwd-lint-attrs",
  "logfwd-types",
  "proptest",
  "serial_test",
@@ -3086,6 +3087,10 @@ dependencies = [
  "xxhash-rust",
  "zstd",
 ]
+
+[[package]]
+name = "logfwd-lint-attrs"
+version = "0.1.0"
 
 [[package]]
 name = "logfwd-otap-proto"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/logfwd-bench",
     "crates/logfwd-competitive-bench",
     "crates/logfwd-test-utils",
+    "crates/logfwd-lint-attrs",
     "crates/logfwd-ebpf-proto",
     "crates/logfwd-ebpf-proto/sensor-ebpf",
     "crates/logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-common",
@@ -25,6 +26,10 @@ members = [
 # It is intentionally excluded from the workspace.
 exclude = [
     "crates/logfwd-ebpf-proto/sensor-ebpf/sensor-ebpf-kern",
+    # logfwd-lints pins a specific rustc nightly and links against
+    # rustc-private crates. It is invoked via `cargo dylint`, not the
+    # regular workspace build.
+    "crates/logfwd-lints",
 ]
 # default-members: crates that compile without datafusion (~30s vs ~3min).
 # Bare `cargo check/clippy` uses these. Use `--workspace` or `-p logfwd`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ cast_precision_loss = "allow"
 cast_lossless = "allow"
 inline_always = "allow"
 needless_pass_by_value = "allow"
-return_self_not_must_use = "allow"
+return_self_not_must_use = "warn"
 struct_excessive_bools = "allow"
 wildcard_imports = "allow"
 unnested_or_patterns = "allow"
@@ -145,6 +145,7 @@ dbg_macro = "deny"
 large_enum_variant = "warn"
 print_stdout = "warn"
 print_stderr = "warn"
+let_underscore_future = "deny"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/crates/logfwd-arrow/Cargo.toml
+++ b/crates/logfwd-arrow/Cargo.toml
@@ -16,6 +16,7 @@ _test-internals = []
 [dependencies]
 logfwd-core = { version = "0.1.0", path = "../logfwd-core" }
 logfwd-types = { version = "0.1.0", path = "../logfwd-types" }
+logfwd-lint-attrs = { version = "0.1.0", path = "../logfwd-lint-attrs" }
 arrow = { workspace = true }
 bytes = "1"
 

--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -17,6 +17,7 @@ use arrow::buffer::{Buffer, NullBuffer};
 use arrow::datatypes::{DataType, Field, Fields, Schema};
 use arrow::error::ArrowError;
 use arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use logfwd_lint_attrs::hot_path;
 
 use logfwd_core::scan_config::{parse_float_fast, parse_int_fast};
 use logfwd_core::scanner::BuilderState;
@@ -245,11 +246,13 @@ impl StreamingBuilder {
         self.line_views.clear();
     }
 
+    #[hot_path]
     #[inline(always)]
     pub fn begin_row(&mut self) {
         self.lifecycle.begin_row();
     }
 
+    #[hot_path]
     #[inline(always)]
     pub fn end_row(&mut self) {
         self.lifecycle.end_row();

--- a/crates/logfwd-bench/src/bin/source_metadata_profile.rs
+++ b/crates/logfwd-bench/src/bin/source_metadata_profile.rs
@@ -1,8 +1,8 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 //! Quick source metadata attachment timing/allocation profile.
 //!
 //! Run:
 //! `cargo run -p logfwd-bench --release --bin source_metadata_profile -- --rows 50000 --sources 300 --iterations 200`
-#![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use std::alloc::System;
 use std::collections::HashMap;

--- a/crates/logfwd-bench/src/bin/source_metadata_profile.rs
+++ b/crates/logfwd-bench/src/bin/source_metadata_profile.rs
@@ -2,6 +2,7 @@
 //!
 //! Run:
 //! `cargo run -p logfwd-bench --release --bin source_metadata_profile -- --rows 50000 --sources 300 --iterations 200`
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use std::alloc::System;
 use std::collections::HashMap;

--- a/crates/logfwd-bench/src/generators/shared_profiles.rs
+++ b/crates/logfwd-bench/src/generators/shared_profiles.rs
@@ -133,36 +133,43 @@ impl CloudTrailProfile {
         }
     }
 
+    #[must_use]
     pub fn with_account_count(mut self, account_count: usize) -> Self {
         self.account_count = account_count.max(1);
         self
     }
 
+    #[must_use]
     pub fn with_account_tenure(mut self, account_tenure: usize) -> Self {
         self.account_tenure = account_tenure.max(1);
         self
     }
 
+    #[must_use]
     pub fn with_principal_count(mut self, principal_count: usize) -> Self {
         self.principal_count = principal_count.max(1);
         self
     }
 
+    #[must_use]
     pub fn with_principal_tenure(mut self, principal_tenure: usize) -> Self {
         self.principal_tenure = principal_tenure.max(1);
         self
     }
 
+    #[must_use]
     pub fn with_service_mix(mut self, service_mix: CloudTrailServiceMix) -> Self {
         self.service_mix = service_mix;
         self
     }
 
+    #[must_use]
     pub fn with_region_mix(mut self, region_mix: CloudTrailRegionMix) -> Self {
         self.region_mix = region_mix;
         self
     }
 
+    #[must_use]
     pub fn with_optional_field_density(mut self, optional_field_density: u8) -> Self {
         self.optional_field_density = optional_field_density.min(100);
         self

--- a/crates/logfwd-io/src/format.rs
+++ b/crates/logfwd-io/src/format.rs
@@ -130,6 +130,7 @@ impl FormatDecoder {
     ///
     /// Used to create per-source format processors so that stateful formats
     /// (CRI P/F aggregation) do not cross-contaminate between sources.
+    #[must_use]
     pub fn new_instance(&self) -> Self {
         match self {
             Self::Passthrough { stats } => Self::Passthrough {

--- a/crates/logfwd-lint-attrs/Cargo.toml
+++ b/crates/logfwd-lint-attrs/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "logfwd-lint-attrs"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+description = "Attribute macros that mark functions for semantic lints (e.g., #[hot_path])."
+
+[lib]
+proc-macro = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/logfwd-lint-attrs/src/lib.rs
+++ b/crates/logfwd-lint-attrs/src/lib.rs
@@ -1,0 +1,44 @@
+//! Attribute macros that tag functions for semantic lints.
+//!
+//! Each attribute is a compile-time no-op: it returns its input token
+//! stream unchanged. The dylint lint library (`crates/logfwd-lints/`)
+//! inspects the attributes post-expansion to enforce the invariant they
+//! assert.
+//!
+//! # Available attributes
+//!
+//! - `#[hot_path]` — the tagged function is on the pipeline's hot path.
+//!   The `hot_path_no_alloc` lint flags any heap allocation inside the
+//!   function body (direct calls to `Box::new`, `Vec::new`,
+//!   `Vec::with_capacity`, `String::from`, `.to_string()`, `.to_vec()`,
+//!   `.to_owned()`, `format!`, `vec![]`, `.collect()` into an owned
+//!   container, `Arc::new`, `Rc::new`).
+//!
+//! # Runtime behavior
+//!
+//! These attributes generate no code. They exist purely so the lint can
+//! find them. Functions behave identically with or without the attribute
+//! at runtime.
+
+#![warn(missing_docs)]
+
+use proc_macro::TokenStream;
+
+/// Mark a function as lying on the pipeline hot path.
+///
+/// The `hot_path_no_alloc` dylint lint flags any heap allocation inside
+/// a function carrying this attribute. See crate-level docs.
+///
+/// The macro prepends a hidden doc attribute
+/// `#[doc = "__logfwd_hot_path__"]` so the lint can find the function
+/// after macro expansion. At runtime the function behaves identically
+/// to the un-annotated version; the doc attribute has no codegen effect.
+#[proc_macro_attribute]
+pub fn hot_path(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let marker: TokenStream = "#[doc = \"__logfwd_hot_path__\"]"
+        .parse()
+        .expect("valid marker attribute");
+    let mut out = marker;
+    out.extend(item);
+    out
+}

--- a/crates/logfwd-lint-attrs/src/lib.rs
+++ b/crates/logfwd-lint-attrs/src/lib.rs
@@ -1,9 +1,10 @@
 //! Attribute macros that tag functions for semantic lints.
 //!
-//! Each attribute is a compile-time no-op: it returns its input token
-//! stream unchanged. The dylint lint library (`crates/logfwd-lints/`)
-//! inspects the attributes post-expansion to enforce the invariant they
-//! assert.
+//! Each attribute is a compile-time marker for the dylint lint library
+//! (`crates/logfwd-lints/`). The macros may attach hidden metadata so
+//! the lint can find annotated items after macro expansion, but they
+//! have no runtime or codegen effect and do not change function
+//! behavior.
 //!
 //! # Available attributes
 //!
@@ -29,10 +30,11 @@ use proc_macro::TokenStream;
 /// The `hot_path_no_alloc` dylint lint flags any heap allocation inside
 /// a function carrying this attribute. See crate-level docs.
 ///
-/// The macro prepends a hidden doc attribute
-/// `#[doc = "__logfwd_hot_path__"]` so the lint can find the function
-/// after macro expansion. At runtime the function behaves identically
-/// to the un-annotated version; the doc attribute has no codegen effect.
+/// The macro prepends a `#[doc = "__logfwd_hot_path__"]` marker so the
+/// lint can find the function after macro expansion. At runtime the
+/// function behaves identically to the un-annotated version; the doc
+/// attribute has no codegen effect. Note: the marker string may appear
+/// in rustdoc output for public items.
 #[proc_macro_attribute]
 pub fn hot_path(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let marker: TokenStream = "#[doc = \"__logfwd_hot_path__\"]"

--- a/crates/logfwd-lints/.cargo/config.toml
+++ b/crates/logfwd-lints/.cargo/config.toml
@@ -1,0 +1,6 @@
+# dylint-link renames the output cdylib to
+# `liblogfwd_lints@<toolchain>.so`, which is the naming convention
+# cargo-dylint scans for. Without this, the build succeeds but
+# cargo-dylint cannot locate the library.
+[target.'cfg(all())']
+rustflags = ["-C", "linker=dylint-link"]

--- a/crates/logfwd-lints/.gitignore
+++ b/crates/logfwd-lints/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/crates/logfwd-lints/Cargo.toml
+++ b/crates/logfwd-lints/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "logfwd_lints"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Dylint library implementing semantic lints for the logfwd workspace."
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "20ce69b9a63bcd2756cd906fe0964d1e901e042a" }
+dylint_linting = "5.0.0"
+
+[dev-dependencies]
+dylint_testing = "5.0.0"
+
+[workspace]
+
+[package.metadata.rust-analyzer]
+rustc_private = true

--- a/crates/logfwd-lints/README.md
+++ b/crates/logfwd-lints/README.md
@@ -1,0 +1,54 @@
+# logfwd-lints
+
+Dylint library implementing semantic lints for the logfwd workspace.
+
+**This crate is excluded from the main workspace.** It pins a specific
+Rust nightly and links against `rustc_private` crates. Run it via
+`cargo dylint`, not `cargo build`.
+
+## Usage
+
+```bash
+# One-time: install dylint.
+cargo install cargo-dylint dylint-link --locked
+
+# From repo root:
+just dylint
+# or equivalently:
+cargo dylint --path crates/logfwd-lints -- --workspace
+```
+
+## Lints
+
+| Lint | Level | What it flags |
+|---|---|---|
+| `hot_path_no_alloc` | warn | Heap allocations inside a function marked `#[logfwd_lint_attrs::hot_path]` — `Box::new`, `Vec::new`/`with_capacity`, `String::from`, `.to_string()`, `.to_vec()`, `.to_owned()`, `.clone()` on heap types, `.collect::<Vec/String/HashMap>()`, `format!`, `vec![]`, `Arc::new`, `Rc::new`, `HashMap::new`/`with_capacity`, `HashSet::new`/`with_capacity`. |
+
+## How to tag a function
+
+```rust
+use logfwd_lint_attrs::hot_path;
+
+#[hot_path]
+fn scan_line(buf: &[u8]) -> usize {
+    // `let owned = buf.to_vec();` would fire the lint.
+    buf.len()
+}
+```
+
+See `dev-docs/CODE_STYLE.md` → *Hot Path Rules* for policy.
+
+## Adding a new lint
+
+1. Add a new `declare_late_lint!` stanza in `src/lib.rs`.
+2. Implement `LateLintPass::check_*` with the predicate.
+3. Add a UI test in `ui/`.
+4. Document it in the table above and in `dev-docs/CODE_STYLE.md`.
+
+Candidate future lints (see `dev-docs/CODE_STYLE.md`):
+
+- `#[cancel_safe]` — no `std::sync::Mutex` guard or buffered
+  `mpsc::Sender` held across `.await` in tokio `select!` branches.
+- `#[no_panic]` — transitive reachability check.
+- `#[checkpoint_ordered]` — protocol assertion for checkpoint-store
+  operations.

--- a/crates/logfwd-lints/rust-toolchain
+++ b/crates/logfwd-lints/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-09-18"
+components = ["llvm-tools-preview", "rustc-dev"]

--- a/crates/logfwd-lints/src/lib.rs
+++ b/crates/logfwd-lints/src/lib.rs
@@ -1,0 +1,271 @@
+//! Dylint library implementing semantic lints for the logfwd workspace.
+//!
+//! Currently provides:
+//!
+//! - `hot_path_no_alloc` — flags heap allocations inside functions marked
+//!   with `#[logfwd_lint_attrs::hot_path]`. Catches `Box::new`,
+//!   `Vec::new`/`with_capacity`, `String::from`/`new`, `.to_string()`,
+//!   `.to_vec()`, `.to_owned()`, `.clone()` on common heap types,
+//!   `.collect::<Vec<_>>()`/`.collect::<String>()`, `format!`, `vec![]`,
+//!   `Arc::new`, `Rc::new`.
+//!
+//! Invoked via `cargo dylint --all` once the workspace registers this
+//! library (see `just dylint`).
+//!
+//! Implementation lives at the HIR level so macro expansions (`format!`,
+//! `vec![]`) and method calls that resolve to heap types are caught.
+
+#![feature(rustc_private)]
+#![warn(unused_extern_crates)]
+
+extern crate rustc_hir;
+extern crate rustc_middle;
+extern crate rustc_span;
+
+use clippy_utils::diagnostics::span_lint_and_then;
+use rustc_hir::def::Res;
+use rustc_hir::intravisit::{FnKind, Visitor, walk_body, walk_expr};
+use rustc_hir::{Body, Expr, ExprKind, FnDecl, HirId, QPath};
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_middle::ty::Ty;
+use rustc_span::{Span, Symbol};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Flags heap allocations and owned-value conversions inside functions
+    /// marked with `#[logfwd_lint_attrs::hot_path]`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Hot-path code in logfwd (reader → framer → scanner → builders → OTLP
+    /// encoder → compress) must be allocation-free per-record. Allocation
+    /// there costs throughput proportional to input volume. The attribute
+    /// exists to declare the no-alloc contract explicitly so drift is
+    /// caught at review time rather than in production profiles.
+    ///
+    /// ### Example
+    ///
+    /// ```ignore
+    /// use logfwd_lint_attrs::hot_path;
+    ///
+    /// #[hot_path]
+    /// fn scan(buf: &[u8]) -> usize {
+    ///     let owned = buf.to_vec(); // fires lint
+    ///     owned.len()
+    /// }
+    /// ```
+    ///
+    /// Rewrite to operate on the borrowed slice:
+    ///
+    /// ```ignore
+    /// use logfwd_lint_attrs::hot_path;
+    ///
+    /// #[hot_path]
+    /// fn scan(buf: &[u8]) -> usize {
+    ///     buf.len()
+    /// }
+    /// ```
+    pub HOT_PATH_NO_ALLOC,
+    Warn,
+    "heap allocation inside a function marked #[hot_path]"
+}
+
+/// Function paths whose call constitutes a heap allocation. These match
+/// against `clippy_utils::match_def_path` on the resolved `DefId`.
+const ALLOC_FN_PATHS: &[&[&str]] = &[
+    &["alloc", "boxed", "Box", "new"],
+    &["alloc", "vec", "Vec", "new"],
+    &["alloc", "vec", "Vec", "with_capacity"],
+    &["alloc", "string", "String", "new"],
+    &["alloc", "string", "String", "with_capacity"],
+    &["alloc", "string", "String", "from"],
+    &["alloc", "sync", "Arc", "new"],
+    &["alloc", "rc", "Rc", "new"],
+    &["std", "collections", "hash", "map", "HashMap", "new"],
+    &["std", "collections", "hash", "map", "HashMap", "with_capacity"],
+    &["std", "collections", "hash", "set", "HashSet", "new"],
+    &["std", "collections", "hash", "set", "HashSet", "with_capacity"],
+];
+
+/// Method-name allocation tells: any receiver plus one of these method
+/// names signals a heap write. These are checked *in addition* to the
+/// resolved-path set above (which covers free functions and inherent
+/// constructors).
+const ALLOC_METHOD_NAMES: &[&str] = &[
+    "to_string",
+    "to_vec",
+    "to_owned",
+    "into_owned",
+    "into_boxed_slice",
+    "into_boxed_str",
+    "into_vec",
+    "clone_into",
+];
+
+/// Marker string that the `#[hot_path]` proc-macro attribute prepends
+/// as a hidden `#[doc = ...]` on the tagged function. Proc-macro
+/// attributes are consumed during expansion, so `#[hot_path]` itself is
+/// gone by the time HIR is available — the doc marker carries the
+/// annotation through.
+const HOT_PATH_MARKER: &str = "__logfwd_hot_path__";
+
+impl<'tcx> LateLintPass<'tcx> for HotPathNoAlloc {
+    fn check_fn(
+        &mut self,
+        cx: &LateContext<'tcx>,
+        _kind: FnKind<'tcx>,
+        _decl: &'tcx FnDecl<'tcx>,
+        body: &'tcx Body<'tcx>,
+        _span: Span,
+        def_id: rustc_span::def_id::LocalDefId,
+    ) {
+        let hir_id = cx.tcx.local_def_id_to_hir_id(def_id);
+        if !function_has_hot_path_attr(cx, hir_id) {
+            return;
+        }
+
+        let mut visitor = AllocVisitor { cx, hits: Vec::new() };
+        walk_body(&mut visitor, body);
+
+        for (span, reason) in visitor.hits {
+            span_lint_and_then(
+                cx,
+                HOT_PATH_NO_ALLOC,
+                span,
+                format!("heap allocation in #[hot_path] function: {reason}"),
+                |_diag| {},
+            );
+        }
+    }
+}
+
+fn function_has_hot_path_attr(cx: &LateContext<'_>, hir_id: HirId) -> bool {
+    // The `#[hot_path]` proc-macro attribute is stripped during macro
+    // expansion. It prepends a `#[doc = "__logfwd_hot_path__"]` marker
+    // that survives to HIR; we look for that.
+    let doc_sym = Symbol::intern("doc");
+    for attr in cx.tcx.hir_attrs(hir_id) {
+        if !attr.has_name(doc_sym) {
+            continue;
+        }
+        if let Some(value) = attr.value_str()
+            && value.as_str() == HOT_PATH_MARKER
+        {
+            return true;
+        }
+    }
+    false
+}
+
+struct AllocVisitor<'a, 'tcx> {
+    cx: &'a LateContext<'tcx>,
+    hits: Vec<(Span, String)>,
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for AllocVisitor<'a, 'tcx> {
+    fn visit_expr(&mut self, expr: &'tcx Expr<'tcx>) {
+        let hit = describe_alloc(self.cx, expr);
+        if let Some(reason) = hit {
+            self.hits.push((expr.span, reason));
+        }
+        walk_expr(self, expr);
+    }
+}
+
+fn describe_alloc<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) -> Option<String> {
+    match &expr.kind {
+        ExprKind::Call(callee, _) => resolved_path_matches_alloc(cx, callee),
+        ExprKind::MethodCall(path, _receiver, _args, _span) => {
+            let name = path.ident.name.as_str();
+            if ALLOC_METHOD_NAMES.contains(&name) {
+                return Some(format!("method `.{name}()`"));
+            }
+            if name == "clone" {
+                // .clone() is only an allocation when the receiver type is
+                // actually heap-backed. We conservatively report for String,
+                // Vec, Box, Arc, Rc, and types containing them.
+                let receiver_ty = cx.typeck_results().expr_ty(expr);
+                if type_is_heap(cx, receiver_ty) {
+                    return Some(format!(
+                        "`.clone()` on heap type `{}`",
+                        receiver_ty
+                    ));
+                }
+            }
+            if name == "collect" {
+                let ty = cx.typeck_results().expr_ty(expr);
+                if type_is_heap(cx, ty) {
+                    return Some(format!("`.collect()` into heap type `{ty}`"));
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn resolved_path_matches_alloc<'tcx>(
+    cx: &LateContext<'tcx>,
+    callee: &Expr<'tcx>,
+) -> Option<String> {
+    let ExprKind::Path(qpath) = &callee.kind else {
+        return None;
+    };
+    let res = match qpath {
+        QPath::Resolved(_, path) => path.res,
+        QPath::TypeRelative(..) | QPath::LangItem(..) => {
+            cx.typeck_results().qpath_res(qpath, callee.hir_id)
+        }
+    };
+    let Res::Def(_, def_id) = res else { return None };
+    let path = cx.get_def_path(def_id);
+    for candidate in ALLOC_FN_PATHS {
+        if path_matches(&path, candidate) {
+            return Some(format!("call `{}`", candidate.join("::")));
+        }
+    }
+    None
+}
+
+fn path_matches(actual: &[Symbol], expected: &[&str]) -> bool {
+    actual.len() == expected.len()
+        && actual
+            .iter()
+            .zip(expected.iter())
+            .all(|(a, e)| a.as_str() == *e)
+}
+
+/// Conservative heap-type classifier: returns true for `String`, `Vec<_>`,
+/// `Box<_>`, `Arc<_>`, `Rc<_>`, and `HashMap<_,_>` / `HashSet<_>`.
+fn type_is_heap<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    use rustc_middle::ty::TyKind;
+    match ty.kind() {
+        TyKind::Adt(adt, _) => {
+            let path = cx.get_def_path(adt.did());
+            let lang = path.iter().map(Symbol::as_str).collect::<Vec<_>>();
+            matches!(
+                lang.as_slice(),
+                ["alloc", "string", "String"]
+                    | ["alloc", "vec", "Vec"]
+                    | ["alloc", "boxed", "Box"]
+                    | ["alloc", "sync", "Arc"]
+                    | ["alloc", "rc", "Rc"]
+                    | ["std", "collections", "hash", "map", "HashMap"]
+                    | ["std", "collections", "hash", "set", "HashSet"]
+            )
+        }
+        _ => false,
+    }
+}
+
+// UI tests are set up in `ui/hot_path_no_alloc.rs`. To enable them, add
+// expected-output `ui/hot_path_no_alloc.stderr` via:
+//   BLESS=1 cargo test --manifest-path crates/logfwd-lints/Cargo.toml
+// and uncomment the `ui` test below. Left disabled for now so the crate
+// builds hermetically in CI without requiring a blessed fixture.
+//
+// #[test]
+// fn ui() {
+//     dylint_testing::ui_test(env!("CARGO_PKG_NAME"), "ui");
+// }

--- a/crates/logfwd-lints/src/lib.rs
+++ b/crates/logfwd-lints/src/lib.rs
@@ -5,12 +5,13 @@
 //! - `hot_path_no_alloc` — flags heap allocations inside functions marked
 //!   with `#[logfwd_lint_attrs::hot_path]`. Catches `Box::new`,
 //!   `Vec::new`/`with_capacity`, `String::from`/`new`, `.to_string()`,
-//!   `.to_vec()`, `.to_owned()`, `.clone()` on common heap types,
+//!   `.to_vec()`, `.to_owned()`, `.clone()` on heap types (excluding
+//!   `Arc`/`Rc` whose clone is a refcount bump),
 //!   `.collect::<Vec<_>>()`/`.collect::<String>()`, `format!`, `vec![]`,
 //!   `Arc::new`, `Rc::new`.
 //!
-//! Invoked via `cargo dylint --all` once the workspace registers this
-//! library (see `just dylint`).
+//! Invoke via `just dylint` (which runs
+//! `cargo dylint --path crates/logfwd-lints -- --workspace`).
 //!
 //! Implementation lives at the HIR level so macro expansions (`format!`,
 //! `vec![]`) and method calls that resolve to heap types are caught.
@@ -86,6 +87,8 @@ const ALLOC_FN_PATHS: &[&[&str]] = &[
     &["std", "collections", "hash", "map", "HashMap", "with_capacity"],
     &["std", "collections", "hash", "set", "HashSet", "new"],
     &["std", "collections", "hash", "set", "HashSet", "with_capacity"],
+    &["alloc", "fmt", "format"],
+    &["core", "fmt", "format"],
 ];
 
 /// Method-name allocation tells: any receiver plus one of these method
@@ -176,17 +179,18 @@ impl<'a, 'tcx> Visitor<'tcx> for AllocVisitor<'a, 'tcx> {
 fn describe_alloc<'tcx>(cx: &LateContext<'tcx>, expr: &Expr<'tcx>) -> Option<String> {
     match &expr.kind {
         ExprKind::Call(callee, _) => resolved_path_matches_alloc(cx, callee),
-        ExprKind::MethodCall(path, _receiver, _args, _span) => {
+        ExprKind::MethodCall(path, receiver, _args, _span) => {
             let name = path.ident.name.as_str();
             if ALLOC_METHOD_NAMES.contains(&name) {
                 return Some(format!("method `.{name}()`"));
             }
             if name == "clone" {
                 // .clone() is only an allocation when the receiver type is
-                // actually heap-backed. We conservatively report for String,
-                // Vec, Box, Arc, Rc, and types containing them.
-                let receiver_ty = cx.typeck_results().expr_ty(expr);
-                if type_is_heap(cx, receiver_ty) {
+                // actually heap-backed. We check the receiver (not the
+                // return type) and exclude Arc/Rc since their clone is a
+                // cheap refcount bump, not a heap allocation.
+                let receiver_ty = cx.typeck_results().expr_ty(receiver);
+                if type_is_heap_cloneable(cx, receiver_ty) {
                     return Some(format!(
                         "`.clone()` on heap type `{}`",
                         receiver_ty
@@ -238,6 +242,9 @@ fn path_matches(actual: &[Symbol], expected: &[&str]) -> bool {
 
 /// Conservative heap-type classifier: returns true for `String`, `Vec<_>`,
 /// `Box<_>`, `Arc<_>`, `Rc<_>`, and `HashMap<_,_>` / `HashSet<_>`.
+///
+/// Note: this checks the outermost type only, not nested fields. A
+/// wrapper struct containing a `Vec` will not be detected.
 fn type_is_heap<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
     use rustc_middle::ty::TyKind;
     match ty.kind() {
@@ -259,11 +266,35 @@ fn type_is_heap<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
     }
 }
 
-// UI tests are set up in `ui/hot_path_no_alloc.rs`. To enable them, add
-// expected-output `ui/hot_path_no_alloc.stderr` via:
-//   BLESS=1 cargo test --manifest-path crates/logfwd-lints/Cargo.toml
-// and uncomment the `ui` test below. Left disabled for now so the crate
-// builds hermetically in CI without requiring a blessed fixture.
+/// Like [`type_is_heap`] but excludes `Arc` and `Rc` — their `clone()`
+/// is a cheap refcount increment, not a heap allocation.
+fn type_is_heap_cloneable<'tcx>(cx: &LateContext<'tcx>, ty: Ty<'tcx>) -> bool {
+    use rustc_middle::ty::TyKind;
+    match ty.kind() {
+        TyKind::Adt(adt, _) => {
+            let path = cx.get_def_path(adt.did());
+            let lang = path.iter().map(Symbol::as_str).collect::<Vec<_>>();
+            matches!(
+                lang.as_slice(),
+                ["alloc", "string", "String"]
+                    | ["alloc", "vec", "Vec"]
+                    | ["alloc", "boxed", "Box"]
+                    | ["std", "collections", "hash", "map", "HashMap"]
+                    | ["std", "collections", "hash", "set", "HashSet"]
+            )
+        }
+        _ => false,
+    }
+}
+
+// UI tests are set up in `ui/hot_path_no_alloc.rs`. To enable them:
+// 1. Bless the expected-output fixture:
+//      cd crates/logfwd-lints && BLESS=1 cargo test
+// 2. Check in the resulting `ui/hot_path_no_alloc.stderr`.
+// 3. Uncomment the `ui` test below.
+//
+// Left disabled until the blessed fixture is committed — running
+// `dylint_testing::ui_test` without it fails immediately.
 //
 // #[test]
 // fn ui() {

--- a/crates/logfwd-lints/ui/hot_path_no_alloc.rs
+++ b/crates/logfwd-lints/ui/hot_path_no_alloc.rs
@@ -1,21 +1,15 @@
-// UI test: every ~should_fire~ function should trigger
+// UI test: every `should_fire` function should trigger
 // `hot_path_no_alloc`. Functions without the attribute, or without an
 // allocation, must stay silent.
 
-// Re-export the attribute under its expected path. The UI harness
-// compiles this file standalone against a stub `logfwd_lint_attrs` crate
-// that `dylint_testing` auto-stubs via `#[allow]` when not present. To
-// keep the test hermetic we declare the attribute locally as an external
-// attribute namespace.
-
-#![feature(register_tool)]
-#![register_tool(logfwd_lint_attrs)]
-
-// A no-op attribute reimplemented locally so the UI test does not
-// depend on the real `logfwd_lint_attrs` crate compiling against the
-// dylint nightly toolchain.
+// A local macro that replicates what the real `logfwd_lint_attrs::hot_path`
+// proc-macro does: prepend a `#[doc = "__logfwd_hot_path__"]` marker so
+// the lint can detect annotated functions.
 macro_rules! hot_path {
-    ($($t:tt)*) => { $($t)* };
+    ($(#[$m:meta])* $vis:vis fn $name:ident $($rest:tt)*) => {
+        #[doc = "__logfwd_hot_path__"]
+        $(#[$m])* $vis fn $name $($rest)*
+    };
 }
 
 fn main() {}
@@ -30,15 +24,52 @@ fn untagged_string() -> String {
     "hello".to_string()
 }
 
-// Should fire: tagged and allocates.
-#[logfwd_lint_attrs::hot_path]
+// Should fire: tagged and allocates via Vec::with_capacity.
+hot_path! {
 fn tagged_alloc() -> usize {
     let v: Vec<u8> = Vec::with_capacity(16);
     v.len()
 }
+}
 
 // Should fire: tagged, .to_string() on a &str.
-#[logfwd_lint_attrs::hot_path]
+hot_path! {
 fn tagged_to_string(s: &str) -> usize {
     s.to_string().len()
+}
+}
+
+// Should fire: tagged, format!() allocates.
+hot_path! {
+fn tagged_format(x: u32) -> String {
+    format!("value: {x}")
+}
+}
+
+// Should NOT fire: tagged but Arc::clone is just a refcount bump.
+hot_path! {
+fn tagged_arc_clone(a: &std::sync::Arc<String>) -> std::sync::Arc<String> {
+    std::sync::Arc::clone(a)
+}
+}
+
+// Should NOT fire: tagged but no allocations.
+hot_path! {
+fn tagged_no_alloc(buf: &[u8]) -> usize {
+    buf.len()
+}
+}
+
+// Should fire: tagged, .clone() on String allocates.
+hot_path! {
+fn tagged_clone_string(s: &String) -> String {
+    s.clone()
+}
+}
+
+// Should fire: tagged, .collect() into Vec.
+hot_path! {
+fn tagged_collect(s: &[u8]) -> Vec<u8> {
+    s.iter().copied().collect()
+}
 }

--- a/crates/logfwd-lints/ui/hot_path_no_alloc.rs
+++ b/crates/logfwd-lints/ui/hot_path_no_alloc.rs
@@ -1,0 +1,44 @@
+// UI test: every ~should_fire~ function should trigger
+// `hot_path_no_alloc`. Functions without the attribute, or without an
+// allocation, must stay silent.
+
+// Re-export the attribute under its expected path. The UI harness
+// compiles this file standalone against a stub `logfwd_lint_attrs` crate
+// that `dylint_testing` auto-stubs via `#[allow]` when not present. To
+// keep the test hermetic we declare the attribute locally as an external
+// attribute namespace.
+
+#![feature(register_tool)]
+#![register_tool(logfwd_lint_attrs)]
+
+// A no-op attribute reimplemented locally so the UI test does not
+// depend on the real `logfwd_lint_attrs` crate compiling against the
+// dylint nightly toolchain.
+macro_rules! hot_path {
+    ($($t:tt)*) => { $($t)* };
+}
+
+fn main() {}
+
+// Should NOT fire: no attribute.
+fn untagged() -> Vec<u8> {
+    Vec::with_capacity(16)
+}
+
+// Should NOT fire: untagged, even though there's an allocation.
+fn untagged_string() -> String {
+    "hello".to_string()
+}
+
+// Should fire: tagged and allocates.
+#[logfwd_lint_attrs::hot_path]
+fn tagged_alloc() -> usize {
+    let v: Vec<u8> = Vec::with_capacity(16);
+    v.len()
+}
+
+// Should fire: tagged, .to_string() on a &str.
+#[logfwd_lint_attrs::hot_path]
+fn tagged_to_string(s: &str) -> usize {
+    s.to_string().len()
+}

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -153,6 +153,7 @@ impl OtlpSink {
     /// The default is the canonical `body` field. Use this builder when a
     /// pipeline stores the primary log message under a different string column.
     #[inline]
+    #[must_use]
     pub fn with_message_field(mut self, message_field: String) -> Self {
         self.message_field = message_field;
         self

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -185,6 +185,7 @@ impl Pipeline {
     /// Replace the output sink with an async sink implementation.
     ///
     /// Wraps the sink in a single-worker pool via [`OnceAsyncFactory`].
+    #[must_use]
     pub fn with_sink(mut self, sink: Box<dyn logfwd_output::Sink>) -> Self {
         let name = self.name.clone();
         let factory = Arc::new(OnceAsyncFactory::new(name, sink));
@@ -196,6 +197,7 @@ impl Pipeline {
     ///
     /// Each new input gets its own passthrough `Scanner + SqlTransform` pair
     /// (`SELECT * FROM logs`) to keep `input_transforms` in sync with `inputs`.
+    #[must_use]
     pub fn with_input(mut self, name: &str, source: Box<dyn InputSource>) -> Self {
         let stats = Arc::new(ComponentStats::new_with_health(ComponentHealth::Starting));
         self.inputs.push(InputState {
@@ -221,6 +223,7 @@ impl Pipeline {
     }
 
     /// Replace the checkpoint store. Useful for injecting an in-memory store in tests.
+    #[must_use]
     pub fn with_checkpoint_store(mut self, store: Box<dyn CheckpointStore>) -> Self {
         self.checkpoint_store = Some(store);
         self
@@ -233,6 +236,7 @@ impl Pipeline {
     /// Panics if `processor.is_stateful()` returns `true`. Stateful processors
     /// require deferred-ACK checkpointing support that is not yet implemented
     /// (tracked in #1404). Register only stateless processors until then.
+    #[must_use]
     pub fn with_processor(mut self, processor: Box<dyn Processor>) -> Self {
         assert!(
             !processor.is_stateful(),
@@ -251,6 +255,7 @@ impl Pipeline {
     ///
     /// Panics if any processor in `processors` returns `is_stateful() == true`.
     /// See [`with_processor`](Self::with_processor) for details.
+    #[must_use]
     pub fn with_processors(mut self, processors: Vec<Box<dyn Processor>>) -> Self {
         for p in &processors {
             assert!(

--- a/crates/logfwd-types/src/io_action.rs
+++ b/crates/logfwd-types/src/io_action.rs
@@ -111,6 +111,7 @@ impl IoAction {
     /// Used by fanout to aggregate results from multiple sinks.
     /// On a severity tie, the action with the larger `Retry-After` hint wins
     /// so callers respect the most conservative delay.
+    #[must_use]
     pub fn worse(self, other: Self) -> Self {
         match other.severity().cmp(&self.severity()) {
             core::cmp::Ordering::Greater => other,

--- a/dev-docs/CODE_STYLE.md
+++ b/dev-docs/CODE_STYLE.md
@@ -100,6 +100,26 @@ Beyond clippy lints, the following Python guards run as part of
 | `scripts/check_no_panic_in_production.py` | No `panic!`/`todo!`/`unimplemented!` in production paths of `logfwd-runtime` and `logfwd-output`. Test modules and `#[test]` functions are exempt; genuinely unreachable invariants can use `// ALLOW-PANIC: <reason>`. |
 | `scripts/check_no_raw_payload_injection.py` | No source-metadata injection into raw payload bytes (see `CRATE_RULES.md` → `logfwd-io`). |
 
+### Semantic lints (dylint)
+
+For invariants that require type resolution — catching `.clone()` on a
+heap type, detecting allocations inside a `#[hot_path]` function,
+verifying `.await` doesn't happen while holding a `Mutex` guard —
+clippy alone is insufficient. These live in `crates/logfwd-lints/` as
+a dylint library and are invoked via `just dylint`.
+
+| Lint | What it flags |
+|---|---|
+| `hot_path_no_alloc` | Heap allocation inside a function marked `#[logfwd_lint_attrs::hot_path]` (`Box::new`, `Vec::new`/`with_capacity`, `String::from`/`new`, `.to_string()`, `.to_vec()`, `.to_owned()`, `.clone()` on heap types, `.collect()` into owned containers, `Arc::new`, `Rc::new`, `HashMap`/`HashSet` allocation). |
+
+The dylint library lives in its own isolated workspace
+(`crates/logfwd-lints/` is excluded from the main workspace because it
+pins a specific rustc nightly and links against `rustc-private` crates).
+The attribute crate (`logfwd-lint-attrs/`) IS in the main workspace —
+it's a regular proc-macro crate. See `crates/logfwd-lints/README.md`
+for installation and the roadmap for additional lints (`#[cancel_safe]`,
+`#[no_panic]`, `#[checkpoint_ordered]`).
+
 ## Ownership and Types
 
 - **Prefer `&str` / `&[u8]` over owned `String` / `Vec<u8>`** in function
@@ -203,6 +223,14 @@ The hot path is: reader → framer → scanner → builders → OTLP encoder →
   `dbg!` in production paths goes through code review specifically
   because it bypasses structured logging and cannot be filtered at runtime.
   `dbg!` is forbidden outright (`clippy::dbg_macro = deny`).
+- **Mark hot-path functions with `#[hot_path]` (from `logfwd-lint-attrs`).**
+  The dylint lint `hot_path_no_alloc` flags heap allocations in the
+  function body — `Box::new`, `Vec::new`/`with_capacity`, `String::new`/`from`,
+  `.to_string()`, `.to_vec()`, `.to_owned()`, `.clone()` on heap types,
+  `.collect()` into owned containers, `Arc::new`, `Rc::new`, `HashMap`/`HashSet`
+  allocation. Run via `just dylint`. See `crates/logfwd-lints/README.md`.
+  The attribute is a compile-time no-op; at runtime the function is
+  identical to the un-annotated version.
 
 ## Abstractions
 

--- a/dev-docs/CODE_STYLE.md
+++ b/dev-docs/CODE_STYLE.md
@@ -65,6 +65,24 @@ overrides — adjust the workspace config instead.
   crates (`logfwd-core`, `logfwd-types`). `logfwd-config` has ~280
   pre-existing schema-field gaps and is not yet gated on this; new
   public items must still carry doc comments by review.
+- **`#[must_use]` discipline.** `clippy::let_underscore_future = deny`
+  (silently dropping a future is always a bug).
+  `clippy::return_self_not_must_use = warn` (builder-chain methods
+  that return `Self` without `#[must_use]` are almost always wrong —
+  the caller built a value and threw it away). Mark the following
+  with `#[must_use]` explicitly:
+  - Every builder method that returns `Self`.
+  - Constructors that return a guard or permit (`_Handle`, `_Permit`,
+    `_Guard`).
+  - `Result`-returning functions where ignoring `Ok(())` means the
+    operation did not actually happen — `flush`, `shutdown`,
+    `commit_checkpoint`, and similar. `Result` already carries
+    `#[must_use]` at the type level, but an explicit annotation on
+    the function makes the intent clear.
+  We deliberately do **not** enable `clippy::let_underscore_must_use`
+  or `clippy::must_use_candidate` — both flag the canonical
+  `let _ = write!(buf, ...)` and `let _ = sender.send(...)` patterns,
+  and would force stylistic churn with negligible correctness gain.
 - **overflow-checks** are enabled in release builds.
 
 All lint levels live at the workspace root or as file-level

--- a/dev-docs/CRATE_RULES.md
+++ b/dev-docs/CRATE_RULES.md
@@ -95,6 +95,24 @@ Rules and constraints for each crate. Enforced by CI, not just convention.
 | Benchmark-only dependencies stay isolated here unless also used by production or test crates | Cargo.toml + dependency review |
 | Source metadata benchmarks must keep raw JSON metadata injection only as a historical comparison baseline, never as production guidance | Code review |
 
+## logfwd-lint-attrs
+
+| Rule | Enforcement |
+|------|-------------|
+| Proc-macro crate only. Exports attribute markers (`#[hot_path]` today, `#[cancel_safe]` / `#[no_panic]` / `#[checkpoint_ordered]` planned) consumed by the dylint lint library | Architecture |
+| All attributes must be compile-time no-ops: the function/item behaves identically with or without the attribute | Code review |
+| May not depend on any other logfwd crate | Cargo.toml |
+
+## logfwd-lints
+
+| Rule | Enforcement |
+|------|-------------|
+| Excluded from the main workspace (`Cargo.toml` `exclude` list). Pins its own rustc nightly via `rust-toolchain` and links against `rustc-private` crates | Workspace config |
+| Dylint library — compiled as `cdylib`, invoked via `cargo dylint` (wrapped by `just dylint`) | Architecture |
+| Every lint that expects a source-level marker looks for the marker the corresponding attribute in `logfwd-lint-attrs` emits (e.g., `#[doc = "__logfwd_hot_path__"]`), because proc-macro attributes are stripped before HIR | Code review |
+| Every new lint adds an entry to the lint table in `dev-docs/CODE_STYLE.md` → *Semantic lints (dylint)* and to `crates/logfwd-lints/README.md` | Code review |
+| CI integration via `just dylint` (not yet on mandatory path — see roadmap) | `justfile` |
+
 ## logfwd-runtime
 
 | Rule | Enforcement |

--- a/justfile
+++ b/justfile
@@ -134,6 +134,13 @@ test:
 test-all:
     LOGFWD_DISABLE_DEFAULT_CHECKPOINTS=1 cargo nextest run --workspace --profile ci
 
+# Run semantic lints via dylint (hot_path_no_alloc, and any future
+# semantic lints defined in crates/logfwd-lints/).
+# Requires: cargo install --locked cargo-dylint dylint-link
+#           rustup toolchain install nightly-2025-09-18 --component llvm-tools-preview --component rustc-dev
+dylint:
+    cargo dylint --path crates/logfwd-lints -- --workspace
+
 # Run required Kani formal verification proofs for production crates
 # Requires: cargo install --locked kani-verifier && cargo kani setup
 kani:


### PR DESCRIPTION
## Summary

Two independent lint-surface additions, one PR, two commits.

### 1. `#[must_use]` discipline (`c29111d`)

- Workspace: `clippy::let_underscore_future = deny` — silently dropping a future is always a bug.
- Workspace: `clippy::return_self_not_must_use = warn` — builder-chain methods that throw away their `Self` are almost always wrong.
- Added `#[must_use]` to the 15 offenders surfaced by the new lint: `IoAction::worse`, `Format::new_instance`, `OtlpSink::with_message_field`, `Pipeline::with_{sink,input,checkpoint_store,processor,processors}`, 7 `CloudTrailProfile::with_*` builders.
- Deliberately skipped `clippy::let_underscore_must_use` and `must_use_candidate` — they'd flag the canonical `let _ = write!(buf, ...)` and `let _ = sender.send(...)` patterns with ~100 hits and negligible correctness gain. Rationale documented in `dev-docs/CODE_STYLE.md`.

### 2. dylint scaffolding + `#[hot_path]` no-alloc lint (`4a73905`)

The hot-path no-alloc rule is the kind of invariant clippy can't check — it needs type resolution (`Vec<T>::clone()` vs `u32::clone()`), post-expansion visibility (`format!`, `vec![]`), and the ability to scope a lint to a tagged subset of functions. Dylint gives us that with the real rustc compiler.

**New crates:**
- `crates/logfwd-lint-attrs/` — regular proc-macro crate, in the main workspace. Exports `#[hot_path]`, a compile-time no-op attribute. Because proc-macro attributes are *stripped* during expansion, the macro prepends a hidden `#[doc = "__logfwd_hot_path__"]` marker that survives to HIR for the lint to find.
- `crates/logfwd-lints/` — dylint library, **excluded from the main workspace** (pins `nightly-2025-09-18`, links `rustc-private`). Compiled as `cdylib`. Contains one lint: `hot_path_no_alloc`, which flags heap allocation in bodies of tagged functions — `Box::new`, `Vec::new`/`with_capacity`, `String::new`/`from`, `.to_string()`, `.to_vec()`, `.to_owned()`, `.clone()` on heap types, `.collect()` into owned containers, `Arc::new`, `Rc::new`, `HashMap`/`HashSet` allocation.

**Integration:**
- `logfwd-arrow` depends on `logfwd-lint-attrs` and tags `StreamingBuilder::begin_row` / `end_row` as the first real `#[hot_path]` users (both genuinely zero-alloc — the lint agrees).
- `just dylint` runs the full suite workspace-wide.
- `dev-docs/CODE_STYLE.md` gains a *Semantic lints (dylint)* subsection; `dev-docs/CRATE_RULES.md` gets entries for both new crates.

**End-to-end verified:**
- Tagged `.to_string()` fires: ✓
- Tagged `Vec::with_capacity(16)` fires: ✓
- Tagged `begin_row`/`end_row` silent (no alloc): ✓
- Untagged `String::from` silent (no attribute): ✓

**Roadmap** — once the scaffolding exists, adding a new semantic lint is ~50 lines each:
- `#[cancel_safe]` — no `std::sync::Mutex` guard or buffered `mpsc::Sender` held across `.await` in tokio `select!` branches.
- `#[no_panic]` — transitive reachability check.
- `#[checkpoint_ordered]` — checkpoint protocol assertion.

## Tradeoffs

- **Dylint pins a rustc nightly** (`2025-09-18`). Needs occasional bumps (~quarterly).
- **CI integration is opt-in via `just dylint`**, not wired into `just lint-all` yet. The cold-build of the lint driver takes ~90s and contributors without dylint installed would see a failure. Suggested follow-up: gate it behind a `ci:full` label or cache the built cdylib.
- **Proc-macro attribute marker is slightly hacky** (`#[doc = "__logfwd_hot_path__"]`). The alternative is a `#![register_tool]` nightly feature, which would force user crates onto nightly. The doc-marker approach works on stable and is invisible at runtime.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Both existing boundary guards (`check_no_box_dyn_error.py`, `check_no_panic_in_production.py`) still pass
- [x] `cargo dylint` against the `logfwd-arrow` lib — produces no false positives on `begin_row`/`end_row`
- [x] `cargo dylint` against synthetic fixtures — correctly fires on tagged allocations, silent on untagged code
- [ ] CI: full lint run (once the runner's nightly toolchain + cargo-dylint install are confirmed)

https://claude.ai/code/session_01UTbyxBK17YiHB1rn4zZrWL

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `#[hot_path]` attribute macro and `hot_path_no_alloc` dylint lint for heap allocation detection
> - Introduces a new `logfwd-lint-attrs` proc-macro crate with a `#[hot_path]` attribute that injects a doc marker string used to identify hot-path functions at lint time.
> - Adds a new `logfwd-lints` dylint crate implementing the `HOT_PATH_NO_ALLOC` lint, which warns on heap allocations (`Box::new`, `Vec::new`, `String::from`, `format!`, `.clone()` on heap types, etc.) inside `#[hot_path]`-annotated functions.
> - Annotates `StreamingBuilder::begin_row` and `end_row` in [streaming_builder.rs](https://github.com/strawgate/fastforward/pull/2404/files#diff-05a83edf355d162945f5713b5186fd14c583cb463359f1d3252e5efac352170d) with `#[hot_path]` as initial adopters.
> - Adds a `dylint` recipe to the [justfile](https://github.com/strawgate/fastforward/pull/2404/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) to run the custom lint against the workspace.
> - Applies `#[must_use]` to builder and value-returning methods across several crates to comply with the new `return_self_not_must_use` warn policy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76cc741.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->