### PR TITLE
refactor(transform): drop unused conflict_schema re-export

### DIFF
--- a/crates/logfwd-transform/src/lib.rs
+++ b/crates/logfwd-transform/src/lib.rs
@@ -3,8 +3,6 @@
 //! Takes a user's SQL string, analyzes it at startup, compiles a DataFusion
 //! execution plan, and executes it against Arrow RecordBatches from the scanner.
 
-pub use logfwd_arrow::conflict_schema;
-
 pub mod enrichment;
 pub mod error;
 pub mod udf;

--- a/crates/logfwd-transform/src/sql_transform.rs
+++ b/crates/logfwd-transform/src/sql_transform.rs
@@ -15,7 +15,8 @@ use logfwd_core::scan_config::ScanConfig;
 use logfwd_types::field_names;
 
 use crate::cast_udf::{FloatCastUdf, IntCastUdf};
-use crate::{QueryAnalyzer, TransformError, conflict_schema, enrichment, udf};
+use crate::{QueryAnalyzer, TransformError, enrichment, udf};
+use logfwd_arrow::conflict_schema;
 
 /// Manages a DataFusion context, compiles and caches plans, executes SQL
 /// transforms against Arrow RecordBatches.


### PR DESCRIPTION
## Summary

`logfwd_transform::conflict_schema` was re-exported from `logfwd-arrow` via `pub use logfwd_arrow::conflict_schema;` in `crates/logfwd-transform/src/lib.rs`, but no external crate imports it.

The only internal user, `sql_transform.rs`, referenced it through `crate::conflict_schema` — which resolved only because of the re-export. Drop the re-export and have `sql_transform.rs` import `logfwd_arrow::conflict_schema` directly, matching how `udf/json_extract.rs` already uses the module.

## Verification

```
$ grep -rn 'logfwd_transform::conflict_schema\|logfwd_transform::{.*conflict_schema' --include='*.rs' crates/
# (no hits)

$ cargo check --workspace  ✅
$ cargo clippy -- -D warnings  ✅
```

## Test plan

- [ ] `just ci-all` passes

https://claude.ai/code/session_01Be9dE9BzfRQxEmY1RUpwbe

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unused `conflict_schema` re-export from `logfwd-transform`
> Removes the `pub use logfwd_arrow::conflict_schema` re-export from [lib.rs](https://github.com/strawgate/fastforward/pull/2430/files#diff-7f99c61e4fa1e19b6c17f6ce4bfe08c3f358ab9022424354b6afc4b9fac069c5) and updates [sql_transform.rs](https://github.com/strawgate/fastforward/pull/2430/files#diff-8ce3ccee08bc61e14a547e796ba428fad9ca0932d50fd3967d925cba11a8f2b7) to import `conflict_schema` directly from `logfwd_arrow` instead of through the current crate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95c36de.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->