### PR TITLE
docs: codify V2-only output schema in CHANGE_MAP and CODE_STYLE

### DIFF
--- a/dev-docs/CHANGE_MAP.md
+++ b/dev-docs/CHANGE_MAP.md
@@ -16,9 +16,10 @@ When you add, rename, or remove config fields:
 
 `OutputConfig` (the flat struct) is the in-memory view used by the runtime,
 but YAML deserialization goes through `OutputConfigV2` (the typed
-`#[serde(tag = "type")]` enum) exclusively. There is no legacy flat-shape
-deserializer — if your PR introduces a new output type, it lives entirely
-as a new `OutputConfigV2` variant with its own typed struct:
+`#[serde(tag = "type", rename_all = "snake_case")]` enum) exclusively.
+There is no legacy flat-shape fallback deserializer — if your PR introduces
+a new output type, it lives entirely as a new `OutputConfigV2` variant
+with its own typed struct:
 
 - Add the variant struct (`FooOutputConfig`) alongside the existing typed
   configs in `crates/logfwd-config/src/types.rs`, with

--- a/dev-docs/CHANGE_MAP.md
+++ b/dev-docs/CHANGE_MAP.md
@@ -12,6 +12,29 @@ When you add, rename, or remove config fields:
 - Related task pages that show examples (`book/src/content/docs/getting-started/`, `book/src/content/docs/deployment/`).
 - Validation and negative tests for invalid configs.
 
+### Output schema is V2-only
+
+`OutputConfig` (the flat struct) is the in-memory view used by the runtime,
+but YAML deserialization goes through `OutputConfigV2` (the typed
+`#[serde(tag = "type")]` enum) exclusively. There is no legacy flat-shape
+deserializer — if your PR introduces a new output type, it lives entirely
+as a new `OutputConfigV2` variant with its own typed struct:
+
+- Add the variant struct (`FooOutputConfig`) alongside the existing typed
+  configs in `crates/logfwd-config/src/types.rs`, with
+  `#[serde(deny_unknown_fields)]`.
+- Add the variant to `OutputConfigV2` and to the `From<OutputConfigV2> for
+  OutputConfig` / `From<&OutputConfig> for OutputConfigV2` matches.
+- Do **not** reintroduce shared "flat" fields — a knob that only applies to
+  one output belongs on that variant's typed struct, not on `OutputConfig`.
+  `deny_unknown_fields` will then reject the field on every other variant
+  for free.
+- Cross-output validation messages ("X is only supported for Y outputs")
+  used to live in `validate.rs`; those are unreachable from YAML now
+  because V2 rejects the field at parse time with `unknown field ...`.
+  Don't write new cross-output validators unless you also have a non-YAML
+  caller that can construct the invalid shape.
+
 ## Pipeline behavior changes
 
 When scan, transform, batching, or output semantics change:

--- a/dev-docs/CODE_STYLE.md
+++ b/dev-docs/CODE_STYLE.md
@@ -261,6 +261,30 @@ Rules of thumb when designing a public (or `pub(crate)`) function or type:
   cost across a crate boundary outweighs the call-site overhead (see
   compile-time notes in `ARCHITECTURE.md`).
 
+## Output Config Schema
+
+Output configuration has exactly one user-facing shape: the tagged enum
+`OutputConfigV2` (`#[serde(tag = "type", rename_all = "snake_case")]`) in
+`crates/logfwd-config/src/types.rs`. The flat `OutputConfig` struct is an
+in-memory normalized view; it is not a deserialization target any more.
+
+- **Don't add shared fields to `OutputConfig`.** Every output knob lives
+  on the typed variant it applies to (`ElasticsearchOutputConfig`,
+  `LokiOutputConfig`, `ArrowIpcOutputConfig`, …). `deny_unknown_fields`
+  on each variant rejects the field on every other type for free.
+- **New output types are new V2 variants**, not new fields on the flat
+  struct. Add the variant struct, extend the V2 enum, extend the two
+  `From` matches, and the runtime picks it up through `build_sink_factory`.
+- **No V1 fallback path.** There used to be a legacy-flat-shape replay
+  deserializer; it is gone. If a new YAML shape has to be supported,
+  extend V2 directly.
+- **Avoid cross-output validators in `validate.rs`.** They ran before the
+  V2-only cutover and caught `tenant_id` on a stdout output, etc. V2's
+  strict schemas now reject those at parse time with a clearer
+  `unknown field ...` error. New validators should assert genuine
+  inter-field relationships on a single variant, not cross-variant
+  exclusion.
+
 ## Comments
 
 - **Doc comments (`///`) on all public items.** Describe behavior, not just the name.

--- a/dev-docs/CODE_STYLE.md
+++ b/dev-docs/CODE_STYLE.md
@@ -275,7 +275,7 @@ in-memory normalized view; it is not a deserialization target any more.
 - **New output types are new V2 variants**, not new fields on the flat
   struct. Add the variant struct, extend the V2 enum, extend the two
   `From` matches, and the runtime picks it up through `build_sink_factory`.
-- **No V1 fallback path.** There used to be a legacy-flat-shape replay
+- **No V1 fallback path.** There used to be a legacy flat-shape fallback
   deserializer; it is gone. If a new YAML shape has to be supported,
   extend V2 directly.
 - **Avoid cross-output validators in `validate.rs`.** They ran before the


### PR DESCRIPTION
## Summary

After #2402 dropped `OutputConfigV1` and the legacy flat-shape fallback deserializer, `OutputConfigV2` is the sole YAML deserialization target for outputs. Codify that in the contributor docs so future PRs don't accidentally re-introduce flat-shape fields or cross-output validators.

### CHANGE_MAP.md

New "Output schema is V2-only" subsection under configuration changes with concrete steps for adding an output type:
1. Add the variant struct alongside existing typed configs with `#[serde(deny_unknown_fields)]`.
2. Extend the `OutputConfigV2` enum and both `From` matches.
3. Don't add shared fields to `OutputConfig` — a knob that applies to one output lives on that variant's typed struct.
4. Don't write new cross-output validators unless a non-YAML caller can construct the invalid shape.

### CODE_STYLE.md

New "Output Config Schema" section under "Public API Shape" reinforcing the same rules and warning against cross-output validators that are now unreachable from YAML (V2's strict schemas catch them at parse time with a clearer `unknown field ...` error).

## Test plan

- [ ] Docs build (Astro / Starlight for the book, plain markdown for `dev-docs`) — these are `dev-docs` only, no book change needed.

https://claude.ai/code/session_01Be9dE9BzfRQxEmY1RUpwbe

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document V2-only output config schema policy in CHANGE_MAP and CODE_STYLE
> Adds two new documentation sections codifying that `OutputConfigV2` (a tagged enum) is the sole YAML deserialization shape, while the flat `OutputConfig` is an in-memory-only runtime view. Both [CHANGE_MAP.md](https://github.com/strawgate/fastforward/pull/2432/files#diff-3e193249a44109b77c6f2804779cb7ce031a8cdb2846f8c17a1d319c23789ddb) and [CODE_STYLE.md](https://github.com/strawgate/fastforward/pull/2432/files#diff-80c749ea489e35f69a21613f5f898a6f1d768983cc416a221ea5179d0499b2c4) now explain how to add new output types (new typed V2 variant struct with `#[serde(deny_unknown_fields)]`, extend the two `From` matches) and advise against cross-output validators since unknown fields are rejected at parse time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca06d7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->