### PR TITLE
fix: address post-merge mtls follow-ups

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -308,6 +308,14 @@ easy ways to get this wrong are synthetic newline insertion and compressed
 request decoding. Capture source bytes at the receiver boundary first, then
 carry them explicitly through `InputEvent::Data` or `InputEvent::Batch`.
 
+### TLS client CA settings must not silently downgrade mTLS
+
+For server-side inputs, `client_ca_file` is meaningful only when
+`require_client_auth` is true. Accepting a client CA while leaving client auth
+disabled looks like mTLS is configured but still accepts unauthenticated clients.
+Reject that combination during startup, and normalize optional certificate paths
+once before validation and file loading.
+
 ### Arrow IPC compression is just a flag
 
 Compressed Arrow IPC is `StreamWriter` with `IpcWriteOptions::try_with_compression(Some(CompressionType::ZSTD))`. Any `RecordBatch` can be compressed. No special builder needed.

--- a/book/src/content/docs/configuration/inputs.md
+++ b/book/src/content/docs/configuration/inputs.md
@@ -202,6 +202,10 @@ input:
     client_ca_file: /etc/logfwd/tls/clients-ca.pem
 ```
 
+`client_ca_file` enables client certificate verification and is accepted only
+when `require_client_auth: true` is set. Supplying a client CA without requiring
+client authentication is rejected at startup.
+
 ## OTLP
 
 Receive OTLP log records from another agent or SDK.

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -212,6 +212,7 @@ Accept log lines on a TCP socket.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `listen` | string | Yes | `host:port`, e.g. `0.0.0.0:5140`. |
+| `tls` | object | No | Optional server TLS options (`cert_file`, `key_file`, `client_ca_file`, `require_client_auth`). `client_ca_file` is valid only when `require_client_auth: true`. |
 
 ```yaml
 input:

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -1538,11 +1538,12 @@ output:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("pipeline 'default' output '#0'"),
-            "error should include pipeline/output context: {msg}"
-        );
-        assert!(
-            msg.contains("null output does not support") && msg.contains("endpoint"),
+            (msg.contains("pipeline 'default' output '#0'")
+                && msg.contains("null output does not support")
+                && msg.contains("endpoint"))
+                || (msg.contains("invalid output config")
+                    && msg.contains("unknown field `endpoint`")
+                    && msg.contains("expected `name`")),
             "explicit null output with endpoint must be rejected: {msg}"
         );
     }
@@ -1573,13 +1574,13 @@ output:
             );
             let err = Config::load_str(&yaml).unwrap_err();
             let msg = err.to_string();
-            assert!(
-                msg.contains("pipeline 'default' output '#0'"),
-                "error should include pipeline/output context: {msg}"
-            );
             let expected = format!("null output does not support '{field}'");
+            let unknown_field = format!("unknown field `{field}`");
             assert!(
-                msg.contains(&expected),
+                (msg.contains("pipeline 'default' output '#0'") && msg.contains(&expected))
+                    || (msg.contains("invalid output config")
+                        && msg.contains(&unknown_field)
+                        && msg.contains("expected `name`")),
                 "explicit null output with {field} must be rejected: {msg}"
             );
         }

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -743,11 +743,18 @@ impl Config {
                                     .as_deref()
                                     .map(str::trim)
                                     .filter(|v| !v.is_empty());
-                                let client_ca_file = tls
-                                    .client_ca_file
-                                    .as_deref()
-                                    .map(str::trim)
-                                    .filter(|v| !v.is_empty());
+                                let client_ca_file = match tls.client_ca_file.as_deref() {
+                                    Some(path) => {
+                                        let path = path.trim();
+                                        if path.is_empty() {
+                                            return Err(ConfigError::Validation(format!(
+                                                "pipeline '{name}' input '{label}': tcp tls client_ca_file must not be empty"
+                                            )));
+                                        }
+                                        Some(path)
+                                    }
+                                    None => None,
+                                };
 
                                 if tls.require_client_auth && client_ca_file.is_none() {
                                     return Err(ConfigError::Validation(format!(
@@ -3014,6 +3021,28 @@ pipelines:
         assert!(
             err.contains("client_ca_file requires tls.require_client_auth: true"),
             "expected client CA without mTLS rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn tcp_client_ca_rejects_blank_path() {
+        let mtls = r#"
+pipelines:
+  test:
+    inputs:
+      - type: tcp
+        listen: 127.0.0.1:5514
+        tls:
+          cert_file: /tmp/server.crt
+          key_file: /tmp/server.key
+          client_ca_file: "   "
+    outputs:
+      - type: "null"
+"#;
+        let err = Config::load_str(mtls).unwrap_err().to_string();
+        assert!(
+            err.contains("client_ca_file must not be empty"),
+            "expected blank client CA rejection, got: {err}"
         );
     }
 }

--- a/crates/logfwd-io/src/tcp_input.rs
+++ b/crates/logfwd-io/src/tcp_input.rs
@@ -394,12 +394,20 @@ impl TcpInput {
                 ),
             )
         })?;
-        let has_client_ca_file = opts
-            .client_ca_file
-            .as_deref()
-            .map(str::trim)
-            .is_some_and(|path| !path.is_empty());
-        if has_client_ca_file && !opts.require_client_auth {
+        let client_ca_file = match opts.client_ca_file.as_deref() {
+            Some(path) => {
+                let path = path.trim();
+                if path.is_empty() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "tcp.tls.client_ca_file must not be empty",
+                    ));
+                }
+                Some(path)
+            }
+            None => None,
+        };
+        if client_ca_file.is_some() && !opts.require_client_auth {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "tcp.tls.client_ca_file requires tcp.tls.require_client_auth: true",
@@ -407,17 +415,12 @@ impl TcpInput {
         }
         let builder = ServerConfig::builder();
         let builder = if opts.require_client_auth {
-            let client_ca_file = opts
-                .client_ca_file
-                .as_deref()
-                .map(str::trim)
-                .filter(|path| !path.is_empty())
-                .ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "tcp.tls.require_client_auth requires tcp.tls.client_ca_file",
-                    )
-                })?;
+            let client_ca_file = client_ca_file.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "tcp.tls.require_client_auth requires tcp.tls.client_ca_file",
+                )
+            })?;
             let client_ca_certs = CertificateDer::pem_file_iter(client_ca_file)
                 .map_err(|e| {
                     io::Error::new(
@@ -1392,10 +1395,43 @@ mod tests {
             Ok(_) => panic!("blank client CA path must fail startup"),
             Err(err) => err,
         };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert!(
-            err.to_string()
-                .contains("require_client_auth requires tcp.tls.client_ca_file"),
-            "error should identify missing tcp.tls.client_ca_file: {err}"
+            err.to_string().contains("client_ca_file must not be empty"),
+            "error should identify blank tcp.tls.client_ca_file: {err}"
+        );
+    }
+
+    #[test]
+    fn mtls_listener_rejects_blank_client_ca_when_auth_disabled() {
+        let certified = generate_simple_self_signed(vec!["localhost".into()])
+            .expect("test cert generation should succeed");
+        let (_tmp, cert_file, key_file) = write_tls_files(
+            &certified.cert.pem(),
+            &certified.signing_key.serialize_pem(),
+        );
+
+        let err = match TcpInput::with_options(
+            "mtls-test",
+            "127.0.0.1:0",
+            TcpInputOptions {
+                tls: Some(TcpInputTlsOptions {
+                    cert_file,
+                    key_file,
+                    client_ca_file: Some("   ".to_string()),
+                    require_client_auth: false,
+                }),
+                ..Default::default()
+            },
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        ) {
+            Ok(_) => panic!("blank client CA path must fail startup"),
+            Err(err) => err,
+        };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains("client_ca_file must not be empty"),
+            "error should identify blank tcp.tls.client_ca_file: {err}"
         );
     }
 
@@ -1427,6 +1463,7 @@ mod tests {
             Ok(_) => panic!("client CA without client auth must fail startup"),
             Err(err) => err,
         };
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
         assert!(
             err.to_string()
                 .contains("client_ca_file requires tcp.tls.require_client_auth: true"),

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -1217,7 +1217,7 @@ mod tests {
             source_metadata: SourceMetadataStyle::None,
             type_config: InputTypeConfig::Tcp(logfwd_config::TcpTypeConfig {
                 listen: "127.0.0.1:0".to_string(),
-                tls: Some(logfwd_config::TlsInputConfig {
+                tls: Some(logfwd_config::TlsServerConfig {
                     cert_file: Some("/tmp/server.crt".to_string()),
                     key_file: Some("/tmp/server.key".to_string()),
                     client_ca_file: None,


### PR DESCRIPTION
## Summary

- Normalize `tcp.tls.client_ca_file` once and reuse it for mTLS validation and CA loading.
- Assert the `InvalidInput` error kind in the client-CA-without-auth regression test.
- Fix the stale runtime test type path so the loom test target compiles.
- Document the TCP mTLS `client_ca_file` / `require_client_auth` contract and update null-output rejection tests for typed output parsing on current `main`.

## Verification

- `just lint`
- `just test`
- `cargo test -p logfwd-runtime --lib --features loom-tests worker_pool::pool::tests::loom_worker_removal_vs_late_event_model_never_resurrects_slot -- --exact`
- `cargo test -p logfwd-io mtls_listener -- --nocapture`
- `cargo test -p logfwd-config quoted_null_output_rejects -- --nocapture`
- `git diff --check`

## Follow-up context

Addresses the unresolved Copilot review threads and post-merge loom compile failure from #2416. Also covers CodeRabbit's documentation warning for the mTLS validation change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject blank and misplaced `client_ca_file` in TCP input mTLS config
> - Config validation and runtime startup now both reject a blank `client_ca_file` (empty or whitespace-only) with an `InvalidInput` error and message `client_ca_file must not be empty`.
> - Providing `client_ca_file` without setting `require_client_auth: true` is rejected at startup, preventing silent mTLS downgrade.
> - Documentation in [inputs.md](https://github.com/strawgate/fastforward/pull/2418/files#diff-769f96612363fd79c87623587069ef5dcd2a1211cac56a1ad5c249fe781efd35) and [reference.mdx](https://github.com/strawgate/fastforward/pull/2418/files#diff-6a69bd5c38c92acca3dd194d75d77551f1b8f6b98890da7e56f2c9cbe564aac4) clarifies that `client_ca_file` is only valid when `require_client_auth: true`.
> - Test coverage is added and strengthened in [validate.rs](https://github.com/strawgate/fastforward/pull/2418/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68) and [tcp_input.rs](https://github.com/strawgate/fastforward/pull/2418/files#diff-fb6ece7048cafbf067d846e591afde225474586202c6ff61a85c0b97ff813be5) to cover blank path and auth-disabled cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 94c2340.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->