### PR TITLE
refactor: enable easy-win clippy lints workspace-wide + doc additions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,6 @@ unnested_or_patterns = "allow"
 unreadable_literal = "allow"
 single_match_else = "allow"
 manual_let_else = "allow"
-uninlined_format_args = "allow"
 too_many_lines = "allow"
 match_same_arms = "allow"
 similar_names = "allow"
@@ -153,6 +152,17 @@ print_stderr = "warn"
 let_underscore_future = "deny"
 await_holding_lock = "warn"
 await_holding_refcell_ref = "warn"
+# ----- easy-win additions -----
+# Tier 1: modernization, auto-fixable.
+uninlined_format_args = "warn"
+redundant_else = "warn"
+semicolon_if_nothing_returned = "warn"
+# Tier 2: catches real bugs with low fallout.
+map_err_ignore = "warn"
+implicit_clone = "warn"
+needless_for_each = "warn"
+or_fun_call = "warn"
+checked_conversions = "warn"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -137,7 +137,7 @@ reproduce a scenario from a failing CI run.
 ## Reading criterion benchmark output
 
 `just bench` writes HTML + JSON under `target/criterion/`. A quick
-cheatsheet for the files you'll actually care about:
+cheat sheet for the files you'll actually care about:
 
 | File | Purpose |
 |---|---|

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -109,6 +109,56 @@ just fuzz scanner 300        # fuzz a target for 300s (nightly)
 > subsequent CI runs (for example, after pushing a commit or rerunning CI):
 > `miri`, macOS tests, and the deeper TLA/TLC sweeps.
 
+## Test filtering and proptest regressions
+
+Common loops when iterating on a single test or investigating a
+proptest failure:
+
+```bash
+# Run one test by pattern (matches test name substring).
+cargo nextest run -p logfwd-core --lib scanner::handles_empty_line
+
+# Run all tests in a module.
+cargo nextest run -p logfwd-arrow --lib scanner::
+
+# Raise proptest case count for a suspected edge case. The default
+# is 256; use 10_000+ when you think a rare shape is being missed.
+PROPTEST_CASES=10000 cargo nextest run -p logfwd-arrow --lib
+
+# Re-run a minimized regression that was pinned into a regression file.
+# `crates/*/proptest-regressions/` holds previously-shrunk failing seeds;
+# proptest reads them automatically when the matching test runs.
+cargo nextest run -p logfwd-arrow --lib scanner::round_trip
+```
+
+Turmoil tests use deterministic seeds: set `TURMOIL_SEED=<N>` to
+reproduce a scenario from a failing CI run.
+
+## Reading criterion benchmark output
+
+`just bench` writes HTML + JSON under `target/criterion/`. A quick
+cheatsheet for the files you'll actually care about:
+
+| File | Purpose |
+|---|---|
+| `target/criterion/report/index.html` | Top-level summary across all benchmarks in the run. |
+| `target/criterion/<bench>/<param>/report/index.html` | Per-case detail: median, confidence interval, violin plot, raw iterations. |
+| `target/criterion/<bench>/<param>/change/estimates.json` | Change vs previous run — `mean.point_estimate` is the percent delta. |
+| `target/criterion/<bench>/<param>/new/sample.json` | Raw sample timings for the current run. Load this if you want to compute a custom statistic. |
+
+Rules of thumb when reading results:
+
+- **Ignore single-run noise under ~2%.** Criterion's noise floor on
+  typical workstation hardware is 1–3 %; changes within that band are
+  usually scheduler jitter, not regressions.
+- **Check the confidence interval** (p5–p95 band on the violin plot).
+  A wide band means high variance — re-run with `--warm-up-time 5
+  --measurement-time 10` for more stable numbers.
+- **For perf PRs**, quote `mean.point_estimate` from
+  `change/estimates.json` in the PR body, plus the 95 % CI. Don't
+  paste the HTML into the PR — link the relevant section of the
+  markdown report (`just bench` generates one alongside the HTML).
+
 ## DataFusion in Dev vs Release
 
 `logfwd` now has a feature-gated SQL engine:

--- a/crates/logfwd-arrow/src/columnar/accumulator.rs
+++ b/crates/logfwd-arrow/src/columnar/accumulator.rs
@@ -839,7 +839,7 @@ fn build_string_array_validated(
     if dense {
         // Dense fast path: skip per-row branch check.
         for &(_, sref) in facts {
-            let off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
+            let off = i32::try_from(values.len()).map_err(|_e| MaterializeError::OffsetOverflow)?;
             offsets.push(off);
             let bytes = read_str_bytes(original_buf, generated_buf, original_len, sref)?;
             values.extend_from_slice(bytes);
@@ -856,7 +856,7 @@ fn build_string_array_validated(
         }
         // Second pass: build offsets and values in row order.
         for entry in &last_fact_for_row {
-            let off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
+            let off = i32::try_from(values.len()).map_err(|_e| MaterializeError::OffsetOverflow)?;
             offsets.push(off);
             if let Some(fi) = entry {
                 let sref = facts[*fi].1;
@@ -868,7 +868,7 @@ fn build_string_array_validated(
             }
         }
     }
-    let final_off = i32::try_from(values.len()).map_err(|_| MaterializeError::OffsetOverflow)?;
+    let final_off = i32::try_from(values.len()).map_err(|_e| MaterializeError::OffsetOverflow)?;
     offsets.push(final_off);
 
     // Validate UTF-8 for all string bytes (covers both original_buf and

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -357,11 +357,12 @@ impl ColumnarBatchBuilder {
                 buffer_len: self.string_buf.len(),
                 value_len: value.len(),
             })?;
-        let offset = u32::try_from(raw_offset).map_err(|_| BuilderError::StringBufferOverflow {
-            buffer_len: self.string_buf.len(),
-            value_len: value.len(),
-        })?;
-        let len = u32::try_from(value.len()).map_err(|_| BuilderError::StringBufferOverflow {
+        let offset =
+            u32::try_from(raw_offset).map_err(|_e| BuilderError::StringBufferOverflow {
+                buffer_len: self.string_buf.len(),
+                value_len: value.len(),
+            })?;
+        let len = u32::try_from(value.len()).map_err(|_e| BuilderError::StringBufferOverflow {
             buffer_len: self.string_buf.len(),
             value_len: value.len(),
         })?;
@@ -418,11 +419,12 @@ impl ColumnarBatchBuilder {
                 buffer_len: self.string_buf.len(),
                 value_len: value.len(),
             })?;
-        let offset = u32::try_from(raw_offset).map_err(|_| BuilderError::StringBufferOverflow {
-            buffer_len: self.string_buf.len(),
-            value_len: value.len(),
-        })?;
-        let len = u32::try_from(value.len()).map_err(|_| BuilderError::StringBufferOverflow {
+        let offset =
+            u32::try_from(raw_offset).map_err(|_e| BuilderError::StringBufferOverflow {
+                buffer_len: self.string_buf.len(),
+                value_len: value.len(),
+            })?;
+        let len = u32::try_from(value.len()).map_err(|_e| BuilderError::StringBufferOverflow {
             buffer_len: self.string_buf.len(),
             value_len: value.len(),
         })?;
@@ -475,11 +477,12 @@ impl ColumnarBatchBuilder {
             });
         }
         let raw_offset = ptr - base;
-        let offset = u32::try_from(raw_offset).map_err(|_| BuilderError::StringBufferOverflow {
-            buffer_len: self.original_buf.len(),
-            value_len: value.len(),
-        })?;
-        let len = u32::try_from(value.len()).map_err(|_| BuilderError::StringBufferOverflow {
+        let offset =
+            u32::try_from(raw_offset).map_err(|_e| BuilderError::StringBufferOverflow {
+                buffer_len: self.original_buf.len(),
+                value_len: value.len(),
+            })?;
+        let len = u32::try_from(value.len()).map_err(|_e| BuilderError::StringBufferOverflow {
             buffer_len: self.original_buf.len(),
             value_len: value.len(),
         })?;

--- a/crates/logfwd-arrow/src/columnar/plan.rs
+++ b/crates/logfwd-arrow/src/columnar/plan.rs
@@ -318,7 +318,7 @@ impl BatchPlan {
     }
 
     fn alloc_handle(&self) -> Result<FieldHandle, PlanError> {
-        let idx = u32::try_from(self.fields.len()).map_err(|_| PlanError::TooManyFields {
+        let idx = u32::try_from(self.fields.len()).map_err(|_e| PlanError::TooManyFields {
             count: self.fields.len(),
         })?;
         Ok(FieldHandle(idx))

--- a/crates/logfwd-arrow/src/star_schema.rs
+++ b/crates/logfwd-arrow/src/star_schema.rs
@@ -1827,8 +1827,7 @@ fn unpivot_attrs_to_flat(
             ATTR_TYPE_STR => {}
             _ => {
                 return Err(ArrowError::SchemaError(format!(
-                    "unsupported column type: {}",
-                    type_tag
+                    "unsupported column type: {type_tag}"
                 )));
             }
         }

--- a/crates/logfwd-arrow/src/streaming_builder.rs
+++ b/crates/logfwd-arrow/src/streaming_builder.rs
@@ -625,7 +625,7 @@ impl StreamingBuilder {
         // StringView offsets use original-buffer offsets for unescaped strings
         // and offsets >= original_buf_len for decoded strings. Keep those as two
         // Arrow blocks so decoding one field never copies the full input buffer.
-        let original_buf_len = u32::try_from(self.buf.len()).map_err(|_| {
+        let original_buf_len = u32::try_from(self.buf.len()).map_err(|_e| {
             ArrowError::InvalidArgumentError("input buffer exceeds StringView offset range".into())
         })?;
         let arrow_buf = Buffer::from(self.buf.clone());

--- a/crates/logfwd-bench/benches/source_metadata.rs
+++ b/crates/logfwd-bench/benches/source_metadata.rs
@@ -258,7 +258,7 @@ fn append_metadata_views_current(
             let (block, len) = if let Some(&(block, len)) = blocks.get(value) {
                 (block, len)
             } else {
-                let len = u32::try_from(value.len()).map_err(|_| {
+                let len = u32::try_from(value.len()).map_err(|_e| {
                     ArrowError::InvalidArgumentError(
                         "benchmark metadata string exceeds Utf8View limit".to_string(),
                     )

--- a/crates/logfwd-bench/src/bin/framed_input_profile.rs
+++ b/crates/logfwd-bench/src/bin/framed_input_profile.rs
@@ -70,7 +70,7 @@ fn main() {
         "- Flamegraph: {}",
         cli.flamegraph
             .as_ref()
-            .map_or("not requested".to_string(), |p| p.display().to_string())
+            .map_or_else(|| "not requested".to_string(), |p| p.display().to_string())
     );
     println!();
     println!("## Baseline stage timings\n");

--- a/crates/logfwd-bench/src/bin/generator_profile.rs
+++ b/crates/logfwd-bench/src/bin/generator_profile.rs
@@ -129,8 +129,7 @@ fn main() {
     ];
 
     println!(
-        "batch-generator-profile lines={} iterations={} seed={} wide_rows={}",
-        lines, iterations, seed, wide_rows
+        "batch-generator-profile lines={lines} iterations={iterations} seed={seed} wide_rows={wide_rows}"
     );
 
     for case in cases {

--- a/crates/logfwd-bench/src/bin/http_receiver_apples.rs
+++ b/crates/logfwd-bench/src/bin/http_receiver_apples.rs
@@ -410,14 +410,11 @@ fn start_tiny_http_server() -> std::io::Result<TinyServer> {
                         if v.is_empty() { None } else { Some(v) }
                     });
 
-                let logs = match decode_and_count(body, content_encoding.as_deref()) {
-                    Ok(n) => n,
-                    Err(_) => {
-                        let _ = request.respond(
-                            tiny_http::Response::from_string("decode error").with_status_code(400),
-                        );
-                        continue;
-                    }
+                let Ok(logs) = decode_and_count(body, content_encoding.as_deref()) else {
+                    let _ = request.respond(
+                        tiny_http::Response::from_string("decode error").with_status_code(400),
+                    );
+                    continue;
                 };
 
                 match tx_req.try_send(logs) {
@@ -495,9 +492,8 @@ async fn axum_handler(
         .and_then(|v| v.to_str().ok())
         .map(str::to_ascii_lowercase);
 
-    let logs = match decode_and_count(body.to_vec(), content_encoding.as_deref()) {
-        Ok(n) => n,
-        Err(_) => return StatusCode::BAD_REQUEST,
+    let Ok(logs) = decode_and_count(body.to_vec(), content_encoding.as_deref()) else {
+        return StatusCode::BAD_REQUEST;
     };
 
     match state.tx.try_send(logs) {
@@ -525,9 +521,8 @@ async fn start_hyper_server() -> std::io::Result<HyperServer> {
                     }
                 }
                 accepted = listener.accept() => {
-                    let (stream, _) = match accepted {
-                        Ok(v) => v,
-                        Err(_) => continue,
+                    let Ok((stream, _)) = accepted else {
+                        continue;
                     };
                     let io = TokioIo::new(stream);
                     let state = state.clone();
@@ -590,9 +585,8 @@ async fn hyper_handler(
         return Ok(hyper_response(StatusCode::PAYLOAD_TOO_LARGE));
     }
 
-    let logs = match decode_and_count(body_bytes.to_vec(), content_encoding.as_deref()) {
-        Ok(n) => n,
-        Err(_) => return Ok(hyper_response(StatusCode::BAD_REQUEST)),
+    let Ok(logs) = decode_and_count(body_bytes.to_vec(), content_encoding.as_deref()) else {
+        return Ok(hyper_response(StatusCode::BAD_REQUEST));
     };
 
     let status = match state.tx.try_send(logs) {
@@ -728,19 +722,19 @@ fn make_scenarios() -> Vec<Scenario> {
 
     vec![
         Scenario {
-            name: format!("otlp.protobuf.identity.small({} logs)", small_logs),
+            name: format!("otlp.protobuf.identity.small({small_logs} logs)"),
             body: Bytes::from(small_payload),
             content_encoding: None,
             logs_per_request: small_logs as u64,
         },
         Scenario {
-            name: format!("otlp.protobuf.zstd.small({} logs)", small_logs),
+            name: format!("otlp.protobuf.zstd.small({small_logs} logs)"),
             body: Bytes::from(small_zstd),
             content_encoding: Some("zstd"),
             logs_per_request: small_logs as u64,
         },
         Scenario {
-            name: format!("otlp.protobuf.zstd.medium({} logs)", medium_logs),
+            name: format!("otlp.protobuf.zstd.medium({medium_logs} logs)"),
             body: Bytes::from(medium_zstd),
             content_encoding: Some("zstd"),
             logs_per_request: medium_logs as u64,

--- a/crates/logfwd-bench/src/bin/otlp_e2e_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_e2e_profile.rs
@@ -333,10 +333,7 @@ fn poll_until_batch(
         backoff = (backoff * 2).min(max_backoff);
     }
 
-    panic!(
-        "timed out waiting for {expected_rows} rows; only got {} batch rows",
-        total_batch_rows
-    );
+    panic!("timed out waiting for {expected_rows} rows; only got {total_batch_rows} batch rows");
 }
 
 fn read_concurrency_list() -> Vec<usize> {

--- a/crates/logfwd-bench/src/file_output_profile.rs
+++ b/crates/logfwd-bench/src/file_output_profile.rs
@@ -120,7 +120,7 @@ fn fmt_bytes(bytes: u64) -> String {
     } else if bytes >= 1024 {
         format!("{:.1} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{} B", bytes)
+        format!("{bytes} B")
     }
 }
 
@@ -493,7 +493,7 @@ fn run_cpu(
     let total_bytes = bytes_per_batch * num_batches as u64;
 
     println!("### Results\n");
-    println!("  Elapsed:     {:.2?}", elapsed);
+    println!("  Elapsed:     {elapsed:.2?}");
     println!(
         "  Throughput:  {}",
         fmt_throughput(total_rows, total_bytes, elapsed)

--- a/crates/logfwd-bench/src/generators/cloudtrail/engine.rs
+++ b/crates/logfwd-bench/src/generators/cloudtrail/engine.rs
@@ -606,9 +606,9 @@ impl CloudTrailState {
         let mut assumed_role_principal_ids = Vec::with_capacity(principal_count);
         let mut federated_principal_ids = Vec::with_capacity(principal_count);
         for idx in 0..principal_count {
-            principals.push(format!("user-{:03}", idx));
-            roles.push(format!("cloudtrail-role-{:03}", idx));
-            sessions.push(format!("session-{:03}", idx));
+            principals.push(format!("user-{idx:03}"));
+            roles.push(format!("cloudtrail-role-{idx:03}"));
+            sessions.push(format!("session-{idx:03}"));
             iam_user_principal_ids.push(format!("AIDA{:08X}", 0x1000_0000 + idx as u32));
             assumed_role_principal_ids.push(format!(
                 "AROA{:08X}:{}",

--- a/crates/logfwd-bench/src/library_eval.rs
+++ b/crates/logfwd-bench/src/library_eval.rs
@@ -460,8 +460,7 @@ async fn main() {
     let json_payload: Vec<u8> = (0..1000)
         .flat_map(|i| {
             format!(
-                r#"{{"timestamp":"2026-04-05T22:00:00Z","level":"info","message":"benchmark log line {}","host":"bench"}}"#,
-                i
+                r#"{{"timestamp":"2026-04-05T22:00:00Z","level":"info","message":"benchmark log line {i}","host":"bench"}}"#
             )
             .into_bytes()
             .into_iter()

--- a/crates/logfwd-bench/src/main.rs
+++ b/crates/logfwd-bench/src/main.rs
@@ -50,7 +50,7 @@ fn format_time(ns: f64) -> String {
     } else if ns >= 1_000.0 {
         format!("{:.1} us", ns / 1_000.0)
     } else {
-        format!("{:.0} ns", ns)
+        format!("{ns:.0} ns")
     }
 }
 
@@ -70,7 +70,7 @@ fn format_rate(ns: f64, count: u64) -> String {
     } else if rate >= 1_000.0 {
         format!("{:.0}K lines/s", rate / 1_000.0)
     } else {
-        format!("{:.0} lines/s", rate)
+        format!("{rate:.0} lines/s")
     }
 }
 
@@ -173,9 +173,8 @@ fn collect_results(dir: &PathBuf, groups: &mut BTreeMap<String, Vec<BenchResult>
 
 /// Recursively find all `new/benchmark.json` files under a directory.
 fn find_bench_files(dir: &PathBuf, results: &mut Vec<PathBuf>) {
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return,
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
     };
     for entry in entries.flatten() {
         let path = entry.path();

--- a/crates/logfwd-bench/src/memory_profile.rs
+++ b/crates/logfwd-bench/src/memory_profile.rs
@@ -202,7 +202,7 @@ fn main() {
     }
 
     let warmup_rss = rss_mb();
-    eprintln!("  Warmup RSS:  {:.1} MB\n", warmup_rss);
+    eprintln!("  Warmup RSS:  {warmup_rss:.1} MB\n");
 
     // -----------------------------------------------------------------------
     // Sustained load loop with sampling
@@ -409,20 +409,11 @@ fn render_report(run: &ProfileRun<'_>) -> String {
     // Growth detection: linear regression on RSS samples
     let (slope_mb_per_min, r_squared) = linear_regression(samples);
     let growth_verdict = if r_squared > 0.7 && slope_mb_per_min > 0.5 {
-        format!(
-            "⚠ GROWING: {:.2} MB/min (R²={:.2}) — possible leak",
-            slope_mb_per_min, r_squared
-        )
+        format!("⚠ GROWING: {slope_mb_per_min:.2} MB/min (R²={r_squared:.2}) — possible leak")
     } else if slope_mb_per_min.abs() < 0.1 {
-        format!(
-            "✓ STABLE: {:.3} MB/min (R²={:.2})",
-            slope_mb_per_min, r_squared
-        )
+        format!("✓ STABLE: {slope_mb_per_min:.3} MB/min (R²={r_squared:.2})")
     } else {
-        format!(
-            "~ MINOR DRIFT: {:.2} MB/min (R²={:.2})",
-            slope_mb_per_min, r_squared
-        )
+        format!("~ MINOR DRIFT: {slope_mb_per_min:.2} MB/min (R²={r_squared:.2})")
     };
 
     // --- Allocation analysis ---
@@ -468,12 +459,12 @@ fn render_report(run: &ProfileRun<'_>) -> String {
     let _ = writeln!(out, "## Sustained Memory Profile Results\n");
     let _ = writeln!(out, "| Parameter | Value |");
     let _ = writeln!(out, "|-----------|-------|");
-    let _ = writeln!(out, "| Schema | {} |", schema_name);
-    let _ = writeln!(out, "| SQL | `{}` |", sql);
-    let _ = writeln!(out, "| Batch size | {} lines |", batch_lines);
-    let _ = writeln!(out, "| Duration | {:.1}s |", elapsed_secs);
-    let _ = writeln!(out, "| Total rows | {} |", total_rows);
-    let _ = writeln!(out, "| Total batches | {} |", total_batches);
+    let _ = writeln!(out, "| Schema | {schema_name} |");
+    let _ = writeln!(out, "| SQL | `{sql}` |");
+    let _ = writeln!(out, "| Batch size | {batch_lines} lines |");
+    let _ = writeln!(out, "| Duration | {elapsed_secs:.1}s |");
+    let _ = writeln!(out, "| Total rows | {total_rows} |");
+    let _ = writeln!(out, "| Total batches | {total_batches} |");
     let _ = writeln!(
         out,
         "| Total input | {:.1} MB |",
@@ -484,19 +475,19 @@ fn render_report(run: &ProfileRun<'_>) -> String {
     let _ = writeln!(out, "### Throughput\n");
     let _ = writeln!(out, "| Metric | Value |");
     let _ = writeln!(out, "|--------|-------|");
-    let _ = writeln!(out, "| Lines/sec | {:.0} |", lines_per_sec);
-    let _ = writeln!(out, "| MB/sec (input) | {:.1} |", mb_per_sec);
-    let _ = writeln!(out, "| Batches/sec | {:.1} |", batches_per_sec);
+    let _ = writeln!(out, "| Lines/sec | {lines_per_sec:.0} |");
+    let _ = writeln!(out, "| MB/sec (input) | {mb_per_sec:.1} |");
+    let _ = writeln!(out, "| Batches/sec | {batches_per_sec:.1} |");
     let _ = writeln!(out);
 
     let _ = writeln!(out, "### Memory (RSS)\n");
     let _ = writeln!(out, "| Metric | Value |");
     let _ = writeln!(out, "|--------|-------|");
-    let _ = writeln!(out, "| Peak RSS | {:.1} MB |", peak_rss);
-    let _ = writeln!(out, "| Min RSS | {:.1} MB |", min_rss);
-    let _ = writeln!(out, "| Steady-state RSS | {:.1} MB |", steady_rss);
+    let _ = writeln!(out, "| Peak RSS | {peak_rss:.1} MB |");
+    let _ = writeln!(out, "| Min RSS | {min_rss:.1} MB |");
+    let _ = writeln!(out, "| Steady-state RSS | {steady_rss:.1} MB |");
     let _ = writeln!(out, "| RSS range | {:.1} MB |", peak_rss - min_rss);
-    let _ = writeln!(out, "| Growth rate | {} |", growth_verdict);
+    let _ = writeln!(out, "| Growth rate | {growth_verdict} |");
     let _ = writeln!(out);
 
     let _ = writeln!(out, "### Allocations\n");
@@ -517,14 +508,13 @@ fn render_report(run: &ProfileRun<'_>) -> String {
         "| Net retained | {:.1} MB |",
         net_retained as f64 / 1_048_576.0
     );
-    let _ = writeln!(out, "| Alloc rate | {:.1} MB/sec |", alloc_rate_mb_per_sec);
+    let _ = writeln!(out, "| Alloc rate | {alloc_rate_mb_per_sec:.1} MB/sec |");
     let _ = writeln!(
         out,
-        "| Alloc count rate | {:.0} allocs/sec |",
-        alloc_rate_per_sec
+        "| Alloc count rate | {alloc_rate_per_sec:.0} allocs/sec |"
     );
-    let _ = writeln!(out, "| Bytes/row | {:.0} |", bytes_per_row);
-    let _ = writeln!(out, "| Allocs/row | {:.1} |", allocs_per_row);
+    let _ = writeln!(out, "| Bytes/row | {bytes_per_row:.0} |");
+    let _ = writeln!(out, "| Allocs/row | {allocs_per_row:.1} |");
     let _ = writeln!(out);
 
     // --- RSS timeline ---
@@ -628,7 +618,7 @@ fn render_report(run: &ProfileRun<'_>) -> String {
             0.0
         }
     );
-    let _ = writeln!(out, "| Allocated bytes/row | {:.0} |", bytes_per_row);
+    let _ = writeln!(out, "| Allocated bytes/row | {bytes_per_row:.0} |");
     let _ = writeln!(
         out,
         "| Amplification factor | {:.1}x |",
@@ -638,11 +628,10 @@ fn render_report(run: &ProfileRun<'_>) -> String {
             0.0
         }
     );
-    let _ = writeln!(out, "| Allocations/row | {:.1} |", allocs_per_row);
+    let _ = writeln!(out, "| Allocations/row | {allocs_per_row:.1} |");
     let _ = writeln!(
         out,
-        "| RSS per batch ({} rows) | {:.1} MB |",
-        batch_lines, steady_rss
+        "| RSS per batch ({batch_lines} rows) | {steady_rss:.1} MB |"
     );
 
     out

--- a/crates/logfwd-competitive-bench/src/main.rs
+++ b/crates/logfwd-competitive-bench/src/main.rs
@@ -625,7 +625,7 @@ fn fmt_rate(lines: usize, ms: u64) -> String {
     } else if lps >= 1_000.0 {
         format!("{:.0}K lines/sec", lps / 1_000.0)
     } else {
-        format!("{:.0} lines/sec", lps)
+        format!("{lps:.0} lines/sec")
     }
 }
 

--- a/crates/logfwd-competitive-bench/src/summarize.rs
+++ b/crates/logfwd-competitive-bench/src/summarize.rs
@@ -211,7 +211,7 @@ fn fmt_rate(lines: u64, ms: u64) -> String {
     } else if lps >= 1_000.0 {
         format!("{:.1}K lines/sec", lps / 1_000.0)
     } else {
-        format!("{:.0} lines/sec", lps)
+        format!("{lps:.0} lines/sec")
     }
 }
 
@@ -226,7 +226,7 @@ fn fmt_bytes(bytes: u64) -> String {
     } else if bytes >= 1024 {
         format!("{:.1} KB", bytes as f64 / 1024.0)
     } else {
-        format!("{} B", bytes)
+        format!("{bytes} B")
     }
 }
 

--- a/crates/logfwd-config/src/serde_helpers.rs
+++ b/crates/logfwd-config/src/serde_helpers.rs
@@ -508,7 +508,7 @@ macro_rules! impl_strict_unsigned {
                 where
                     E: DeError,
                 {
-                    value.try_into().map_err(|_| {
+                    value.try_into().map_err(|_e| {
                         E::invalid_value(Unexpected::Signed(value), &StrictScalarExpected::<Self>::new())
                     })
                 }
@@ -517,7 +517,7 @@ macro_rules! impl_strict_unsigned {
                 where
                     E: DeError,
                 {
-                    value.try_into().map_err(|_| {
+                    value.try_into().map_err(|_e| {
                         E::invalid_value(Unexpected::Unsigned(value), &StrictScalarExpected::<Self>::new())
                     })
                 }
@@ -545,7 +545,7 @@ macro_rules! impl_strict_signed {
                 where
                     E: DeError,
                 {
-                    value.try_into().map_err(|_| {
+                    value.try_into().map_err(|_e| {
                         E::invalid_value(Unexpected::Signed(value), &StrictScalarExpected::<Self>::new())
                     })
                 }
@@ -554,7 +554,7 @@ macro_rules! impl_strict_signed {
                 where
                     E: DeError,
                 {
-                    value.try_into().map_err(|_| {
+                    value.try_into().map_err(|_e| {
                         E::invalid_value(Unexpected::Unsigned(value), &StrictScalarExpected::<Self>::new())
                     })
                 }
@@ -661,7 +661,7 @@ impl StrictScalar for PositiveMillis {
     where
         E: DeError,
     {
-        let n: u64 = value.try_into().map_err(|_| {
+        let n: u64 = value.try_into().map_err(|_e| {
             E::invalid_value(Unexpected::Signed(value), &"a positive integer (> 0)")
         })?;
         NonZeroU64::new(n)
@@ -731,7 +731,7 @@ impl StrictScalar for PositiveSecs {
     where
         E: DeError,
     {
-        let n: u64 = value.try_into().map_err(|_| {
+        let n: u64 = value.try_into().map_err(|_e| {
             E::invalid_value(Unexpected::Signed(value), &"a positive integer (> 0)")
         })?;
         NonZeroU64::new(n)

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -1645,7 +1645,7 @@ fn canonical_listen_addr_key(transport: &str, listen: &str) -> Result<Option<Str
     };
     let port = port_str
         .parse::<u16>()
-        .map_err(|_| validation_error(format!("'{listen}' has an invalid port '{port_str}'")))?;
+        .map_err(|_e| validation_error(format!("'{listen}' has an invalid port '{port_str}'")))?;
     if port == 0 {
         return Ok(None);
     }
@@ -1838,7 +1838,7 @@ pub fn validate_host_port(addr: &str) -> Result<(), ConfigError> {
                 "'{addr}' has an empty IPv6 address inside brackets"
             )));
         }
-        inner.parse::<std::net::Ipv6Addr>().map_err(|_| {
+        inner.parse::<std::net::Ipv6Addr>().map_err(|_e| {
             validation_error(format!(
                 "'{addr}' contains a non-IPv6 value inside brackets"
             ))
@@ -1890,7 +1890,7 @@ pub fn validate_host_port(addr: &str) -> Result<(), ConfigError> {
 
     port_str
         .parse::<u16>()
-        .map_err(|_| validation_error(format!("'{addr}' has an invalid port '{port_str}'")))?;
+        .map_err(|_e| validation_error(format!("'{addr}' has an invalid port '{port_str}'")))?;
     Ok(())
 }
 
@@ -2064,7 +2064,7 @@ fn validate_endpoint_url(endpoint: &str) -> Result<(), ConfigError> {
     let safe = redact_url(endpoint);
 
     let parsed = Url::parse(endpoint)
-        .map_err(|_| validation_error(format!("endpoint '{safe}' is not a valid URL")))?;
+        .map_err(|_e| validation_error(format!("endpoint '{safe}' is not a valid URL")))?;
 
     if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(validation_error(format!(

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -177,8 +177,9 @@ fn scan_line<B: ScanBuilder>(
 
         // Scan key string using quote bitmask
         let key_start = pos + 1;
-        let Some(key_end) = next_quote(pos + 1, end, blocks) else {
-            break;
+        let key_end = match next_quote(pos + 1, end, blocks) {
+            Some(p) => p,
+            None => break,
         };
         let raw_key = &buf[key_start..key_end];
         let key = if memchr::memchr(b'\\', raw_key).is_some() {
@@ -207,8 +208,9 @@ fn scan_line<B: ScanBuilder>(
             b'"' => {
                 // String value — decode JSON escape sequences (#410)
                 let val_start = pos + 1;
-                let Some(val_end) = next_quote(pos + 1, end, blocks) else {
-                    break;
+                let val_end = match next_quote(pos + 1, end, blocks) {
+                    Some(p) => p,
+                    None => break,
                 };
                 if wanted {
                     let idx = builder.resolve_field(key);
@@ -525,9 +527,12 @@ fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>
         out.push(b'\\');
         return pos + 1;
     }
-    let Some(cp) = parse_hex4(&input[pos + 2..pos + 6]) else {
-        out.push(b'\\');
-        return pos + 1;
+    let cp = match parse_hex4(&input[pos + 2..pos + 6]) {
+        Some(v) => v,
+        None => {
+            out.push(b'\\');
+            return pos + 1;
+        }
     };
 
     // High surrogate — expect a following \uXXXX low surrogate

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -177,9 +177,8 @@ fn scan_line<B: ScanBuilder>(
 
         // Scan key string using quote bitmask
         let key_start = pos + 1;
-        let key_end = match next_quote(pos + 1, end, blocks) {
-            Some(p) => p,
-            None => break,
+        let Some(key_end) = next_quote(pos + 1, end, blocks) else {
+            break;
         };
         let raw_key = &buf[key_start..key_end];
         let key = if memchr::memchr(b'\\', raw_key).is_some() {
@@ -208,9 +207,8 @@ fn scan_line<B: ScanBuilder>(
             b'"' => {
                 // String value — decode JSON escape sequences (#410)
                 let val_start = pos + 1;
-                let val_end = match next_quote(pos + 1, end, blocks) {
-                    Some(p) => p,
-                    None => break,
+                let Some(val_end) = next_quote(pos + 1, end, blocks) else {
+                    break;
                 };
                 if wanted {
                     let idx = builder.resolve_field(key);
@@ -527,12 +525,9 @@ fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>
         out.push(b'\\');
         return pos + 1;
     }
-    let cp = match parse_hex4(&input[pos + 2..pos + 6]) {
-        Some(v) => v,
-        None => {
-            out.push(b'\\');
-            return pos + 1;
-        }
+    let Some(cp) = parse_hex4(&input[pos + 2..pos + 6]) else {
+        out.push(b'\\');
+        return pos + 1;
     };
 
     // High surrogate — expect a following \uXXXX low surrogate

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -246,7 +246,7 @@ pub fn skip_field(buf: &[u8], wire_type: u8, pos: usize) -> Result<usize, &'stat
         2 => {
             // Length-delimited.
             let (len, new_pos) = decode_varint(buf, pos)?;
-            let len_usize = usize::try_from(len).map_err(|_| "skip: length overflow")?;
+            let len_usize = usize::try_from(len).map_err(|_e| "skip: length overflow")?;
             let end = new_pos
                 .checked_add(len_usize)
                 .ok_or("skip: length-delimited overflow")?;

--- a/crates/logfwd-diagnostics/src/diagnostics/server.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics/server.rs
@@ -535,8 +535,7 @@ fn status_payload(state: &DiagnosticsState) -> StatusSnapshotResponse {
             (
                 "input",
                 format!(
-                    "backpressure stalls at {:.1}/sec — input faster than pipeline can drain",
-                    stalls_per_sec
+                    "backpressure stalls at {stalls_per_sec:.1}/sec — input faster than pipeline can drain"
                 ),
             )
         } else if transform_ratio > 0.3 {
@@ -650,8 +649,7 @@ fn build_stats_body(state: &DiagnosticsState) -> String {
     let uptime_s = state.start_time.elapsed().as_secs_f64();
     let process_json = match process_metrics() {
         Some((rss_bytes, cpu_user_ms, cpu_sys_ms)) => format!(
-            r#","rss_bytes":{},"cpu_user_ms":{},"cpu_sys_ms":{}"#,
-            rss_bytes, cpu_user_ms, cpu_sys_ms
+            r#","rss_bytes":{rss_bytes},"cpu_user_ms":{cpu_user_ms},"cpu_sys_ms":{cpu_sys_ms}"#
         ),
         None => String::from(r#","rss_bytes":null,"cpu_user_ms":null,"cpu_sys_ms":null"#),
     };

--- a/crates/logfwd-diagnostics/src/diagnostics/telemetry.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics/telemetry.rs
@@ -436,7 +436,7 @@ pub(super) fn collect_new_spans(
                 attrs.push(("output_start_unix_ns", b.output_start_unix_ns.to_string()));
             }
             spans.push(SpanRecord {
-                trace_id: format!("{:016x}{:016x}", pipeline_hash, id),
+                trace_id: format!("{pipeline_hash:016x}{id:016x}"),
                 span_id: format!("{:016x}", id ^ pipeline_hash),
                 parent_id: "0000000000000000".to_string(),
                 name: "batch".to_string(),
@@ -496,23 +496,26 @@ pub(super) fn metrics_to_otlp_json(points: &[MetricPoint]) -> String {
         match &pt.value {
             MetricValue::Gauge(v) => {
                 out.push_str(r#","gauge":{"dataPoints":[{"timeUnixNano":""#);
-                let _ = write!(out, "{}", now);
+                let _ = write!(out, "{now}");
                 out.push_str(r#"","asDouble":"#);
                 if !v.is_finite() {
                     let _ = write!(out, "null");
                 } else if v.fract() == 0.0 && *v >= i64::MIN as f64 && *v <= i64::MAX as f64 {
-                    let _ = write!(out, "{}", *v as i64);
+                    let _ = {
+                        let vi = *v as i64;
+                        write!(out, "{vi}")
+                    };
                 } else {
-                    let _ = write!(out, "{}", v);
+                    let _ = write!(out, "{v}");
                 }
                 write_attributes(&mut out, &pt.attributes);
                 out.push_str("}]}");
             }
             MetricValue::Sum(v) => {
                 out.push_str(r#","sum":{"dataPoints":[{"timeUnixNano":""#);
-                let _ = write!(out, "{}", now);
+                let _ = write!(out, "{now}");
                 out.push_str(r#"","asInt":""#);
-                let _ = write!(out, "{}", v);
+                let _ = write!(out, "{v}");
                 out.push('"');
                 write_attributes(&mut out, &pt.attributes);
                 out.push_str(r#"}],"aggregationTemporality":2,"isMonotonic":true}"#);
@@ -575,7 +578,7 @@ pub(super) fn spans_to_otlp_json(spans: &[SpanRecord]) -> String {
             "error" => 2,
             _ => 0,
         };
-        let _ = write!(out, r#","status":{{"code":{}}}}}"#, status_code);
+        let _ = write!(out, r#","status":{{"code":{status_code}}}}}"#);
     }
 
     out.push_str("]}]}]}");

--- a/crates/logfwd-diagnostics/src/diagnostics/telemetry.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics/telemetry.rs
@@ -501,10 +501,8 @@ pub(super) fn metrics_to_otlp_json(points: &[MetricPoint]) -> String {
                 if !v.is_finite() {
                     let _ = write!(out, "null");
                 } else if v.fract() == 0.0 && *v >= i64::MIN as f64 && *v <= i64::MAX as f64 {
-                    let _ = {
-                        let vi = *v as i64;
-                        write!(out, "{vi}")
-                    };
+                    let vi = *v as i64;
+                    let _ = write!(out, "{vi}");
                 } else {
                     let _ = write!(out, "{v}");
                 }

--- a/crates/logfwd-diagnostics/src/telemetry_buffer.rs
+++ b/crates/logfwd-diagnostics/src/telemetry_buffer.rs
@@ -779,7 +779,7 @@ pub fn active_batch_to_span_point(id: u64, batch: &ActiveBatch, pipeline: &str) 
     pipeline.hash(&mut hasher);
     let pipeline_hash = hasher.finish();
 
-    let trace_id = format!("{:016x}{:016x}", pipeline_hash, id);
+    let trace_id = format!("{pipeline_hash:016x}{id:016x}");
     let span_id = format!("{:016x}", id ^ pipeline_hash);
 
     let mut attrs = vec![
@@ -904,8 +904,7 @@ pub fn sample_health_transitions<S: std::hash::BuildHasher>(
                 buf.push(LogPoint {
                     severity,
                     body: format!(
-                        "component '{}' ({}) health changed: {:?} -> {:?}",
-                        name, role, old_name, new_name,
+                        "component '{name}' ({role}) health changed: {old_name:?} -> {new_name:?}"
                     ),
                     attributes: vec![
                         ("pipeline", pm.name.clone()),

--- a/crates/logfwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/logfwd-io/src/arrow_ipc_receiver.rs
@@ -181,27 +181,18 @@ impl ArrowIpcReceiver {
         let handle = std::thread::Builder::new()
             .name("arrow-ipc-receiver".into())
             .spawn(move || {
-                let runtime = match tokio::runtime::Builder::new_current_thread()
+                let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
-                {
-                    Ok(runtime) => runtime,
-                    Err(_) => {
-                        store_health_event(&health_for_server, ReceiverHealthEvent::FatalFailure);
-                        return;
-                    }
+                else {
+                    store_health_event(&health_for_server, ReceiverHealthEvent::FatalFailure);
+                    return;
                 };
 
                 runtime.block_on(async move {
-                    let listener = match tokio::net::TcpListener::from_std(std_listener) {
-                        Ok(listener) => listener,
-                        Err(_) => {
-                            store_health_event(
-                                &health_for_server,
-                                ReceiverHealthEvent::FatalFailure,
-                            );
-                            return;
-                        }
+                    let Ok(listener) = tokio::net::TcpListener::from_std(std_listener) else {
+                        store_health_event(&health_for_server, ReceiverHealthEvent::FatalFailure);
+                        return;
                     };
 
                     let app = axum::Router::new()
@@ -341,7 +332,7 @@ fn record_parse_error(stats: Option<&Arc<ComponentStats>>) {
 
 /// Decompress zstd body with size limit.
 fn decompress_zstd(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>, InputError> {
-    let decoder = zstd::Decoder::new(body).map_err(|_| {
+    let decoder = zstd::Decoder::new(body).map_err(|_e| {
         InputError::Receiver("zstd decompression failed: invalid header".to_string())
     })?;
     let mut decompressed = Vec::with_capacity(body.len().min(max_message_size_bytes));
@@ -685,7 +676,7 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<ContentEncodingF
     let Some(value) = headers.get(CONTENT_ENCODING) else {
         return Ok(None);
     };
-    let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let parsed = value.to_str().map_err(|_e| StatusCode::BAD_REQUEST)?;
     let mut flags = ContentEncodingFlags::default();
     let mut has_token = false;
     for token in parsed.split(',').map(str::trim) {
@@ -714,7 +705,7 @@ fn parse_content_type(headers: &HeaderMap) -> Result<Option<&str>, StatusCode> {
     let Some(value) = headers.get(CONTENT_TYPE) else {
         return Ok(None);
     };
-    let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let parsed = value.to_str().map_err(|_e| StatusCode::BAD_REQUEST)?;
     let media_type = parsed.split(';').next().unwrap_or(parsed).trim();
     if media_type.is_empty() {
         return Err(StatusCode::BAD_REQUEST);

--- a/crates/logfwd-io/src/compress.rs
+++ b/crates/logfwd-io/src/compress.rs
@@ -113,7 +113,7 @@ impl ChunkCompressor {
 }
 
 fn check_wire_size(name: &str, size: usize) -> io::Result<u32> {
-    u32::try_from(size).map_err(|_| {
+    u32::try_from(size).map_err(|_e| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
             format!("{name} {size} exceeds u32::MAX"),

--- a/crates/logfwd-io/src/http_input.rs
+++ b/crates/logfwd-io/src/http_input.rs
@@ -214,26 +214,19 @@ impl HttpInput {
         let handle = std::thread::Builder::new()
             .name("http-input".into())
             .spawn(move || {
-                let runtime = match tokio::runtime::Builder::new_current_thread()
+                let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
-                {
-                    Ok(runtime) => runtime,
-                    Err(_) => {
-                        health_for_server
-                            .store(ComponentHealth::Failed.as_repr(), Ordering::Relaxed);
-                        return;
-                    }
+                else {
+                    health_for_server.store(ComponentHealth::Failed.as_repr(), Ordering::Relaxed);
+                    return;
                 };
 
                 runtime.block_on(async move {
-                    let listener = match tokio::net::TcpListener::from_std(std_listener) {
-                        Ok(listener) => listener,
-                        Err(_) => {
-                            health_for_server
-                                .store(ComponentHealth::Failed.as_repr(), Ordering::Relaxed);
-                            return;
-                        }
+                    let Ok(listener) = tokio::net::TcpListener::from_std(std_listener) else {
+                        health_for_server
+                            .store(ComponentHealth::Failed.as_repr(), Ordering::Relaxed);
+                        return;
                     };
 
                     let app = axum::Router::new()
@@ -540,7 +533,7 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
     let Some(value) = headers.get(CONTENT_ENCODING) else {
         return Ok(None);
     };
-    let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?.trim();
+    let parsed = value.to_str().map_err(|_e| StatusCode::BAD_REQUEST)?.trim();
     if parsed.is_empty() {
         return Err(StatusCode::BAD_REQUEST);
     }
@@ -624,7 +617,7 @@ fn is_supported_content_encoding(content_encoding: &str) -> bool {
 
 fn decompress_zstd(body: &[u8], max_request_body_size: usize) -> Result<Vec<u8>, InputError> {
     let decoder = zstd::Decoder::new(body)
-        .map_err(|_| InputError::Receiver("zstd decompression failed".to_string()))?;
+        .map_err(|_e| InputError::Receiver("zstd decompression failed".to_string()))?;
     read_decompressed_body(
         decoder,
         body.len(),

--- a/crates/logfwd-io/src/journal_ffi.rs
+++ b/crates/logfwd-io/src/journal_ffi.rs
@@ -226,7 +226,7 @@ impl Journal {
     pub fn open_directory(path: &str, flags: i32) -> io::Result<Self> {
         let lib = Arc::new(LibSystemd::load()?);
         let c_path = CString::new(path)
-            .map_err(|_| io::Error::other("journal directory path contains null byte"))?;
+            .map_err(|_e| io::Error::other("journal directory path contains null byte"))?;
         let mut handle: *mut SdJournal = ptr::null_mut();
         // SAFETY: `c_path` is a valid NUL-terminated C string. `handle` pointer
         // is valid for the duration of this call.
@@ -252,7 +252,7 @@ impl Journal {
             io::Error::other("sd_journal_open_namespace not available (requires systemd >= 245)")
         })?;
         let c_ns = CString::new(namespace)
-            .map_err(|_| io::Error::other("journal namespace contains null byte"))?;
+            .map_err(|_e| io::Error::other("journal namespace contains null byte"))?;
         let mut handle: *mut SdJournal = ptr::null_mut();
         // SAFETY: `c_ns` is a valid NUL-terminated C string. `handle` pointer
         // is valid for the duration of this call.
@@ -312,7 +312,7 @@ impl Journal {
     /// Seek to the entry after the given cursor.
     pub fn seek_cursor(&mut self, cursor: &str) -> io::Result<()> {
         let c_cursor =
-            CString::new(cursor).map_err(|_| io::Error::other("cursor contains null byte"))?;
+            CString::new(cursor).map_err(|_e| io::Error::other("cursor contains null byte"))?;
         // SAFETY: `self.handle` is valid. `c_cursor` is a valid NUL-terminated
         // C string that remains live for the duration of this call.
         let ret = unsafe { (self.lib.seek_cursor)(self.handle, c_cursor.as_ptr()) };
@@ -351,7 +351,7 @@ impl Journal {
     /// still exists or if the journal positioned on the next closest entry.
     pub fn test_cursor(&mut self, cursor: &str) -> io::Result<bool> {
         let c_cursor =
-            CString::new(cursor).map_err(|_| io::Error::other("cursor contains null byte"))?;
+            CString::new(cursor).map_err(|_e| io::Error::other("cursor contains null byte"))?;
         // SAFETY: `self.handle` is valid. `c_cursor` is a valid NUL-terminated
         // C string that remains live for the duration of this call.
         let ret = unsafe { (self.lib.test_cursor)(self.handle, c_cursor.as_ptr()) };
@@ -368,7 +368,7 @@ impl Journal {
     /// present in the current entry.
     pub fn get_data(&mut self, field: &str) -> io::Result<Option<&[u8]>> {
         let c_field =
-            CString::new(field).map_err(|_| io::Error::other("field name contains null byte"))?;
+            CString::new(field).map_err(|_e| io::Error::other("field name contains null byte"))?;
         let mut data: *const u8 = ptr::null();
         let mut len: usize = 0;
         // SAFETY: `sd_journal_get_data` writes a pointer to internal buffer

--- a/crates/logfwd-io/src/journald_input.rs
+++ b/crates/logfwd-io/src/journald_input.rs
@@ -564,9 +564,8 @@ fn entry_to_json(
         if field_bytes.len() > MAX_BINARY_FIELD_SIZE {
             continue;
         }
-        let eq_pos = match memchr::memchr(b'=', field_bytes) {
-            Some(p) => p,
-            None => continue,
+        let Some(eq_pos) = memchr::memchr(b'=', field_bytes) else {
+            continue;
         };
         fields.push((
             field_bytes[..eq_pos].to_vec(),
@@ -836,19 +835,16 @@ fn subprocess_reader_loop(
         health.store(HEALTH_OK, Ordering::Release);
         tracing::info!("journalctl started (pid={})", child.id());
 
-        let stdout = match child.stdout.take() {
-            Some(stdout) => stdout,
-            None => {
-                tracing::error!("journalctl stdout not captured");
-                child_pid.store(0, Ordering::Release);
-                let _ = child.kill();
-                let _ = child.wait();
-                health.store(HEALTH_DEGRADED, Ordering::Release);
-                if !backoff_or_stop(&running) {
-                    return;
-                }
-                continue;
+        let Some(stdout) = child.stdout.take() else {
+            tracing::error!("journalctl stdout not captured");
+            child_pid.store(0, Ordering::Release);
+            let _ = child.kill();
+            let _ = child.wait();
+            health.store(HEALTH_DEGRADED, Ordering::Release);
+            if !backoff_or_stop(&running) {
+                return;
             }
+            continue;
         };
 
         // Drain stderr so it doesn't block.

--- a/crates/logfwd-io/src/otap_receiver.rs
+++ b/crates/logfwd-io/src/otap_receiver.rs
@@ -140,27 +140,18 @@ impl OtapReceiver {
         let handle = std::thread::Builder::new()
             .name("otap-receiver".into())
             .spawn(move || {
-                let runtime = match tokio::runtime::Builder::new_current_thread()
+                let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()
-                {
-                    Ok(runtime) => runtime,
-                    Err(_) => {
-                        store_health_event(&health_for_server, ReceiverHealthEvent::FatalFailure);
-                        return;
-                    }
+                else {
+                    store_health_event(&health_for_server, ReceiverHealthEvent::FatalFailure);
+                    return;
                 };
 
                 runtime.block_on(async move {
-                    let listener = match tokio::net::TcpListener::from_std(std_listener) {
-                        Ok(listener) => listener,
-                        Err(_) => {
-                            store_health_event(
-                                &health_for_server,
-                                ReceiverHealthEvent::FatalFailure,
-                            );
-                            return;
-                        }
+                    let Ok(listener) = tokio::net::TcpListener::from_std(std_listener) else {
+                        store_health_event(&health_for_server, ReceiverHealthEvent::FatalFailure);
+                        return;
                     };
 
                     let app = axum::Router::new()
@@ -211,7 +202,7 @@ impl OtapReceiver {
             return Err(io::Error::other("OTAP receiver: already closed"));
         };
         rx.recv()
-            .map_err(|_| io::Error::other("OTAP receiver: channel disconnected"))
+            .map_err(|_e| io::Error::other("OTAP receiver: channel disconnected"))
     }
 
     /// Receive with a timeout.
@@ -456,7 +447,7 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
     let Some(value) = headers.get(CONTENT_ENCODING) else {
         return Ok(None);
     };
-    let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let parsed = value.to_str().map_err(|_e| StatusCode::BAD_REQUEST)?;
     let encoding = parsed.trim();
     if encoding.is_empty() {
         return Err(StatusCode::BAD_REQUEST);

--- a/crates/logfwd-io/src/otlp_receiver/convert.rs
+++ b/crates/logfwd-io/src/otlp_receiver/convert.rs
@@ -156,7 +156,7 @@ fn convert_otlp_timestamp(raw: u64, field_name: &str) -> Result<Option<i64>, Inp
     if raw == 0 {
         return Ok(None);
     }
-    let converted = i64::try_from(raw).map_err(|_| {
+    let converted = i64::try_from(raw).map_err(|_e| {
         InputError::Receiver(format!(
             "invalid OTLP {field_name}: value {raw} exceeds signed 64-bit nanosecond range"
         ))
@@ -601,7 +601,7 @@ pub(super) fn write_f64_to_buf(out: &mut Vec<u8>, d: f64) {
         return;
     }
     // Use the standard formatter here; non-finite values are handled above.
-    let _ = write!(out, "{}", d);
+    let _ = write!(out, "{d}");
 }
 
 pub(super) fn write_json_string_field(out: &mut Vec<u8>, key: &str, value: &str) {

--- a/crates/logfwd-io/src/otlp_receiver/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/decode.rs
@@ -26,7 +26,7 @@ use super::projection::ProjectionError;
 
 pub(super) fn decompress_zstd(body: &[u8], max_body_size: usize) -> Result<Vec<u8>, InputError> {
     let decoder = zstd::Decoder::new(body)
-        .map_err(|_| InputError::Receiver("zstd decompression failed".to_string()))?;
+        .map_err(|_e| InputError::Receiver("zstd decompression failed".to_string()))?;
     read_decompressed_body(
         decoder,
         body.len(),
@@ -167,13 +167,10 @@ fn decode_otlp_logs_json(body: &[u8], resource_prefix: &str) -> Result<Vec<u8>, 
     let root: serde_json::Value = sonic_rs::from_slice(body)
         .map_err(|e| InputError::Receiver(format!("invalid JSON: {e}")))?;
 
-    let resource_logs = match root.get("resourceLogs").and_then(|v| v.as_array()) {
-        Some(arr) => arr,
-        None => {
-            return Err(InputError::Receiver(
-                "missing required field 'resourceLogs' in OTLP JSON payload".to_string(),
-            ));
-        }
+    let Some(resource_logs) = root.get("resourceLogs").and_then(|v| v.as_array()) else {
+        return Err(InputError::Receiver(
+            "missing required field 'resourceLogs' in OTLP JSON payload".to_string(),
+        ));
     };
 
     let mut out = Vec::new();

--- a/crates/logfwd-io/src/otlp_receiver/projection.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection.rs
@@ -781,7 +781,7 @@ fn for_each_field<'a>(
             }
             2 => {
                 let len = usize::try_from(read_varint(&mut input)?)
-                    .map_err(|_| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
                 if input.len() < len {
                     return Err(ProjectionError::Invalid("truncated length-delimited field"));
                 }
@@ -822,7 +822,7 @@ fn decode_field_number(key: u64) -> Result<u32, ProjectionError> {
             "protobuf field number out of range",
         ));
     }
-    u32::try_from(field).map_err(|_| ProjectionError::Invalid("protobuf field number overflow"))
+    u32::try_from(field).map_err(|_e| ProjectionError::Invalid("protobuf field number overflow"))
 }
 
 const PROTOBUF_MAX_GROUP_DEPTH: usize = 64;
@@ -848,7 +848,7 @@ fn skip_group(input: &mut &[u8], start_field: u32) -> Result<(), ProjectionError
             }
             2 => {
                 let len = usize::try_from(read_varint(input)?)
-                    .map_err(|_| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
                 if input.len() < len {
                     return Err(ProjectionError::Invalid("truncated length-delimited field"));
                 }

--- a/crates/logfwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection/generated.rs
@@ -966,7 +966,7 @@ fn consume_fixed(input: &mut &[u8], len: usize, msg: &'static str) -> Result<(),
 
 fn consume_len<'a>(input: &mut &'a [u8]) -> Result<&'a [u8], ProjectionError> {
     let len = usize::try_from(read_varint(input)?)
-        .map_err(|_| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+        .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
     if input.len() < len {
         return Err(ProjectionError::Invalid("truncated length-delimited field"));
     }
@@ -1039,7 +1039,7 @@ fn decode_field_number(key: u64) -> Result<u32, ProjectionError> {
             "protobuf field number out of range",
         ));
     }
-    u32::try_from(field).map_err(|_| ProjectionError::Invalid("protobuf field number overflow"))
+    u32::try_from(field).map_err(|_e| ProjectionError::Invalid("protobuf field number overflow"))
 }
 
 fn read_varint(input: &mut &[u8]) -> Result<u64, ProjectionError> {

--- a/crates/logfwd-io/src/otlp_receiver/server.rs
+++ b/crates/logfwd-io/src/otlp_receiver/server.rs
@@ -317,7 +317,7 @@ fn parse_content_encoding(headers: &HeaderMap) -> Result<Option<String>, StatusC
     let Some(value) = headers.get(CONTENT_ENCODING) else {
         return Ok(None);
     };
-    let parsed = value.to_str().map_err(|_| StatusCode::BAD_REQUEST)?.trim();
+    let parsed = value.to_str().map_err(|_e| StatusCode::BAD_REQUEST)?.trim();
     if parsed.is_empty() {
         return Err(StatusCode::BAD_REQUEST);
     }

--- a/crates/logfwd-io/src/receiver_http.rs
+++ b/crates/logfwd-io/src/receiver_http.rs
@@ -24,7 +24,7 @@ pub(crate) fn parse_content_type(headers: &HeaderMap) -> Result<Option<String>, 
     };
     let raw = value
         .to_str()
-        .map_err(|_| StatusCode::UNSUPPORTED_MEDIA_TYPE)?;
+        .map_err(|_e| StatusCode::UNSUPPORTED_MEDIA_TYPE)?;
     let media_type = raw.split(';').next().unwrap_or_default().trim();
     if media_type.is_empty() {
         return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
@@ -49,7 +49,7 @@ pub(crate) async fn read_limited_body(
     );
 
     while let Some(frame) = body.frame().await {
-        let frame = frame.map_err(|_| StatusCode::BAD_REQUEST)?;
+        let frame = frame.map_err(|_e| StatusCode::BAD_REQUEST)?;
         let Ok(chunk) = frame.into_data() else {
             continue;
         };

--- a/crates/logfwd-io/src/s3_input/client.rs
+++ b/crates/logfwd-io/src/s3_input/client.rs
@@ -171,9 +171,9 @@ impl S3Client {
     fn object_signing_path(&self, key: &str) -> String {
         let encoded = url_encode_path(key);
         if self.path_style {
-            format!("/{}/{}", self.bucket, encoded)
+            format!("/{}/{encoded}", self.bucket)
         } else {
-            format!("/{}", encoded)
+            format!("/{encoded}")
         }
     }
 
@@ -250,14 +250,13 @@ impl S3Client {
 
         let canonical_headers: String = headers.iter().fold(String::new(), |mut s, (k, v)| {
             use std::fmt::Write;
-            let _ = writeln!(s, "{}:{}", k, v);
+            let _ = writeln!(s, "{k}:{v}");
             s
         });
         let signed_headers: String = headers.keys().cloned().collect::<Vec<_>>().join(";");
 
         let canonical_request = format!(
-            "{}\n{}\n{}\n{}\n{}\n{}",
-            method, path, query, canonical_headers, signed_headers, body_sha256
+            "{method}\n{path}\n{query}\n{canonical_headers}\n{signed_headers}\n{body_sha256}"
         );
 
         let credential_scope = format!("{date}/{}/{service}/aws4_request", self.region);

--- a/crates/logfwd-io/src/s3_input/mod.rs
+++ b/crates/logfwd-io/src/s3_input/mod.rs
@@ -341,7 +341,7 @@ impl S3Input {
         let health = Arc::new(AtomicU8::new(ComponentHealth::Healthy.as_repr()));
         let is_running = Arc::new(AtomicBool::new(true));
 
-        let thread_name = format!("s3-input-{}", name);
+        let thread_name = format!("s3-input-{name}");
         let health_bg = Arc::clone(&health);
         let is_running_bg = Arc::clone(&is_running);
         let name_bg = name.clone();

--- a/crates/logfwd-io/src/s3_input/sqs.rs
+++ b/crates/logfwd-io/src/s3_input/sqs.rs
@@ -218,14 +218,12 @@ async fn sqs_post(
 
     let canonical_headers: String = cheaders.iter().fold(String::new(), |mut s, (k, v)| {
         use std::fmt::Write;
-        let _ = writeln!(s, "{}:{}", k, v);
+        let _ = writeln!(s, "{k}:{v}");
         s
     });
     let signed_headers: String = cheaders.keys().cloned().collect::<Vec<_>>().join(";");
-    let canonical_request = format!(
-        "POST\n{}\n\n{}\n{}\n{}",
-        path, canonical_headers, signed_headers, body_sha256
-    );
+    let canonical_request =
+        format!("POST\n{path}\n\n{canonical_headers}\n{signed_headers}\n{body_sha256}");
 
     let string_to_sign = format!(
         "AWS4-HMAC-SHA256\n{}\n{}\n{}",

--- a/crates/logfwd-io/src/tail/glob.rs
+++ b/crates/logfwd-io/src/tail/glob.rs
@@ -31,7 +31,7 @@ pub(super) fn glob_root(pattern: &str) -> PathBuf {
             PathBuf::from(trimmed)
         }
     } else {
-        let parent = Path::new(prefix).parent().unwrap_or(Path::new(""));
+        let parent = Path::new(prefix).parent().unwrap_or_else(|| Path::new(""));
         if parent.as_os_str().is_empty() {
             PathBuf::from(".")
         } else {

--- a/crates/logfwd-output/src/elasticsearch.rs
+++ b/crates/logfwd-output/src/elasticsearch.rs
@@ -1159,7 +1159,7 @@ impl ElasticsearchSink {
         let next_capacity = chunk.capacity().max(min_capacity);
         let body = std::mem::replace(chunk, Vec::with_capacity(next_capacity));
         tx.blocking_send(Ok(body))
-            .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "ES body receiver dropped"))
+            .map_err(|_e| io::Error::new(io::ErrorKind::BrokenPipe, "ES body receiver dropped"))
     }
 
     fn serialize_batch_streaming(
@@ -1572,10 +1572,8 @@ impl ElasticsearchSinkFactory {
         let client = client_builder.build().map_err(io::Error::other)?;
 
         let endpoint = endpoint.trim_end_matches('/').to_string();
-        let bulk_url = format!(
-            "{}/_bulk?filter_path=errors,took,items.*.error,items.*.status",
-            endpoint
-        );
+        let bulk_url =
+            format!("{endpoint}/_bulk?filter_path=errors,took,items.*.error,items.*.status");
 
         // Pre-compute the action line bytes once so serialize_batch doesn't have
         // to allocate a String on every call.

--- a/crates/logfwd-output/src/generated/otap_fast_v1.rs
+++ b/crates/logfwd-output/src/generated/otap_fast_v1.rs
@@ -21,7 +21,7 @@ fn varint_field_len(field_number: u32, value: u64) -> usize {
 /// Compute `next_pos + len` with overflow and bounds checks.
 fn checked_end(next_pos: usize, len: u64, data_len: usize) -> io::Result<usize> {
     let len = usize::try_from(len)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "field length exceeds address space"))?;
+        .map_err(|_e| io::Error::new(io::ErrorKind::InvalidData, "field length exceeds address space"))?;
     let end = next_pos
         .checked_add(len)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "field length overflow"))?;

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -494,7 +494,7 @@ impl LokiSink {
         let mut timestamp_state = self
             .last_timestamp_by_stream
             .lock()
-            .map_err(|_| io::Error::other("Loki timestamp state lock poisoned"))?;
+            .map_err(|_e| io::Error::other("Loki timestamp state lock poisoned"))?;
         let payloads = Self::prepare_payloads(stream_map, &timestamp_state, LOKI_MAX_PAYLOAD_BYTES);
         // Reserve before awaiting network IO so concurrent workers cannot prepare
         // overlapping timestamp ranges for the same Loki stream. A failed send may

--- a/crates/logfwd-output/src/otlp_sink.rs
+++ b/crates/logfwd-output/src/otlp_sink.rs
@@ -1665,7 +1665,7 @@ fn encode_key_value_bool(buf: &mut Vec<u8>, field_number: u32, key: &[u8], value
 /// [N bytes: protobuf message]
 /// ```
 fn write_grpc_frame(buf: &mut Vec<u8>, payload: &[u8], compressed: bool) -> io::Result<()> {
-    let len = u32::try_from(payload.len()).map_err(|_| {
+    let len = u32::try_from(payload.len()).map_err(|_e| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
             "gRPC message payload must be < 4 GiB",

--- a/crates/logfwd-output/src/row_json.rs
+++ b/crates/logfwd-output/src/row_json.rs
@@ -109,7 +109,7 @@ pub(crate) fn write_json_string(out: &mut Vec<u8>, v: &str) -> io::Result<()> {
             b'\n' => out.extend_from_slice(b"\\n"),
             b'\r' => out.extend_from_slice(b"\\r"),
             b'\t' => out.extend_from_slice(b"\\t"),
-            b => Write::write_fmt(out, format_args!("\\u{:04x}", b))?,
+            b => Write::write_fmt(out, format_args!("\\u{b:04x}"))?,
         }
         start += rel_pos + 1;
     }

--- a/crates/logfwd-output/src/sink.rs
+++ b/crates/logfwd-output/src/sink.rs
@@ -566,7 +566,7 @@ impl SinkFactory for OnceAsyncFactory {
         let mut guard = self
             .inner
             .lock()
-            .map_err(|_| io::Error::other("OnceAsyncFactory mutex poisoned"))?;
+            .map_err(|_e| io::Error::other("OnceAsyncFactory mutex poisoned"))?;
         match guard.take() {
             Some(s) => Ok(s),
             None => Err(io::Error::other(

--- a/crates/logfwd-output/src/stdout.rs
+++ b/crates/logfwd-output/src/stdout.rs
@@ -197,7 +197,7 @@ impl StdoutSink {
                 if !col.is_null(row) {
                     let ts = safe_col_to_string(col, row);
                     // Show just the time portion if it's a full ISO timestamp.
-                    let short = ts.find('T').map_or(ts.as_ref(), |i| &ts[i + 1..]);
+                    let short = ts.find('T').map_or_else(|| ts.as_ref(), |i| &ts[i + 1..]);
                     if self.color {
                         self.buf.extend_from_slice(b"\x1b[2m");
                     }
@@ -225,7 +225,7 @@ impl StdoutSink {
                         self.buf.extend_from_slice(color.as_bytes());
                     }
                     // Pad to 5 chars for alignment.
-                    write!(self.buf, "{:<5}", level)?;
+                    write!(self.buf, "{level:<5}")?;
                     if self.color {
                         self.buf.extend_from_slice(b"\x1b[0m");
                     }

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -158,7 +158,7 @@ impl Pipeline {
                                                     .map(|db| Arc::new(db) as Arc<dyn crate::transform::enrichment::GeoDatabase>)
                                                     .map_err(|e| e.to_string())
                                             }
-                                            _ => Err(format!("unsupported geo database format for reload: {:?}", fmt)),
+                                            _ => Err(format!("unsupported geo database format for reload: {fmt:?}")),
                                         }
                                     })
                                     .await;
@@ -513,7 +513,7 @@ impl Pipeline {
                 for table in &enrichment_tables {
                     transform
                         .add_enrichment_table(Arc::clone(table))
-                        .map_err(|e| format!("input '{}': enrichment error: {e}", input_name))?;
+                        .map_err(|e| format!("input '{input_name}': enrichment error: {e}"))?;
                 }
             }
 

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -44,8 +44,7 @@ fn make_format(
         Format::Raw => FormatDecoder::passthrough(Arc::clone(stats)),
         unsupported => {
             return Err(format!(
-                "input '{name}': format {:?} is not supported for {:?} inputs",
-                unsupported, input_type
+                "input '{name}': format {unsupported:?} is not supported for {input_type:?} inputs"
             ));
         }
     };
@@ -58,14 +57,12 @@ fn validate_input_format(name: &str, input_type: InputType, format: &Format) -> 
             if !matches!(format, Format::Json) =>
         {
             return Err(format!(
-                "input '{name}': format {:?} is not supported for {:?} inputs (expected json)",
-                format, input_type
+                "input '{name}': format {format:?} is not supported for {input_type:?} inputs (expected json)"
             ));
         }
         InputType::Http if !matches!(format, Format::Json | Format::Raw) => {
             return Err(format!(
-                "input '{name}': format {:?} is not supported for {:?} inputs (expected json or raw)",
-                format, input_type
+                "input '{name}': format {format:?} is not supported for {input_type:?} inputs (expected json or raw)"
             ));
         }
         InputType::Stdin
@@ -75,8 +72,7 @@ fn validate_input_format(name: &str, input_type: InputType, format: &Format) -> 
             ) =>
         {
             return Err(format!(
-                "input '{name}': format {:?} is not supported for {:?} inputs (expected cri, auto, json, or raw)",
-                format, input_type
+                "input '{name}': format {format:?} is not supported for {input_type:?} inputs (expected cri, auto, json, or raw)"
             ));
         }
         _ => {}
@@ -266,7 +262,7 @@ pub(super) fn build_input_state(
                                 Some(s) if s.eq_ignore_ascii_case("now") => {
                                     std::time::SystemTime::now()
                                         .duration_since(std::time::UNIX_EPOCH)
-                                        .map_err(|_| {
+                                        .map_err(|_e| {
                                             format!("input '{name}': system clock is before Unix epoch, cannot resolve timestamp.start=\"now\"")
                                         })?
                                         .as_millis() as i64

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -596,7 +596,7 @@ fn source_path_metadata_array(
         let (block, len) = if let Some(&(block, len)) = blocks.get(&source_id) {
             (block, len)
         } else {
-            let len = u32::try_from(value.len()).map_err(|_| {
+            let len = u32::try_from(value.len()).map_err(|_e| {
                 ArrowError::InvalidArgumentError(
                     "source metadata string is too large for Utf8View".to_string(),
                 )

--- a/crates/logfwd-runtime/src/processor/blocklist.rs
+++ b/crates/logfwd-runtime/src/processor/blocklist.rs
@@ -135,14 +135,11 @@ impl Processor for BlocklistProcessor {
         }
 
         // Locate the source column.
-        let col = match batch.column_by_name(&self.source_column) {
-            Some(c) => c,
-            None => {
-                return Err(ProcessorError::Permanent(format!(
-                    "blocklist: source column '{}' not found in batch",
-                    self.source_column
-                )));
-            }
+        let Some(col) = batch.column_by_name(&self.source_column) else {
+            return Err(ProcessorError::Permanent(format!(
+                "blocklist: source column '{}' not found in batch",
+                self.source_column
+            )));
         };
 
         let mut match_builder = BooleanBuilder::with_capacity(num_rows);

--- a/crates/logfwd-runtime/src/processor/http_enrich.rs
+++ b/crates/logfwd-runtime/src/processor/http_enrich.rs
@@ -241,10 +241,9 @@ impl HttpEnrichProcessor {
                         .take(limit.saturating_add(1))
                         .read_to_string(&mut buf)
                     {
-                        Ok(n) if n as u64 > limit => LookupResult::Error(format!(
-                            "response body exceeds {} byte limit",
-                            limit
-                        )),
+                        Ok(n) if n as u64 > limit => {
+                            LookupResult::Error(format!("response body exceeds {limit} byte limit"))
+                        }
                         Ok(_) if buf.trim().is_empty() => LookupResult::Miss,
                         Ok(_) => {
                             let trimmed = buf.trim_start();

--- a/crates/logfwd-test-utils/src/json.rs
+++ b/crates/logfwd-test-utils/src/json.rs
@@ -32,7 +32,7 @@ pub fn arb_json_string() -> impl Strategy<Value = String> {
 /// Generate a simple JSON value (no nested objects — avoids recursive types).
 pub fn arb_json_value_simple() -> impl Strategy<Value = String> {
     prop_oneof![
-        40 => arb_json_string().prop_map(|s| format!("\"{}\"", s)),
+        40 => arb_json_string().prop_map(|s| format!("\"{s}\"")),
         20 => (-1_000_000i64..1_000_000).prop_map(|n| n.to_string()),
         10 => (-1.0e6f64..1.0e6).prop_filter("finite", |f| f.is_finite())
             .prop_map(|f| format!("{f}")),
@@ -40,7 +40,7 @@ pub fn arb_json_value_simple() -> impl Strategy<Value = String> {
         5 => Just("null".to_string()),
         15 => prop::collection::vec(
             prop_oneof![
-                arb_json_string().prop_map(|s| format!("\"{}\"", s)),
+                arb_json_string().prop_map(|s| format!("\"{s}\"")),
                 (-100i64..100).prop_map(|n| n.to_string()),
                 Just("null".to_string()),
             ],
@@ -60,7 +60,7 @@ pub fn arb_flat_object(
     .prop_map(|fields| {
         let pairs: Vec<String> = fields
             .into_iter()
-            .map(|(k, v)| format!("\"{}\":{}", k, v))
+            .map(|(k, v)| format!("\"{k}\":{v}"))
             .collect();
         format!("{{{}}}", pairs.join(","))
     })

--- a/crates/logfwd-transform/src/udf/geo_lookup.rs
+++ b/crates/logfwd-transform/src/udf/geo_lookup.rs
@@ -320,9 +320,8 @@ fn build_struct_array(
     mut asn: Int64Builder,
     mut org: StringBuilder,
 ) -> StructArray {
-    let fields = match geo_result_type() {
-        DataType::Struct(f) => f,
-        _ => unreachable!(),
+    let DataType::Struct(fields) = geo_result_type() else {
+        unreachable!()
     };
     let arrays: Vec<ArrayRef> = vec![
         Arc::new(country_code.finish()),
@@ -339,9 +338,8 @@ fn build_struct_array(
 
 /// Convert a single `GeoResult` into a DataFusion `ScalarValue::Struct`.
 fn geo_result_to_scalar(result: Option<&GeoResult>) -> DfResult<datafusion::common::ScalarValue> {
-    let fields = match geo_result_type() {
-        DataType::Struct(f) => f,
-        _ => unreachable!(),
+    let DataType::Struct(fields) = geo_result_type() else {
+        unreachable!()
     };
 
     let utf8 = |v: Option<&String>| datafusion::common::ScalarValue::Utf8(v.cloned());

--- a/crates/logfwd-transform/src/udf/grok.rs
+++ b/crates/logfwd-transform/src/udf/grok.rs
@@ -153,7 +153,7 @@ impl GrokUdf {
 
     fn get_or_compile_grok(&self, pattern: &str) -> DfResult<Arc<CompiledGrok>> {
         {
-            let mut cache = self.grok_cache.lock().map_err(|_| {
+            let mut cache = self.grok_cache.lock().map_err(|_e| {
                 datafusion::error::DataFusionError::Execution(
                     "grok() internal cache lock poisoned".to_string(),
                 )
@@ -168,7 +168,7 @@ impl GrokUdf {
                 datafusion::error::DataFusionError::Execution(format!("grok: {e}"))
             })?);
 
-        let mut cache = self.grok_cache.lock().map_err(|_| {
+        let mut cache = self.grok_cache.lock().map_err(|_e| {
             datafusion::error::DataFusionError::Execution(
                 "grok() internal cache lock poisoned".to_string(),
             )

--- a/crates/logfwd-transform/src/udf/hash.rs
+++ b/crates/logfwd-transform/src/udf/hash.rs
@@ -127,8 +127,7 @@ impl ScalarUDFImpl for HashUdf {
                     }
                     _ => {
                         return Err(datafusion::error::DataFusionError::Execution(format!(
-                            "hash() expected string argument, got {:?}",
-                            dt
+                            "hash() expected string argument, got {dt:?}"
                         )));
                     }
                 };

--- a/crates/logfwd-transform/src/udf/json_extract.rs
+++ b/crates/logfwd-transform/src/udf/json_extract.rs
@@ -211,8 +211,7 @@ impl ScalarUDFImpl for JsonExtractUdf {
 
         if args.args.len() != 2 {
             return Err(DataFusionError::Execution(format!(
-                "{}() expects exactly two arguments",
-                udf_name
+                "{udf_name}() expects exactly two arguments"
             )));
         }
 

--- a/crates/logfwd-transform/src/udf/regexp_extract.rs
+++ b/crates/logfwd-transform/src/udf/regexp_extract.rs
@@ -117,7 +117,7 @@ impl RegexpExtractUdf {
 
     fn get_or_compile_regex(&self, pattern: &str) -> DfResult<Arc<Regex>> {
         {
-            let mut cache = self.regex_cache.lock().map_err(|_| {
+            let mut cache = self.regex_cache.lock().map_err(|_e| {
                 datafusion::error::DataFusionError::Execution(
                     "regexp_extract() internal cache lock poisoned".to_string(),
                 )
@@ -129,12 +129,11 @@ impl RegexpExtractUdf {
 
         let compiled = Arc::new(Regex::new(pattern).map_err(|e| {
             datafusion::error::DataFusionError::Execution(format!(
-                "regexp_extract: invalid pattern '{}': {}",
-                pattern, e
+                "regexp_extract: invalid pattern '{pattern}': {e}"
             ))
         })?);
 
-        let mut cache = self.regex_cache.lock().map_err(|_| {
+        let mut cache = self.regex_cache.lock().map_err(|_e| {
             datafusion::error::DataFusionError::Execution(
                 "regexp_extract() internal cache lock poisoned".to_string(),
             )

--- a/crates/logfwd/src/main.rs
+++ b/crates/logfwd/src/main.rs
@@ -833,7 +833,7 @@ async fn cmd_blast(mut args: BlastArgs) -> Result<(), CliError> {
         args.batch_lines
     );
     match args.duration_secs {
-        Some(duration) => println!("duration={}s", duration),
+        Some(duration) => println!("duration={duration}s"),
         None => println!("duration=until-stopped (Ctrl-C)"),
     }
     if let Some(endpoint) = &args.endpoint {
@@ -878,7 +878,7 @@ async fn cmd_devour(args: DevourArgs) -> Result<(), CliError> {
     println!("dropping all received data (blackhole mode)");
     println!("diagnostics={}", args.diagnostics_addr);
     if let Some(duration) = args.duration_secs {
-        println!("duration={}s", duration);
+        println!("duration={duration}s");
     }
 
     let generated = logfwd_runtime::generated_cli::build_devour_generated_config(
@@ -947,10 +947,10 @@ fn maybe_prompt_blast_setup(args: &mut BlastArgs) -> Result<(), CliError> {
 
     args.workers = prompt_text("Workers", &args.workers.to_string())?
         .parse::<usize>()
-        .map_err(|_| CliError::Config("Workers must be a positive integer".to_owned()))?;
+        .map_err(|_e| CliError::Config("Workers must be a positive integer".to_owned()))?;
     args.batch_lines = prompt_text("Batch lines", &args.batch_lines.to_string())?
         .parse::<usize>()
-        .map_err(|_| CliError::Config("Batch lines must be a positive integer".to_owned()))?;
+        .map_err(|_e| CliError::Config("Batch lines must be a positive integer".to_owned()))?;
     let duration_default = args
         .duration_secs
         .map(|v| v.to_string())
@@ -962,7 +962,7 @@ fn maybe_prompt_blast_setup(args: &mut BlastArgs) -> Result<(), CliError> {
     args.duration_secs = if duration_raw.trim().is_empty() {
         None
     } else {
-        Some(duration_raw.parse::<u64>().map_err(|_| {
+        Some(duration_raw.parse::<u64>().map_err(|_e| {
             CliError::Config("Duration seconds must be a positive integer".to_owned())
         })?)
     };
@@ -1909,11 +1909,11 @@ fn validate_pipeline_read_only(
             for table in &enrichment_tables {
                 transform
                     .add_enrichment_table(Arc::clone(table))
-                    .map_err(|e| format!("input '{}': enrichment error: {e}", input_name))?;
+                    .map_err(|e| format!("input '{input_name}': enrichment error: {e}"))?;
             }
         }
         validate_transform_probe_read_only(&mut transform)
-            .map_err(|e| format!("input '{}': {e}", input_name))?;
+            .map_err(|e| format!("input '{input_name}': {e}"))?;
     }
 
     Ok(())
@@ -1942,8 +1942,7 @@ fn validate_input_format_read_only(
                 "validate_input_format_read_only: unhandled input type {other:?} for input {name}"
             );
             return Err(format!(
-                "input '{name}': type {:?} is not yet supported in read-only validation",
-                other
+                "input '{name}': type {other:?} is not yet supported in read-only validation"
             ));
         }
     };
@@ -1953,8 +1952,7 @@ fn validate_input_format_read_only(
     }
 
     Err(format!(
-        "input '{name}': format {:?} is not supported for {:?} inputs",
-        format, input_type
+        "input '{name}': format {format:?} is not supported for {input_type:?} inputs"
     ))
 }
 

--- a/dev-docs/CODE_STYLE.md
+++ b/dev-docs/CODE_STYLE.md
@@ -90,8 +90,9 @@ overrides — adjust the workspace config instead.
   and would force stylistic churn with negligible correctness gain.
 - **Modernization + easy-win lints** (all warn workspace-wide):
   - `uninlined_format_args`, `redundant_else`,
-    `semicolon_if_nothing_returned` — modernize syntax, all
-    `cargo clippy --fix`-able.
+    `semicolon_if_nothing_returned` — modernize syntax. Auto-apply
+    via `cargo clippy --fix --workspace --allow-dirty`, then verify
+    with `just lint`.
   - `map_err_ignore` — flags `.map_err(|_| …)` which drops the
     original error. Use `.map_err(|_e| …)` if the drop is intentional,
     or preserve the source via `thiserror #[source]`.
@@ -252,10 +253,12 @@ Pick the one that reads straightest for the specific control flow:
   pull long arms into named helper functions.
 
 Auto-fix hint: `clippy::manual_let_else` fires on the "old" idiom
-`let x = match … { Some(v) => v, None => return };`. The fix is
-mechanical; apply via `cargo clippy --fix`. (This lint is currently
-allowed workspace-wide because some call sites use `Err(e)` bindings
-that don't translate cleanly.)
+`let x = match … { Some(v) => v, None => return };`. Apply via
+`cargo clippy --fix --workspace --allow-dirty`, then verify with
+`just lint`. (This lint is currently allowed workspace-wide because
+some call sites use `Err(e)` bindings that don't translate cleanly,
+and because the auto-fix does not apply inside `logfwd-core` where
+changes must be re-verified through the Kani proof pipeline.)
 
 ## Unsafe Code
 

--- a/dev-docs/CODE_STYLE.md
+++ b/dev-docs/CODE_STYLE.md
@@ -88,6 +88,19 @@ overrides — adjust the workspace config instead.
   or `clippy::must_use_candidate` — both flag the canonical
   `let _ = write!(buf, ...)` and `let _ = sender.send(...)` patterns,
   and would force stylistic churn with negligible correctness gain.
+- **Modernization + easy-win lints** (all warn workspace-wide):
+  - `uninlined_format_args`, `redundant_else`,
+    `semicolon_if_nothing_returned` — modernize syntax, all
+    `cargo clippy --fix`-able.
+  - `map_err_ignore` — flags `.map_err(|_| …)` which drops the
+    original error. Use `.map_err(|_e| …)` if the drop is intentional,
+    or preserve the source via `thiserror #[source]`.
+  - `implicit_clone` — prefer `.clone()` over `.to_owned()` on
+    `Clone` types for clarity.
+  - `needless_for_each` — prefer `for x in …` over `.for_each(|x| …)`.
+  - `or_fun_call` — `.unwrap_or(expensive())` → `.unwrap_or_else(|| …)`.
+  - `checked_conversions` — nudges `i32::try_from(x)` over `x as i32`
+    at fallible boundaries.
 - **overflow-checks** are enabled in release builds.
 
 All lint levels live at the workspace root or as file-level
@@ -197,12 +210,52 @@ for installation and the roadmap for additional lints
   ability to recover.
 - **Public APIs:** return `Result`, never `panic!` or `assert!` on user input
 - **Internal invariants:** `debug_assert!` for programmer errors, not `assert!`
-- **Error messages:** include context — `"failed to open {path}: {err}"` not `"IO error"`
+- **Error messages** follow a fixed shape so they read consistently in
+  logs and diagnostics output:
+  - Lowercase first word, no trailing period.
+  - Verb phrase naming the operation that failed, then a colon, then
+    the source: `"failed to open {path}: {err}"`, not `"IO error"` or
+    `"Cannot open file."`.
+  - Include every piece of context a reader needs to identify the
+    failing resource without grepping other fields: path, index,
+    component name, configured field name. `"input '{name}': format
+    {format:?} is not supported for {input_type:?} inputs"` is the
+    style — noun-phrase quoting around user-supplied names, `{:?}`
+    for type tags, fully-qualified in the message.
+  - If you use `map_err(|_| ...)` and discard the source, clippy
+    (`map_err_ignore`) will flag it. Either preserve the source
+    (`.map_err(|e| MyError::Kind { source: e })`) or rename the closure
+    argument to `|_e|` to signal "yes, we intentionally dropped it."
 - **No `unwrap()` in production paths.** Use `?` or `.expect("reason")`.
   Every surviving `expect` must name the invariant that makes it safe
   (`"config schema guarantees at least one input"`), not just restate the
   call.
 - **Sentinel values:** use `Option` instead of magic values (0, -1, empty string)
+
+## Match Ergonomics
+
+Rust 2024 gives us three forms for the same pattern-matching idea.
+Pick the one that reads straightest for the specific control flow:
+
+- **`let … else { diverging }`** — when the happy path is the body of
+  the function and the alternative diverges (`return`, `break`,
+  `continue`, `panic!`, `std::process::exit`). Prefer this over
+  `match` when the failure case is a one-liner.
+  ```rust
+  let Some(value) = parse(input) else { return Err(ParseError::Missing) };
+  ```
+- **`if let Some(v) = opt { … }`** — when only the `Some`/`Ok` arm
+  needs action and the `None`/`Err` arm is a no-op. Avoids the noise
+  of a match with an empty arm.
+- **`match`** — when both arms have non-trivial logic, or when you
+  need to match on more than two discriminants. Keep match arms short;
+  pull long arms into named helper functions.
+
+Auto-fix hint: `clippy::manual_let_else` fires on the "old" idiom
+`let x = match … { Some(v) => v, None => return };`. The fix is
+mechanical; apply via `cargo clippy --fix`. (This lint is currently
+allowed workspace-wide because some call sites use `Err(e)` bindings
+that don't translate cleanly.)
 
 ## Unsafe Code
 


### PR DESCRIPTION
## Summary

Enable 8 easy-win clippy lints workspace-wide, sweep the codebase to pass them, and add two small doc sections the lints earn their own place in.

Branched off `main` — no dependency on the in-flight dylint PR stack.

### Lints added (all `warn` in `[workspace.lints.clippy]`)

**Modernization (auto-fixable):**
- `uninlined_format_args` — `format!("{}", x)` → `format!("{x}")`
- `redundant_else` — removes diverging `else` blocks
- `semicolon_if_nothing_returned` — stylistic consistency

**Correctness-leaning:**
- `map_err_ignore` — flags `.map_err(|_| const)` that drops the original error. Normalized 52 sites to `|_e|` to signal the drop is intentional. Broader `#[source]` threading is a separate cleanup.
- `implicit_clone` — `.to_owned()` on `Clone` types becomes `.clone()`.
- `needless_for_each` — prefers `for x in …` over `.for_each(|x| …)`.
- `or_fun_call` — `.unwrap_or(expensive())` → `.unwrap_or_else(|| …)`. Fixed 3 real perf footguns.
- `checked_conversions` — nudges `TryFrom` over `as` at fallible boundaries.

**Deliberately skipped:** `manual_let_else` (`allow` retained). The auto-fix cascades into nested matches and the clear-win profile broke down. Handful of obvious sites modernized opportunistically while fixing the others.

### Fallout

~100 source sites updated across ~50 files — mostly `format!` modernization and the `.map_err(|_|)` → `|_e|` pass. No behavior changes. All workspace clippy, fmt, and CI boundary guards pass.

### Docs

**CODE_STYLE.md:**
- New "Match Ergonomics" section — when `let else` wins, when `if let` wins, when `match` is still the right tool.
- Expanded the "Error messages" bullet with the fixed shape (lowercase, no trailing period, noun-phrase quoting, `map_err_ignore` ↔ `|_e|` convention).
- Workspace Lint Policy bullet listing the newly-enabled lints.

**DEVELOPING.md:**
- New "Test filtering and proptest regressions" section — `cargo nextest run -p X --lib <pattern>`, `PROPTEST_CASES=N`, how proptest regression files work, `TURMOIL_SEED` for sim reproduction.
- New "Reading criterion benchmark output" section — which files matter, noise-floor guidance (~2%), what to quote in perf PRs.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo build --workspace`
- [x] Both CI boundary guards (`check_no_box_dyn_error.py`, `check_no_panic_in_production.py`) pass

https://claude.ai/code/session_01UTbyxBK17YiHB1rn4zZrWL

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable workspace-wide clippy lints for format strings, let-else, and error handling patterns
> - Adds clippy lint warnings to [Cargo.toml](https://github.com/strawgate/fastforward/pull/2439/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) for `uninlined_format_args`, `map_err_ignore`, `redundant_else`, `or_fun_call`, `implicit_clone`, and related easy-win lints workspace-wide.
> - Fixes all resulting lint violations across the codebase: converts positional `format!` arguments to captured-identifier style (e.g. `{foo}` instead of `{}`, foo`), renames ignored `|_|` error bindings to `|_e|`, and rewrites `match` blocks to `let-else` where appropriate.
> - Expands [dev-docs/CODE_STYLE.md](https://github.com/strawgate/fastforward/pull/2439/files#diff-80c749ea489e35f69a21613f5f898a6f1d768983cc416a221ea5179d0499b2c4) with sections on these lint patterns and error message style guidance, and adds developer guidance to [DEVELOPING.md](https://github.com/strawgate/fastforward/pull/2439/files#diff-8822179a8da757fde968cf80a9162e1c1d6f8cc170509cfbdea10be03b7e7d20) for test filtering and benchmark interpretation.
> - No logic or runtime behavior changes; all edits are purely stylistic or structural.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84e9af4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->