### PR TITLE
feat: cargo-mutants integration — config, recipes, and surviving mutant fixes

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -48,8 +48,8 @@ exclude_globs = [
 # Cap lint level to avoid deny-warnings build failures on mutated code.
 cap_lints = true
 
-# Timeout: 2x baseline to catch infinite loops without being too generous.
-# Baseline test is ~26s, so 2x = ~80s effective timeout after multiplier.
+# Timeout: 2.5x baseline to catch infinite loops without being too generous.
+# Baseline test is ~26s, so 2.5x = ~65s effective timeout after multiplier.
 timeout_multiplier = 2.5
 
 # Build timeout: generous since incremental builds vary.

--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,59 @@
+# cargo-mutants configuration
+# https://mutants.rs/config.html
+#
+# Run: cargo mutants -p logfwd-core --test-tool nextest
+# PR:  git diff origin/main...HEAD | cargo mutants --in-diff - --test-tool nextest
+
+# Use nextest (matches CI test runner).
+test_tool = "nextest"
+
+# Exclude Kani verification modules — these are proof harnesses that only run
+# under `cargo kani`, not `cargo test`.  Without this exclusion ~32% of
+# logfwd-core mutants are false-positive "missed".
+exclude_re = [
+    "verification::",          # Kani proof harnesses (all crates)
+    "::tests::",               # test-only helper functions
+    "impl.*Display",           # Display impls — cosmetic, not logic
+    "impl.*Debug",             # Debug impls — cosmetic
+    "tracing::",               # tracing instrumentation
+]
+
+# Skip mutations inside calls to these functions — they're side-effect-only
+# logging/tracing or allocation hints that don't affect correctness.
+skip_calls = [
+    "trace",
+    "debug",
+    "info",
+    "warn",
+    "error",
+    "tracing::trace",
+    "tracing::debug",
+    "tracing::info",
+    "tracing::warn",
+    "tracing::error",
+    "eprintln",
+    "with_capacity",
+    "reserve",
+    "shrink_to_fit",
+]
+skip_calls_defaults = true
+
+# Exclude generated code and benchmarks from mutation.
+exclude_globs = [
+    "**/generated/**",
+    "**/benches/**",
+    "**/examples/**",
+]
+
+# Cap lint level to avoid deny-warnings build failures on mutated code.
+cap_lints = true
+
+# Timeout: 2x baseline to catch infinite loops without being too generous.
+# Baseline test is ~26s, so 2x = ~80s effective timeout after multiplier.
+timeout_multiplier = 2.5
+
+# Build timeout: generous since incremental builds vary.
+build_timeout_multiplier = 5.0
+
+# Minimum test timeout floor (seconds).
+minimum_test_timeout = 30.0

--- a/crates/logfwd-core/src/cri.rs
+++ b/crates/logfwd-core/src/cri.rs
@@ -879,15 +879,16 @@ mod tests {
     }
 
     #[test]
-    fn json_escape_control_chars_hex_a_through_f() {
+    fn json_escape_all_control_characters() {
         // These control chars produce \u00XX where XX has hex digits a-f.
         // Bytes 0x0A through 0x1F have low nibble >= 10 (some hit the
         // `b'a' + (nibble - 10)` branch in json_escape_bytes).
         // Note: 0x08 (\b), 0x09 (\t), 0x0A (\n), 0x0C (\f), 0x0D (\r) use
         // named escapes, so we check the generic \u00XX path for the rest.
+        let mut buf = Vec::new();
         for byte in 0x00u8..=0x1F {
+            buf.clear();
             let input = [byte];
-            let mut buf = Vec::new();
             json_escape_bytes(&input, &mut buf);
             let escaped = core::str::from_utf8(&buf).unwrap();
             match byte {
@@ -903,7 +904,7 @@ mod tests {
             }
         }
         // Also verify 0x7F (DEL) uses the generic escape path.
-        let mut buf = Vec::new();
+        buf.clear();
         json_escape_bytes(&[0x7F], &mut buf);
         assert_eq!(
             core::str::from_utf8(&buf).unwrap(),

--- a/crates/logfwd-core/src/cri.rs
+++ b/crates/logfwd-core/src/cri.rs
@@ -877,6 +877,40 @@ mod tests {
         }
         reassembler.reset();
     }
+
+    #[test]
+    fn json_escape_control_chars_hex_a_through_f() {
+        // These control chars produce \u00XX where XX has hex digits a-f.
+        // Bytes 0x0A through 0x1F have low nibble >= 10 (some hit the
+        // `b'a' + (nibble - 10)` branch in json_escape_bytes).
+        // Note: 0x08 (\b), 0x09 (\t), 0x0A (\n), 0x0C (\f), 0x0D (\r) use
+        // named escapes, so we check the generic \u00XX path for the rest.
+        for byte in 0x00u8..=0x1F {
+            let input = [byte];
+            let mut buf = Vec::new();
+            json_escape_bytes(&input, &mut buf);
+            let escaped = core::str::from_utf8(&buf).unwrap();
+            match byte {
+                0x08 => assert_eq!(escaped, "\\b", "byte 0x{byte:02x}"),
+                b'\t' => assert_eq!(escaped, "\\t", "byte 0x{byte:02x}"),
+                b'\n' => assert_eq!(escaped, "\\n", "byte 0x{byte:02x}"),
+                0x0C => assert_eq!(escaped, "\\f", "byte 0x{byte:02x}"),
+                b'\r' => assert_eq!(escaped, "\\r", "byte 0x{byte:02x}"),
+                _ => {
+                    let expected = format!("\\u00{byte:02x}");
+                    assert_eq!(escaped, expected, "byte 0x{byte:02x}");
+                }
+            }
+        }
+        // Also verify 0x7F (DEL) uses the generic escape path.
+        let mut buf = Vec::new();
+        json_escape_bytes(&[0x7F], &mut buf);
+        assert_eq!(
+            core::str::from_utf8(&buf).unwrap(),
+            "\\u007f",
+            "byte 0x7F (DEL)"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/justfile
+++ b/justfile
@@ -307,13 +307,16 @@ test-linearizability:
 # ---------------------------------------------------------------------------
 
 # Run mutation testing on a single crate (default: logfwd-core).
-# Requires: cargo install cargo-mutants
+# Requires: cargo install cargo-mutants cargo-nextest
 # Config:   .cargo/mutants.toml (exclusions, timeout, nextest)
 mutants crate="logfwd-core":
     cargo mutants -p {{crate}}
 
 # Run mutation testing only on code changed vs origin/main (fast, CI-friendly).
 mutants-diff crate="logfwd-core":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git rev-parse --verify origin/main >/dev/null
     git diff origin/main...HEAD | cargo mutants -p {{crate}} --in-diff -
 
 # Build release binary (full package, includes DataFusion SQL)

--- a/justfile
+++ b/justfile
@@ -302,6 +302,20 @@ test-extended:
 test-linearizability:
     cargo test -p logfwd --features turmoil --test turmoil_sim linearizability::porcupine_checker_accepts_runtime_history
 
+# ---------------------------------------------------------------------------
+# Mutation testing (cargo-mutants)
+# ---------------------------------------------------------------------------
+
+# Run mutation testing on a single crate (default: logfwd-core).
+# Requires: cargo install cargo-mutants
+# Config:   .cargo/mutants.toml (exclusions, timeout, nextest)
+mutants crate="logfwd-core":
+    cargo mutants -p {{crate}}
+
+# Run mutation testing only on code changed vs origin/main (fast, CI-friendly).
+mutants-diff crate="logfwd-core":
+    git diff origin/main...HEAD | cargo mutants -p {{crate}} --in-diff -
+
 # Build release binary (full package, includes DataFusion SQL)
 build:
     cargo build --release -p logfwd


### PR DESCRIPTION
## Summary

- Add `.cargo/mutants.toml` with exclusions for Kani modules, generated code, benchmarks, Display/tracing impls, and `skip_calls` for logging/allocation hints
- Add `just mutants` and `just mutants-diff` recipes using nextest (config-driven, no CLI flag duplication)
- Add test for `json_escape_bytes` control char hex digit encoding — covers all bytes 0x00-0x1F and 0x7F, killing surviving mutants in the `b'a' + (nibble - 10)` branch

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test -p logfwd-core -- json_escape` passes (new test)
- [ ] `just mutants-diff` runs successfully
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cargo-mutants integration with config, justfile recipes, and test coverage fixes
> - Adds [`.cargo/mutants.toml`](https://github.com/strawgate/fastforward/pull/2425/files#diff-09edad43e7472f8482e4ee4e6c32f7e317c94c8b550239a03e153a7b311c531d) configuring cargo-mutants to use nextest, exclude generated code/benches/examples, skip logging/tracing calls, and set timeout multipliers.
> - Adds `just mutants` and `just mutants-diff` recipes in the [justfile](https://github.com/strawgate/fastforward/pull/2425/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) to run mutation testing against a specified crate, with `mutants-diff` scoping mutations to changes vs `origin/main`.
> - Adds a unit test in [`cri.rs`](https://github.com/strawgate/fastforward/pull/2425/files#diff-829f2a1180f6c62efb98de842e2acb1abeb43f544f72c7f86da209f2816585d0) covering all control character escaping in `json_escape_bytes`, including named escapes and generic `\u00xx` forms, to fix surviving mutants.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f53eb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->