### PR TITLE
fix: clean bench clippy allows and mTLS validation

### DIFF
--- a/crates/logfwd-bench/src/bin/http_receiver_apples.rs
+++ b/crates/logfwd-bench/src/bin/http_receiver_apples.rs
@@ -15,8 +15,6 @@
 //! Optional env vars:
 //!   LOGFWD_HTTP_BENCH_DURATION_SECS=6
 //!   LOGFWD_HTTP_BENCH_CONCURRENCY=8,32
-#![allow(clippy::print_stdout, clippy::print_stderr)]
-
 use std::convert::Infallible;
 use std::io::Read as _;
 use std::net::SocketAddr;

--- a/crates/logfwd-bench/src/bin/otlp_encode_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_encode_profile.rs
@@ -27,8 +27,6 @@
 //!   3. `iterations` — encode loop count (e.g. 5000)
 //!   4. `encoder`    — `manual` | `generated_fast`
 //!   5. `svg_path`   — output flamegraph SVG path
-#![allow(clippy::print_stdout, clippy::print_stderr)]
-
 use std::fs::File;
 use std::hint::black_box;
 use std::path::PathBuf;

--- a/crates/logfwd-bench/src/es_throughput.rs
+++ b/crates/logfwd-bench/src/es_throughput.rs
@@ -15,8 +15,6 @@
 //!   `./es-throughput 60 16 5000 1 4 buffered`   # 16 workers, gzip, 5k batch, 4 indices
 //!   `./es-throughput 30 4 5000 0 1 streaming`   # 4 workers, streamed request body
 //!   `./es-throughput 30 1 1000 0`               # baseline (single worker, buffered, no compress)
-
-#![allow(clippy::print_stdout, clippy::print_stderr)]
 use std::fmt::Write as FmtWrite;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/logfwd-bench/src/file_output_profile.rs
+++ b/crates/logfwd-bench/src/file_output_profile.rs
@@ -19,8 +19,6 @@
 //!   --batches N                 (default: 500)
 //!   --batch-size N              (default: 10000)
 //!   --output DIR                (default: /tmp/logfwd-file-profile)
-
-#![allow(clippy::print_stdout, clippy::print_stderr)]
 use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/crates/logfwd-bench/src/library_eval.rs
+++ b/crates/logfwd-bench/src/library_eval.rs
@@ -8,8 +8,6 @@
 //! 4. `async-compression` write path — streaming compress throughput
 //!
 //! Run: `cargo run --release --bin library-eval -p logfwd-bench`
-
-#![allow(clippy::print_stdout, clippy::print_stderr)]
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/logfwd-bench/src/memory_profile.rs
+++ b/crates/logfwd-bench/src/memory_profile.rs
@@ -20,7 +20,6 @@
 //!   --batch     batch size in lines (default: 10000)
 
 #![allow(deprecated)] // Benchmarks use sync OutputSink; migration tracked separately.
-#![allow(clippy::print_stdout, clippy::print_stderr)]
 use stats_alloc::{INSTRUMENTED_SYSTEM, Region, StatsAlloc};
 use std::alloc::System;
 use std::fmt::Write as _;

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -394,6 +394,17 @@ impl TcpInput {
                 ),
             )
         })?;
+        let has_client_ca_file = opts
+            .client_ca_file
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|path| !path.is_empty());
+        if has_client_ca_file && !opts.require_client_auth {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "tcp.tls.client_ca_file requires tcp.tls.require_client_auth: true",
+            ));
+        }
         let builder = ServerConfig::builder();
         let builder = if opts.require_client_auth {
             let client_ca_file = opts
@@ -1385,6 +1396,41 @@ mod tests {
             err.to_string()
                 .contains("require_client_auth requires tcp.tls.client_ca_file"),
             "error should identify missing tcp.tls.client_ca_file: {err}"
+        );
+    }
+
+    #[test]
+    fn mtls_listener_rejects_client_ca_when_auth_disabled() {
+        let certified = generate_simple_self_signed(vec!["localhost".into()])
+            .expect("test cert generation should succeed");
+        let (tmp, cert_file, key_file) = write_tls_files(
+            &certified.cert.pem(),
+            &certified.signing_key.serialize_pem(),
+        );
+        let ca_path = tmp.path().join("client-ca.crt");
+        fs::write(&ca_path, certified.cert.pem()).expect("client CA file should be written");
+
+        let err = match TcpInput::with_options(
+            "mtls-test",
+            "127.0.0.1:0",
+            TcpInputOptions {
+                tls: Some(TcpInputTlsOptions {
+                    cert_file,
+                    key_file,
+                    client_ca_file: Some(ca_path.to_string_lossy().to_string()),
+                    require_client_auth: false,
+                }),
+                ..Default::default()
+            },
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        ) {
+            Ok(_) => panic!("client CA without client auth must fail startup"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("client_ca_file requires tcp.tls.require_client_auth: true"),
+            "error should identify disabled client auth: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary
- remove duplicate `clippy::print_stdout` / `print_stderr` allow attributes from bench binaries that failed workspace clippy after #2406 merged
- make `TcpInput::with_options` reject `client_ca_file` when `require_client_auth` is false, matching config/runtime validation and avoiding silent mTLS downgrade
- add a regression test for the direct TCP input constructor path

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p logfwd-bench -- -D warnings`
- `cargo test -p logfwd-io mtls_listener -- --nocapture`
- `cargo clippy -p logfwd-io -- -D warnings`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate mTLS config and remove duplicate clippy allows in logfwd-bench
> - Adds validation in `TcpInput.load_tls_server_config` that rejects a non-empty `client_ca_file` when `require_client_auth` is false, returning an `InvalidInput` error.
> - Adds a test `mtls_listener_rejects_client_ca_when_auth_disabled` to cover this new validation path.
> - Removes duplicate `#![allow(clippy::print_stdout, clippy::print_stderr)]` attributes from several files in `crates/logfwd-bench`.
> - Behavioral Change: TLS server initialization now fails early if `client_ca_file` is set without `require_client_auth: true`, whereas previously it would silently continue.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d672bf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->