### PR TITLE
refactor(config): drop unused shared config types

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -19,9 +19,7 @@ pub use serde_helpers::{PositiveMillis, PositiveSecs};
 
 #[cfg(test)]
 pub(crate) use env::expand_env_vars;
-pub use shared::{
-    BatchConfig, Compression, NetworkConfig, RetryConfig, TlsClientConfig, TlsServerConfig,
-};
+pub use shared::{TlsClientConfig, TlsServerConfig};
 pub use types::{
     ArrowIpcOutputConfig, ArrowIpcTypeConfig, AuthConfig, CompressionFormat, Config, ConfigError,
     CsvEnrichmentConfig, ElasticsearchOutputConfig, ElasticsearchRequestMode, EnrichmentConfig,

--- a/crates/logfwd-config/src/shared.rs
+++ b/crates/logfwd-config/src/shared.rs
@@ -1,13 +1,10 @@
 //! Shared configuration types used across inputs and outputs.
 //!
-//! These types provide a uniform config surface so every input and output uses
-//! the same structs and naming for cross-cutting concerns like TLS, retries,
-//! batching, compression, and network settings.
+//! Today this is just the client/server TLS structs. Per-component retry,
+//! batch, network, and compression knobs live on each input/output's own
+//! typed config (see `OutputConfigV2` and the input types in `types.rs`).
 
-use crate::serde_helpers::{
-    deserialize_from_string_or_value, deserialize_option_from_string_or_value,
-    deserialize_option_strict_string,
-};
+use crate::serde_helpers::{deserialize_from_string_or_value, deserialize_option_strict_string};
 use serde::Deserialize;
 
 // ── TLS ────────────────────────────────────────────────────────────────
@@ -52,81 +49,4 @@ pub struct TlsServerConfig {
     /// Require client certificate authentication. Default: false.
     #[serde(default, deserialize_with = "deserialize_from_string_or_value")]
     pub require_client_auth: bool,
-}
-
-// ── Retry ──────────────────────────────────────────────────────────────
-
-/// Retry configuration for transient failures.
-///
-/// Provides exponential backoff with jitter. When all fields are `None` the
-/// output falls back to its built-in defaults.
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
-pub struct RetryConfig {
-    /// Max retry attempts. Use -1 for infinite. Default: 3.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_attempts: Option<i32>,
-    /// Initial backoff delay in seconds. Default: 1.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub initial_backoff_secs: Option<u64>,
-    /// Maximum backoff delay in seconds. Default: 60.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_backoff_secs: Option<u64>,
-}
-
-// ── Batch ──────────────────────────────────────────────────────────────
-
-/// Batch configuration for aggregating events before sending.
-///
-/// Outputs collect events into batches and flush when *any* limit is reached.
-/// When all fields are `None` the output falls back to its built-in defaults.
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
-pub struct BatchConfig {
-    /// Maximum events per batch.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_events: Option<usize>,
-    /// Maximum bytes per batch.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_bytes: Option<usize>,
-    /// Max time before flushing a partial batch, in seconds.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub timeout_secs: Option<u64>,
-}
-
-// ── Compression ────────────────────────────────────────────────────────
-
-/// Compression algorithm for output payloads.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum Compression {
-    #[default]
-    None,
-    Gzip,
-    Zstd,
-    Snappy,
-    Lz4,
-}
-
-// ── Network ──────────────────────────────────────────────────────────
-
-/// Network and connection configuration shared across inputs and outputs.
-///
-/// Provides uniform timeout and connection limit fields. When all fields
-/// are `None` the component falls back to its built-in defaults.
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(deny_unknown_fields)]
-pub struct NetworkConfig {
-    /// Request or send timeout in seconds.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub timeout_secs: Option<u64>,
-    /// Connection establishment timeout in seconds.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub connection_timeout_secs: Option<u64>,
-    /// Maximum concurrent connections.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_connections: Option<usize>,
-    /// Maximum incoming message or packet size in bytes.
-    #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_message_size_bytes: Option<usize>,
 }

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -1217,7 +1217,7 @@ mod tests {
             source_metadata: SourceMetadataStyle::None,
             type_config: InputTypeConfig::Tcp(logfwd_config::TcpTypeConfig {
                 listen: "127.0.0.1:0".to_string(),
-                tls: Some(logfwd_config::TlsInputConfig {
+                tls: Some(logfwd_config::TlsServerConfig {
                     cert_file: Some("/tmp/server.crt".to_string()),
                     key_file: Some("/tmp/server.key".to_string()),
                     client_ca_file: None,


### PR DESCRIPTION
## Summary

`RetryConfig`, `BatchConfig`, `NetworkConfig`, and the shared `Compression` enum in `crates/logfwd-config/src/shared.rs` were defined and re-exported but never consumed by any input or output — per-component retry, batch, network, and compression knobs live on each typed input/output config directly (`OutputConfigV2` variants, input type configs). Delete the structs and their re-exports.

Also updates a stray `TlsInputConfig` reference in the runtime test helper at `input_build.rs:1220` (added after #2402 by the mTLS work) to the canonical `TlsServerConfig` name.

## Verification

- `cargo check --workspace --all-targets` clean
- `logfwd-config` tests pass (the 2 `quoted_null_*` failures surfaced are pre-existing on main, not from this PR)

```
$ grep -rn '\b\(RetryConfig\|BatchConfig\|NetworkConfig\)\b' --include='*.rs' crates/
# (no results outside shared.rs)

$ grep -rn 'logfwd_config::Compression\b' --include='*.rs' crates/
# (no results — `logfwd_output::Compression` is a different type)
```

## Test plan

- [ ] `just ci-all` passes
- [ ] No downstream crate silently depended on these re-exports (verified via grep; only `logfwd-output`'s own `Compression` is used by benches)

https://claude.ai/code/session_01Be9dE9BzfRQxEmY1RUpwbe

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop unused shared config types from `logfwd-config`
> Removes `RetryConfig`, `BatchConfig`, `Compression`, and `NetworkConfig` from [shared.rs](https://github.com/strawgate/fastforward/pull/2419/files#diff-f11ee15414947085b206e2a8ef46d13c80564df649c089e459d6235d03ec6fef) and stops re-exporting them from [lib.rs](https://github.com/strawgate/fastforward/pull/2419/files#diff-8ce51c6580ec7211876aab0f3aa4c8dece56cbaf454430aa08a8b0992e8f3150). Only `TlsClientConfig` and `TlsServerConfig` remain in the shared module, with docs updated to reflect this. A test in [input_build.rs](https://github.com/strawgate/fastforward/pull/2419/files#diff-ca354d25bc72dec0d7f48518cd76a40d5bfab0a1f22f56449adbd8e2a81ffc4f) is updated to use `TlsServerConfig` directly instead of the removed `TlsInputConfig` alias.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e8e050.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->