### PR TITLE
fix(verification): correct proof counts and add encode_varint compositional stubs

### DIFF
--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -1908,4 +1908,136 @@ mod verification {
         kani::cover!(WIRE_TYPE_VARINT == 0, "varint is 0");
         kani::cover!(WIRE_TYPE_FIXED32 == 5, "fixed32 is 5");
     }
+
+    // -----------------------------------------------------------------------
+    // Manual encode_varint stub for compositional proofs
+    //
+    // encode_varint takes `&mut Vec<u8>` which doesn't implement
+    // `kani::Arbitrary`, so standard `#[kani::ensures]` contracts can't be
+    // used with `stub_verified`. Instead we use a manual `#[kani::stub]`
+    // that models encode_varint's proven behavior: appends 1-10 bytes.
+    // The ground-truth correctness is already established by the
+    // verify_varint_* proofs above; these compositional variants focus on
+    // the *caller's* logic with encode_varint abstracted away.
+    // -----------------------------------------------------------------------
+
+    /// Manual stub modelling `encode_varint`'s proven output contract:
+    /// appends between 1 and 10 arbitrary bytes to `buf`.
+    fn encode_varint_stub(buf: &mut Vec<u8>, _value: u64) {
+        let len: usize = kani::any();
+        kani::assume(len >= 1 && len <= 10);
+        let mut i = 0;
+        while i < len {
+            buf.push(kani::any());
+            i += 1;
+        }
+    }
+
+    /// Compositional proof: encode_tag with encode_varint stubbed out.
+    ///
+    /// encode_tag computes `(field_number << 3) | wire_type` and passes it
+    /// to encode_varint. With the stub, we verify the caller logic produces
+    /// a buffer of 1-10 bytes (the tag varint) for any valid inputs.
+    #[kani::proof]
+    #[kani::stub(encode_varint, encode_varint_stub)]
+    #[kani::unwind(12)]
+    fn verify_encode_tag_compositional() {
+        let field_number: u32 = kani::any();
+        let wire_type: u8 = kani::any();
+        kani::assume(field_number > 0);
+        kani::assume(field_number <= 0x1FFFFFFF);
+        kani::assume(wire_type <= 5);
+
+        let mut buf = Vec::new();
+        encode_tag(&mut buf, field_number, wire_type);
+
+        // encode_tag calls encode_varint once, so output is 1-10 bytes
+        assert!(buf.len() >= 1 && buf.len() <= 10);
+
+        kani::cover!(buf.len() == 1, "single-byte tag");
+        kani::cover!(buf.len() > 1, "multi-byte tag");
+    }
+
+    /// Compositional proof: encode_fixed64 with encode_varint stubbed out.
+    ///
+    /// encode_fixed64 calls encode_tag (which calls encode_varint) then
+    /// appends 8 LE bytes. With the stub, we verify the total output is
+    /// tag (1-10 bytes) + 8 fixed bytes = 9-18 bytes.
+    #[kani::proof]
+    #[kani::stub(encode_varint, encode_varint_stub)]
+    #[kani::unwind(12)]
+    fn verify_encode_fixed64_compositional() {
+        let field_number: u32 = kani::any();
+        let value: u64 = kani::any();
+        kani::assume(field_number > 0 && field_number <= 1000);
+
+        let mut buf = Vec::new();
+        encode_fixed64(&mut buf, field_number, value);
+
+        // Tag (1-10 bytes via stub) + 8 fixed bytes
+        assert!(buf.len() >= 9 && buf.len() <= 18);
+
+        // Last 8 bytes are the value in little-endian
+        let tail = &buf[buf.len() - 8..];
+        let decoded = u64::from_le_bytes(tail.try_into().unwrap());
+        assert!(decoded == value, "fixed64 value mismatch");
+
+        kani::cover!(buf.len() == 9, "single-byte tag + 8 value bytes");
+    }
+
+    /// Compositional proof: encode_varint_field with encode_varint stubbed.
+    ///
+    /// encode_varint_field calls encode_tag (1 encode_varint for the tag)
+    /// then encode_varint again for the value. With the stub, each call
+    /// appends 1-10 bytes, so total is 2-20 bytes.
+    #[kani::proof]
+    #[kani::stub(encode_varint, encode_varint_stub)]
+    #[kani::unwind(12)]
+    fn verify_encode_varint_field_compositional() {
+        let field_number: u32 = kani::any();
+        let value: u64 = kani::any();
+        kani::assume(field_number > 0 && field_number <= 1000);
+
+        let mut buf = Vec::new();
+        encode_varint_field(&mut buf, field_number, value);
+
+        // Two encode_varint calls: tag (1-10) + value (1-10)
+        assert!(buf.len() >= 2 && buf.len() <= 20);
+
+        kani::cover!(buf.len() == 2, "minimal encoding");
+        kani::cover!(buf.len() > 10, "large encoding");
+    }
+
+    /// Compositional proof: encode_bytes_field with encode_varint stubbed.
+    ///
+    /// encode_bytes_field calls encode_tag (1 encode_varint for the tag),
+    /// then encode_varint for the length, then extends with the data slice.
+    /// With the stub, tag and length each append 1-10 bytes, plus data_len
+    /// bytes of payload.
+    #[kani::proof]
+    #[kani::stub(encode_varint, encode_varint_stub)]
+    #[kani::unwind(12)]
+    fn verify_encode_bytes_field_content_compositional() {
+        let field_number: u32 = kani::any();
+        kani::assume(field_number > 0 && field_number <= 100);
+        let data_len: usize = kani::any_where(|&l: &usize| l <= 8);
+        let data: [u8; 8] = kani::any();
+
+        let mut buf = Vec::new();
+        encode_bytes_field(&mut buf, field_number, &data[..data_len]);
+
+        // Tag (1-10) + length varint (1-10) + data (0-8) = 2-28 bytes
+        assert!(buf.len() >= 2 + data_len && buf.len() <= 20 + data_len);
+
+        // Last data_len bytes must be the exact input data
+        let payload = &buf[buf.len() - data_len..];
+        let mut i = 0;
+        while i < data_len {
+            assert!(payload[i] == data[i], "data mismatch at byte");
+            i += 1;
+        }
+
+        kani::cover!(data_len == 0, "empty payload");
+        kani::cover!(data_len > 0, "non-empty payload");
+    }
 }

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -331,16 +331,16 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 
 | Module | What it does | Verification |
 |--------|-------------|-------------|
-| `structural.rs` | Escape detection, quote classification, SIMD structural detection | Kani exhaustive (9 proofs) + proptest (SIMD ≡ scalar) |
+| `structural.rs` | Escape detection, quote classification, SIMD structural detection | Kani exhaustive (6 proofs) + proptest (SIMD ≡ scalar) |
 | `structural_iter.rs` | Streaming structural position iterator, including space-only `next_non_space` semantics where tab/CR remain non-space | Kani exhaustive (3 proofs) |
-| `framer.rs` | Newline framing, line boundary detection | Kani exhaustive + oracle (4 proofs) |
-| `reassembler.rs` | CRI partial line reassembly (P/F merging) | Kani exhaustive (8 proofs) |
+| `framer.rs` | Newline framing, line boundary detection | Kani exhaustive + oracle (6 proofs) |
+| `reassembler.rs` | CRI partial line reassembly (P/F merging) | Kani exhaustive (9 proofs) |
 | `byte_search.rs` | Proven byte search (find_byte, rfind_byte) | Kani exhaustive + oracle (3 proofs) |
 | `scanner.rs` | Scanner-to-builder protocol (`ScanBuilder`, `BuilderState`) | Kani bounded (4 proofs) + property-based protocol coverage |
-| `json_scanner.rs` | Streaming JSON field scanner via bitmask iteration, including escaped key/value decoding, CRLF normalization, and JSON whitespace boundary regressions | Kani bounded (5 proofs) + proptest oracle + compliance regressions |
+| `json_scanner.rs` | Streaming JSON field scanner via bitmask iteration, including escaped key/value decoding, CRLF normalization, and JSON whitespace boundary regressions | Kani bounded (10 proofs) + proptest oracle + compliance regressions |
 | `scan_config.rs` | `parse_int_fast`, `parse_float_fast`, `ScanConfig` | Kani exhaustive (2 proofs) |
-| `cri.rs` | CRI log parsing + partial line reassembly | Kani exhaustive (8 proofs) |
-| `otlp.rs` | Protobuf wire format + OTLP encoding + timestamp parsing | Kani mixed exhaustive + bounded (30 proofs incl. 3 contract verifications) |
+| `cri.rs` | CRI log parsing + partial line reassembly | Kani exhaustive (19 proofs) |
+| `otlp.rs` | Protobuf wire format + OTLP encoding + timestamp parsing | Kani mixed exhaustive + bounded (37 proofs incl. 3 contract verifications + 4 compositional stubs) |
 | `pipeline/lifecycle.rs` | Pipeline state machine (ordered ACK, drain, shutdown) | Kani exhaustive (16 proofs) + proptest + **TLA+** |
 | `logfwd-runtime/pipeline/health.rs` | Pipeline component-health transition reducer (`observed`, bounded startup poll failure escalation, shutdown) | Kani exhaustive (6 proofs) + unit tests + proptest sequence checks |
 | `pipeline/batch.rs` | BatchTicket typestate (ack/nack/fail/reject) | Kani exhaustive (5 proofs) + compile-time |
@@ -367,7 +367,7 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 | `logfwd-io/framed.rs` | Per-source framing/remainder checkpoint boundary (`overflow_tainted`, EOF remainder flush, source-scoped EOF semantics, idle source-state reclamation) | Unit tests (remainder carry/overflow, per-source isolation, EOF flush + checkpoint advancement contracts, complete-state reclamation and CRI partial retention) |
 | `logfwd-io/tail/verification.rs` | File tailer pure reducers for EOF emission + shutdown EOF gating + error backoff (`eof_model_transition`, `shutdown_should_emit_eof`, `backoff_transition`) | Kani (8 proofs: EOF at-most-once thresholding, reset semantics, two-poll/repeat cycle, shutdown caught-up gating, backoff cap/reset/monotonicity) + proptest (state reducer invariants in `tail/state.rs`) + **TLA+** (`tla/TailLifecycle.tla`) |
 | `logfwd-io/segment.rs` | Checkpoint segment envelope read/write/recovery (`LCHK` header/footer, checksum, replay plan) | Unit tests for panic/OOM/silent-mask hardening (unsupported-version, permission-denied I/O surfacing, write/read size-bound parity, recovery error semantics) |
-| `logfwd-runtime/pipeline/checkpoint_policy.rs` | Typed delivery outcome -> checkpoint disposition mapping plus bounded ordered-commit seam model (`Ack`, `Reject`, `Hold`) | Kani exhaustive/bounded (6 proofs: outcome mapping, hold no-advance, ack/reject terminal equivalence, mixed-sequence monotonicity/no-gap jumps) + unit tests + proptest ordered sequence invariants |
+| `logfwd-runtime/pipeline/checkpoint_policy.rs` | Typed delivery outcome -> checkpoint disposition mapping plus bounded ordered-commit seam model (`Ack`, `Reject`, `Hold`) | Kani exhaustive/bounded (3 proofs: outcome mapping, hold no-advance, ack/reject terminal equivalence) + unit tests + proptest ordered sequence invariants |
 | `logfwd-runtime/pipeline/checkpoint_io.rs` | Final checkpoint flush retry window (`MAX_ATTEMPTS`, retry/no-retry boundary, retryable error classification, stop-on-success behavior) | Kani (3 proofs: zero/one-attempt no-retry, retry-window equivalence, retryable error classification) + unit tests + proptest retry-window equivalence checks + async retry behavior tests |
 | `logfwd-runtime/pipeline/input_poll.rs` | Turmoil input-loop flush predicate (`should_flush_buffer`) for byte-batch/timeout emission policy | Kani (3 proofs: empty-buffer no-flush, timeout gate semantics, predicate equivalence) + unit tests + proptest policy equivalence |
 | `logfwd-runtime/worker_pool/health.rs` | Pool idle-phase insertion + worker-slot aggregation policy | Kani exhaustive (3 proofs) + unit tests + proptest aggregation checks |


### PR DESCRIPTION
## Summary

- Fix all VERIFICATION.md proof counts to match actual code (7 discrepancies from audit)
  - `structural.rs`: 9 → 6, `framer.rs`: 4 → 6, `reassembler.rs`: 8 → 9
  - `json_scanner.rs`: 5 → 10, `cri.rs`: 8 → 19, `otlp.rs`: 30 → 33
  - `checkpoint_policy.rs`: 6 → 3
- Add 4 compositional proof variants using manual `#[kani::stub]` for `encode_varint`
- Demonstrates the workaround for `&mut Vec<u8>` functions that can't use standard contracts

## Test plan
- [x] `just lint` passes
- [x] `cargo test -p logfwd-core -- otlp` passes (31 tests)
- [ ] Kani proofs pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add compositional Kani stubs for `encode_varint` and correct verification proof counts
> - Adds `encode_varint_stub` in [otlp.rs](https://github.com/strawgate/fastforward/pull/2436/files#diff-c45bc29b4d59fee2317cecce3b4061a1c4017aad89e68047a1dbbb09a8ad87fe), a Kani stub that appends 1–10 arbitrary bytes, allowing compositional verification of functions that call `encode_varint`.
> - Adds four new compositional Kani proofs (`encode_tag`, `encode_fixed64`, `encode_varint_field`, `encode_bytes_field`) that use the stub to verify output length bounds and payload correctness without fully verifying `encode_varint` itself.
> - Updates proof counts and descriptions in [VERIFICATION.md](https://github.com/strawgate/fastforward/pull/2436/files#diff-9ee6083bcef7ba7a04169944b164331c00618ea836614229e2ad1b240b70eb77) to match the current verification inventory across all modules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1d4dc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->