### PR TITLE
fix: restore main after S3 metadata merge

### DIFF
--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -138,8 +138,8 @@ Read objects from AWS S3 or an S3-compatible endpoint. The S3 input can poll
 | `s3.access_key_id` | string | No | AWS access key ID. Falls back to `AWS_ACCESS_KEY_ID`. |
 | `s3.secret_access_key` | string | No | AWS secret access key. Falls back to `AWS_SECRET_ACCESS_KEY`. |
 | `s3.session_token` | string | No | AWS session token. Falls back to `AWS_SESSION_TOKEN`. |
-| `s3.part_size_bytes` | integer | No | Range-GET part size. Defaults to 8388608. |
-| `s3.max_concurrent_fetches` | integer | No | Maximum concurrent range GETs per object. Defaults to 8. |
+| `s3.part_size_bytes` | integer | No | Range-GET part size. Defaults to 1048576. |
+| `s3.max_concurrent_fetches` | integer | No | Maximum concurrent range GETs per object. Defaults to 16. |
 | `s3.max_concurrent_objects` | integer | No | Maximum objects fetched at once. Defaults to 4. |
 | `s3.visibility_timeout_secs` | integer | No | SQS visibility timeout. Defaults to 300 and must be at least 30. |
 | `s3.compression` | string | No | Compression override: `auto`, `gzip`, `zstd`, `snappy`, or `none`. Defaults to `auto`. |

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -1561,7 +1561,12 @@ mod verification {
             offset < original.len() as u32 && end > original.len(),
             "spanning/OOB in original range"
         );
-        kani::cover!(offset >= original.len() as u32, "OOB in generated range");
+        kani::cover!(
+            offset >= original.len() as u32
+                && (offset as usize - original.len()).saturating_add(len as usize)
+                    > generated.len(),
+            "OOB in generated range"
+        );
         kani::cover!(offset == 0, "zero offset error");
     }
 

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -1315,280 +1315,254 @@ mod verification {
 
     // ── make_string_view ────────────────────────────────────────────────────
 
-    /// Inline path (len ≤ 12): length encodes correctly, data bytes round-trip.
-    /// Uses fully symbolic byte content (not constant fill) so the solver
-    /// explores all byte-value-dependent paths.
+    /// Consolidated valid-path proof: covers zero-length, inline (1..=12),
+    /// and buffer-ref (>12) paths in a single harness with `kani::cover!()`
+    /// verifying each case is reachable.
+    ///
+    /// Replaces the former 3 separate proofs:
+    /// - `verify_make_string_view_zero_length`
+    /// - `verify_make_string_view_inline_roundtrip`
+    /// - `verify_make_string_view_buffer_ref_packing`
     #[kani::proof]
-    #[kani::unwind(17)] // 12-byte loop + margin
-    fn verify_make_string_view_inline_roundtrip() {
+    #[kani::unwind(17)]
+    #[kani::solver(kissat)]
+    fn verify_make_string_view_valid_paths() {
         let len: u32 = kani::any();
-        kani::assume(len > 0 && len <= 12);
+        kani::assume(len <= 20);
 
-        // Symbolic bytes — solver explores all values (unlike constant fill).
-        let mut buf = [0u8; 12];
+        // Fixed 32-byte buffer with symbolic first 12 bytes (covers inline
+        // data round-trip and buffer-ref prefix verification).
+        let mut buf = [0u8; 32];
         for i in 0..12 {
             buf[i] = kani::any();
         }
 
-        let sref = StringRef { offset: 0, len };
-        let view =
-            make_string_view(sref, &buf[..len as usize], &[], len as usize, 0, None).unwrap();
+        if len == 0 {
+            // Zero-length path
+            let sref = StringRef { offset: 0, len: 0 };
+            let view = make_string_view(sref, &[], &[], 0, 0, None).unwrap();
+            assert_eq!(view, 0u128, "zero-length string must be all-zero view");
+        } else if len <= 12 {
+            // Inline path
+            let sref = StringRef { offset: 0, len };
+            let view =
+                make_string_view(sref, &buf[..len as usize], &[], len as usize, 0, None).unwrap();
 
-        // Oracle: independently decode the u128 and verify every field.
-        let view_bytes = view.to_le_bytes();
-        let extracted_len =
-            u32::from_le_bytes([view_bytes[0], view_bytes[1], view_bytes[2], view_bytes[3]]);
-        assert_eq!(extracted_len, len, "encoded length must match");
+            let view_bytes = view.to_le_bytes();
+            let extracted_len =
+                u32::from_le_bytes([view_bytes[0], view_bytes[1], view_bytes[2], view_bytes[3]]);
+            assert_eq!(extracted_len, len, "encoded length must match");
 
-        for i in 0..len as usize {
-            assert_eq!(
-                view_bytes[4 + i],
-                buf[i],
-                "inline data byte must match source"
-            );
+            for i in 0..len as usize {
+                assert_eq!(
+                    view_bytes[4 + i],
+                    buf[i],
+                    "inline data byte must match source"
+                );
+            }
+            for i in (4 + len as usize)..16 {
+                assert_eq!(view_bytes[i], 0, "padding byte must be zero");
+            }
+        } else {
+            // Buffer-ref path (len > 12)
+            kani::assume((len as usize) <= 20);
+            let block_idx: u32 = kani::any();
+            kani::assume(block_idx <= 4);
+            let local_offset: u32 = kani::any();
+            kani::assume(local_offset <= 8);
+            kani::assume((local_offset as usize) + (len as usize) <= 32);
+
+            let buf_len = local_offset as usize + len as usize;
+            let sref = StringRef {
+                offset: local_offset,
+                len,
+            };
+            let view =
+                make_string_view(sref, &buf[..buf_len], &[], buf_len, block_idx, None).unwrap();
+
+            let start = local_offset as usize;
+            let expected_prefix =
+                u32::from_le_bytes([buf[start], buf[start + 1], buf[start + 2], buf[start + 3]]);
+            let expected_view = (len as u128)
+                | ((expected_prefix as u128) << 32)
+                | ((block_idx as u128) << 64)
+                | ((local_offset as u128) << 96);
+            assert_eq!(view, expected_view, "view must match oracle computation");
         }
-        // Padding bytes beyond data must be zero.
-        for i in (4 + len as usize)..16 {
-            assert_eq!(view_bytes[i], 0, "padding byte must be zero");
-        }
 
+        kani::cover!(len == 0, "zero-length path");
         kani::cover!(len == 1, "minimal inline");
         kani::cover!(len == 12, "max inline");
-        kani::cover!(buf[0] == 0x00, "zero first byte");
+        kani::cover!(len > 12, "buffer-ref path");
         kani::cover!(buf[0] == 0xFF, "high first byte");
     }
 
-    /// Zero-length string encodes as zero u128.
-    #[kani::proof]
-    fn verify_make_string_view_zero_length() {
-        let sref = StringRef { offset: 0, len: 0 };
-        let view = make_string_view(sref, &[], &[], 0, 0, None).unwrap();
-        assert_eq!(view, 0u128, "zero-length string must be all-zero view");
-    }
-
-    /// Buffer-ref path (len > 12): u128 field packing is non-overlapping and
-    /// each 32-bit lane round-trips correctly.
+    /// Consolidated error-path proof: covers OOB references and buffer
+    /// selection (original vs generated vs missing generated).
     ///
-    /// Uses symbolic prefix bytes (not constant fill) so solver explores
-    /// endianness-dependent bugs. Fixed 32-byte buffer to keep CBMC tractable.
+    /// Replaces the former 2 separate proofs:
+    /// - `verify_make_string_view_out_of_bounds`
+    /// - `verify_make_string_view_buffer_selection`
     #[kani::proof]
     #[kani::solver(kissat)]
-    fn verify_make_string_view_buffer_ref_packing() {
+    fn verify_make_string_view_error_and_selection() {
         let len: u32 = kani::any();
-        kani::assume(len > 12 && len <= 20); // bounded for solver tractability
-
-        let block_idx: u32 = kani::any();
-        kani::assume(block_idx <= 4); // bounded for solver tractability
-        let local_offset: u32 = kani::any();
-        kani::assume(local_offset <= 8); // keep buffer small
-        kani::assume((local_offset as usize) + (len as usize) <= 32);
-
-        // Symbolic first 4 bytes (prefix) + remaining bytes are fixed.
-        let buf_len = local_offset as usize + len as usize;
-        let mut buf = [0u8; 32];
-        let start = local_offset as usize;
-        buf[start] = kani::any();
-        buf[start + 1] = kani::any();
-        buf[start + 2] = kani::any();
-        buf[start + 3] = kani::any();
-
-        let sref = StringRef {
-            offset: local_offset,
-            len,
-        };
-        let view = make_string_view(sref, &buf[..buf_len], &[], buf_len, block_idx, None).unwrap();
-
-        // Oracle: independently recompute expected u128 from the spec.
-        let expected_prefix =
-            u32::from_le_bytes([buf[start], buf[start + 1], buf[start + 2], buf[start + 3]]);
-        let expected_view = (len as u128)
-            | ((expected_prefix as u128) << 32)
-            | ((block_idx as u128) << 64)
-            | ((local_offset as u128) << 96);
-        assert_eq!(view, expected_view, "view must match oracle computation");
-
-        kani::cover!(block_idx > 0, "non-zero block index");
-        kani::cover!(local_offset > 0, "non-zero local offset");
-        kani::cover!(buf[start] == 0x00, "zero prefix byte");
-        kani::cover!(buf[start] == 0xFF, "high prefix byte");
-    }
-
-    /// Out-of-bounds StringRef returns error, never panics.
-    /// Uses fixed-size array (not vec with symbolic length) to avoid CBMC timeout.
-    #[kani::proof]
-    #[kani::solver(kissat)]
-    fn verify_make_string_view_out_of_bounds() {
-        let offset: u32 = kani::any();
-        let len: u32 = kani::any();
-        kani::assume(len > 0 && len <= 128);
-        kani::assume(offset <= 128);
-
-        let buf_len: usize = kani::any();
-        kani::assume(buf_len <= 64);
-        let total = (offset as usize).saturating_add(len as usize);
-        kani::assume(total > buf_len);
-
-        // Fixed-size array avoids CBMC symbolic-allocation explosion.
-        let buf = [0u8; 64];
-        let sref = StringRef { offset, len };
-        let result = make_string_view(sref, &buf[..buf_len], &[], buf_len, 0, None);
-        assert!(result.is_err(), "OOB reference must return error");
-
-        kani::cover!(offset == 0, "zero offset with large len");
-        kani::cover!(offset > 0 && len > 0, "non-zero offset and len");
-        kani::cover!(buf_len == 0, "empty buffer");
-    }
-
-    /// Buffer selection: offset < original_len uses original buffer,
-    /// offset >= original_len uses generated buffer.
-    #[kani::proof]
-    fn verify_make_string_view_buffer_selection() {
-        let len: u32 = kani::any();
-        kani::assume(len > 0 && len <= 4);
+        kani::assume(len > 0 && len <= 16);
 
         let original_len: usize = 8;
         let original = [0xAAu8; 8];
         let generated = [0xBBu8; 8];
 
-        // Original buffer path: offset < original_len.
-        let orig_offset: u32 = kani::any();
-        kani::assume(orig_offset <= (original_len as u32) - len);
-        let sref_orig = StringRef {
-            offset: orig_offset,
-            len,
-        };
-        let result_orig =
-            make_string_view(sref_orig, &original, &generated, original_len, 0, Some(1));
-        assert!(result_orig.is_ok(), "valid original ref must succeed");
+        let scenario: u8 = kani::any_where(|&s: &u8| s < 4);
+        match scenario {
+            0 => {
+                // OOB in original buffer
+                let offset: u32 = kani::any();
+                kani::assume(offset <= 16);
+                let total = (offset as usize).saturating_add(len as usize);
+                kani::assume(total > original_len);
+                kani::assume(offset < original_len as u32);
+                let sref = StringRef { offset, len };
+                let result = make_string_view(sref, &original, &[], original_len, 0, None);
+                assert!(result.is_err(), "OOB original ref must return error");
+            }
+            1 => {
+                // Valid original buffer path
+                let orig_offset: u32 = kani::any();
+                kani::assume(len <= 8);
+                kani::assume(orig_offset <= (original_len as u32) - len);
+                let sref = StringRef {
+                    offset: orig_offset,
+                    len,
+                };
+                let result =
+                    make_string_view(sref, &original, &generated, original_len, 0, Some(1));
+                assert!(result.is_ok(), "valid original ref must succeed");
+            }
+            2 => {
+                // Valid generated buffer path
+                let gen_offset: u32 = kani::any();
+                kani::assume(len <= 8);
+                kani::assume(gen_offset <= (generated.len() as u32) - len);
+                let sref = StringRef {
+                    offset: original_len as u32 + gen_offset,
+                    len,
+                };
+                let result =
+                    make_string_view(sref, &original, &generated, original_len, 0, Some(1));
+                assert!(result.is_ok(), "valid generated ref must succeed");
+            }
+            _ => {
+                // No generated buffer + offset in generated range → error
+                let sref = StringRef {
+                    offset: original_len as u32,
+                    len: 1,
+                };
+                let result = make_string_view(sref, &original, &[], original_len, 0, None);
+                assert!(
+                    result.is_err(),
+                    "generated offset with no generated buffer must error"
+                );
+            }
+        }
 
-        // Generated buffer path: offset >= original_len.
-        let gen_offset: u32 = kani::any();
-        kani::assume(gen_offset <= (generated.len() as u32) - len);
-        let sref_gen = StringRef {
-            offset: original_len as u32 + gen_offset,
-            len,
-        };
-        let result_gen =
-            make_string_view(sref_gen, &original, &generated, original_len, 0, Some(1));
-        assert!(result_gen.is_ok(), "valid generated ref must succeed");
-
-        // No generated buffer + offset in generated range → error.
-        let sref_no_gen = StringRef {
-            offset: original_len as u32,
-            len: 1,
-        };
-        let result_no_gen = make_string_view(sref_no_gen, &original, &[], original_len, 0, None);
-        assert!(
-            result_no_gen.is_err(),
-            "generated offset with no generated buffer must error"
-        );
-
-        kani::cover!(orig_offset == 0, "start of original");
-        kani::cover!(gen_offset == 0, "start of generated");
+        kani::cover!(scenario == 0, "OOB error path");
+        kani::cover!(scenario == 1, "valid original path");
+        kani::cover!(scenario == 2, "valid generated path");
+        kani::cover!(scenario == 3, "missing generated buffer error");
     }
 
     // ── read_str_bytes — 2-buffer dispatch ─────────────────────────────────
 
-    /// Valid original-buffer reference returns correct bytes.
+    /// Consolidated valid-path proof: covers original and generated buffer
+    /// dispatch in a single harness.
+    ///
+    /// Replaces the former 2 separate proofs:
+    /// - `verify_read_str_bytes_original`
+    /// - `verify_read_str_bytes_generated`
     #[kani::proof]
     #[kani::unwind(10)]
-    fn verify_read_str_bytes_original() {
+    fn verify_read_str_bytes_valid_paths() {
         let original = [0xAAu8; 8];
         let generated = [0xBBu8; 8];
-        let offset: u32 = kani::any();
         let len: u32 = kani::any();
         kani::assume(len > 0 && len <= 8);
-        kani::assume(offset <= 8 - len);
 
-        let sref = StringRef { offset, len };
-        let result = read_str_bytes(&original, &generated, original.len(), sref);
-        assert!(result.is_ok());
-        let bytes = result.unwrap();
-        assert_eq!(bytes.len(), len as usize);
-        for &b in bytes {
-            assert_eq!(b, 0xAA);
+        let use_generated: bool = kani::any();
+
+        if use_generated {
+            let gen_offset: u32 = kani::any();
+            kani::assume(gen_offset <= 8 - len);
+            let sref = StringRef {
+                offset: original.len() as u32 + gen_offset,
+                len,
+            };
+            let result = read_str_bytes(&original, &generated, original.len(), sref);
+            assert!(result.is_ok());
+            let bytes = result.unwrap();
+            assert_eq!(bytes.len(), len as usize);
+            for &b in bytes {
+                assert_eq!(b, 0xBB);
+            }
+        } else {
+            let offset: u32 = kani::any();
+            kani::assume(offset <= 8 - len);
+            let sref = StringRef { offset, len };
+            let result = read_str_bytes(&original, &generated, original.len(), sref);
+            assert!(result.is_ok());
+            let bytes = result.unwrap();
+            assert_eq!(bytes.len(), len as usize);
+            for &b in bytes {
+                assert_eq!(b, 0xAA);
+            }
         }
 
-        kani::cover!(len == 1, "single-byte original ref");
-        kani::cover!(offset == 0, "ref from start of original");
+        kani::cover!(use_generated, "generated buffer path");
+        kani::cover!(!use_generated, "original buffer path");
+        kani::cover!(len == 1, "single-byte ref");
+        kani::cover!(len == 8, "full-buffer ref");
     }
 
-    /// Valid generated-buffer reference returns correct bytes.
+    /// Consolidated error-path proof: covers OOB and boundary-spanning
+    /// errors in a single harness.
+    ///
+    /// Replaces the former 2 separate proofs:
+    /// - `verify_read_str_bytes_oob`
+    /// - `verify_read_str_bytes_no_spanning`
     #[kani::proof]
-    #[kani::unwind(10)]
-    fn verify_read_str_bytes_generated() {
-        let original = [0xAAu8; 8];
-        let generated = [0xBBu8; 8];
-        let gen_offset: u32 = kani::any();
-        let len: u32 = kani::any();
-        kani::assume(len > 0 && len <= 8);
-        kani::assume(gen_offset <= 8 - len);
-
-        let sref = StringRef {
-            offset: original.len() as u32 + gen_offset,
-            len,
-        };
-        let result = read_str_bytes(&original, &generated, original.len(), sref);
-        assert!(result.is_ok());
-        let bytes = result.unwrap();
-        assert_eq!(bytes.len(), len as usize);
-        for &b in bytes {
-            assert_eq!(b, 0xBB);
-        }
-
-        kani::cover!(len == 1, "single-byte generated ref");
-        kani::cover!(gen_offset == 0, "ref from start of generated");
-    }
-
-    /// Out-of-bounds StringRef returns error for both buffers.
-    #[kani::proof]
-    fn verify_read_str_bytes_oob() {
-        let original = [0u8; 4];
-        let generated = [0u8; 4];
+    fn verify_read_str_bytes_errors() {
+        let original = [0xAAu8; 4];
+        let generated = [0xBBu8; 4];
         let offset: u32 = kani::any();
         let len: u32 = kani::any();
         kani::assume(len > 0 && len <= 16);
         kani::assume(offset <= 16);
 
         let sref = StringRef { offset, len };
-
         let end = (offset as usize).saturating_add(len as usize);
+
         if offset < original.len() as u32 {
             if end > original.len() {
+                // Spanning or OOB in original range
                 let result = read_str_bytes(&original, &generated, original.len(), sref);
-                assert!(result.is_err());
+                assert!(result.is_err(), "spanning/OOB original ref must error");
             }
         } else {
             let adj_start = offset as usize - original.len();
             let adj_end = adj_start + len as usize;
             if adj_end > generated.len() {
+                // OOB in generated range
                 let result = read_str_bytes(&original, &generated, original.len(), sref);
-                assert!(result.is_err());
+                assert!(result.is_err(), "OOB generated ref must error");
             }
         }
 
-        kani::cover!(offset < original.len() as u32, "OOB in original range");
+        kani::cover!(
+            offset < original.len() as u32 && end > original.len(),
+            "spanning/OOB in original range"
+        );
         kani::cover!(offset >= original.len() as u32, "OOB in generated range");
-    }
-
-    /// No StringRef can span across the original/generated boundary.
-    #[kani::proof]
-    fn verify_read_str_bytes_no_spanning() {
-        let original = [0xAAu8; 4];
-        let generated = [0xBBu8; 4];
-        let len: u32 = kani::any();
-        kani::assume(len > 0 && len <= 8);
-
-        let offset: u32 = kani::any();
-        kani::assume(offset < original.len() as u32);
-        kani::assume((offset as usize) + (len as usize) > original.len());
-
-        let sref = StringRef { offset, len };
-        let result = read_str_bytes(&original, &generated, original.len(), sref);
-        assert!(result.is_err(), "spanning ref must be rejected");
-
-        kani::cover!(len >= 2, "multi-byte spanning ref");
-        kani::cover!(offset == 0, "spanning from start of original");
+        kani::cover!(offset == 0, "zero offset error");
     }
 
     // ── scatter_values — dense/sparse placement ────────────────────────────

--- a/crates/logfwd-bench/src/bin/source_metadata_profile.rs
+++ b/crates/logfwd-bench/src/bin/source_metadata_profile.rs
@@ -3,9 +3,6 @@
 //!
 //! Run:
 //! `cargo run -p logfwd-bench --release --bin source_metadata_profile -- --rows 50000 --sources 300 --iterations 200`
-
-#![allow(clippy::print_stdout)]
-
 use std::alloc::System;
 use std::collections::HashMap;
 use std::io::{self, Write};

--- a/crates/logfwd-bench/src/bin/source_metadata_profile.rs
+++ b/crates/logfwd-bench/src/bin/source_metadata_profile.rs
@@ -1,7 +1,10 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 //! Quick source metadata attachment timing/allocation profile.
 //!
 //! Run:
 //! `cargo run -p logfwd-bench --release --bin source_metadata_profile -- --rows 50000 --sources 300 --iterations 200`
+
+#![allow(clippy::print_stdout)]
 
 use std::alloc::System;
 use std::collections::HashMap;

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -1520,6 +1520,66 @@ pipelines:
     }
 
     #[test]
+    fn quoted_null_output_rejects_endpoint() {
+        let yaml = r#"
+input:
+  type: file
+  path: /tmp/x.log
+output:
+  type: "null"
+  endpoint: https://collector:4318
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pipeline 'default' output '#0'"),
+            "error should include pipeline/output context: {msg}"
+        );
+        assert!(
+            msg.contains("null output does not support") && msg.contains("endpoint"),
+            "explicit null output with endpoint must be rejected: {msg}"
+        );
+    }
+
+    #[test]
+    fn quoted_null_output_rejects_unrelated_output_fields() {
+        for (field, value) in [
+            ("auth", "\n    bearer_token: secret"),
+            ("batch_size", "100"),
+            ("compression", "gzip"),
+            ("format", "json"),
+            ("headers", "\n    x-test: value"),
+            ("index", "logs"),
+            ("path", "/tmp/out.log"),
+            ("protocol", "grpc"),
+            ("request_timeout_ms", "1000"),
+            ("tls", "\n    ca_file: /tmp/ca.pem"),
+        ] {
+            let yaml = format!(
+                r#"
+input:
+  type: file
+  path: /tmp/x.log
+output:
+  type: "null"
+  {field}: {value}
+"#
+            );
+            let err = Config::load_str(&yaml).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("pipeline 'default' output '#0'"),
+                "error should include pipeline/output context: {msg}"
+            );
+            let expected = format!("null output does not support '{field}'");
+            assert!(
+                msg.contains(&expected),
+                "explicit null output with {field} must be rejected: {msg}"
+            );
+        }
+    }
+
+    #[test]
     fn whole_output_null_is_rejected() {
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput: null\n";
         let err = Config::load_str(yaml).unwrap_err();
@@ -2255,6 +2315,25 @@ pipelines:
     }
 
     #[test]
+    fn tcp_mtls_accepts_required_client_ca() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: tcp
+        listen: 0.0.0.0:514
+        tls:
+          cert_file: /tmp/server.pem
+          key_file: /tmp/server.key
+          client_ca_file: /tmp/ca.pem
+          require_client_auth: true
+    outputs:
+      - type: "null"
+"#;
+        Config::load_str(yaml).expect("tcp mTLS with client CA should validate");
+    }
+
+    #[test]
     fn tcp_mtls_requires_client_ca() {
         let yaml = r#"
 pipelines:
@@ -2272,8 +2351,31 @@ pipelines:
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
             err.to_string()
-                .contains("client authentication is not supported"),
-            "expected TCP mTLS validation failure: {err}"
+                .contains("require_client_auth requires tls.client_ca_file"),
+            "expected TCP mTLS client CA validation failure: {err}"
+        );
+    }
+
+    #[test]
+    fn tcp_client_ca_requires_mtls_enabled() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: tcp
+        listen: 0.0.0.0:514
+        tls:
+          cert_file: /tmp/server.pem
+          key_file: /tmp/server.key
+          client_ca_file: /tmp/ca.pem
+    outputs:
+      - type: "null"
+"#;
+        let err = Config::load_str(yaml).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("client_ca_file requires tls.require_client_auth: true"),
+            "expected TCP client CA without mTLS validation failure: {err}"
         );
     }
 

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -311,9 +311,14 @@ impl Config {
                                     .map(str::trim)
                                     .filter(|v| !v.is_empty());
 
-                                if client_ca_file.is_some() || tls.require_client_auth {
+                                if tls.require_client_auth && client_ca_file.is_none() {
                                     return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': tcp tls client authentication is not supported (tls.client_ca_file and tls.require_client_auth are reserved for #2332)"
+                                        "pipeline '{name}' input '{label}': tcp tls require_client_auth requires tls.client_ca_file"
+                                    )));
+                                }
+                                if client_ca_file.is_some() && !tls.require_client_auth {
+                                    return Err(ConfigError::Validation(format!(
+                                        "pipeline '{name}' input '{label}': tcp tls client_ca_file requires tls.require_client_auth: true"
                                     )));
                                 }
 
@@ -2838,7 +2843,7 @@ pipelines:
     }
 
     #[test]
-    fn tcp_tls_rejects_partial_or_mtls_fields() {
+    fn tcp_tls_rejects_partial_cert_key_pair() {
         let partial = r#"
 pipelines:
   test:
@@ -2855,7 +2860,51 @@ pipelines:
             err.contains("tls.cert_file") && err.contains("tls.key_file"),
             "expected cert/key pairing validation error, got: {err}"
         );
+    }
 
+    #[test]
+    fn tcp_mtls_requires_client_ca() {
+        let mtls = r#"
+pipelines:
+  test:
+    inputs:
+      - type: tcp
+        listen: 127.0.0.1:5514
+        tls:
+          cert_file: /tmp/server.crt
+          key_file: /tmp/server.key
+          require_client_auth: true
+    outputs:
+      - type: "null"
+"#;
+        let err = Config::load_str(mtls).unwrap_err().to_string();
+        assert!(
+            err.contains("require_client_auth requires tls.client_ca_file"),
+            "expected missing client CA rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn tcp_mtls_accepts_client_ca_when_auth_required() {
+        let mtls = r#"
+pipelines:
+  test:
+    inputs:
+      - type: tcp
+        listen: 127.0.0.1:5514
+        tls:
+          cert_file: /tmp/server.crt
+          key_file: /tmp/server.key
+          client_ca_file: /tmp/ca.crt
+          require_client_auth: true
+    outputs:
+      - type: "null"
+"#;
+        Config::load_str(mtls).expect("mTLS with client CA should validate");
+    }
+
+    #[test]
+    fn tcp_client_ca_requires_auth_required() {
         let mtls = r#"
 pipelines:
   test:
@@ -2871,8 +2920,8 @@ pipelines:
 "#;
         let err = Config::load_str(mtls).unwrap_err().to_string();
         assert!(
-            err.contains("client authentication is not supported"),
-            "expected mTLS rejection, got: {err}"
+            err.contains("client_ca_file requires tls.require_client_auth: true"),
+            "expected client CA without mTLS rejection, got: {err}"
         );
     }
 }

--- a/crates/logfwd-io/src/receiver_health.rs
+++ b/crates/logfwd-io/src/receiver_health.rs
@@ -153,6 +153,11 @@ mod tests {
     }
 }
 
+// NOTE: This Kani verification module follows the same per-event-variant proof
+// pattern as `crates/logfwd-output/src/sink/health.rs`. Both verify a
+// `reduce_*_health(ComponentHealth, Event) -> ComponentHealth` reducer with one
+// proof per event variant. They are NOT merged because they are different
+// compilation units with distinct event enums and transition tables.
 #[cfg(kani)]
 mod verification {
     use super::{ReceiverHealthEvent, reduce_receiver_health};

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -12,8 +12,10 @@ use std::time::{Duration, Instant};
 
 use logfwd_types::diagnostics::ComponentHealth;
 use logfwd_types::pipeline::SourceId;
+use rustls::RootCertStore;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::WebPkiClientVerifier;
 use rustls::{ServerConfig, ServerConnection, StreamOwned};
 use socket2::SockRef;
 
@@ -313,6 +315,10 @@ pub struct TcpInputTlsOptions {
     pub cert_file: String,
     /// Path to a PEM-encoded private key file matching `cert_file`.
     pub key_file: String,
+    /// Path to a PEM-encoded CA bundle used to verify client certificates.
+    pub client_ca_file: Option<String>,
+    /// Require clients to present a certificate signed by `client_ca_file`.
+    pub require_client_auth: bool,
 }
 
 /// TCP input that accepts connections and reads newline-delimited data.
@@ -388,18 +394,77 @@ impl TcpInput {
                 ),
             )
         })?;
-        let cfg = ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(certs, key)
-            .map_err(|e| {
-                io::Error::new(
+        let builder = ServerConfig::builder();
+        let builder = if opts.require_client_auth {
+            let client_ca_file = opts
+                .client_ca_file
+                .as_deref()
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "tcp.tls.require_client_auth requires tcp.tls.client_ca_file",
+                    )
+                })?;
+            let client_ca_certs = CertificateDer::pem_file_iter(client_ca_file)
+                .map_err(|e| {
+                    io::Error::new(
+                        pem_error_kind(&e),
+                        format!(
+                            "tcp.tls.client_ca_file '{client_ca_file}' could not be opened or parsed as PEM: {e}"
+                        ),
+                    )
+                })?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "tcp.tls.client_ca_file '{client_ca_file}' could not be parsed as PEM: {e}"
+                        ),
+                    )
+                })?;
+            if client_ca_certs.is_empty() {
+                return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!(
-                        "tcp.tls cert/key mismatch between '{}' and '{}': {e}",
-                        opts.cert_file, opts.key_file
-                    ),
-                )
-            })?;
+                    format!("tcp.tls.client_ca_file '{client_ca_file}' contained no certificates"),
+                ));
+            }
+            let mut roots = RootCertStore::empty();
+            for cert in client_ca_certs {
+                roots.add(cert).map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "tcp.tls.client_ca_file '{client_ca_file}' contained an invalid CA certificate: {e}"
+                        ),
+                    )
+                })?;
+            }
+            let verifier = WebPkiClientVerifier::builder(std::sync::Arc::new(roots))
+                .build()
+                .map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "tcp.tls.client_ca_file '{client_ca_file}' could not build a client certificate verifier: {e}"
+                        ),
+                    )
+                })?;
+            builder.with_client_cert_verifier(verifier)
+        } else {
+            builder.with_no_client_auth()
+        };
+        let cfg = builder.with_single_cert(certs, key).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "tcp.tls cert/key mismatch between '{}' and '{}': {e}",
+                    opts.cert_file, opts.key_file
+                ),
+            )
+        })?;
         Ok(std::sync::Arc::new(cfg))
     }
 
@@ -783,7 +848,10 @@ impl InputSource for TcpInput {
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use rcgen::generate_simple_self_signed;
+    use rcgen::{
+        BasicConstraints, Certificate, CertificateParams, ExtendedKeyUsagePurpose, IsCa, Issuer,
+        KeyPair, KeyUsagePurpose, generate_simple_self_signed,
+    };
     use rustls::pki_types::ServerName;
     use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
     use std::fs;
@@ -836,13 +904,94 @@ mod tests {
         )
     }
 
+    fn write_mtls_files(
+        server_cert_pem: &str,
+        server_key_pem: &str,
+        ca_cert_pem: &str,
+    ) -> (tempfile::TempDir, String, String, String) {
+        let (dir, cert_file, key_file) = write_tls_files(server_cert_pem, server_key_pem);
+        let ca_path = dir.path().join("client-ca.crt");
+        fs::write(&ca_path, ca_cert_pem).expect("CA file should be written");
+        (
+            dir,
+            cert_file,
+            key_file,
+            ca_path.to_string_lossy().to_string(),
+        )
+    }
+
     fn make_tls_options(cert_file: String, key_file: String) -> TcpInputOptions {
         TcpInputOptions {
             tls: Some(TcpInputTlsOptions {
                 cert_file,
                 key_file,
+                client_ca_file: None,
+                require_client_auth: false,
             }),
             ..Default::default()
+        }
+    }
+
+    fn make_mtls_options(cert_file: String, key_file: String, ca_file: String) -> TcpInputOptions {
+        TcpInputOptions {
+            tls: Some(TcpInputTlsOptions {
+                cert_file,
+                key_file,
+                client_ca_file: Some(ca_file),
+                require_client_auth: true,
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn make_ca() -> (Certificate, Issuer<'static, KeyPair>) {
+        let mut params =
+            CertificateParams::new(Vec::<String>::new()).expect("empty SAN should be valid");
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        params.key_usages.push(KeyUsagePurpose::KeyCertSign);
+        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+
+        let key_pair = KeyPair::generate().expect("CA key should generate");
+        let cert = params
+            .self_signed(&key_pair)
+            .expect("CA cert should self-sign");
+        (cert, Issuer::new(params, key_pair))
+    }
+
+    fn make_signed_cert(
+        name: &str,
+        eku: ExtendedKeyUsagePurpose,
+        issuer: &Issuer<'static, KeyPair>,
+    ) -> (Certificate, String) {
+        let mut params = CertificateParams::new(vec![name.to_string()])
+            .expect("certificate SAN should be valid");
+        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+        params.extended_key_usages.push(eku);
+        let key_pair = KeyPair::generate().expect("leaf key should generate");
+        let cert = params
+            .signed_by(&key_pair, issuer)
+            .expect("leaf cert should be signed by CA");
+        (cert, key_pair.serialize_pem())
+    }
+
+    fn client_config(
+        server_ca: &Certificate,
+        client_cert: Option<(&Certificate, &str)>,
+    ) -> ClientConfig {
+        let mut roots = RootCertStore::empty();
+        roots
+            .add(server_ca.der().clone())
+            .expect("generated CA should load as trust anchor");
+        let builder = ClientConfig::builder().with_root_certificates(roots);
+        match client_cert {
+            Some((cert, key_pem)) => builder
+                .with_client_auth_cert(
+                    vec![cert.der().clone()],
+                    PrivateKeyDer::from_pem_slice(key_pem.as_bytes())
+                        .expect("client key PEM should parse"),
+                )
+                .expect("client cert/key should match"),
+            None => builder.with_no_client_auth(),
         }
     }
 
@@ -904,6 +1053,138 @@ mod tests {
             .join()
             .expect("tls client writer thread should complete");
         assert_eq!(joined, b"{\"msg\":\"tls\"}\n");
+    }
+
+    #[test]
+    fn mtls_listener_accepts_trusted_client_certificate() {
+        let (ca_cert, ca_issuer) = make_ca();
+        let (server_cert, server_key_pem) =
+            make_signed_cert("localhost", ExtendedKeyUsagePurpose::ServerAuth, &ca_issuer);
+        let (client_cert, client_key_pem) =
+            make_signed_cert("client", ExtendedKeyUsagePurpose::ClientAuth, &ca_issuer);
+        let (_tmp, cert_file, key_file, ca_file) =
+            write_mtls_files(&server_cert.pem(), &server_key_pem, &ca_cert.pem());
+
+        let stats = std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new());
+        let mut input = TcpInput::with_options(
+            "mtls-test",
+            "127.0.0.1:0",
+            make_mtls_options(cert_file, key_file, ca_file),
+            stats,
+        )
+        .expect("mTLS listener should start");
+        let addr = input.local_addr().expect("mTLS listener local addr");
+
+        let conn = ClientConnection::new(
+            std::sync::Arc::new(client_config(
+                &ca_cert,
+                Some((&client_cert, &client_key_pem)),
+            )),
+            ServerName::try_from("localhost").expect("valid SNI"),
+        )
+        .expect("client connection should initialize");
+        let tcp = StdTcpStream::connect(addr).expect("client should connect");
+        let writer = std::thread::spawn(move || {
+            let mut tls = StreamOwned::new(conn, tcp);
+            tls.write_all(b"{\"msg\":\"mtls\"}\n")?;
+            tls.flush()
+        });
+
+        let joined = poll_tcp_bytes_until(&mut input, |bytes| bytes == b"{\"msg\":\"mtls\"}\n");
+        writer
+            .join()
+            .expect("mTLS client writer thread should complete")
+            .expect("mTLS write should succeed");
+        assert_eq!(joined, b"{\"msg\":\"mtls\"}\n");
+    }
+
+    #[test]
+    fn mtls_listener_rejects_missing_client_certificate() {
+        let (ca_cert, ca_issuer) = make_ca();
+        let (server_cert, server_key_pem) =
+            make_signed_cert("localhost", ExtendedKeyUsagePurpose::ServerAuth, &ca_issuer);
+        let (_tmp, cert_file, key_file, ca_file) =
+            write_mtls_files(&server_cert.pem(), &server_key_pem, &ca_cert.pem());
+
+        let stats = std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new());
+        let mut input = TcpInput::with_options(
+            "mtls-test",
+            "127.0.0.1:0",
+            make_mtls_options(cert_file, key_file, ca_file),
+            stats,
+        )
+        .expect("mTLS listener should start");
+        let addr = input.local_addr().expect("mTLS listener local addr");
+
+        let conn = ClientConnection::new(
+            std::sync::Arc::new(client_config(&ca_cert, None)),
+            ServerName::try_from("localhost").expect("valid SNI"),
+        )
+        .expect("client connection should initialize");
+        let tcp = StdTcpStream::connect(addr).expect("client should connect");
+        let writer = std::thread::spawn(move || {
+            let mut tls = StreamOwned::new(conn, tcp);
+            let _ = tls.write_all(b"{\"msg\":\"missing-cert\"}\n");
+            let _ = tls.flush();
+        });
+
+        let data_events = poll_for_data_events(&mut input, 50);
+        writer
+            .join()
+            .expect("mTLS client writer thread should complete");
+        assert!(
+            data_events.is_empty(),
+            "mTLS listener must not emit records when the client omits a certificate"
+        );
+    }
+
+    #[test]
+    fn mtls_listener_rejects_untrusted_client_certificate() {
+        let (ca_cert, ca_issuer) = make_ca();
+        let (_untrusted_ca_cert, untrusted_ca_issuer) = make_ca();
+        let (server_cert, server_key_pem) =
+            make_signed_cert("localhost", ExtendedKeyUsagePurpose::ServerAuth, &ca_issuer);
+        let (client_cert, client_key_pem) = make_signed_cert(
+            "client",
+            ExtendedKeyUsagePurpose::ClientAuth,
+            &untrusted_ca_issuer,
+        );
+        let (_tmp, cert_file, key_file, ca_file) =
+            write_mtls_files(&server_cert.pem(), &server_key_pem, &ca_cert.pem());
+
+        let stats = std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new());
+        let mut input = TcpInput::with_options(
+            "mtls-test",
+            "127.0.0.1:0",
+            make_mtls_options(cert_file, key_file, ca_file),
+            stats,
+        )
+        .expect("mTLS listener should start");
+        let addr = input.local_addr().expect("mTLS listener local addr");
+
+        let conn = ClientConnection::new(
+            std::sync::Arc::new(client_config(
+                &ca_cert,
+                Some((&client_cert, &client_key_pem)),
+            )),
+            ServerName::try_from("localhost").expect("valid SNI"),
+        )
+        .expect("client connection should initialize");
+        let tcp = StdTcpStream::connect(addr).expect("client should connect");
+        let writer = std::thread::spawn(move || {
+            let mut tls = StreamOwned::new(conn, tcp);
+            let _ = tls.write_all(b"{\"msg\":\"untrusted\"}\n");
+            let _ = tls.flush();
+        });
+
+        let data_events = poll_for_data_events(&mut input, 50);
+        writer
+            .join()
+            .expect("mTLS client writer thread should complete");
+        assert!(
+            data_events.is_empty(),
+            "mTLS listener must not emit records for untrusted client certificates"
+        );
     }
 
     #[test]
@@ -1053,6 +1334,57 @@ mod tests {
         assert!(
             err.to_string().contains("cert/key mismatch"),
             "error should mention cert/key mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn mtls_listener_fails_on_malformed_client_ca_pem() {
+        let certified = generate_simple_self_signed(vec!["localhost".into()])
+            .expect("test cert generation should succeed");
+        let (tmp, cert_file, key_file) = write_tls_files(
+            &certified.cert.pem(),
+            &certified.signing_key.serialize_pem(),
+        );
+        let ca_path = tmp.path().join("client-ca.crt");
+        fs::write(&ca_path, "not-a-ca").expect("client CA file should be written");
+
+        let err = match TcpInput::with_options(
+            "mtls-test",
+            "127.0.0.1:0",
+            make_mtls_options(cert_file, key_file, ca_path.to_string_lossy().to_string()),
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        ) {
+            Ok(_) => panic!("malformed client CA must fail startup"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("tcp.tls.client_ca_file"),
+            "error should identify tcp.tls.client_ca_file: {err}"
+        );
+    }
+
+    #[test]
+    fn mtls_listener_requires_non_empty_client_ca_path() {
+        let certified = generate_simple_self_signed(vec!["localhost".into()])
+            .expect("test cert generation should succeed");
+        let (_tmp, cert_file, key_file) = write_tls_files(
+            &certified.cert.pem(),
+            &certified.signing_key.serialize_pem(),
+        );
+
+        let err = match TcpInput::with_options(
+            "mtls-test",
+            "127.0.0.1:0",
+            make_mtls_options(cert_file, key_file, "   ".to_string()),
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        ) {
+            Ok(_) => panic!("blank client CA path must fail startup"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("require_client_auth requires tcp.tls.client_ca_file"),
+            "error should identify missing tcp.tls.client_ca_file: {err}"
         );
     }
 

--- a/crates/logfwd-output/src/sink/health.rs
+++ b/crates/logfwd-output/src/sink/health.rs
@@ -274,6 +274,11 @@ mod tests {
     }
 }
 
+// NOTE: This Kani verification module follows the same per-event-variant proof
+// pattern as `crates/logfwd-io/src/receiver_health.rs`. Both verify a
+// `reduce_*_health(ComponentHealth, Event) -> ComponentHealth` reducer with one
+// proof per event variant. They are NOT merged because they are different
+// compilation units with distinct event enums and transition tables.
 #[cfg(kani)]
 mod verification {
     use super::{OutputHealthEvent, aggregate_fanout_health, reduce_output_health};

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -435,9 +435,14 @@ pub(super) fn build_input_state(
                     .as_deref()
                     .map(str::trim)
                     .is_some_and(|v| !v.is_empty());
-                if has_client_ca || tls.require_client_auth {
+                if tls.require_client_auth && !has_client_ca {
                     return Err(format!(
-                        "input '{name}': tcp.tls.client_ca_file and tcp.tls.require_client_auth are not supported for TCP inputs yet (tracked by #2332)"
+                        "input '{name}': tcp.tls.require_client_auth requires non-empty 'tcp.tls.client_ca_file'"
+                    ));
+                }
+                if has_client_ca && !tls.require_client_auth {
+                    return Err(format!(
+                        "input '{name}': tcp.tls.client_ca_file requires 'tcp.tls.require_client_auth: true'"
                     ));
                 }
                 let cert_file =
@@ -447,6 +452,13 @@ pub(super) fn build_input_state(
                 options.tls = Some(logfwd_io::tcp_input::TcpInputTlsOptions {
                     cert_file: cert_file.to_string(),
                     key_file: key_file.to_string(),
+                    client_ca_file: tls
+                        .client_ca_file
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|v| !v.is_empty())
+                        .map(str::to_string),
+                    require_client_auth: tls.require_client_auth,
                 });
             }
             let source = logfwd_io::tcp_input::TcpInput::with_options(
@@ -1188,6 +1200,42 @@ mod tests {
         assert!(
             err.contains("tcp.tls.cert_file") || err.contains("tcp.tls.key_file"),
             "expected tcp tls field context in startup error: {err}"
+        );
+    }
+
+    #[test]
+    fn build_input_state_tcp_mtls_requires_client_ca_file() {
+        use logfwd_diagnostics::diagnostics::PipelineMetrics;
+
+        let meter = logfwd_test_utils::test_meter();
+        let mut pm = PipelineMetrics::new("p", "SELECT 1", &meter);
+        let stats = pm.add_input("tcp-in", "tcp");
+        let cfg = InputConfig {
+            name: Some("tcp-in".to_string()),
+            format: Some(Format::Json),
+            sql: None,
+            source_metadata: SourceMetadataStyle::None,
+            type_config: InputTypeConfig::Tcp(logfwd_config::TcpTypeConfig {
+                listen: "127.0.0.1:0".to_string(),
+                tls: Some(logfwd_config::TlsInputConfig {
+                    cert_file: Some("/tmp/server.crt".to_string()),
+                    key_file: Some("/tmp/server.key".to_string()),
+                    client_ca_file: None,
+                    require_client_auth: true,
+                }),
+                max_connections: None,
+                connection_timeout_ms: None,
+                read_timeout_ms: None,
+            }),
+        };
+
+        let err = match build_input_state("tcp-in", &cfg, stats) {
+            Ok(_) => panic!("mTLS without client_ca_file should fail startup"),
+            Err(err) => err,
+        };
+        assert!(
+            err.contains("tcp.tls.require_client_auth") && err.contains("tcp.tls.client_ca_file"),
+            "expected mTLS client CA field context in startup error: {err}"
         );
     }
     #[test]

--- a/crates/logfwd-runtime/src/worker_pool/dispatch.rs
+++ b/crates/logfwd-runtime/src/worker_pool/dispatch.rs
@@ -68,12 +68,19 @@ mod kani_proofs {
     use crate::worker_pool::types::DeliveryOutcome;
 
     // -----------------------------------------------------------------------
-    // Proof 1: Dispatch always sends to a valid index, spawns, or waits.
-    // The item is NEVER silently dropped.
+    // Proof 1: Consolidated dispatch invariants — item is never dropped,
+    // SentToIndex picks the FIRST HasSpace worker, SpawnNew only fires
+    // when no HasSpace exists, and WaitOnFront only at capacity.
+    //
+    // Replaces the former 4 separate proofs:
+    // - verify_dispatch_never_drops_item
+    // - verify_dispatch_picks_first_available
+    // - verify_spawn_only_when_no_space
+    // - verify_wait_only_at_capacity
     // -----------------------------------------------------------------------
     #[kani::proof]
     #[kani::unwind(6)]
-    fn verify_dispatch_never_drops_item() {
+    fn verify_dispatch_invariants() {
         const MAX_N: usize = 4;
         let n: usize = kani::any();
         kani::assume(n <= MAX_N);
@@ -85,6 +92,11 @@ mod kani_proofs {
         kani::assume(n <= max_workers);
 
         let states: [ChannelState; MAX_N] = kani::any();
+        let has_space = states[..n].iter().any(|&s| s == ChannelState::HasSpace);
+        let active = states[..n]
+            .iter()
+            .filter(|&&s| s != ChannelState::Closed)
+            .count();
 
         let outcome = dispatch_step(&states[..n], max_workers);
 
@@ -101,127 +113,34 @@ mod kani_proofs {
             matches!(outcome, DispatchOutcome::WaitOnFront),
             "WaitOnFront path reachable"
         );
-
-        match outcome {
-            DispatchOutcome::SentToIndex(i) => {
-                // Must be a valid index.
-                assert!(i < n);
-                // Must point to a non-closed, non-full slot.
-                assert_eq!(states[i], ChannelState::HasSpace);
-            }
-            DispatchOutcome::SpawnNew => {
-                // Must be under the limit.
-                let active = states[..n]
-                    .iter()
-                    .filter(|&&s| s != ChannelState::Closed)
-                    .count();
-                assert!(active < max_workers);
-                // No HasSpace worker exists (else we'd have sent to it).
-                assert!(!states[..n].iter().any(|&s| s == ChannelState::HasSpace));
-            }
-            DispatchOutcome::WaitOnFront => {
-                // Must be at the limit.
-                let active = states[..n]
-                    .iter()
-                    .filter(|&&s| s != ChannelState::Closed)
-                    .count();
-                assert_eq!(active, max_workers);
-                // No HasSpace worker exists.
-                assert!(!states[..n].iter().any(|&s| s == ChannelState::HasSpace));
-            }
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // Proof 2: SentToIndex always picks the FIRST HasSpace worker (MRU-first).
-    // -----------------------------------------------------------------------
-    #[kani::proof]
-    #[kani::unwind(6)]
-    fn verify_dispatch_picks_first_available() {
-        const MAX_N: usize = 4;
-        let n: usize = kani::any();
-        kani::assume(n > 0 && n <= MAX_N);
-
-        let max_workers: usize = kani::any();
-        kani::assume(max_workers >= n);
-
-        let states: [ChannelState; MAX_N] = kani::any();
-
-        let outcome = dispatch_step(&states[..n], max_workers);
-
-        // Guard: confirm MRU path (SentToIndex) is reachable under these inputs.
-        kani::cover!(
-            matches!(outcome, DispatchOutcome::SentToIndex(_)),
-            "SentToIndex reachable in picks_first proof"
-        );
-
-        if let DispatchOutcome::SentToIndex(i) = outcome {
-            // All workers before i must be Full or Closed.
-            for j in 0..i {
-                assert_ne!(states[j], ChannelState::HasSpace);
-            }
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // Proof 3: SpawnNew only fires when no HasSpace worker exists.
-    // -----------------------------------------------------------------------
-    #[kani::proof]
-    #[kani::unwind(6)]
-    fn verify_spawn_only_when_no_space() {
-        const MAX_N: usize = 4;
-        let n: usize = kani::any();
-        kani::assume(n <= MAX_N);
-
-        let max_workers: usize = kani::any();
-        kani::assume(max_workers >= 1 && max_workers <= 8);
-        kani::assume(n <= max_workers);
-
-        let states: [ChannelState; MAX_N] = kani::any();
-        let has_space = states[..n].iter().any(|&s| s == ChannelState::HasSpace);
-
-        let outcome = dispatch_step(&states[..n], max_workers);
-
-        // Guard: both branches (has_space / no_space) must be reachable.
         kani::cover!(has_space, "has_space=true path exercised");
         kani::cover!(!has_space, "has_space=false path exercised");
 
-        if has_space {
-            // Must send to an existing worker, not spawn.
-            assert!(!matches!(outcome, DispatchOutcome::SpawnNew));
+        match outcome {
+            DispatchOutcome::SentToIndex(i) => {
+                // Must be a valid index pointing to a HasSpace slot.
+                assert!(i < n);
+                assert_eq!(states[i], ChannelState::HasSpace);
+                // Must be the FIRST HasSpace worker (MRU-first ordering).
+                for j in 0..i {
+                    assert_ne!(states[j], ChannelState::HasSpace);
+                }
+            }
+            DispatchOutcome::SpawnNew => {
+                // Must be under the limit with no HasSpace worker.
+                assert!(active < max_workers);
+                assert!(!has_space);
+            }
+            DispatchOutcome::WaitOnFront => {
+                // Must be at capacity with no HasSpace worker.
+                assert_eq!(active, max_workers);
+                assert!(!has_space);
+            }
         }
-    }
 
-    // -----------------------------------------------------------------------
-    // Proof 4: WaitOnFront only fires when active == max_workers.
-    // -----------------------------------------------------------------------
-    #[kani::proof]
-    #[kani::unwind(6)]
-    fn verify_wait_only_at_capacity() {
-        const MAX_N: usize = 4;
-        let n: usize = kani::any();
-        kani::assume(n <= MAX_N);
-
-        let max_workers: usize = kani::any();
-        kani::assume(max_workers >= 1 && max_workers <= 4);
-        kani::assume(n <= max_workers);
-
-        let states: [ChannelState; MAX_N] = kani::any();
-        let active = states[..n]
-            .iter()
-            .filter(|&&s| s != ChannelState::Closed)
-            .count();
-
-        let outcome = dispatch_step(&states[..n], max_workers);
-
-        // Guard: WaitOnFront must be reachable (not vacuously avoided).
-        kani::cover!(
-            matches!(outcome, DispatchOutcome::WaitOnFront),
-            "WaitOnFront reachable in wait_only_at_capacity proof"
-        );
-
-        if matches!(outcome, DispatchOutcome::WaitOnFront) {
-            assert_eq!(active, max_workers);
+        // HasSpace → never SpawnNew (subsumed from former proof 3)
+        if has_space {
+            assert!(!matches!(outcome, DispatchOutcome::SpawnNew));
         }
     }
 

--- a/crates/logfwd-types/src/pipeline/batch.rs
+++ b/crates/logfwd-types/src/pipeline/batch.rs
@@ -269,9 +269,15 @@ mod verification {
     /// Every transition from Queued produces a valid Sending ticket.
     #[kani::proof]
     fn verify_queued_to_sending() {
-        let id = BatchId(kani::any());
-        let source = SourceId(kani::any());
+        let id_val: u64 = kani::any();
+        let src_val: u64 = kani::any();
         let checkpoint: u64 = kani::any();
+        // Domain narrowing: typestate field-move verification, not ID arithmetic.
+        kani::assume(id_val <= 1000);
+        kani::assume(src_val <= 1000);
+        kani::assume(checkpoint <= 1000);
+        let id = BatchId(id_val);
+        let source = SourceId(src_val);
 
         let ticket = BatchTicket::new(id, source, checkpoint);
         let sending = ticket.begin_send();
@@ -285,9 +291,15 @@ mod verification {
     /// Ack produces a receipt with correct source and checkpoint.
     #[kani::proof]
     fn verify_ack_receipt() {
-        let id = BatchId(kani::any());
-        let source = SourceId(kani::any());
+        let id_val: u64 = kani::any();
+        let src_val: u64 = kani::any();
         let checkpoint: u64 = kani::any();
+        // Domain narrowing: typestate field-move verification, not ID arithmetic.
+        kani::assume(id_val <= 1000);
+        kani::assume(src_val <= 1000);
+        kani::assume(checkpoint <= 1000);
+        let id = BatchId(id_val);
+        let source = SourceId(src_val);
 
         let ticket = BatchTicket::new(id, source, checkpoint);
         let sending = ticket.begin_send();
@@ -302,9 +314,15 @@ mod verification {
     /// Fail increments attempts and preserves all other fields.
     #[kani::proof]
     fn verify_fail_preserves_fields() {
-        let id = BatchId(kani::any());
-        let source = SourceId(kani::any());
+        let id_val: u64 = kani::any();
+        let src_val: u64 = kani::any();
         let checkpoint: u64 = kani::any();
+        // Domain narrowing: typestate field-move verification, not ID arithmetic.
+        kani::assume(id_val <= 1000);
+        kani::assume(src_val <= 1000);
+        kani::assume(checkpoint <= 1000);
+        let id = BatchId(id_val);
+        let source = SourceId(src_val);
 
         let ticket = BatchTicket::new(id, source, checkpoint);
         let sending = ticket.begin_send();
@@ -319,9 +337,15 @@ mod verification {
     /// Reject produces a receipt with delivered=false.
     #[kani::proof]
     fn verify_reject_receipt() {
-        let id = BatchId(kani::any());
-        let source = SourceId(kani::any());
+        let id_val: u64 = kani::any();
+        let src_val: u64 = kani::any();
         let checkpoint: u64 = kani::any();
+        // Domain narrowing: typestate field-move verification, not ID arithmetic.
+        kani::assume(id_val <= 1000);
+        kani::assume(src_val <= 1000);
+        kani::assume(checkpoint <= 1000);
+        let id = BatchId(id_val);
+        let source = SourceId(src_val);
 
         let ticket = BatchTicket::new(id, source, checkpoint);
         let sending = ticket.begin_send();
@@ -336,9 +360,15 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(7)]
     fn verify_retry_sequence() {
-        let id = BatchId(kani::any());
-        let source = SourceId(kani::any());
+        let id_val: u64 = kani::any();
+        let src_val: u64 = kani::any();
         let checkpoint: u64 = kani::any();
+        // Domain narrowing: retry-count behavior, not ID arithmetic.
+        kani::assume(id_val <= 1000);
+        kani::assume(src_val <= 1000);
+        kani::assume(checkpoint <= 1000);
+        let id = BatchId(id_val);
+        let source = SourceId(src_val);
         let max_retries: u32 = kani::any_where(|&r: &u32| r <= 5);
 
         let mut ticket = BatchTicket::new(id, source, checkpoint);

--- a/crates/logfwd-types/src/pipeline/lifecycle.rs
+++ b/crates/logfwd-types/src/pipeline/lifecycle.rs
@@ -785,6 +785,11 @@ mod verification {
         let cp1: Cp = kani::any();
         let cp2: Cp = kani::any();
         let cp3: Cp = kani::any();
+        // Domain narrowing: state-machine behavior, not checkpoint arithmetic.
+        // 9 values (0..=8) cover equal, less-than, and greater-than cases.
+        kani::assume(cp1 <= 8);
+        kani::assume(cp2 <= 8);
+        kani::assume(cp3 <= 8);
         kani::assume(cp1 <= cp2);
         kani::assume(cp2 <= cp3);
         kani::cover!(
@@ -834,6 +839,9 @@ mod verification {
 
         let cp1: Cp = kani::any();
         let cp2: Cp = kani::any();
+        // Domain narrowing: state-machine ordering, not value arithmetic.
+        kani::assume(cp1 <= 8);
+        kani::assume(cp2 <= 8);
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);
@@ -1034,6 +1042,10 @@ mod verification {
         let cp1: Cp = kani::any();
         let cp2: Cp = kani::any();
         let cp3: Cp = kani::any();
+        // Domain narrowing: monotonicity is a state-machine property, not arithmetic.
+        kani::assume(cp1 <= 8);
+        kani::assume(cp2 <= 8);
+        kani::assume(cp3 <= 8);
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);
@@ -1115,6 +1127,7 @@ mod verification {
         let src = SourceId(0);
 
         let cp: Cp = kani::any();
+        kani::assume(cp <= 8); // domain narrowing: state-machine behavior
         let t1 = running.create_batch(src, cp);
         let s1 = running.begin_send(t1);
 
@@ -1203,6 +1216,10 @@ mod verification {
         let cp1: Cp = kani::any();
         let cp2: Cp = kani::any();
         let cp3: Cp = kani::any();
+        // Domain narrowing: ack/reject ordering, not checkpoint value space.
+        kani::assume(cp1 <= 8);
+        kani::assume(cp2 <= 8);
+        kani::assume(cp3 <= 8);
 
         let t1 = running.create_batch(src, cp1);
         let t2 = running.create_batch(src, cp2);

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -3111,7 +3111,7 @@ input:
   path: /var/log/*.log
   format: cri
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT _timestampp FROM logs
 "#;
@@ -3131,7 +3131,7 @@ input:
   path: /var/log/*.log
   format: cri
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT _timestamp, _stream, body FROM logs
 "#;
@@ -3151,7 +3151,7 @@ input:
   path: /var/log/*.log
   format: cri
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT level, msg, custom_field FROM logs
 "#;
@@ -3171,7 +3171,7 @@ input:
   path: /var/log/*.log
   format: json
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT custom_field FROM logs
 "#;
@@ -3191,7 +3191,7 @@ input:
   path: /var/log/*.log
   format: cri
 output:
-  type: null
+  type: "null"
 enrichment:
   - type: static
     table_name: labels
@@ -3215,7 +3215,7 @@ input:
   type: file
   path: /var/log/*.log
 output:
-  type: null
+  type: "null"
 transform: |
   SELECT _unknown_col FROM logs
 "#;

--- a/crates/logfwd/tests/it/compliance_file.rs
+++ b/crates/logfwd/tests/it/compliance_file.rs
@@ -43,14 +43,14 @@ fn build_pipeline(yaml: &str) -> Pipeline {
 /// Build a simple pipeline config YAML for a single file input.
 fn file_pipeline_yaml(log_path: &std::path::Path) -> String {
     format!(
-        r"
+        r#"
 input:
   type: file
   path: {}
   format: json
 output:
   type: "null"
-",
+"#,
         log_path.display()
     )
 }


### PR DESCRIPTION
## Summary
- restore the mainline changes that were accidentally dropped by the merged S3 metadata PR head
- correct the S3 input documentation defaults back to the code values: 1 MiB part size and 16 concurrent fetches
- keep the explicit S3 test credentials improvement from the merged head
- remove the duplicate bench clippy allow that failed CI

## Verification
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p logfwd-runtime --features s3 public_source_path_style_allows_s3_key_snapshots -- --nocapture`
- `cargo test -p logfwd-io --features s3 s3_input::tests -- --nocapture`
- `cargo clippy -p logfwd-runtime --features s3 -- -D warnings`
- `cargo clippy -p logfwd-bench -- -D warnings`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add mTLS support to TCP input and fix S3 metadata merge conflicts
> - Adds `client_ca_file` and `require_client_auth` fields to `TcpInputTlsOptions`, enabling mutual TLS for TCP inputs when both fields are provided together
> - Updates validation in `validate_with_base_path` and `build_input_state` to emit specific errors when only one of the two mTLS fields is set, instead of blanket rejection
> - Fixes YAML embedded examples and integration tests to quote the null output type as `type: "null"` after the S3 metadata merge
> - Updates documented defaults for `s3.part_size_bytes` (1048576) and `s3.max_concurrent_fetches` (16) in the config reference
> - Consolidates several Kani verification harnesses across accumulator, dispatch, batch, and lifecycle modules with no production logic changes
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 281ddb4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->