### PR TITLE
refactor: drop flat output config model

### DIFF
--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -30,10 +30,10 @@ pub use types::{
     HttpTypeConfig, InputConfig, InputType, InputTypeConfig, JournaldBackendConfig,
     JournaldInputConfig, JournaldTypeConfig, JsonlEnrichmentConfig, K8sPathConfig,
     LokiOutputConfig, NullOutputConfig, OtlpOutputConfig, OtlpProtobufDecodeModeConfig,
-    OtlpProtocol, OtlpTypeConfig, OutputConfig, OutputConfigV2, OutputType, ParquetOutputConfig,
-    PipelineConfig, S3InputConfig, S3TypeConfig, SensorTypeConfig, ServerConfig,
-    SocketOutputConfig, SourceMetadataStyle, StaticEnrichmentConfig, StdoutOutputConfig,
-    StorageConfig, TcpTypeConfig, UdpTypeConfig,
+    OtlpProtocol, OtlpTypeConfig, OutputConfigV2, OutputType, ParquetOutputConfig, PipelineConfig,
+    S3InputConfig, S3TypeConfig, SensorTypeConfig, ServerConfig, SocketOutputConfig,
+    SourceMetadataStyle, StaticEnrichmentConfig, StdoutOutputConfig, StorageConfig, TcpTypeConfig,
+    UdpTypeConfig,
 };
 pub use validate::validate_host_port;
 
@@ -45,6 +45,13 @@ pub use validate::validate_host_port;
 mod tests {
     use super::*;
     use std::fs;
+
+    fn elasticsearch_request_mode(output: &OutputConfigV2) -> Option<ElasticsearchRequestMode> {
+        match output {
+            OutputConfigV2::Elasticsearch(config) => config.request_mode,
+            _ => None,
+        }
+    }
 
     #[test]
     fn simple_config() {
@@ -82,7 +89,7 @@ storage:
         assert!(pipe.transform.as_ref().unwrap().contains("SELECT"));
         assert_eq!(pipe.outputs[0].output_type(), OutputType::Otlp);
         assert_eq!(
-            pipe.outputs[0].compat_config().endpoint.as_deref(),
+            pipe.outputs[0].endpoint(),
             Some("http://otel-collector:4317")
         );
         assert_eq!(cfg.server.diagnostics.as_deref(), Some("0.0.0.0:9090"));
@@ -224,10 +231,7 @@ output:
 ";
         let cfg = Config::load_str(yaml).expect("env var substitution");
         let pipe = &cfg.pipelines["default"];
-        assert_eq!(
-            pipe.outputs[0].compat_config().endpoint.as_deref(),
-            Some("http://my-collector:4317")
-        );
+        assert_eq!(pipe.outputs[0].endpoint(), Some("http://my-collector:4317"));
         // SAFETY: this test is not run concurrently with other tests that
         // depend on the same environment variable.
         unsafe { std::env::remove_var("LOGFWD_TEST_ENDPOINT") };
@@ -1177,8 +1181,7 @@ output:
 "#;
         let cfg = Config::load_str(yaml).expect("auth bearer_token");
         let pipe = &cfg.pipelines["default"];
-        let output = pipe.outputs[0].compat_config();
-        let auth = output.auth.as_ref().expect("auth present");
+        let auth = pipe.outputs[0].auth().expect("auth present");
         assert_eq!(auth.bearer_token.as_deref(), Some("my-secret-token"));
         assert!(auth.headers.is_empty());
     }
@@ -1199,8 +1202,7 @@ output:
 "#;
         let cfg = Config::load_str(yaml).expect("auth custom headers");
         let pipe = &cfg.pipelines["default"];
-        let output = pipe.outputs[0].compat_config();
-        let auth = output.auth.as_ref().expect("auth present");
+        let auth = pipe.outputs[0].auth().expect("auth present");
         assert_eq!(auth.bearer_token, None);
         assert_eq!(
             auth.headers.get("X-API-Key").map(String::as_str),
@@ -1228,8 +1230,7 @@ output:
 "#;
         let cfg = Config::load_str(yaml).expect("auth env var bearer");
         let pipe = &cfg.pipelines["default"];
-        let output = pipe.outputs[0].compat_config();
-        let auth = output.auth.as_ref().expect("auth present");
+        let auth = pipe.outputs[0].auth().expect("auth present");
         assert_eq!(auth.bearer_token.as_deref(), Some("env-bearer-token"));
         // SAFETY: this test is not run concurrently with other tests that
         // depend on the same environment variable.
@@ -1248,7 +1249,7 @@ output:
 ";
         let cfg = Config::load_str(yaml).expect("no auth");
         let pipe = &cfg.pipelines["default"];
-        assert!(pipe.outputs[0].compat_config().auth.is_none());
+        assert!(pipe.outputs[0].auth().is_none());
     }
 
     #[test]
@@ -1265,7 +1266,7 @@ output:
         let cfg = Config::load_str(yaml).expect("streaming request_mode should validate");
         let pipe = &cfg.pipelines["default"];
         assert_eq!(
-            pipe.outputs[0].compat_config().request_mode,
+            elasticsearch_request_mode(&pipe.outputs[0]),
             Some(ElasticsearchRequestMode::Streaming)
         );
     }
@@ -1476,7 +1477,7 @@ output:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("invalid output config"),
+            msg.contains("invalid type: unit value") && msg.contains("output.type"),
             "unquoted type: null must be rejected: {msg}"
         );
     }
@@ -1487,7 +1488,7 @@ output:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("invalid output config"),
+            msg.contains("invalid type: unit value") && msg.contains("output.type"),
             "empty output type with endpoint must be rejected before it can become the null sink: {msg}"
         );
     }
@@ -1507,7 +1508,7 @@ pipelines:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("invalid output config") || msg.contains("did not match"),
+            msg.contains("invalid type: unit value") && msg.contains("pipelines.app.outputs[0]"),
             "unquoted type: null in list must be rejected: {msg}"
         );
     }
@@ -1536,12 +1537,9 @@ output:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            (msg.contains("pipeline 'default' output '#0'")
-                && msg.contains("null output does not support")
-                && msg.contains("endpoint"))
-                || (msg.contains("invalid output config")
-                    && msg.contains("unknown field `endpoint`")
-                    && msg.contains("expected `name`")),
+            msg.contains("unknown field `endpoint`")
+                && msg.contains("expected `name`")
+                && msg.contains("output"),
             "explicit null output with endpoint must be rejected: {msg}"
         );
     }
@@ -1572,13 +1570,9 @@ output:
             );
             let err = Config::load_str(&yaml).unwrap_err();
             let msg = err.to_string();
-            let expected = format!("null output does not support '{field}'");
             let unknown_field = format!("unknown field `{field}`");
             assert!(
-                (msg.contains("pipeline 'default' output '#0'") && msg.contains(&expected))
-                    || (msg.contains("invalid output config")
-                        && msg.contains(&unknown_field)
-                        && msg.contains("expected `name`")),
+                msg.contains(&unknown_field) && msg.contains("expected `name`"),
                 "explicit null output with {field} must be rejected: {msg}"
             );
         }
@@ -1601,9 +1595,7 @@ output:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("invalid output config")
-                && msg.contains("missing")
-                && msg.contains("type"),
+            msg.contains("missing configuration field \"output.type\""),
             "missing output type must fail clearly: {msg}"
         );
     }
@@ -1614,7 +1606,7 @@ output:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("invalid output config") && msg.contains("unknown variant ``"),
+            msg.contains("unknown variant ``") && msg.contains("output.type"),
             "empty-string output type must fail clearly: {msg}"
         );
     }
@@ -1627,7 +1619,7 @@ output:
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
-            msg.contains("invalid output config"),
+            msg.contains("invalid type: unit value") && msg.contains("output.type"),
             "null type field value must be rejected: {msg}"
         );
     }
@@ -3328,13 +3320,13 @@ format: json
         ];
 
         for (yaml, expected_type) in cases {
-            let v2 = serde_yaml_ng::from_str::<OutputConfigV2>(yaml).unwrap();
-            assert_eq!(OutputConfig::from(v2).output_type, expected_type);
+            let output = serde_yaml_ng::from_str::<OutputConfigV2>(yaml).unwrap();
+            assert_eq!(output.output_type(), expected_type);
         }
     }
 
     #[test]
-    fn example_outputs_parse_as_v2_and_normalize_equivalently() {
+    fn example_outputs_parse_as_v2() {
         use serde::Deserialize;
         use serde_yaml_ng::Value;
 
@@ -3353,16 +3345,9 @@ format: json
             let value: Value = serde_yaml_ng::from_str(&yaml)
                 .unwrap_or_else(|err| panic!("{} should parse as YAML: {err}", path.display()));
             for output_value in collect_output_values(&value) {
-                let v2 = OutputConfigV2::deserialize(output_value.clone()).unwrap_or_else(|err| {
+                OutputConfigV2::deserialize(output_value.clone()).unwrap_or_else(|err| {
                     panic!("{} output should parse as v2: {err}", path.display())
                 });
-                let flat = OutputConfig::deserialize(output_value.clone()).unwrap_or_else(|err| {
-                    panic!(
-                        "{} output should normalize to flat shape: {err}",
-                        path.display()
-                    )
-                });
-                assert_eq!(OutputConfig::from(v2), flat, "{}", path.display());
                 checked += 1;
             }
         }

--- a/crates/logfwd-config/src/load.rs
+++ b/crates/logfwd-config/src/load.rs
@@ -3,7 +3,7 @@ use crate::serde_helpers::{
     deserialize_option_strict_string, deserialize_string_map_strict_values,
 };
 use crate::types::{
-    Config, ConfigError, EnrichmentConfig, InputConfig, InputTypeConfig, OutputConfigEntry,
+    Config, ConfigError, EnrichmentConfig, InputConfig, InputTypeConfig, OutputConfigV2,
     PipelineConfig, ServerConfig, StorageConfig,
 };
 use config as config_rs;
@@ -19,7 +19,7 @@ struct RawConfig {
     input: Option<InputConfig>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     transform: Option<String>,
-    output: Option<OutputConfigEntry>,
+    output: Option<OutputConfigV2>,
     #[serde(default)]
     enrichment: Vec<EnrichmentConfig>,
     #[serde(default, deserialize_with = "deserialize_string_map_strict_values")]

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -158,6 +158,44 @@ pub enum OutputType {
     ArrowIpc,
 }
 
+impl OutputType {
+    /// Return whether this output type requires an explicit `endpoint`.
+    ///
+    /// ```
+    /// use logfwd_config::OutputType;
+    ///
+    /// assert!(OutputType::Otlp.is_endpoint_required());
+    /// assert!(!OutputType::Stdout.is_endpoint_required());
+    /// ```
+    pub fn is_endpoint_required(&self) -> bool {
+        matches!(
+            self,
+            Self::Otlp
+                | Self::Http
+                | Self::Elasticsearch
+                | Self::Loki
+                | Self::ArrowIpc
+                | Self::Tcp
+                | Self::Udp
+        )
+    }
+
+    /// Return whether this output type supports HTTP-style `auth`.
+    ///
+    /// ```
+    /// use logfwd_config::OutputType;
+    ///
+    /// assert!(OutputType::Loki.is_auth_supported());
+    /// assert!(!OutputType::Tcp.is_auth_supported());
+    /// ```
+    pub fn is_auth_supported(&self) -> bool {
+        matches!(
+            self,
+            Self::Otlp | Self::Http | Self::Elasticsearch | Self::Loki | Self::ArrowIpc
+        )
+    }
+}
+
 impl fmt::Display for OutputType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -848,146 +886,6 @@ pub struct S3InputConfig {
     pub poll_interval_ms: Option<PositiveMillis>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct OutputConfig {
-    pub name: Option<String>,
-    pub output_type: OutputType,
-    pub endpoint: Option<String>,
-    pub protocol: Option<OtlpProtocol>,
-    pub compression: Option<CompressionFormat>,
-    pub request_mode: Option<ElasticsearchRequestMode>,
-    pub format: Option<Format>,
-    pub path: Option<String>,
-    pub index: Option<String>,
-    pub auth: Option<AuthConfig>,
-    pub tenant_id: Option<String>,
-    pub static_labels: Option<HashMap<String, String>>,
-    pub label_columns: Option<Vec<String>>,
-    /// Client TLS configuration for outbound connections.
-    pub tls: Option<TlsClientConfig>,
-    /// Custom HTTP headers to include in requests.
-    pub headers: Option<HashMap<String, String>>,
-    /// Number of retry attempts for transient errors.
-    pub retry_attempts: Option<u32>,
-    /// Initial backoff delay for retries.
-    pub retry_initial_backoff_ms: Option<PositiveMillis>,
-    /// Maximum backoff delay for retries.
-    pub retry_max_backoff_ms: Option<PositiveMillis>,
-    /// Timeout for each HTTP request.
-    pub request_timeout_ms: Option<PositiveMillis>,
-    /// Maximum number of log records to send per batch.
-    pub batch_size: Option<usize>,
-    /// Maximum time to wait before sending a batch.
-    pub batch_timeout_ms: Option<PositiveMillis>,
-    /// Host for socket-based IPC.
-    pub host: Option<String>,
-    /// Port for socket-based IPC.
-    pub port: Option<u16>,
-    /// Buffer size for the IPC writer in bytes.
-    pub buffer_size_bytes: Option<usize>,
-    /// Whether to write the schema immediately upon connection.
-    pub write_schema_on_connect: Option<bool>,
-}
-
-impl<'de> Deserialize<'de> for OutputConfig {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        OutputConfigV2::deserialize(deserializer)
-            .map(OutputConfig::from)
-            .map_err(|e| serde::de::Error::custom(format!("invalid output config: {e}")))
-    }
-}
-
-/// Convert the flat `OutputConfig` view back into the typed V2 enum used by
-/// runtime sink-factory code paths.
-impl From<&OutputConfig> for OutputConfigV2 {
-    fn from(config: &OutputConfig) -> Self {
-        match config.output_type {
-            OutputType::Otlp => OutputConfigV2::Otlp(OtlpOutputConfig {
-                name: config.name.clone(),
-                endpoint: config.endpoint.clone(),
-                protocol: config.protocol,
-                compression: config.compression,
-                auth: config.auth.clone(),
-                tls: config.tls.clone(),
-                headers: config.headers.clone(),
-                retry_attempts: config.retry_attempts,
-                retry_initial_backoff_ms: config.retry_initial_backoff_ms,
-                retry_max_backoff_ms: config.retry_max_backoff_ms,
-                request_timeout_ms: config.request_timeout_ms,
-                batch_size: config.batch_size,
-                batch_timeout_ms: config.batch_timeout_ms,
-            }),
-            OutputType::Http => OutputConfigV2::Http(HttpOutputConfig {
-                name: config.name.clone(),
-                endpoint: config.endpoint.clone(),
-                compression: config.compression,
-                format: config.format.clone(),
-                auth: config.auth.clone(),
-            }),
-            OutputType::Elasticsearch => OutputConfigV2::Elasticsearch(ElasticsearchOutputConfig {
-                name: config.name.clone(),
-                endpoint: config.endpoint.clone(),
-                compression: config.compression,
-                request_mode: config.request_mode,
-                index: config.index.clone(),
-                auth: config.auth.clone(),
-                tls: config.tls.clone(),
-                request_timeout_ms: config.request_timeout_ms,
-            }),
-            OutputType::Loki => OutputConfigV2::Loki(LokiOutputConfig {
-                name: config.name.clone(),
-                endpoint: config.endpoint.clone(),
-                auth: config.auth.clone(),
-                tenant_id: config.tenant_id.clone(),
-                static_labels: config.static_labels.clone(),
-                label_columns: config.label_columns.clone(),
-                tls: config.tls.clone(),
-                request_timeout_ms: config.request_timeout_ms,
-            }),
-            OutputType::Stdout => OutputConfigV2::Stdout(StdoutOutputConfig {
-                name: config.name.clone(),
-                format: config.format.clone(),
-            }),
-            OutputType::File => OutputConfigV2::File(FileOutputConfig {
-                name: config.name.clone(),
-                path: config.path.clone(),
-                format: config.format.clone(),
-            }),
-            OutputType::Parquet => OutputConfigV2::Parquet(ParquetOutputConfig {
-                name: config.name.clone(),
-                path: config.path.clone(),
-                compression: config.compression,
-                format: config.format.clone(),
-            }),
-            OutputType::Null => OutputConfigV2::Null(NullOutputConfig {
-                name: config.name.clone(),
-            }),
-            OutputType::Tcp => OutputConfigV2::Tcp(SocketOutputConfig {
-                name: config.name.clone(),
-                endpoint: config.endpoint.clone(),
-            }),
-            OutputType::Udp => OutputConfigV2::Udp(SocketOutputConfig {
-                name: config.name.clone(),
-                endpoint: config.endpoint.clone(),
-            }),
-            OutputType::ArrowIpc => OutputConfigV2::ArrowIpc(ArrowIpcOutputConfig {
-                name: config.name.clone(),
-                endpoint: config.endpoint.clone(),
-                compression: config.compression,
-                auth: config.auth.clone(),
-                host: config.host.clone(),
-                port: config.port,
-                buffer_size_bytes: config.buffer_size_bytes,
-                batch_size: config.batch_size,
-                write_schema_on_connect: config.write_schema_on_connect,
-            }),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[non_exhaustive]
@@ -1003,24 +901,6 @@ pub enum OutputConfigV2 {
     Tcp(SocketOutputConfig),
     Udp(SocketOutputConfig),
     ArrowIpc(ArrowIpcOutputConfig),
-}
-
-impl From<OutputConfigV2> for OutputConfig {
-    fn from(config: OutputConfigV2) -> Self {
-        match config {
-            OutputConfigV2::Otlp(config) => config.into_output_config(),
-            OutputConfigV2::Http(config) => config.into_output_config(),
-            OutputConfigV2::Elasticsearch(config) => config.into_output_config(),
-            OutputConfigV2::Loki(config) => config.into_output_config(),
-            OutputConfigV2::Stdout(config) => config.into_output_config(),
-            OutputConfigV2::File(config) => config.into_output_config(),
-            OutputConfigV2::Parquet(config) => config.into_output_config(),
-            OutputConfigV2::Null(config) => config.into_output_config(),
-            OutputConfigV2::Tcp(config) => config.into_output_config(OutputType::Tcp),
-            OutputConfigV2::Udp(config) => config.into_output_config(OutputType::Udp),
-            OutputConfigV2::ArrowIpc(config) => config.into_output_config(),
-        }
-    }
 }
 
 impl OutputConfigV2 {
@@ -1041,6 +921,72 @@ impl OutputConfigV2 {
         }
     }
 
+    /// Return the endpoint for output variants that connect to a destination.
+    ///
+    /// ```
+    /// use logfwd_config::{OutputConfigV2, SocketOutputConfig, StdoutOutputConfig};
+    ///
+    /// let tcp = OutputConfigV2::Tcp(SocketOutputConfig {
+    ///     endpoint: Some("127.0.0.1:15140".to_owned()),
+    ///     ..Default::default()
+    /// });
+    /// assert_eq!(tcp.endpoint(), Some("127.0.0.1:15140"));
+    ///
+    /// let stdout = OutputConfigV2::Stdout(StdoutOutputConfig::default());
+    /// assert_eq!(stdout.endpoint(), None);
+    /// ```
+    pub fn endpoint(&self) -> Option<&str> {
+        match self {
+            OutputConfigV2::Otlp(config) => config.endpoint.as_deref(),
+            OutputConfigV2::Http(config) => config.endpoint.as_deref(),
+            OutputConfigV2::Elasticsearch(config) => config.endpoint.as_deref(),
+            OutputConfigV2::Loki(config) => config.endpoint.as_deref(),
+            OutputConfigV2::Tcp(config) => config.endpoint.as_deref(),
+            OutputConfigV2::Udp(config) => config.endpoint.as_deref(),
+            OutputConfigV2::ArrowIpc(config) => config.endpoint.as_deref(),
+            OutputConfigV2::Stdout(_)
+            | OutputConfigV2::File(_)
+            | OutputConfigV2::Parquet(_)
+            | OutputConfigV2::Null(_) => None,
+        }
+    }
+
+    /// Return authentication settings for output variants that support them.
+    ///
+    /// ```
+    /// use logfwd_config::{AuthConfig, OtlpOutputConfig, OutputConfigV2, SocketOutputConfig};
+    ///
+    /// let otlp = OutputConfigV2::Otlp(OtlpOutputConfig {
+    ///     auth: Some(AuthConfig {
+    ///         bearer_token: Some("token".to_owned()),
+    ///         ..Default::default()
+    ///     }),
+    ///     ..Default::default()
+    /// });
+    /// assert_eq!(
+    ///     otlp.auth().and_then(|auth| auth.bearer_token.as_deref()),
+    ///     Some("token")
+    /// );
+    ///
+    /// let tcp = OutputConfigV2::Tcp(SocketOutputConfig::default());
+    /// assert!(tcp.auth().is_none());
+    /// ```
+    pub fn auth(&self) -> Option<&AuthConfig> {
+        match self {
+            OutputConfigV2::Otlp(config) => config.auth.as_ref(),
+            OutputConfigV2::Http(config) => config.auth.as_ref(),
+            OutputConfigV2::Elasticsearch(config) => config.auth.as_ref(),
+            OutputConfigV2::Loki(config) => config.auth.as_ref(),
+            OutputConfigV2::ArrowIpc(config) => config.auth.as_ref(),
+            OutputConfigV2::Stdout(_)
+            | OutputConfigV2::File(_)
+            | OutputConfigV2::Parquet(_)
+            | OutputConfigV2::Null(_)
+            | OutputConfigV2::Tcp(_)
+            | OutputConfigV2::Udp(_) => None,
+        }
+    }
+
     /// Return the flat output type tag corresponding to this typed variant.
     pub fn output_type(&self) -> OutputType {
         match self {
@@ -1056,74 +1002,6 @@ impl OutputConfigV2 {
             OutputConfigV2::Udp(_) => OutputType::Udp,
             OutputConfigV2::ArrowIpc(_) => OutputType::ArrowIpc,
         }
-    }
-}
-
-/// Pipeline output entry stored in the config model.
-///
-/// Stores the typed `OutputConfigV2` parsed from YAML alongside the normalized
-/// flat `OutputConfig` view, so validation and runtime code paths can each read
-/// the form they need without re-converting on every access.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OutputConfigEntry {
-    config: OutputConfigV2,
-    flat: OutputConfig,
-}
-
-impl OutputConfigEntry {
-    /// Return the typed output configuration used by new internal consumers.
-    pub fn typed(&self) -> &OutputConfigV2 {
-        &self.config
-    }
-
-    /// Return the optional user-provided output name from the typed config.
-    pub fn name(&self) -> Option<&str> {
-        self.config.name()
-    }
-
-    /// Return the flat output type tag for diagnostics and compatibility code.
-    pub fn output_type(&self) -> OutputType {
-        self.config.output_type()
-    }
-
-    /// Return a flat compatibility view, preserving legacy fields when present.
-    pub(crate) fn compat_config(&self) -> &OutputConfig {
-        &self.flat
-    }
-}
-
-impl From<OutputConfigV2> for OutputConfigEntry {
-    fn from(config: OutputConfigV2) -> Self {
-        let flat = OutputConfig::from(config.clone());
-        Self { config, flat }
-    }
-}
-
-impl From<OutputConfig> for OutputConfigEntry {
-    fn from(config: OutputConfig) -> Self {
-        Self {
-            config: OutputConfigV2::from(&config),
-            flat: config,
-        }
-    }
-}
-
-impl std::ops::Deref for OutputConfigEntry {
-    type Target = OutputConfig;
-
-    fn deref(&self) -> &Self::Target {
-        &self.flat
-    }
-}
-
-impl<'de> Deserialize<'de> for OutputConfigEntry {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        OutputConfigV2::deserialize(deserializer)
-            .map(OutputConfigEntry::from)
-            .map_err(|e| serde::de::Error::custom(format!("invalid output config: {e}")))
     }
 }
 
@@ -1161,28 +1039,6 @@ pub struct OtlpOutputConfig {
     pub batch_timeout_ms: Option<PositiveMillis>,
 }
 
-impl OtlpOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::Otlp,
-            endpoint: self.endpoint,
-            protocol: self.protocol,
-            compression: self.compression,
-            auth: self.auth,
-            tls: self.tls,
-            headers: self.headers,
-            retry_attempts: self.retry_attempts,
-            retry_initial_backoff_ms: self.retry_initial_backoff_ms,
-            retry_max_backoff_ms: self.retry_max_backoff_ms,
-            request_timeout_ms: self.request_timeout_ms,
-            batch_size: self.batch_size,
-            batch_timeout_ms: self.batch_timeout_ms,
-            ..OutputConfig::default()
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct HttpOutputConfig {
@@ -1195,20 +1051,6 @@ pub struct HttpOutputConfig {
     pub format: Option<Format>,
     #[serde(default)]
     pub auth: Option<AuthConfig>,
-}
-
-impl HttpOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::Http,
-            endpoint: self.endpoint,
-            compression: self.compression,
-            format: self.format,
-            auth: self.auth,
-            ..OutputConfig::default()
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
@@ -1230,23 +1072,6 @@ pub struct ElasticsearchOutputConfig {
     pub tls: Option<TlsClientConfig>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub request_timeout_ms: Option<PositiveMillis>,
-}
-
-impl ElasticsearchOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::Elasticsearch,
-            endpoint: self.endpoint,
-            compression: self.compression,
-            request_mode: self.request_mode,
-            index: self.index,
-            auth: self.auth,
-            tls: self.tls,
-            request_timeout_ms: self.request_timeout_ms,
-            ..OutputConfig::default()
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
@@ -1273,23 +1098,6 @@ pub struct LokiOutputConfig {
     pub request_timeout_ms: Option<PositiveMillis>,
 }
 
-impl LokiOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::Loki,
-            endpoint: self.endpoint,
-            auth: self.auth,
-            tenant_id: self.tenant_id,
-            static_labels: self.static_labels,
-            label_columns: self.label_columns,
-            tls: self.tls,
-            request_timeout_ms: self.request_timeout_ms,
-            ..OutputConfig::default()
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct StdoutOutputConfig {
@@ -1298,42 +1106,18 @@ pub struct StdoutOutputConfig {
     pub format: Option<Format>,
 }
 
-impl StdoutOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::Stdout,
-            format: self.format,
-            ..OutputConfig::default()
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 /// File output configuration for the typed V2 schema.
 ///
-/// File compression is intentionally not part of the typed schema. Legacy flat
-/// configs may still carry `compression`; compatibility code preserves that
-/// field in the flat view so it can reject the unsupported option explicitly.
+/// File compression is intentionally not part of the typed schema; unknown
+/// fields are rejected during deserialization.
 pub struct FileOutputConfig {
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub path: Option<String>,
     pub format: Option<Format>,
-}
-
-impl FileOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::File,
-            path: self.path,
-            format: self.format,
-            ..OutputConfig::default()
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
@@ -1348,34 +1132,11 @@ pub struct ParquetOutputConfig {
     pub format: Option<Format>,
 }
 
-impl ParquetOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::Parquet,
-            path: self.path,
-            compression: self.compression,
-            format: self.format,
-            ..OutputConfig::default()
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct NullOutputConfig {
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub name: Option<String>,
-}
-
-impl NullOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::Null,
-            ..OutputConfig::default()
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
@@ -1385,17 +1146,6 @@ pub struct SocketOutputConfig {
     pub name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub endpoint: Option<String>,
-}
-
-impl SocketOutputConfig {
-    fn into_output_config(self, output_type: OutputType) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type,
-            endpoint: self.endpoint,
-            ..OutputConfig::default()
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
@@ -1419,24 +1169,6 @@ pub struct ArrowIpcOutputConfig {
     pub batch_size: Option<usize>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub write_schema_on_connect: Option<bool>,
-}
-
-impl ArrowIpcOutputConfig {
-    fn into_output_config(self) -> OutputConfig {
-        OutputConfig {
-            name: self.name,
-            output_type: OutputType::ArrowIpc,
-            endpoint: self.endpoint,
-            compression: self.compression,
-            auth: self.auth,
-            host: self.host,
-            port: self.port,
-            buffer_size_bytes: self.buffer_size_bytes,
-            batch_size: self.batch_size,
-            write_schema_on_connect: self.write_schema_on_connect,
-            ..OutputConfig::default()
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -1600,9 +1332,50 @@ pub struct PipelineConfig {
     pub inputs: Vec<InputConfig>,
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub transform: Option<String>,
-    /// Typed output configurations accepted from V2 or legacy output YAML.
+    /// Output sinks for this pipeline.
+    ///
+    /// YAML accepts either one output mapping or a list because this field uses
+    /// `deserialize_one_or_many`. Each item is parsed as an `OutputConfigV2`
+    /// tagged enum variant, so fields are strict for the selected output type
+    /// and unknown or variant-inapplicable fields are rejected during
+    /// deserialization.
+    ///
+    /// ```
+    /// use logfwd_config::{Config, OutputConfigV2};
+    ///
+    /// let single = Config::load_str(r#"
+    /// pipelines:
+    ///   app:
+    ///     inputs:
+    ///       - type: stdin
+    ///     outputs:
+    ///       type: stdout
+    /// "#).expect("single output form should parse");
+    /// assert!(matches!(
+    ///     &single.pipelines["app"].outputs[0],
+    ///     OutputConfigV2::Stdout(_)
+    /// ));
+    ///
+    /// let list = Config::load_str(r#"
+    /// pipelines:
+    ///   app:
+    ///     inputs:
+    ///       - type: stdin
+    ///     outputs:
+    ///       - type: stdout
+    ///       - type: "null"
+    /// "#).expect("list output form should parse");
+    /// assert!(matches!(
+    ///     &list.pipelines["app"].outputs[0],
+    ///     OutputConfigV2::Stdout(_)
+    /// ));
+    /// assert!(matches!(
+    ///     &list.pipelines["app"].outputs[1],
+    ///     OutputConfigV2::Null(_)
+    /// ));
+    /// ```
     #[serde(default, deserialize_with = "deserialize_one_or_many")]
-    pub outputs: Vec<OutputConfigEntry>,
+    pub outputs: Vec<OutputConfigV2>,
     #[serde(default)]
     pub enrichment: Vec<EnrichmentConfig>,
     #[serde(default, deserialize_with = "deserialize_string_map_strict_values")]

--- a/crates/logfwd-config/src/types.rs
+++ b/crates/logfwd-config/src/types.rs
@@ -1112,6 +1112,24 @@ pub struct StdoutOutputConfig {
 ///
 /// File compression is intentionally not part of the typed schema; unknown
 /// fields are rejected during deserialization.
+///
+/// ```
+/// use logfwd_config::{Config, OutputConfigV2};
+///
+/// let cfg = Config::load_str(r#"
+/// input:
+///   type: generator
+/// output:
+///   type: file
+///   path: ./out.ndjson
+/// "#)
+/// .expect("file output should parse");
+///
+/// assert!(matches!(
+///     &cfg.pipelines["default"].outputs[0],
+///     OutputConfigV2::File(_)
+/// ));
+/// ```
 pub struct FileOutputConfig {
     #[serde(default, deserialize_with = "deserialize_option_strict_string")]
     pub name: Option<String>,

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     CompressionFormat, Config, ConfigError, ElasticsearchRequestMode, EnrichmentConfig, Format,
     GeneratorAttributeValueConfig, GeneratorProfileConfig, InputType, InputTypeConfig,
-    JournaldBackendConfig, OutputConfig, OutputConfigV2, OutputType, PIPELINE_WORKERS_MAX,
+    JournaldBackendConfig, OutputConfigV2, OutputType, PIPELINE_WORKERS_MAX,
 };
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
@@ -20,79 +20,6 @@ fn validation_message(error: ConfigError) -> String {
         ConfigError::Io(error) => error.to_string(),
         ConfigError::Yaml(error) => error.to_string(),
     }
-}
-
-fn null_output_unsupported_field(output: &OutputConfig) -> Option<&'static str> {
-    if output.endpoint.is_some() {
-        return Some("endpoint");
-    }
-    if output.protocol.is_some() {
-        return Some("protocol");
-    }
-    if output.compression.is_some() {
-        return Some("compression");
-    }
-    if output.request_mode.is_some() {
-        return Some("request_mode");
-    }
-    if output.format.is_some() {
-        return Some("format");
-    }
-    if output.path.is_some() {
-        return Some("path");
-    }
-    if output.index.is_some() {
-        return Some("index");
-    }
-    if output.auth.is_some() {
-        return Some("auth");
-    }
-    if output.tenant_id.is_some() {
-        return Some("tenant_id");
-    }
-    if output.static_labels.is_some() {
-        return Some("static_labels");
-    }
-    if output.label_columns.is_some() {
-        return Some("label_columns");
-    }
-    if output.tls.is_some() {
-        return Some("tls");
-    }
-    if output.headers.is_some() {
-        return Some("headers");
-    }
-    if output.retry_attempts.is_some() {
-        return Some("retry_attempts");
-    }
-    if output.retry_initial_backoff_ms.is_some() {
-        return Some("retry_initial_backoff_ms");
-    }
-    if output.retry_max_backoff_ms.is_some() {
-        return Some("retry_max_backoff_ms");
-    }
-    if output.request_timeout_ms.is_some() {
-        return Some("request_timeout_ms");
-    }
-    if output.batch_size.is_some() {
-        return Some("batch_size");
-    }
-    if output.batch_timeout_ms.is_some() {
-        return Some("batch_timeout_ms");
-    }
-    if output.host.is_some() {
-        return Some("host");
-    }
-    if output.port.is_some() {
-        return Some("port");
-    }
-    if output.buffer_size_bytes.is_some() {
-        return Some("buffer_size_bytes");
-    }
-    if output.write_schema_on_connect.is_some() {
-        return Some("write_schema_on_connect");
-    }
-    None
 }
 
 fn output_label(output: &OutputConfigV2, index: usize) -> String {
@@ -148,166 +75,6 @@ fn validate_socket_output_endpoint(
             "pipeline '{pipeline_name}' output '{label}': {}",
             validation_message(err)
         )));
-    }
-
-    Ok(())
-}
-
-fn validate_legacy_output_compat_fields(
-    pipeline_name: &str,
-    label: &str,
-    output_type: OutputType,
-    legacy: &OutputConfig,
-) -> Result<(), ConfigError> {
-    if output_type == OutputType::Null
-        && let Some(field) = null_output_unsupported_field(legacy)
-    {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': null output does not support '{field}'; remove the field"
-        )));
-    }
-
-    if output_type != OutputType::Elasticsearch && legacy.request_mode.is_some() {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': request_mode is only supported for elasticsearch outputs"
-        )));
-    }
-    if output_type != OutputType::Elasticsearch && legacy.index.is_some() {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': 'index' is only supported for elasticsearch outputs"
-        )));
-    }
-    if output_type == OutputType::Loki && legacy.compression.is_some() {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': 'compression' is not supported for loki outputs"
-        )));
-    }
-
-    if !matches!(
-        output_type,
-        OutputType::Otlp | OutputType::Elasticsearch | OutputType::Loki
-    ) && legacy.tls.is_some()
-    {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': 'tls' is only supported for otlp, elasticsearch, and loki outputs"
-        )));
-    }
-    if output_type != OutputType::Otlp {
-        if legacy.headers.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'headers' is only supported for otlp outputs"
-            )));
-        }
-        if legacy.retry_attempts.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'retry_attempts' is only supported for otlp outputs"
-            )));
-        }
-        if legacy.retry_initial_backoff_ms.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'retry_initial_backoff_ms' is only supported for otlp outputs"
-            )));
-        }
-        if legacy.retry_max_backoff_ms.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'retry_max_backoff_ms' is only supported for otlp outputs"
-            )));
-        }
-        if !matches!(output_type, OutputType::Elasticsearch | OutputType::Loki)
-            && legacy.request_timeout_ms.is_some()
-        {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'request_timeout_ms' is only supported for otlp, elasticsearch, and loki outputs"
-            )));
-        }
-        if legacy.batch_timeout_ms.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'batch_timeout_ms' is only supported for otlp outputs"
-            )));
-        }
-    }
-
-    if output_type != OutputType::Otlp && legacy.protocol.is_some() {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': 'protocol' is only supported for otlp outputs"
-        )));
-    }
-    if output_type != OutputType::Loki {
-        if legacy.tenant_id.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'tenant_id' is only supported for loki outputs"
-            )));
-        }
-        if legacy.static_labels.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'static_labels' is only supported for loki outputs"
-            )));
-        }
-        if legacy.label_columns.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'label_columns' is only supported for loki outputs"
-            )));
-        }
-    }
-
-    if !matches!(output_type, OutputType::File | OutputType::Parquet) && legacy.path.is_some() {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': 'path' is only supported for file/parquet outputs"
-        )));
-    }
-    if !matches!(
-        output_type,
-        OutputType::Otlp
-            | OutputType::Http
-            | OutputType::Elasticsearch
-            | OutputType::Loki
-            | OutputType::ArrowIpc
-    ) && legacy.auth.is_some()
-    {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': 'auth' is only supported for HTTP-based outputs"
-        )));
-    }
-    if matches!(
-        output_type,
-        OutputType::Stdout
-            | OutputType::Null
-            | OutputType::Tcp
-            | OutputType::Udp
-            | OutputType::File
-    ) && legacy.compression.is_some()
-    {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': 'compression' is not supported for this output type"
-        )));
-    }
-
-    if output_type != OutputType::ArrowIpc {
-        if legacy.host.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'host' is only supported for arrow_ipc outputs"
-            )));
-        }
-        if legacy.port.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'port' is only supported for arrow_ipc outputs"
-            )));
-        }
-        if legacy.buffer_size_bytes.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'buffer_size_bytes' is only supported for arrow_ipc outputs"
-            )));
-        }
-        if legacy.batch_size.is_some() && output_type != OutputType::Otlp {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'batch_size' is only supported for otlp and arrow_ipc outputs"
-            )));
-        }
-        if legacy.write_schema_on_connect.is_some() {
-            return Err(ConfigError::Validation(format!(
-                "pipeline '{pipeline_name}' output '{label}': 'write_schema_on_connect' is only supported for arrow_ipc outputs"
-            )));
-        }
     }
 
     Ok(())
@@ -375,17 +142,8 @@ fn validate_output_config(
     pipeline_name: &str,
     label: &str,
     output: &OutputConfigV2,
-    legacy: &OutputConfig,
 ) -> Result<(), ConfigError> {
     let output_type = output.output_type();
-
-    if matches!(output_type, OutputType::Parquet | OutputType::Http) {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': {output_type} output type is not yet implemented",
-        )));
-    }
-
-    validate_legacy_output_compat_fields(pipeline_name, label, output_type.clone(), legacy)?;
 
     match output {
         OutputConfigV2::Otlp(config) => {
@@ -488,11 +246,6 @@ fn validate_output_config(
                 OutputType::Tcp,
                 config.endpoint.as_deref(),
             )?;
-            if legacy.format.is_some() {
-                return Err(ConfigError::Validation(format!(
-                    "pipeline '{pipeline_name}' output '{label}': tcp output does not support 'format'; remove the field",
-                )));
-            }
         }
         OutputConfigV2::Udp(config) => {
             validate_socket_output_endpoint(
@@ -501,11 +254,6 @@ fn validate_output_config(
                 OutputType::Udp,
                 config.endpoint.as_deref(),
             )?;
-            if legacy.format.is_some() {
-                return Err(ConfigError::Validation(format!(
-                    "pipeline '{pipeline_name}' output '{label}': udp output does not support 'format'; remove the field",
-                )));
-            }
         }
         OutputConfigV2::ArrowIpc(config) => {
             validate_url_output_endpoint(
@@ -1242,9 +990,8 @@ impl Config {
                 }
 
                 for (i, output) in pipe.outputs.iter().enumerate() {
-                    let typed = output.typed();
-                    let label = output_label(typed, i);
-                    validate_output_config(name, &label, typed, output.compat_config())?;
+                    let label = output_label(output, i);
+                    validate_output_config(name, &label, output)?;
                 }
 
                 // Validate enrichment entries (#550).
@@ -1387,7 +1134,6 @@ impl Config {
                 }
 
                 for (j, output) in pipe.outputs.iter().enumerate() {
-                    let output = output.typed();
                     let out_label = output_label(output, j);
 
                     let Some(out_path) = output_path_for_feedback_loop(output) else {

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -433,7 +433,10 @@ output:
 "#;
 
     let config = Config::load_str(yaml).expect("config should parse env-backed TLS bool");
-    let output = &config.pipelines["default"].outputs[0];
+    let logfwd_config::OutputConfigV2::Otlp(output) = &config.pipelines["default"].outputs[0]
+    else {
+        panic!("expected otlp output");
+    };
     let tls = output.tls.as_ref().expect("TLS config should be present");
 
     assert!(tls.insecure_skip_verify);

--- a/crates/logfwd-core/src/structural_iter.rs
+++ b/crates/logfwd-core/src/structural_iter.rs
@@ -430,7 +430,8 @@ mod verification {
 
     /// classify_bit always returns a valid StructuralKind, and the
     /// selected kind matches exactly one of the bitmask fields.
-    /// Exhaustive over all bit positions and arbitrary bitmasks.
+    /// Exhaustive over all bit positions where at least one structural
+    /// category has the tested bit set.
     #[kani::proof]
     #[kani::solver(cadical)]
     fn verify_classify_bit_correct() {
@@ -449,17 +450,19 @@ mod verification {
             open_bracket: kani::any(),
             close_bracket: kani::any(),
         };
-        kani::assume(
-            (p.newline
-                | p.real_quotes
-                | p.comma
-                | p.colon
-                | p.open_brace
-                | p.close_brace
-                | p.open_bracket
-                | p.close_bracket)
-                & mask
-                != 0,
+        let structural_bits = p.newline
+            | p.real_quotes
+            | p.comma
+            | p.colon
+            | p.open_brace
+            | p.close_brace
+            | p.open_bracket
+            | p.close_bracket;
+        kani::assume(structural_bits & mask != 0);
+        kani::cover!(p.real_quotes & mask != 0, "quote path reachable");
+        kani::cover!(
+            p.real_quotes & mask == 0 && p.open_bracket & mask != 0,
+            "open bracket fallback path reachable"
         );
 
         // Build a minimal iterator just to call classify_bit

--- a/crates/logfwd-core/src/structural_iter.rs
+++ b/crates/logfwd-core/src/structural_iter.rs
@@ -449,6 +449,18 @@ mod verification {
             open_bracket: kani::any(),
             close_bracket: kani::any(),
         };
+        kani::assume(
+            (p.newline
+                | p.real_quotes
+                | p.comma
+                | p.colon
+                | p.open_brace
+                | p.close_brace
+                | p.open_bracket
+                | p.close_bracket)
+                & mask
+                != 0,
+        );
 
         // Build a minimal iterator just to call classify_bit
         let iter = StructuralIter {

--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -282,7 +282,7 @@ pub async fn run_pipelines(
                 "     {}out{}  {}",
                 dim(use_color),
                 reset(use_color),
-                output_label(output.typed())
+                output_label(output)
             );
         }
     }

--- a/crates/logfwd-runtime/src/generated_cli.rs
+++ b/crates/logfwd-runtime/src/generated_cli.rs
@@ -1,9 +1,9 @@
 use std::fmt::Write as _;
 
 use logfwd_config::{
-    ArrowIpcOutputConfig, AuthConfig, Config, ElasticsearchOutputConfig, FileOutputConfig,
-    LokiOutputConfig, NullOutputConfig, OtlpOutputConfig, OutputConfigV2, OutputType,
-    SocketOutputConfig, StdoutOutputConfig,
+    ArrowIpcOutputConfig, AuthConfig, Config, ElasticsearchOutputConfig, LokiOutputConfig,
+    NullOutputConfig, OtlpOutputConfig, OutputConfigV2, OutputType, SocketOutputConfig,
+    StdoutOutputConfig,
 };
 
 /// Fully rendered generated config plus its validated in-memory config.
@@ -67,7 +67,10 @@ pub fn resolve_blast_output_config(
     auth_bearer_token: Option<&str>,
     auth_header: &[String],
 ) -> Result<OutputConfigV2, String> {
-    if matches!(output_type, OutputType::Http | OutputType::Parquet) {
+    if matches!(
+        output_type,
+        OutputType::Http | OutputType::Parquet | OutputType::File
+    ) {
         return Err(format!("unsupported blast destination '{output_type}'"));
     }
 
@@ -119,7 +122,6 @@ pub fn resolve_blast_output_config(
             ..Default::default()
         }),
         OutputType::Stdout => OutputConfigV2::Stdout(StdoutOutputConfig::default()),
-        OutputType::File => OutputConfigV2::File(FileOutputConfig::default()),
         OutputType::Null => OutputConfigV2::Null(NullOutputConfig::default()),
         OutputType::Tcp => OutputConfigV2::Tcp(SocketOutputConfig {
             endpoint,
@@ -310,7 +312,7 @@ mod tests {
 
     #[test]
     fn resolve_blast_output_config_rejects_unimplemented_destinations() {
-        for output_type in [OutputType::Http, OutputType::Parquet] {
+        for output_type in [OutputType::Http, OutputType::Parquet, OutputType::File] {
             let err =
                 resolve_blast_output_config(output_type.clone(), Some("http://example"), None, &[])
                     .expect_err("unimplemented blast destination should be rejected");

--- a/crates/logfwd-runtime/src/generated_cli.rs
+++ b/crates/logfwd-runtime/src/generated_cli.rs
@@ -1,6 +1,10 @@
 use std::fmt::Write as _;
 
-use logfwd_config::{Config, OutputConfig, OutputType};
+use logfwd_config::{
+    ArrowIpcOutputConfig, AuthConfig, Config, ElasticsearchOutputConfig, FileOutputConfig,
+    LokiOutputConfig, NullOutputConfig, OtlpOutputConfig, OutputConfigV2, OutputType,
+    SocketOutputConfig, StdoutOutputConfig,
+};
 
 /// Fully rendered generated config plus its validated in-memory config.
 ///
@@ -62,43 +66,30 @@ pub fn resolve_blast_output_config(
     endpoint: Option<&str>,
     auth_bearer_token: Option<&str>,
     auth_header: &[String],
-) -> Result<OutputConfig, String> {
-    let mut output_cfg = OutputConfig {
-        output_type: output_type.clone(),
-        ..OutputConfig::default()
-    };
-
-    if matches!(
-        output_type,
-        OutputType::Otlp
-            | OutputType::Http
-            | OutputType::Elasticsearch
-            | OutputType::Loki
-            | OutputType::ArrowIpc
-            | OutputType::Tcp
-            | OutputType::Udp
-    ) {
-        let endpoint =
-            endpoint.ok_or_else(|| "blast requires --endpoint for this destination".to_owned())?;
-        output_cfg.endpoint = Some(endpoint.to_owned());
+) -> Result<OutputConfigV2, String> {
+    if matches!(output_type, OutputType::Http | OutputType::Parquet) {
+        return Err(format!("unsupported blast destination '{output_type}'"));
     }
 
-    if auth_bearer_token.is_some() || !auth_header.is_empty() {
-        if !matches!(
-            output_type,
-            OutputType::Otlp
-                | OutputType::Http
-                | OutputType::Elasticsearch
-                | OutputType::Loki
-                | OutputType::ArrowIpc
-        ) {
+    let endpoint = if output_type.is_endpoint_required() {
+        Some(
+            endpoint
+                .ok_or_else(|| "blast requires --endpoint for this destination".to_owned())?
+                .to_owned(),
+        )
+    } else {
+        None
+    };
+
+    let auth = if auth_bearer_token.is_some() || !auth_header.is_empty() {
+        if !output_type.is_auth_supported() {
             return Err(
                 "--auth-bearer-token/--auth-header are only supported for otlp, http, elasticsearch, loki, and arrow_ipc destinations"
                     .to_owned(),
             );
         }
 
-        let mut auth = output_cfg.auth.clone().unwrap_or_default();
+        let mut auth = AuthConfig::default();
         if let Some(token) = auth_bearer_token {
             auth.bearer_token = Some(token.to_owned());
         }
@@ -106,15 +97,50 @@ pub fn resolve_blast_output_config(
             let (key, value) = split_header(spec)?;
             auth.headers.insert(key.to_string(), value.to_string());
         }
-        output_cfg.auth = Some(auth);
-    }
+        Some(auth)
+    } else {
+        None
+    };
 
-    Ok(output_cfg)
+    Ok(match output_type {
+        OutputType::Otlp => OutputConfigV2::Otlp(OtlpOutputConfig {
+            endpoint,
+            auth,
+            ..Default::default()
+        }),
+        OutputType::Elasticsearch => OutputConfigV2::Elasticsearch(ElasticsearchOutputConfig {
+            endpoint,
+            auth,
+            ..Default::default()
+        }),
+        OutputType::Loki => OutputConfigV2::Loki(LokiOutputConfig {
+            endpoint,
+            auth,
+            ..Default::default()
+        }),
+        OutputType::Stdout => OutputConfigV2::Stdout(StdoutOutputConfig::default()),
+        OutputType::File => OutputConfigV2::File(FileOutputConfig::default()),
+        OutputType::Null => OutputConfigV2::Null(NullOutputConfig::default()),
+        OutputType::Tcp => OutputConfigV2::Tcp(SocketOutputConfig {
+            endpoint,
+            ..Default::default()
+        }),
+        OutputType::Udp => OutputConfigV2::Udp(SocketOutputConfig {
+            endpoint,
+            ..Default::default()
+        }),
+        OutputType::ArrowIpc => OutputConfigV2::ArrowIpc(ArrowIpcOutputConfig {
+            endpoint,
+            auth,
+            ..Default::default()
+        }),
+        _ => return Err(format!("unsupported blast destination '{output_type}'")),
+    })
 }
 
 /// Render the blast-generated YAML.
 pub fn render_blast_yaml(
-    output_cfg: &OutputConfig,
+    output_cfg: &OutputConfigV2,
     workers: usize,
     batch_lines: usize,
     diagnostics_addr: &str,
@@ -130,12 +156,16 @@ pub fn render_blast_yaml(
     let _ = writeln!(yaml, "          batch_size: {batch_lines}");
     yaml.push_str("          events_per_sec: 0\n");
     yaml.push_str("    outputs:\n");
-    let _ = writeln!(yaml, "      - type: {}", output_cfg.output_type);
+    let _ = writeln!(
+        yaml,
+        "      - type: {}",
+        yaml_quote(&output_cfg.output_type().to_string())
+    );
 
-    if let Some(endpoint) = &output_cfg.endpoint {
+    if let Some(endpoint) = output_cfg.endpoint() {
         let _ = writeln!(yaml, "        endpoint: {}", yaml_quote(endpoint));
     }
-    if let Some(auth) = &output_cfg.auth {
+    if let Some(auth) = output_cfg.auth() {
         yaml.push_str("        auth:\n");
         if let Some(token) = &auth.bearer_token {
             let _ = writeln!(yaml, "          bearer_token: {}", yaml_quote(token));
@@ -238,9 +268,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_blast_output_config_http_requires_endpoint() {
-        let err = resolve_blast_output_config(OutputType::Http, None, None, &[])
-            .expect_err("http blast destination should require endpoint");
+    fn resolve_blast_output_config_otlp_requires_endpoint() {
+        let err = resolve_blast_output_config(OutputType::Otlp, None, None, &[])
+            .expect_err("otlp blast destination should require endpoint");
         assert!(
             err.contains("blast requires --endpoint"),
             "unexpected error: {err}"
@@ -248,36 +278,59 @@ mod tests {
     }
 
     #[test]
-    fn resolve_blast_output_config_http_preserves_endpoint() {
+    fn resolve_blast_output_config_otlp_preserves_endpoint() {
         let cfg = resolve_blast_output_config(
-            OutputType::Http,
+            OutputType::Otlp,
             Some("http://127.0.0.1:8080/ingest"),
             None,
             &[],
         )
-        .expect("http blast destination should preserve endpoint");
-        assert_eq!(
-            cfg.endpoint.as_deref(),
-            Some("http://127.0.0.1:8080/ingest")
-        );
+        .expect("otlp blast destination should preserve endpoint");
+        assert_eq!(cfg.endpoint(), Some("http://127.0.0.1:8080/ingest"));
     }
 
     #[test]
-    fn resolve_blast_output_config_http_allows_auth() {
+    fn resolve_blast_output_config_otlp_allows_auth() {
         let headers = vec!["X-API-Key=secret".to_owned()];
         let cfg = resolve_blast_output_config(
-            OutputType::Http,
+            OutputType::Otlp,
             Some("http://127.0.0.1:8080/ingest"),
             Some("token-123"),
             &headers,
         )
-        .expect("http blast destination should allow auth");
+        .expect("otlp blast destination should allow auth");
 
-        let auth = cfg.auth.expect("auth should be present");
+        let auth = cfg.auth().expect("auth should be present");
         assert_eq!(auth.bearer_token.as_deref(), Some("token-123"));
         assert_eq!(
             auth.headers.get("X-API-Key").map(String::as_str),
             Some("secret")
         );
+    }
+
+    #[test]
+    fn resolve_blast_output_config_rejects_unimplemented_destinations() {
+        for output_type in [OutputType::Http, OutputType::Parquet] {
+            let err =
+                resolve_blast_output_config(output_type.clone(), Some("http://example"), None, &[])
+                    .expect_err("unimplemented blast destination should be rejected");
+            assert!(
+                err.contains(&format!("unsupported blast destination '{output_type}'")),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_blast_yaml_quotes_null_output_type() {
+        let yaml = render_blast_yaml(
+            &OutputConfigV2::Null(NullOutputConfig::default()),
+            1,
+            1,
+            "127.0.0.1:0",
+        );
+
+        assert!(yaml.contains("      - type: \"null\""));
+        Config::load_str(&yaml).expect("quoted null blast YAML should parse");
     }
 }

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -595,13 +595,13 @@ impl Pipeline {
         // Build output sink factory → pool.
         let factory: Arc<dyn SinkFactory> = if config.outputs.len() == 1 {
             let output_cfg = &config.outputs[0];
-            build_output_factory_from_config(0, output_cfg.typed(), base_path, &mut metrics)?
+            build_output_factory_from_config(0, output_cfg, base_path, &mut metrics)?
         } else {
             let mut factories: Vec<Arc<dyn SinkFactory>> = Vec::new();
             for (i, output_cfg) in config.outputs.iter().enumerate() {
                 factories.push(build_output_factory_from_config(
                     i,
-                    output_cfg.typed(),
+                    output_cfg,
                     base_path,
                     &mut metrics,
                 )?);
@@ -705,9 +705,7 @@ fn should_open_checkpoint_store(checkpoint_dir: &Path, has_explicit_data_dir: bo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use logfwd_config::{
-        InputConfig, InputTypeConfig, OutputConfig, OutputConfigV2, OutputType, StdoutOutputConfig,
-    };
+    use logfwd_config::{InputConfig, InputTypeConfig, OutputConfigV2, StdoutOutputConfig};
     use logfwd_types::source_metadata::SourcePathColumn;
 
     fn minimal_input(path: String) -> InputConfig {
@@ -728,17 +726,14 @@ mod tests {
         }
     }
 
-    fn minimal_output() -> OutputConfig {
-        OutputConfig {
-            output_type: OutputType::Stdout,
-            ..Default::default()
-        }
+    fn minimal_output() -> OutputConfigV2 {
+        OutputConfigV2::Stdout(StdoutOutputConfig::default())
     }
 
     fn minimal_config(path: String) -> PipelineConfig {
         PipelineConfig {
             inputs: vec![minimal_input(path)],
-            outputs: vec![minimal_output().into()],
+            outputs: vec![minimal_output()],
             transform: None,
             enrichment: vec![],
             resource_attrs: std::collections::HashMap::new(),
@@ -756,13 +751,10 @@ mod tests {
         std::fs::write(&log_path, b"{\"msg\":\"hello\"}\n").unwrap();
 
         let mut config = minimal_config(log_path.display().to_string());
-        config.outputs = vec![
-            OutputConfigV2::Stdout(StdoutOutputConfig {
-                name: Some("typed_stdout".to_string()),
-                format: None,
-            })
-            .into(),
-        ];
+        config.outputs = vec![OutputConfigV2::Stdout(StdoutOutputConfig {
+            name: Some("typed_stdout".to_string()),
+            format: None,
+        })];
 
         Pipeline::from_config("default", &config, &logfwd_test_utils::test_meter(), None)
             .expect("native typed output entry should build");
@@ -777,7 +769,7 @@ mod tests {
         let cfg = PipelineConfig {
             inputs: vec![minimal_input(log_path.to_string_lossy().into_owned())],
             transform: None,
-            outputs: vec![minimal_output().into()],
+            outputs: vec![minimal_output()],
             enrichment: Vec::new(),
             resource_attrs: Default::default(),
             workers: None,
@@ -897,7 +889,7 @@ mod tests {
                 }),
             }],
             transform: None,
-            outputs: vec![minimal_output().into()],
+            outputs: vec![minimal_output()],
             enrichment: Vec::new(),
             resource_attrs: Default::default(),
             workers: None,
@@ -948,7 +940,7 @@ mod tests {
                 }),
             }],
             transform: None,
-            outputs: vec![minimal_output().into()],
+            outputs: vec![minimal_output()],
             enrichment: Vec::new(),
             resource_attrs: Default::default(),
             workers: None,

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -868,7 +868,8 @@ mod tests {
 
     use arrow::record_batch::RecordBatch;
     use logfwd_config::{
-        CompressionFormat, Format, OtlpProtocol, OutputConfig, OutputConfigV2, OutputType,
+        CompressionFormat, Format, OtlpOutputConfig, OtlpProtocol, OutputConfigV2,
+        StdoutOutputConfig,
     };
     use logfwd_core::scan_config::ScanConfig;
     use logfwd_diagnostics::diagnostics::ComponentStats;
@@ -907,15 +908,12 @@ mod tests {
 
     #[test]
     fn test_build_sink_factory_stdout() {
-        let cfg = OutputConfig {
+        let cfg = OutputConfigV2::Stdout(StdoutOutputConfig {
             name: Some("test".to_string()),
-            output_type: OutputType::Stdout,
             format: Some(Format::Json),
-            ..Default::default()
-        };
-        let typed = OutputConfigV2::from(&cfg);
+        });
         let factory =
-            build_sink_factory("test", &typed, None, Arc::new(ComponentStats::new())).unwrap();
+            build_sink_factory("test", &cfg, None, Arc::new(ComponentStats::new())).unwrap();
         assert_eq!(factory.name(), "test");
         let sink = factory.create().expect("create should succeed");
         assert_eq!(sink.name(), "test");
@@ -923,29 +921,25 @@ mod tests {
 
     #[test]
     fn test_build_sink_factory_otlp() {
-        let cfg = OutputConfig {
+        let cfg = OutputConfigV2::Otlp(OtlpOutputConfig {
             name: Some("otel".to_string()),
-            output_type: OutputType::Otlp,
             endpoint: Some("http://localhost:4318".to_string()),
             protocol: Some(OtlpProtocol::Http),
             compression: Some(CompressionFormat::Zstd),
             ..Default::default()
-        };
-        let typed = OutputConfigV2::from(&cfg);
+        });
         let factory =
-            build_sink_factory("otel", &typed, None, Arc::new(ComponentStats::new())).unwrap();
+            build_sink_factory("otel", &cfg, None, Arc::new(ComponentStats::new())).unwrap();
         assert_eq!(factory.name(), "otel");
     }
 
     #[test]
     fn test_build_sink_factory_missing_endpoint() {
-        let cfg = OutputConfig {
+        let cfg = OutputConfigV2::Otlp(OtlpOutputConfig {
             name: Some("bad".to_string()),
-            output_type: OutputType::Otlp,
             ..Default::default()
-        };
-        let typed = OutputConfigV2::from(&cfg);
-        let result = build_sink_factory("bad", &typed, None, Arc::new(ComponentStats::new()));
+        });
+        let result = build_sink_factory("bad", &cfg, None, Arc::new(ComponentStats::new()));
         assert!(result.is_err());
         let err = result.err().unwrap();
         assert!(err.to_string().contains("endpoint"), "got: {err}");

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -971,7 +971,9 @@ fn maybe_prompt_blast_setup(args: &mut BlastArgs) -> Result<(), CliError> {
 }
 
 #[cfg(test)]
-fn resolve_blast_output_config(args: &BlastArgs) -> Result<logfwd_config::OutputConfig, CliError> {
+fn resolve_blast_output_config(
+    args: &BlastArgs,
+) -> Result<logfwd_config::OutputConfigV2, CliError> {
     let destination = args
         .destination
         .ok_or_else(|| CliError::Config("blast requires --destination".to_owned()))?;
@@ -2730,6 +2732,9 @@ outputs:
 
         let output_cfg =
             resolve_blast_output_config(&args).expect("tcp destination should preserve endpoint");
+        let logfwd_config::OutputConfigV2::Tcp(output_cfg) = output_cfg else {
+            panic!("expected tcp output config");
+        };
         assert_eq!(output_cfg.endpoint.as_deref(), Some("127.0.0.1:15140"));
     }
 


### PR DESCRIPTION
## Summary
- remove the flat `OutputConfig` / `OutputConfigEntry` compatibility layer
- store `PipelineConfig.outputs` as `Vec<OutputConfigV2>` and validate/build sinks directly from typed variants
- update generated `blast` config rendering and tests to construct typed output variants directly
- update config tests to assert typed-schema parse-time errors for invalid output fields/tags

## Tests
- `cargo fmt --check`
- `cargo check -p logfwd-config -p logfwd-runtime`
- `cargo test -p logfwd-config`
- `cargo test -p logfwd-runtime generated_cli --lib`
- `cargo test -p logfwd --bin ff blast -- --nocapture`
- `cargo clippy -p logfwd-config -p logfwd-runtime -p logfwd -- -D warnings`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove flat `OutputConfig` compatibility layer in favor of typed `OutputConfigV2`
> - Removes the flat `OutputConfig` struct, `OutputConfigEntry` wrapper, and all conversion/compatibility code across `logfwd-config`, `logfwd-runtime`, and `logfwd`.
> - `OutputConfigV2` gains `endpoint()`, `auth()`, `name()`, and `output_type()` accessor methods to replace fields previously exposed via the flat model.
> - `OutputType` gains `is_endpoint_required()` and `is_auth_supported()` helper methods used in validation and CLI resolution.
> - `PipelineConfig.outputs` and `RawConfig.output` now hold `OutputConfigV2` directly; validation and sink construction pass typed configs throughout.
> - Behavioral Change: serde error messages change (e.g., field paths like `output.type` or `pipelines.app.outputs[0]`); unknown fields are now rejected at deserialization time via `deny_unknown_fields` rather than via explicit compatibility checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e895656.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->