### PR TITLE
style: drop needless raw-string hashes + adjacent pedantic fixes from --fix

### DIFF
--- a/crates/logfwd-arrow/src/conflict_schema.rs
+++ b/crates/logfwd-arrow/src/conflict_schema.rs
@@ -523,7 +523,7 @@ mod tests {
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             "point",
-            DataType::Struct(struct_fields.clone()),
+            DataType::Struct(struct_fields),
             true,
         )]));
         let batch =

--- a/crates/logfwd-arrow/src/materialize.rs
+++ b/crates/logfwd-arrow/src/materialize.rs
@@ -323,8 +323,7 @@ mod tests {
         let new_schema = Arc::new(Schema::new_with_metadata(fields, schema_meta));
 
         // Rebuild batch with metadata
-        let batch_with_meta =
-            RecordBatch::try_new(new_schema.clone(), batch.columns().to_vec()).unwrap();
+        let batch_with_meta = RecordBatch::try_new(new_schema, batch.columns().to_vec()).unwrap();
 
         let owned = detach(&batch_with_meta);
 

--- a/crates/logfwd-arrow/src/scanner.rs
+++ b/crates/logfwd-arrow/src/scanner.rs
@@ -417,25 +417,23 @@ mod tests {
             ))
             .unwrap();
         // Single-type bool field: bare name
-        assert_eq!(
+        assert!(
             batch
                 .column_by_name("a")
                 .unwrap()
                 .as_any()
                 .downcast_ref::<BooleanArray>()
                 .unwrap()
-                .value(0),
-            true
+                .value(0)
         );
-        assert_eq!(
-            batch
+        assert!(
+            !batch
                 .column_by_name("b")
                 .unwrap()
                 .as_any()
                 .downcast_ref::<BooleanArray>()
                 .unwrap()
-                .value(0),
-            false
+                .value(0)
         );
     }
     #[test]
@@ -515,15 +513,14 @@ mod tests {
                 .to_vec(),
             ))
             .unwrap();
-        assert_eq!(
+        assert!(
             batch
                 .column_by_name("ok")
                 .unwrap()
                 .as_any()
                 .downcast_ref::<BooleanArray>()
                 .unwrap()
-                .value(0),
-            true
+                .value(0)
         );
     }
     #[test]

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -2385,8 +2385,8 @@ mod tests {
             .as_any()
             .downcast_ref::<BooleanArray>()
             .expect("scope.enabled bool");
-        assert_eq!(scope_enabled.value(0), true);
-        assert_eq!(scope_enabled.value(1), true);
+        assert!(scope_enabled.value(0));
+        assert!(scope_enabled.value(1));
 
         let scope_rank = roundtrip
             .column(
@@ -3463,7 +3463,7 @@ mod tests {
             }
         }
         assert!(
-            status_values.iter().any(|value| *value == Some("200")),
+            status_values.contains(&Some("200")),
             "status=200 (from int child) must appear in log_attrs, got: {:?}",
             status_values
                 .iter()
@@ -3471,9 +3471,7 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert!(
-            status_values
-                .iter()
-                .any(|value| *value == Some("NOT_FOUND")),
+            status_values.contains(&Some("NOT_FOUND")),
             "status=NOT_FOUND (from str child) must appear in log_attrs"
         );
     }

--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -1739,7 +1739,7 @@ mod tests {
     fn test_read_str_out_of_bounds() {
         let buf = bytes::Bytes::from_static(b"abcd");
         let mut b = StreamingBuilder::new(None);
-        b.begin_batch(buf.clone());
+        b.begin_batch(buf);
 
         let res = b.read_str(0, 10, false); // Out of bounds length
         assert_eq!(res, None); // Handled safely
@@ -2480,7 +2480,7 @@ mod tests {
         let json = b"hello world padding";
         let buf = bytes::Bytes::from(json.to_vec());
         let mut b = StreamingBuilder::new(None);
-        b.begin_batch(buf.clone());
+        b.begin_batch(buf);
         let idx = b.resolve_field(b"msg");
         b.begin_row();
         // Decoded string goes into decoded_buf, not the original buffer

--- a/crates/logfwd-arrow/tests/allocation_regression.rs
+++ b/crates/logfwd-arrow/tests/allocation_regression.rs
@@ -129,15 +129,11 @@ fn scanner_allocs_scale_linearly() {
     let data_5000 = make_ndjson(5000);
 
     let reg_s500 = Region::new(GLOBAL);
-    let _ = streaming
-        .scan(bytes::Bytes::from(data_500.clone()))
-        .unwrap();
+    let _ = streaming.scan(bytes::Bytes::from(data_500)).unwrap();
     let stats_s500 = reg_s500.change();
 
     let reg_s5000 = Region::new(GLOBAL);
-    let _ = streaming
-        .scan(bytes::Bytes::from(data_5000.clone()))
-        .unwrap();
+    let _ = streaming.scan(bytes::Bytes::from(data_5000)).unwrap();
     let stats_s5000 = reg_s5000.change();
 
     let streaming_ratio = stats_s5000.allocations as f64 / stats_s500.allocations.max(1) as f64;

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -349,7 +349,7 @@ output:
         fs::write(&path, b"not-a-directory").expect("write temp file");
 
         let yaml = format!(
-            r#"
+            r"
 input:
   type: file
   path: /var/log/test.log
@@ -357,7 +357,7 @@ output:
   type: stdout
 storage:
   data_dir: {}
-"#,
+",
             path.display()
         );
 
@@ -397,14 +397,14 @@ output:
 
     #[test]
     fn otlp_input_accepts_experimental_protobuf_decode_mode() {
-        let yaml = r#"
+        let yaml = r"
 input:
   type: otlp
   listen: 127.0.0.1:4318
   protobuf_decode_mode: projected_fallback
 output:
   type: stdout
-"#;
+";
         let cfg =
             Config::load_str(yaml).expect("otlp input with protobuf_decode_mode should parse");
         let pipe = &cfg.pipelines["default"];
@@ -417,14 +417,14 @@ output:
 
     #[test]
     fn otlp_input_rejects_resource_prefix() {
-        let yaml = r#"
+        let yaml = r"
 input:
   type: otlp
   listen: 127.0.0.1:4318
   resource_prefix: resource.attributes.
 output:
   type: stdout
-"#;
+";
         let err = Config::load_str(yaml).expect_err("resource_prefix is no longer supported");
         let msg = err.to_string();
         assert!(
@@ -435,14 +435,14 @@ output:
 
     #[test]
     fn non_otlp_input_rejects_protobuf_decode_mode() {
-        let yaml = r#"
+        let yaml = r"
 input:
   type: file
   path: /var/log/app.log
   protobuf_decode_mode: projected_fallback
 output:
   type: stdout
-"#;
+";
         let err = Config::load_str(yaml).expect_err("protobuf_decode_mode must be otlp-only");
         let msg = err.to_string();
         assert!(
@@ -866,14 +866,14 @@ output:
         let validation_cases = [("read_buf_size", 0), ("per_file_read_budget_bytes", 0)];
         for (field, value) in validation_cases {
             let yaml = format!(
-                r#"
+                r"
 input:
   type: file
   path: /tmp/test.log
   {field}: {value}
 output:
   type: stdout
-"#
+"
             );
             let err = Config::load_str(&yaml).unwrap_err().to_string();
             assert!(
@@ -883,14 +883,14 @@ output:
         }
 
         // Duration field (poll_interval_ms) is rejected at parse time via PositiveMillis.
-        let yaml = r#"
+        let yaml = r"
 input:
   type: file
   path: /tmp/test.log
   poll_interval_ms: 0
 output:
   type: stdout
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err().to_string();
         assert!(
             err.contains("invalid value") || err.contains("positive"),
@@ -935,14 +935,14 @@ output:
         for (in_type, extra) in inputs {
             for field in fields {
                 let yaml = format!(
-                    r#"
+                    r"
 input:
   type: {in_type}
   {extra}
   {field}
 output:
   type: stdout
-"#
+"
                 );
                 let err = Config::load_str(&yaml).unwrap_err().to_string();
                 let field_name = field.split(':').next().unwrap();
@@ -977,14 +977,14 @@ output:
 
     #[test]
     fn arrow_ipc_rejects_format_override() {
-        let yaml = r#"
+        let yaml = r"
 input:
   type: arrow_ipc
   listen: 0.0.0.0:4319
   format: raw
 output:
   type: stdout
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err().to_string();
         assert!(
             err.contains("'format' is not supported for arrow_ipc inputs"),
@@ -1964,7 +1964,7 @@ pipelines:
 
     #[test]
     fn enrichment_static_config_accepted() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   app:
     inputs:
@@ -1978,7 +1978,7 @@ pipelines:
         labels:
           dc: us-east-1
           team: platform
-"#;
+";
         let cfg = Config::load_str(yaml).expect("static enrichment should parse");
         let pipe = &cfg.pipelines["app"];
         assert_eq!(pipe.enrichment.len(), 1);
@@ -2901,7 +2901,7 @@ pipelines:
 
     #[test]
     fn non_elasticsearch_output_rejects_index() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2911,7 +2911,7 @@ pipelines:
       - type: otlp
         endpoint: http://localhost:4317
         index: my-index
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
             err.to_string().contains("index"),
@@ -2921,7 +2921,7 @@ pipelines:
 
     #[test]
     fn non_otlp_output_rejects_protocol() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2931,7 +2931,7 @@ pipelines:
       - type: elasticsearch
         endpoint: http://localhost:9200
         protocol: grpc
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
             err.to_string().contains("protocol"),
@@ -2941,7 +2941,7 @@ pipelines:
 
     #[test]
     fn stdout_output_rejects_compression() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2950,7 +2950,7 @@ pipelines:
     outputs:
       - type: stdout
         compression: zstd
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
             err.to_string().contains("compression"),
@@ -2980,7 +2980,7 @@ pipelines:
 
     #[test]
     fn stdout_output_rejects_path() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2989,7 +2989,7 @@ pipelines:
     outputs:
       - type: stdout
         path: /tmp/out.log
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         assert!(
             err.to_string().contains("path"),
@@ -3022,7 +3022,7 @@ output:
 
     #[test]
     fn non_loki_output_rejects_tenant_id() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -3031,7 +3031,7 @@ pipelines:
     outputs:
       - type: stdout
         tenant_id: my-tenant
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -3042,7 +3042,7 @@ pipelines:
 
     #[test]
     fn non_loki_output_rejects_static_labels() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -3052,7 +3052,7 @@ pipelines:
       - type: stdout
         static_labels:
           env: prod
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -3107,7 +3107,7 @@ pipelines:
 
     #[test]
     fn non_loki_output_rejects_label_columns() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -3117,7 +3117,7 @@ pipelines:
       - type: stdout
         label_columns:
           - container_name
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -3210,7 +3210,7 @@ pipelines:
     /// accepted and would fail at runtime.
     #[test]
     fn arrow_ipc_output_rejects_gzip_compression() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -3220,7 +3220,7 @@ pipelines:
       - type: arrow_ipc
         endpoint: http://localhost:4317
         compression: gzip
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -3232,7 +3232,7 @@ pipelines:
 
     #[test]
     fn arrow_ipc_output_accepts_none_compression() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -3242,7 +3242,7 @@ pipelines:
       - type: arrow_ipc
         endpoint: http://localhost:4317
         compression: none
-"#;
+";
         Config::load_str(yaml).expect("arrow_ipc output should accept none compression");
     }
 

--- a/crates/logfwd-config/src/tests_otlp_config.rs
+++ b/crates/logfwd-config/src/tests_otlp_config.rs
@@ -40,7 +40,7 @@ pipelines:
                 assert_eq!(tls.cert_file.as_deref(), Some("/path/to/cert"));
                 assert_eq!(tls.key_file.as_deref(), Some("/path/to/key"));
                 assert_eq!(tls.client_ca_file.as_deref(), Some("/path/to/ca"));
-                assert_eq!(tls.require_client_auth, true);
+                assert!(tls.require_client_auth);
             }
             _ => panic!("Expected OTLP input config"),
         }

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1999,11 +1999,11 @@ mod validate_host_port_tests {
         // Double closing bracket — [::1]]:4317 is malformed
         assert!(host_port_error("[::1]]:4317").contains("missing a port"));
         // Path-like host rejected (#1461)
-        assert!(host_port_error("foo/bar:4317").contains("/"));
+        assert!(host_port_error("foo/bar:4317").contains('/'));
         // Unmatched closing bracket rejected (#1461)
-        assert!(host_port_error("foo]:4317").contains("]"));
+        assert!(host_port_error("foo]:4317").contains(']'));
         // Unmatched opening bracket rejected (#2060)
-        assert!(host_port_error("foo[bar:4317").contains("["));
+        assert!(host_port_error("foo[bar:4317").contains('['));
     }
 
     #[test]
@@ -2256,7 +2256,7 @@ mod feedback_loop_tests {
 
     #[test]
     fn file_output_same_as_input_rejected() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   looping:
     inputs:
@@ -2266,7 +2266,7 @@ pipelines:
       - type: file
         path: /tmp/logfwd-feedback-test.log
         format: json
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -2277,7 +2277,7 @@ pipelines:
 
     #[test]
     fn file_output_different_from_input_allowed() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   ok:
     inputs:
@@ -2287,13 +2287,13 @@ pipelines:
       - type: file
         path: /tmp/logfwd-output.log
         format: json
-"#;
+";
         Config::load_str(yaml).expect("different input/output paths should be allowed");
     }
 
     #[test]
     fn file_output_same_as_input_rejected_after_lexical_normalization() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   looping:
     inputs:
@@ -2303,7 +2303,7 @@ pipelines:
       - type: file
         path: tmp/./app.log
         format: json
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err();
         let msg = err.to_string();
         assert!(
@@ -2751,7 +2751,7 @@ mod validate_otlp_options_tests {
 
     #[test]
     fn otlp_accepts_new_options() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2770,13 +2770,13 @@ pipelines:
           X-Custom: value
         tls:
           insecure_skip_verify: true
-"#;
+";
         Config::load_str(yaml).expect("otlp options should be accepted");
     }
 
     #[test]
     fn non_otlp_rejects_new_options() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2785,7 +2785,7 @@ pipelines:
     outputs:
       - type: stdout
         retry_attempts: 3
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err().to_string();
         assert!(
             err.contains("unknown field") && err.contains("retry_attempts"),
@@ -2795,7 +2795,7 @@ pipelines:
 
     #[test]
     fn elasticsearch_accepts_tls_and_request_timeout_ms() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2807,13 +2807,13 @@ pipelines:
         request_timeout_ms: 5000
         tls:
           insecure_skip_verify: true
-"#;
+";
         Config::load_str(yaml).expect("elasticsearch should accept tls and request_timeout_ms");
     }
 
     #[test]
     fn loki_accepts_tls_and_request_timeout_ms() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2825,13 +2825,13 @@ pipelines:
         request_timeout_ms: 5000
         tls:
           insecure_skip_verify: true
-"#;
+";
         Config::load_str(yaml).expect("loki should accept tls and request_timeout_ms");
     }
 
     #[test]
     fn elasticsearch_rejects_zero_request_timeout_ms() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2841,14 +2841,14 @@ pipelines:
       - type: elasticsearch
         endpoint: https://localhost:9200
         request_timeout_ms: 0
-"#;
+";
         // Now rejected at parse time via PositiveMillis.
         let _ = Config::load_str(yaml).expect_err("zero request_timeout_ms should be rejected");
     }
 
     #[test]
     fn otlp_rejects_zero_request_timeout_ms() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2858,14 +2858,14 @@ pipelines:
       - type: otlp
         endpoint: http://localhost:4317
         request_timeout_ms: 0
-"#;
+";
         // Now rejected at parse time via PositiveMillis.
         let _ = Config::load_str(yaml).expect_err("zero request_timeout_ms should be rejected");
     }
 
     #[test]
     fn otlp_rejects_zero_batch_timeout_ms() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2875,14 +2875,14 @@ pipelines:
       - type: otlp
         endpoint: http://localhost:4317
         batch_timeout_ms: 0
-"#;
+";
         // Now rejected at parse time via PositiveMillis.
         let _ = Config::load_str(yaml).expect_err("zero batch_timeout_ms should be rejected");
     }
 
     #[test]
     fn otlp_rejects_initial_backoff_exceeding_max() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2893,7 +2893,7 @@ pipelines:
         endpoint: http://localhost:4317
         retry_initial_backoff_ms: 5000
         retry_max_backoff_ms: 1000
-"#;
+";
         let err = Config::load_str(yaml).unwrap_err().to_string();
         assert!(
             err.contains("retry_initial_backoff_ms") && err.contains("retry_max_backoff_ms"),
@@ -2903,7 +2903,7 @@ pipelines:
 
     #[test]
     fn arrow_ipc_accepts_batch_size() {
-        let yaml = r#"
+        let yaml = r"
 pipelines:
   test:
     inputs:
@@ -2913,7 +2913,7 @@ pipelines:
       - type: arrow_ipc
         endpoint: http://localhost:9000
         batch_size: 512
-"#;
+";
         Config::load_str(yaml).expect("arrow_ipc should accept batch_size");
     }
 

--- a/crates/logfwd-config/tests/validation_gaps.rs
+++ b/crates/logfwd-config/tests/validation_gaps.rs
@@ -45,13 +45,13 @@ fn unique_temp_dir(prefix: &str) -> PathBuf {
 
 #[test]
 fn config_deserialization_error_includes_simple_layout_field_path() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: generator
 output:
   type: stdout
   batch_size: not-a-number
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -67,7 +67,7 @@ output:
 
 #[test]
 fn config_deserialization_error_includes_pipeline_field_path() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   app:
     workers: not-a-number
@@ -75,7 +75,7 @@ pipelines:
       - type: generator
     outputs:
       - type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -96,13 +96,13 @@ pipelines:
 
 #[test]
 fn raw_yaml_number_for_string_field_is_rejected() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: file
   path: 123
 output:
   type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -117,7 +117,7 @@ output:
 
 #[test]
 fn raw_yaml_bool_for_string_field_is_rejected() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: http
   listen: 127.0.0.1:8080
@@ -125,7 +125,7 @@ input:
     path: true
 output:
   type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -140,7 +140,7 @@ output:
 
 #[test]
 fn raw_yaml_bool_for_numeric_field_is_rejected() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   app:
     workers: true
@@ -148,7 +148,7 @@ pipelines:
       - type: generator
     outputs:
       - type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -163,7 +163,7 @@ pipelines:
 
 #[test]
 fn raw_yaml_float_for_integer_field_is_rejected() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   app:
     workers: 1.5
@@ -171,7 +171,7 @@ pipelines:
       - type: generator
     outputs:
       - type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -186,7 +186,7 @@ pipelines:
 
 #[test]
 fn raw_yaml_number_for_bool_field_is_rejected() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: http
   listen: 127.0.0.1:8080
@@ -194,7 +194,7 @@ input:
     strict_path: 1
 output:
   type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -209,13 +209,13 @@ output:
 
 #[test]
 fn top_level_dotted_yaml_key_is_rejected_as_unknown_field() {
-    let yaml = r#"
+    let yaml = r"
 server.log_level: debug
 input:
   type: generator
 output:
   type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -275,7 +275,7 @@ fn env_generator_attribute_values_remain_strings() {
     let _count = EnvVarGuard::set("LOGFWD_ISSUE_1855_GENERATOR_COUNT", "7");
     let _enabled = EnvVarGuard::set("LOGFWD_ISSUE_1855_GENERATOR_ENABLED", "true");
 
-    let yaml = r#"
+    let yaml = r"
 input:
   type: generator
   generator:
@@ -285,7 +285,7 @@ input:
       enabled: ${LOGFWD_ISSUE_1855_GENERATOR_ENABLED}
 output:
   type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("generator attributes should parse");
     let input = &config.pipelines["default"].inputs[0];
@@ -314,13 +314,13 @@ fn env_expansion_preserves_yaml_hash_content() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855", "/var/log/my app #1.log");
 
-    let yaml = r#"
+    let yaml = r"
 input:
   type: file
   path: ${LOGFWD_ISSUE_1855}
 output:
   type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("config should parse after env expansion");
     let input = &config.pipelines["default"].inputs[0];
@@ -337,13 +337,13 @@ fn effective_yaml_preserves_yaml_hash_content() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_EFFECTIVE", "/var/log/my app #1.log");
 
-    let yaml = r#"
+    let yaml = r"
 input:
   type: file
   path: ${LOGFWD_ISSUE_1855_EFFECTIVE}
 output:
   type: stdout
-"#;
+";
 
     let expanded =
         Config::expand_env_yaml_str(yaml).expect("YAML-aware env expansion should succeed");
@@ -367,7 +367,7 @@ fn env_numeric_string_is_parsed_by_typed_schema() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_WORKERS", "4");
 
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   test:
     workers: ${LOGFWD_ISSUE_1855_WORKERS}
@@ -375,7 +375,7 @@ pipelines:
       - type: generator
     outputs:
       - type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("config should parse env-backed numeric string");
     assert_eq!(config.pipelines["test"].workers, Some(4));
@@ -395,7 +395,7 @@ fn env_bool_string_is_parsed_by_typed_schema() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_STRICT_PATH", "false");
 
-    let yaml = r#"
+    let yaml = r"
 input:
   type: http
   listen: 127.0.0.1:8080
@@ -403,7 +403,7 @@ input:
     strict_path: ${LOGFWD_ISSUE_1855_STRICT_PATH}
 output:
   type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("config should parse env-backed bool");
     let input = &config.pipelines["default"].inputs[0];
@@ -422,7 +422,7 @@ fn env_bool_string_is_parsed_by_shared_tls_schema() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_TLS_SKIP_VERIFY", "true");
 
-    let yaml = r#"
+    let yaml = r"
 input:
   type: generator
 output:
@@ -430,7 +430,7 @@ output:
   endpoint: http://127.0.0.1:4318
   tls:
     insecure_skip_verify: ${LOGFWD_ISSUE_1855_TLS_SKIP_VERIFY}
-"#;
+";
 
     let config = Config::load_str(yaml).expect("config should parse env-backed TLS bool");
     let output = &config.pipelines["default"].outputs[0];
@@ -492,13 +492,13 @@ fn tagged_unquoted_env_expansion_preserves_string_scalars() {
 
     // Env substitution already produces string data; the explicit string tag
     // should preserve that behavior.
-    let yaml = r#"
+    let yaml = r"
 input:
   type: file
   path: !str ${LOGFWD_ISSUE_1855_TAGGED_UNQUOTED}
 output:
   type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("tagged unquoted env-backed string should parse");
     let input = &config.pipelines["default"].inputs[0];
@@ -512,13 +512,13 @@ output:
 
 #[test]
 fn explicit_string_yaml_tag_preserves_string_field() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: file
   path: !!str 123
 output:
   type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("explicit string tag should parse as string");
     let input = &config.pipelines["default"].inputs[0];
@@ -570,14 +570,14 @@ output:
 
 #[test]
 fn custom_yaml_tag_for_mapping_key_is_rejected() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: generator
 output:
   type: stdout
 resource_attrs:
   !custom key: value
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -637,13 +637,13 @@ pipelines:
 
 #[test]
 fn plain_scalar_apostrophe_is_not_treated_as_quote_boundary() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: file
   path: /var/log/it's.log
 output:
   type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("plain scalar apostrophe should parse");
     let input = &config.pipelines["default"].inputs[0];
@@ -687,7 +687,7 @@ pipelines:
 
 #[test]
 fn single_quoted_yaml_escape_survives_env_expansion() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   test:
     resource_attrs:
@@ -696,7 +696,7 @@ pipelines:
       - type: generator
     outputs:
       - type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("single-quoted escape should parse");
 
@@ -712,7 +712,7 @@ fn env_expanded_mapping_key_collision_is_rejected() {
     let _env_a = EnvVarGuard::set("LOGFWD_ISSUE_1855_KEY_A", "prod");
     let _env_b = EnvVarGuard::set("LOGFWD_ISSUE_1855_KEY_B", "prod");
 
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   test:
     resource_attrs:
@@ -722,7 +722,7 @@ pipelines:
       - type: generator
     outputs:
       - type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
 
@@ -737,14 +737,14 @@ fn env_expansion_applies_to_mapping_keys() {
     let _env_lock = env_lock();
     let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_PIPELINE", "from-env");
 
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   ${LOGFWD_ISSUE_1855_PIPELINE}:
     inputs:
       - type: generator
     outputs:
       - type: stdout
-"#;
+";
 
     let config = Config::load_str(yaml).expect("config should parse env-backed mapping key");
     assert!(config.pipelines.contains_key("from-env"));
@@ -752,7 +752,7 @@ pipelines:
 
 #[test]
 fn issue_1856_allow_same_listen_address_for_different_transports() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   p1:
     inputs:
@@ -766,14 +766,14 @@ pipelines:
         listen: 0.0.0.0:9000
     outputs:
       - type: stdout
-"#;
+";
 
     Config::load_str(yaml).expect("tcp and udp should share an address because transports differ");
 }
 
 #[test]
 fn issue_1856_reject_duplicate_listen_addresses_for_same_transport() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   p1:
     inputs:
@@ -787,7 +787,7 @@ pipelines:
         listen: 0.0.0.0:09000
     outputs:
       - type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -823,7 +823,7 @@ pipelines:
 
 #[test]
 fn issue_1856_allow_duplicate_ephemeral_port_zero_for_same_transport() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   p1:
     inputs:
@@ -837,14 +837,14 @@ pipelines:
         listen: 127.0.0.1:0
     outputs:
       - type: stdout
-"#;
+";
 
     Config::load_str(yaml).expect("port 0 asks the OS for distinct ephemeral ports");
 }
 
 #[test]
 fn issue_1857_reject_duplicate_file_output_paths_across_pipelines() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   p1:
     inputs:
@@ -858,7 +858,7 @@ pipelines:
     outputs:
       - type: file
         path: /tmp/shared.log
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -872,7 +872,7 @@ fn issue_1857_reject_relative_and_absolute_file_output_aliases() {
     let base = std::env::current_dir().expect("current dir should be available");
     let absolute = base.join("logs/shared.log");
     let yaml = format!(
-        r#"
+        r"
 pipelines:
   p1:
     inputs:
@@ -886,7 +886,7 @@ pipelines:
     outputs:
       - type: file
         path: {}
-"#,
+",
         absolute.display()
     );
 
@@ -900,7 +900,7 @@ pipelines:
 #[test]
 fn issue_1857_reject_relative_glob_input_matching_relative_output() {
     let base = std::env::current_dir().expect("current dir should be available");
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   test:
     inputs:
@@ -909,7 +909,7 @@ pipelines:
     outputs:
       - type: file
         path: logs/app.log
-"#;
+";
 
     let err = Config::load_str_with_base_path(yaml, Some(&base))
         .unwrap_err()
@@ -923,7 +923,7 @@ pipelines:
 
 #[test]
 fn issue_1858_reject_workers_above_max_bound() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   test:
     workers: 5000
@@ -931,7 +931,7 @@ pipelines:
       - type: generator
     outputs:
       - type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -942,7 +942,7 @@ pipelines:
 
 #[test]
 fn issue_1862_reject_tcp_udp_output_formats() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   test:
     inputs:
@@ -951,7 +951,7 @@ pipelines:
       - type: tcp
         endpoint: localhost:9001
         format: json
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -962,7 +962,7 @@ pipelines:
 
 #[test]
 fn issue_1920_reject_duplicate_named_inputs_and_outputs_in_pipeline() {
-    let duplicate_input_yaml = r#"
+    let duplicate_input_yaml = r"
 pipelines:
   test:
     inputs:
@@ -973,7 +973,7 @@ pipelines:
         path: /var/log/test.log
     outputs:
       - type: stdout
-"#;
+";
 
     let input_err = Config::load_str(duplicate_input_yaml)
         .unwrap_err()
@@ -1047,7 +1047,7 @@ fn issue_2035_reject_file_output_when_parent_directory_missing() {
     let missing_parent = unique_temp_dir("missing-parent").join("child");
     let out_path = missing_parent.join("out.ndjson");
     let yaml = format!(
-        r#"
+        r"
 pipelines:
   test:
     inputs:
@@ -1055,7 +1055,7 @@ pipelines:
     outputs:
       - type: file
         path: {}
-"#,
+",
         out_path.display()
     );
 
@@ -1070,7 +1070,7 @@ pipelines:
 fn issue_2035_reject_relative_file_output_when_base_parent_directory_missing() {
     let base = unique_temp_dir("relative-base");
     fs::create_dir_all(&base).expect("base dir should be created");
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   test:
     inputs:
@@ -1078,7 +1078,7 @@ pipelines:
     outputs:
       - type: file
         path: missing/out.ndjson
-"#;
+";
 
     let err = Config::load_str_with_base_path(yaml, Some(&base))
         .unwrap_err()
@@ -1099,7 +1099,7 @@ fn issue_2035_reject_file_output_when_parent_path_is_file() {
     fs::write(&parent_file, b"not a directory").expect("parent file should be written");
     let out_path = parent_file.join("out.ndjson");
     let yaml = format!(
-        r#"
+        r"
 pipelines:
   test:
     inputs:
@@ -1107,7 +1107,7 @@ pipelines:
     outputs:
       - type: file
         path: {}
-"#,
+",
         out_path.display()
     );
 
@@ -1135,7 +1135,7 @@ fn issue_2035_reject_file_output_when_parent_directory_is_read_only() {
 
     let out_path = dir.join("out.ndjson");
     let yaml = format!(
-        r#"
+        r"
 pipelines:
   test:
     inputs:
@@ -1143,7 +1143,7 @@ pipelines:
     outputs:
       - type: file
         path: {}
-"#,
+",
         out_path.display()
     );
 
@@ -1171,7 +1171,7 @@ fn issue_2035_reject_file_output_when_existing_file_is_read_only() {
     fs::set_permissions(&out_path, readonly_perms).expect("setting read-only should succeed");
 
     let yaml = format!(
-        r#"
+        r"
 pipelines:
   test:
     inputs:
@@ -1179,7 +1179,7 @@ pipelines:
     outputs:
       - type: file
         path: {}
-"#,
+",
         out_path.display()
     );
 
@@ -1204,7 +1204,7 @@ fn issue_2035_reject_file_output_when_existing_path_is_directory() {
     let out_path = dir.join("capture.ndjson");
     fs::create_dir_all(&out_path).expect("output directory should be created");
     let yaml = format!(
-        r#"
+        r"
 pipelines:
   test:
     inputs:
@@ -1212,7 +1212,7 @@ pipelines:
     outputs:
       - type: file
         path: {}
-"#,
+",
         out_path.display()
     );
 
@@ -1231,7 +1231,7 @@ fn issue_2035_accept_file_output_when_parent_directory_is_writable() {
     fs::create_dir_all(&dir).expect("temp dir should be created");
     let out_path = dir.join("out.ndjson");
     let yaml = format!(
-        r#"
+        r"
 pipelines:
   test:
     inputs:
@@ -1239,7 +1239,7 @@ pipelines:
     outputs:
       - type: file
         path: {}
-"#,
+",
         out_path.display()
     );
 
@@ -1278,7 +1278,7 @@ pipelines:
 
 #[test]
 fn issue_1957_reject_loki_static_and_dynamic_label_collisions() {
-    let yaml = r#"
+    let yaml = r"
 pipelines:
   test:
     inputs:
@@ -1292,7 +1292,7 @@ pipelines:
           app: my-service
         label_columns:
           - app
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -1303,7 +1303,7 @@ pipelines:
 
 #[test]
 fn issue_1958_generator_record_profile_preserves_null_attribute_values() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: generator
   generator:
@@ -1312,20 +1312,20 @@ input:
       deleted_at: null
 output:
   type: stdout
-"#;
+";
 
     Config::load_str(yaml).expect("generator null attributes should remain supported");
 }
 
 #[test]
 fn issue_2060_reject_unmatched_opening_bracket_in_host_port() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: udp
   listen: foo[bar:4317
 output:
   type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(err.contains("unmatched '['"), "unexpected error: {err}");
@@ -1333,14 +1333,14 @@ output:
 
 #[test]
 fn issue_2062_reject_sensor_max_rows_per_poll_zero() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: host_metrics
   sensor:
     max_rows_per_poll: 0
 output:
   type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
@@ -1351,14 +1351,14 @@ output:
 
 #[test]
 fn issue_2178_reject_otlp_max_recv_message_size_bytes_zero() {
-    let yaml = r#"
+    let yaml = r"
 input:
   type: otlp
   listen: 127.0.0.1:4318
   max_recv_message_size_bytes: 0
 output:
   type: stdout
-"#;
+";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(

--- a/crates/logfwd-core/benches/scanner.rs
+++ b/crates/logfwd-core/benches/scanner.rs
@@ -238,13 +238,12 @@ fn sonic_rs_parse(data: &[u8], ndjson: &mut Vec<u8>) -> arrow::record_batch::Rec
         if line.is_empty() {
             continue;
         }
-        if let Ok(val) = sonic_rs::from_slice::<sonic_rs::Value>(line) {
-            if val.is_object() {
-                if let Ok(s) = sonic_rs::to_string(&val) {
-                    ndjson.extend_from_slice(s.as_bytes());
-                    ndjson.push(b'\n');
-                }
-            }
+        if let Ok(val) = sonic_rs::from_slice::<sonic_rs::Value>(line)
+            && val.is_object()
+            && let Ok(s) = sonic_rs::to_string(&val)
+        {
+            ndjson.extend_from_slice(s.as_bytes());
+            ndjson.push(b'\n');
         }
     }
 

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -945,43 +945,43 @@ mod tests {
         let mut out = Vec::new();
 
         // Simple escapes
-        decode_json_escapes(br#"hello"#, &mut out);
+        decode_json_escapes(br"hello", &mut out);
         assert_eq!(&out, b"hello");
 
         decode_json_escapes(br#"say \"hi\""#, &mut out);
         assert_eq!(&out, b"say \"hi\"");
 
-        decode_json_escapes(br#"a\\b"#, &mut out);
+        decode_json_escapes(br"a\\b", &mut out);
         assert_eq!(&out, b"a\\b");
 
-        decode_json_escapes(br#"a\/b"#, &mut out);
+        decode_json_escapes(br"a\/b", &mut out);
         assert_eq!(&out, b"a/b");
 
-        decode_json_escapes(br#"a\nb\tc"#, &mut out);
+        decode_json_escapes(br"a\nb\tc", &mut out);
         assert_eq!(&out, b"a\nb\tc");
 
-        decode_json_escapes(br#"\b\f"#, &mut out);
+        decode_json_escapes(br"\b\f", &mut out);
         assert_eq!(&out, &[0x08, 0x0C]);
 
         // Unicode escape
-        decode_json_escapes(br#"\u0041"#, &mut out);
+        decode_json_escapes(br"\u0041", &mut out);
         assert_eq!(&out, b"A");
 
         // Multi-byte unicode
-        decode_json_escapes(br#"\u00e9"#, &mut out);
+        decode_json_escapes(br"\u00e9", &mut out);
         assert_eq!(&out, "é".as_bytes());
 
         // Surrogate pair
-        decode_json_escapes(br#"\uD83D\uDE00"#, &mut out);
+        decode_json_escapes(br"\uD83D\uDE00", &mut out);
         assert_eq!(&out, "😀".as_bytes());
 
         // Truncated escape at end — pass through
-        decode_json_escapes(br#"abc\"#, &mut out);
-        assert_eq!(&out, br#"abc\"#);
+        decode_json_escapes(br"abc\", &mut out);
+        assert_eq!(&out, br"abc\");
 
         // Unknown escape letter — pass through backslash
-        decode_json_escapes(br#"\x"#, &mut out);
-        assert_eq!(&out, br#"\x"#);
+        decode_json_escapes(br"\x", &mut out);
+        assert_eq!(&out, br"\x");
     }
 
     #[test]
@@ -1081,9 +1081,9 @@ mod tests {
         for _ in 0..35 {
             buf_str.push_str("{\"x\":");
         }
-        buf_str.push_str("1");
+        buf_str.push('1');
         for _ in 0..35 {
-            buf_str.push_str("}");
+            buf_str.push('}');
         }
         buf_str.push_str(",\"b\":2}");
 
@@ -1149,9 +1149,9 @@ mod tests {
         for _ in 0..32 {
             buf_str.push_str("{\"x\":");
         }
-        buf_str.push_str("1");
+        buf_str.push('1');
         for _ in 0..32 {
-            buf_str.push_str("}");
+            buf_str.push('}');
         }
         buf_str.push_str(",\"b\":2}");
 

--- a/crates/logfwd-core/tests/it/compliance_data.rs
+++ b/crates/logfwd-core/tests/it/compliance_data.rs
@@ -167,18 +167,17 @@ fn get_struct_bool(batch: &RecordBatch, field: &str, row: usize) -> Option<bool>
 
 /// Assert that the named child field of a conflict StructArray column is null at `row`.
 fn assert_struct_child_null(batch: &RecordBatch, field: &str, child: &str, row: usize) {
-    if let Some(col) = batch.column_by_name(field) {
-        if let Some(sa) = col.as_any().downcast_ref::<StructArray>() {
-            if let Some(child_idx) = sa.fields().iter().position(|f| f.name() == child) {
-                let child_col = sa.column(child_idx);
-                assert!(
-                    child_col.is_null(row),
-                    "{field}.{child}[{row}] expected null, got non-null"
-                );
-            }
-            // Child not present is also acceptable.
-        }
+    if let Some(col) = batch.column_by_name(field)
+        && let Some(sa) = col.as_any().downcast_ref::<StructArray>()
+        && let Some(child_idx) = sa.fields().iter().position(|f| f.name() == child)
+    {
+        let child_col = sa.column(child_idx);
+        assert!(
+            child_col.is_null(row),
+            "{field}.{child}[{row}] expected null, got non-null"
+        );
     }
+    // Child not present is also acceptable.
     // Column not existing is also acceptable.
 }
 

--- a/crates/logfwd-core/tests/it/scanner_conformance.rs
+++ b/crates/logfwd-core/tests/it/scanner_conformance.rs
@@ -809,7 +809,7 @@ fn no_panic_random_bytes() {
         .to_vec();
     let mut simd = Scanner::new(ScanConfig::default());
     let _batch = simd
-        .scan_detached(Bytes::from(input.clone()))
+        .scan_detached(Bytes::from(input))
         .expect("scan should not fail on valid UTF-8");
 }
 

--- a/crates/logfwd-diagnostics/src/diagnostics/server.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics/server.rs
@@ -2476,7 +2476,7 @@ output:
 
         let metrics = &rm[0]["scopeMetrics"][0]["metrics"];
         assert!(
-            metrics.as_array().map_or(false, |a| !a.is_empty()),
+            metrics.as_array().is_some_and(|a| !a.is_empty()),
             "expected at least one metric"
         );
     }
@@ -2515,7 +2515,7 @@ output:
 
         let spans = &parsed["resourceSpans"][0]["scopeSpans"][0]["spans"];
         assert!(
-            spans.as_array().map_or(false, |a| !a.is_empty()),
+            spans.as_array().is_some_and(|a| !a.is_empty()),
             "expected at least one span, got: {body}"
         );
 

--- a/crates/logfwd-io/src/blocking_stage.rs
+++ b/crates/logfwd-io/src/blocking_stage.rs
@@ -279,7 +279,9 @@ mod tests {
         type Error = &'static str;
 
         fn process(&mut self, job: Self::Job) -> Result<Self::Output, Self::Error> {
-            assert!(job != usize::MAX, "forced panic");
+            if job == usize::MAX {
+                panic!("forced panic");
+            }
             if job == usize::MAX - 1 {
                 return Err("forced worker error");
             }

--- a/crates/logfwd-io/src/blocking_stage.rs
+++ b/crates/logfwd-io/src/blocking_stage.rs
@@ -279,9 +279,7 @@ mod tests {
         type Error = &'static str;
 
         fn process(&mut self, job: Self::Job) -> Result<Self::Output, Self::Error> {
-            if job == usize::MAX {
-                panic!("forced panic");
-            }
+            assert!(job != usize::MAX, "forced panic");
             if job == usize::MAX - 1 {
                 return Err("forced worker error");
             }

--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -1217,7 +1217,7 @@ mod tests {
                 batch_size,
                 total_events: total,
                 events_per_sec: 0, // unlimited
-                timestamp: ts_config.clone(),
+                timestamp: ts_config,
                 profile: GeneratorProfile::Logs,
                 complexity: GeneratorComplexity::Simple,
                 message_template: None,
@@ -2347,7 +2347,7 @@ mod tests {
                     counter,
                     &ts_config,
                     GeneratorComplexity::Simple,
-                    message_template.map(|s| s.as_bytes()),
+                    message_template.map(str::as_bytes),
                 )
                 .expect("valid counter");
                 write_log_fields_json(&mut json_buf, &fields);

--- a/crates/logfwd-io/src/host_metrics.rs
+++ b/crates/logfwd-io/src/host_metrics.rs
@@ -1998,7 +1998,7 @@ mod tests {
         let batch = first_batch(&events);
         let pids = u32_col_optional(batch, "process_pid");
         assert!(
-            pids.iter().any(|v| v.is_some()),
+            pids.iter().any(std::option::Option::is_some),
             "process snapshot rows should have process_pid set"
         );
         let kinds = string_col(batch, "event_kind");
@@ -2032,7 +2032,7 @@ mod tests {
             let batch = first_batch(&events);
             let ifaces = string_col(batch, "network_interface");
             assert!(
-                ifaces.iter().any(|v| v.is_some()),
+                ifaces.iter().any(std::option::Option::is_some),
                 "network snapshot rows should have network_interface set"
             );
         }

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -706,7 +706,7 @@ mod tests {
         // disconnected channel. The main loop drains MAX chunks, the post-limit
         // probe consumes the (MAX+1)th, and the follow-up terminal check must
         // detect the disconnected channel and emit synthetic EOF.
-        let messages = (0..(STDIN_MAX_SHUTDOWN_EVENTS + 1))
+        let messages = (0..=STDIN_MAX_SHUTDOWN_EVENTS)
             .map(|i| StdinMessage::Data(format!("chunk-{i}\n").into_bytes()))
             .collect();
         let mut input = stdin_from_messages(messages);

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -1380,7 +1380,7 @@ mod tests {
     fn json_escape_control_chars() {
         let mut buf = Vec::new();
         json_escape_into(&mut buf, &[0x00, 0x1f]);
-        assert_eq!(String::from_utf8(buf).unwrap(), r#"\u0000\u001f"#);
+        assert_eq!(String::from_utf8(buf).unwrap(), r"\u0000\u001f");
     }
 
     // ── backend selection ─────────────────────────────────────────────

--- a/crates/logfwd-io/src/otlp_receiver/decode_stage.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode_stage.rs
@@ -204,9 +204,10 @@ impl BlockingWorker for OtlpRequestCpuWorker {
     fn process(&mut self, job: Self::Job) -> Result<Self::Output, Self::Error> {
         #[cfg(test)]
         {
-            if job.body == b"__panic_worker__" {
-                panic!("otlp decode worker panic requested by test");
-            }
+            assert!(
+                job.body != b"__panic_worker__",
+                "otlp decode worker panic requested by test"
+            );
             if job.body == b"__sleep_worker__" {
                 std::thread::sleep(std::time::Duration::from_millis(200));
                 return self.decode_prost(&[]);

--- a/crates/logfwd-io/src/otlp_receiver/decode_stage.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode_stage.rs
@@ -204,10 +204,9 @@ impl BlockingWorker for OtlpRequestCpuWorker {
     fn process(&mut self, job: Self::Job) -> Result<Self::Output, Self::Error> {
         #[cfg(test)]
         {
-            assert!(
-                job.body != b"__panic_worker__",
-                "otlp decode worker panic requested by test"
-            );
+            if job.body == b"__panic_worker__" {
+                panic!("otlp decode worker panic requested by test");
+            }
             if job.body == b"__sleep_worker__" {
                 std::thread::sleep(std::time::Duration::from_millis(200));
                 return self.decode_prost(&[]);

--- a/crates/logfwd-io/src/otlp_receiver/projection.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection.rs
@@ -2892,7 +2892,7 @@ mod tests {
         ) {
             let prost = crate::otlp_receiver::decode_protobuf_to_batch_prost_reference(&data);
             let fallback = crate::otlp_receiver::decode_protobuf_bytes_to_batch_projected_experimental(
-                Bytes::from(data.clone()),
+                Bytes::from(data),
             );
 
             match (prost, fallback) {
@@ -3012,7 +3012,7 @@ mod tests {
                                             0 => kv_string(&key, &format!("v-{row}-{attr_idx}")),
                                             1 => kv_i64(&key, row as i64 + attr_idx as i64),
                                             2 => kv_f64(&key, row as f64 + attr_idx as f64 / 10.0),
-                                            3 => kv_bool(&key, (row + attr_idx) % 2 == 0),
+                                            3 => kv_bool(&key, (row + attr_idx).is_multiple_of(2)),
                                             _ => kv_bytes(&key, &[row as u8, attr_idx as u8]),
                                         }
                                     })

--- a/crates/logfwd-io/tests/it/journald_e2e.rs
+++ b/crates/logfwd-io/tests/it/journald_e2e.rs
@@ -96,7 +96,7 @@ fn poll_until_lines(
     let text = String::from_utf8_lossy(&raw);
     text.lines()
         .filter(|l| !l.is_empty())
-        .map(|l| l.to_string())
+        .map(std::string::ToString::to_string)
         .collect()
 }
 
@@ -125,7 +125,7 @@ fn poll_until_match(input: &mut dyn InputSource, needle: &str, timeout: Duration
             return text
                 .lines()
                 .filter(|l| !l.is_empty())
-                .map(|l| l.to_string())
+                .map(std::string::ToString::to_string)
                 .collect();
         }
         std::thread::sleep(Duration::from_millis(100));
@@ -133,7 +133,7 @@ fn poll_until_match(input: &mut dyn InputSource, needle: &str, timeout: Duration
     let text = String::from_utf8_lossy(&all_bytes);
     text.lines()
         .filter(|l| !l.is_empty())
-        .map(|l| l.to_string())
+        .map(std::string::ToString::to_string)
         .collect()
 }
 
@@ -230,8 +230,7 @@ fn subprocess_entries_contain_standard_fields() {
         .filter(|v: &serde_json::Value| {
             v.get("syslog_identifier")
                 .and_then(|s| s.as_str())
-                .map(|s| s == tag)
-                .unwrap_or(false)
+                .is_some_and(|s| s == tag)
         })
         .collect();
 
@@ -375,8 +374,7 @@ fn subprocess_exclude_units_filters() {
                         .and_then(|u| u.as_str())
                         .map(String::from)
                 })
-                .map(|u| u == "ssh.service")
-                .unwrap_or(false)
+                .is_some_and(|u| u == "ssh.service")
         })
         .collect();
 
@@ -535,8 +533,7 @@ fn native_entries_contain_standard_fields() {
         .filter(|v: &serde_json::Value| {
             v.get("syslog_identifier")
                 .and_then(|s| s.as_str())
-                .map(|s| s == tag)
-                .unwrap_or(false)
+                .is_some_and(|s| s == tag)
         })
         .collect();
 

--- a/crates/logfwd-output/examples/smart_codegen_bench.rs
+++ b/crates/logfwd-output/examples/smart_codegen_bench.rs
@@ -156,7 +156,7 @@ fn resolve_generated_columns(batch: &RecordBatch) -> GeneratedRowRefs<'_> {
             span_id_col = Some(arr);
             continue;
         }
-        attrs.push((name.to_string(), arr));
+        attrs.push((name.clone(), arr));
     }
 
     GeneratedRowRefs {
@@ -607,7 +607,8 @@ fn run<F: FnMut()>(label: &str, iterations: usize, bytes_per_iter: usize, mut f:
     }
     let start = Instant::now();
     for _ in 0..iterations {
-        black_box(f());
+        f();
+        black_box(());
     }
     let elapsed = start.elapsed();
     let ns_per_iter = elapsed.as_secs_f64() * 1e9 / iterations as f64;

--- a/crates/logfwd-output/examples/smart_codegen_bench.rs
+++ b/crates/logfwd-output/examples/smart_codegen_bench.rs
@@ -607,8 +607,7 @@ fn run<F: FnMut()>(label: &str, iterations: usize, bytes_per_iter: usize, mut f:
     }
     let start = Instant::now();
     for _ in 0..iterations {
-        f();
-        black_box(());
+        black_box(f());
     }
     let elapsed = start.elapsed();
     let ns_per_iter = elapsed.as_secs_f64() * 1e9 / iterations as f64;

--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -331,8 +331,7 @@ impl ElasticsearchSink {
                     result
                         .permanent_errors
                         .first()
-                        .map(String::as_str)
-                        .unwrap_or("retryable item failure")
+                        .map_or("retryable item failure", String::as_str)
                 ),
             ));
         }

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -925,7 +925,7 @@ mod tests {
         let retained: u64 = payloads.iter().map(|p| p.row_count).sum();
         let payload = &payloads[0].payload;
         let parsed: serde_json::Value =
-            serde_json::from_str(&payload).expect("payload must be valid JSON");
+            serde_json::from_str(payload).expect("payload must be valid JSON");
         let stream = &parsed["streams"][0]["stream"];
 
         assert_eq!(retained, 1);
@@ -939,7 +939,7 @@ mod tests {
         let labels: StreamLabels = vec![("app".to_string(), "logfwd".to_string())];
         let mut stream_map = StreamMap::new();
         stream_map.insert(
-            labels.clone(),
+            labels,
             vec![
                 (1, "{\"message\":\"aaaaaaaaaaaaaaaaaaaaaaaa\"}".to_string()),
                 (2, "{\"message\":\"bbbbbbbbbbbbbbbbbbbbbbbb\"}".to_string()),
@@ -956,7 +956,10 @@ mod tests {
         for payload in &payloads {
             let parsed: serde_json::Value =
                 serde_json::from_str(&payload.payload).expect("chunk must be valid JSON");
-            assert_eq!(parsed["streams"].as_array().map_or(0, |a| a.len()), 1);
+            assert_eq!(
+                parsed["streams"].as_array().map_or(0, std::vec::Vec::len),
+                1
+            );
         }
     }
 

--- a/crates/logfwd-types/src/pipeline/lifecycle.rs
+++ b/crates/logfwd-types/src/pipeline/lifecycle.rs
@@ -1404,29 +1404,26 @@ mod proptests {
                         sending.entry(source).or_default().push(s);
                     }
                     Action::Ack { source } => {
-                        if let Some(queue) = sending.get_mut(&source) {
-                            if !queue.is_empty() {
+                        if let Some(queue) = sending.get_mut(&source)
+                            && !queue.is_empty() {
                                 let s = queue.remove(0);
                                 running.apply_ack(s.ack());
                             }
-                        }
                     }
                     Action::Fail { source } => {
-                        if let Some(queue) = sending.get_mut(&source) {
-                            if !queue.is_empty() {
+                        if let Some(queue) = sending.get_mut(&source)
+                            && !queue.is_empty() {
                                 let s = queue.remove(0);
                                 let requeued = s.fail();
                                 queue.push(running.begin_send(requeued));
                             }
-                        }
                     }
                     Action::Reject { source } => {
-                        if let Some(queue) = sending.get_mut(&source) {
-                            if !queue.is_empty() {
+                        if let Some(queue) = sending.get_mut(&source)
+                            && !queue.is_empty() {
                                 let s = queue.remove(0);
                                 running.apply_ack(s.reject());
                             }
-                        }
                     }
                 }
             }
@@ -1625,12 +1622,12 @@ mod proptests {
                         sending.entry(source).or_default().push(s);
                     }
                     Action::Ack { source } => {
-                        if let Some(queue) = sending.get_mut(&source) {
-                            if !queue.is_empty() {
+                        if let Some(queue) = sending.get_mut(&source)
+                            && !queue.is_empty() {
                                 let s = queue.remove(0);
                                 let advance = running.apply_ack(s.ack());
-                                if advance.advanced {
-                                    if let Some(cp) = advance.checkpoint {
+                                if advance.advanced
+                                    && let Some(cp) = advance.checkpoint {
                                         let prev = max_committed
                                             .get(&u64::from(source))
                                             .copied()
@@ -1642,26 +1639,23 @@ mod proptests {
                                         );
                                         max_committed.insert(u64::from(source), cp);
                                     }
-                                }
                             }
-                        }
                     }
                     Action::Fail { source } => {
-                        if let Some(queue) = sending.get_mut(&source) {
-                            if !queue.is_empty() {
+                        if let Some(queue) = sending.get_mut(&source)
+                            && !queue.is_empty() {
                                 let s = queue.remove(0);
                                 let requeued = s.fail();
                                 queue.push(running.begin_send(requeued));
                             }
-                        }
                     }
                     Action::Reject { source } => {
-                        if let Some(queue) = sending.get_mut(&source) {
-                            if !queue.is_empty() {
+                        if let Some(queue) = sending.get_mut(&source)
+                            && !queue.is_empty() {
                                 let s = queue.remove(0);
                                 let advance = running.apply_ack(s.reject());
-                                if advance.advanced {
-                                    if let Some(cp) = advance.checkpoint {
+                                if advance.advanced
+                                    && let Some(cp) = advance.checkpoint {
                                         let prev = max_committed
                                             .get(&u64::from(source))
                                             .copied()
@@ -1673,9 +1667,7 @@ mod proptests {
                                         );
                                         max_committed.insert(u64::from(source), cp);
                                     }
-                                }
                             }
-                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

`cargo clippy --all-targets -- -D warnings` surfaces 146 pre-existing `clippy::needless_raw_string_hashes` warnings across the workspace — raw strings written `r#"..."#` that don't contain a `"` and could just be `r"..."`. These hit test, bench, and lib files alike. CI's lint recipe (`cargo clippy -- -D warnings`) doesn't cover test targets, so the warnings have accumulated silently.

Generated by:
```
cargo clippy --all-targets --fix --allow-dirty --allow-staged -- -W clippy::needless_raw_string_hashes
cargo fmt
```

**Note on scope:** `cargo clippy --fix` also applied the fixes for a handful of adjacent pedantic-tier lints that were already warnings on the touched files (`let`-chain flattening, `map(...).unwrap_or(...)` → `map_or(...)`, `is_some_and`, `is_multiple_of`, needless clone removal, `push_str(&"x")` → `push('x')`, etc.). These are lexical too, no behavior change.

**Two non-lexical auto-fixes were reverted** after review feedback:

- `smart_codegen_bench.rs`: `black_box(f())` had been collapsed to `f(); black_box(())` because `f()` returns `()` — the optimizer could then elide the measured call. Restored `black_box(f())`.
- `decode_stage.rs` and `blocking_stage.rs`: `if cond { panic!(msg) }` rewritten to `assert!(!cond, msg)` — functionally equivalent but changes panic-message formatting. Reverted both to avoid behavioral drift.

27 files touched. After this, `cargo clippy --all-targets -- -D warnings` reports zero hits for `needless_raw_string_hashes`.

## Verification

```
$ cargo clippy --all-targets -- -D warnings 2>&1 | grep -c needless_raw_string_hashes
0

$ cargo fmt --check  ✅
$ cargo test         # matches main's baseline (pre-existing failures unchanged)
```

## Test plan

- [ ] `just ci-all` passes
- [ ] No test relied on the exact `r#"..."#` form to embed a literal `"#` (grep confirms — all converted strings contain no `"`)

https://claude.ai/code/session_01Be9dE9BzfRQxEmY1RUpwbe