### PR TITLE
bench: cover complex OTLP projection profiles

### DIFF
--- a/crates/logfwd-bench/benches/otlp_io.rs
+++ b/crates/logfwd-bench/benches/otlp_io.rs
@@ -71,32 +71,24 @@ fn build_fixture(profile: OtlpFixtureProfile) -> FixtureData {
     assert_encode_paths_match(&projected_fallback_batch, profile.name);
     let zstd_payload =
         zstd::encode_all(otlp_data.payload.as_slice(), 1).expect("fixture should zstd compress");
-    let mut projected_batch = None;
-    let mut projected_view_batch = None;
-    if !profile.has_complex_any {
-        let wire_batch =
-            decode_protobuf_to_batch_projected_detached_experimental(&otlp_data.payload)
-                .expect("experimental wire decoder should decode primitive fixture");
-        assert_batch_matches(&prost_reference_batch, &wire_batch, profile.name);
-        assert_encode_paths_match(&wire_batch, profile.name);
-        let view_batch = decode_protobuf_bytes_to_batch_projected_only_experimental(
-            otlp_data.payload_bytes.clone(),
-        )
-        .expect("experimental wire view decoder should decode primitive fixture");
-        let detached_view_batch = logfwd_arrow::materialize::detach(&view_batch);
-        assert_batch_matches(&prost_reference_batch, &detached_view_batch, profile.name);
-        assert_encode_paths_match(&view_batch, profile.name);
-        projected_batch = Some(wire_batch);
-        projected_view_batch = Some(view_batch);
-    }
+    let wire_batch = decode_protobuf_to_batch_projected_detached_experimental(&otlp_data.payload)
+        .expect("experimental wire decoder should decode fixture");
+    assert_batch_matches(&prost_reference_batch, &wire_batch, profile.name);
+    assert_encode_paths_match(&wire_batch, profile.name);
+    let view_batch =
+        decode_protobuf_bytes_to_batch_projected_only_experimental(otlp_data.payload_bytes.clone())
+            .expect("experimental wire view decoder should decode fixture");
+    let detached_view_batch = logfwd_arrow::materialize::detach(&view_batch);
+    assert_batch_matches(&prost_reference_batch, &detached_view_batch, profile.name);
+    assert_encode_paths_match(&view_batch, profile.name);
     FixtureData {
         profile,
         payload: otlp_data.payload,
         payload_bytes: otlp_data.payload_bytes,
         zstd_payload,
         production_batch,
-        projected_batch,
-        projected_view_batch,
+        projected_batch: Some(wire_batch),
+        projected_view_batch: Some(view_batch),
         projected_fallback_batch,
     }
 }
@@ -286,34 +278,30 @@ fn bench_decode_materialize(c: &mut Criterion) {
             },
         );
 
-        if !fixture.profile.has_complex_any {
-            group.bench_with_input(
-                BenchmarkId::new("projected_detached_to_batch", fixture.profile.name),
-                &fixture.payload,
-                |b, payload| {
-                    b.iter(|| {
-                        let batch =
-                            decode_protobuf_to_batch_projected_detached_experimental(payload)
-                                .expect("experimental wire decoder should decode fixture");
-                        std::hint::black_box(batch.num_rows());
-                    });
-                },
-            );
+        group.bench_with_input(
+            BenchmarkId::new("projected_detached_to_batch", fixture.profile.name),
+            &fixture.payload,
+            |b, payload| {
+                b.iter(|| {
+                    let batch = decode_protobuf_to_batch_projected_detached_experimental(payload)
+                        .expect("experimental wire decoder should decode fixture");
+                    std::hint::black_box(batch.num_rows());
+                });
+            },
+        );
 
-            group.bench_with_input(
-                BenchmarkId::new("projected_view_to_batch", fixture.profile.name),
-                &fixture.payload_bytes,
-                |b, payload| {
-                    b.iter(|| {
-                        let batch = decode_protobuf_bytes_to_batch_projected_only_experimental(
-                            payload.clone(),
-                        )
-                        .expect("experimental wire view decoder should decode fixture");
-                        std::hint::black_box(batch.num_rows());
-                    });
-                },
-            );
-        }
+        group.bench_with_input(
+            BenchmarkId::new("projected_view_to_batch", fixture.profile.name),
+            &fixture.payload_bytes,
+            |b, payload| {
+                b.iter(|| {
+                    let batch =
+                        decode_protobuf_bytes_to_batch_projected_only_experimental(payload.clone())
+                            .expect("experimental wire view decoder should decode fixture");
+                    std::hint::black_box(batch.num_rows());
+                });
+            },
+        );
     }
 
     group.finish();
@@ -585,41 +573,37 @@ fn bench_end_to_end(c: &mut Criterion) {
             },
         );
 
-        if !fixture.profile.has_complex_any {
-            group.bench_with_input(
-                BenchmarkId::new(
-                    "projected_detached_to_handwritten_encode",
-                    fixture.profile.name,
-                ),
-                &fixture.payload,
-                |b, payload| {
-                    let mut sink = make_otlp_sink(Compression::None);
-                    b.iter(|| {
-                        let batch =
-                            decode_protobuf_to_batch_projected_detached_experimental(payload)
-                                .expect("experimental wire decoder should decode fixture");
-                        sink.encode_batch(&batch, &metadata);
-                        std::hint::black_box(sink.encoded_payload().len());
-                    });
-                },
-            );
+        group.bench_with_input(
+            BenchmarkId::new(
+                "projected_detached_to_handwritten_encode",
+                fixture.profile.name,
+            ),
+            &fixture.payload,
+            |b, payload| {
+                let mut sink = make_otlp_sink(Compression::None);
+                b.iter(|| {
+                    let batch = decode_protobuf_to_batch_projected_detached_experimental(payload)
+                        .expect("experimental wire decoder should decode fixture");
+                    sink.encode_batch(&batch, &metadata);
+                    std::hint::black_box(sink.encoded_payload().len());
+                });
+            },
+        );
 
-            group.bench_with_input(
-                BenchmarkId::new("projected_view_to_handwritten_encode", fixture.profile.name),
-                &fixture.payload_bytes,
-                |b, payload| {
-                    let mut sink = make_otlp_sink(Compression::None);
-                    b.iter(|| {
-                        let batch = decode_protobuf_bytes_to_batch_projected_only_experimental(
-                            payload.clone(),
-                        )
-                        .expect("experimental wire view decoder should decode fixture");
-                        sink.encode_batch(&batch, &metadata);
-                        std::hint::black_box(sink.encoded_payload().len());
-                    });
-                },
-            );
-        }
+        group.bench_with_input(
+            BenchmarkId::new("projected_view_to_handwritten_encode", fixture.profile.name),
+            &fixture.payload_bytes,
+            |b, payload| {
+                let mut sink = make_otlp_sink(Compression::None);
+                b.iter(|| {
+                    let batch =
+                        decode_protobuf_bytes_to_batch_projected_only_experimental(payload.clone())
+                            .expect("experimental wire view decoder should decode fixture");
+                    sink.encode_batch(&batch, &metadata);
+                    std::hint::black_box(sink.encoded_payload().len());
+                });
+            },
+        );
     }
 
     group.finish();

--- a/crates/logfwd-bench/src/bin/otlp_io_profile.rs
+++ b/crates/logfwd-bench/src/bin/otlp_io_profile.rs
@@ -498,20 +498,16 @@ fn build_fixture(profile: OtlpFixtureProfile) -> FixtureData {
     let detached_projected_fallback = logfwd_arrow::materialize::detach(&projected_fallback);
     assert_batch_matches(&batch, &detached_projected_fallback, profile.name);
     assert_encode_paths_match(&projected_fallback, profile.name);
-    if !profile.has_complex_any {
-        let projected =
-            decode_protobuf_to_batch_projected_detached_experimental(&otlp_data.payload)
-                .expect("projected fixture decodes");
-        assert_batch_matches(&batch, &projected, profile.name);
-        assert_encode_paths_match(&projected, profile.name);
-        let view = decode_protobuf_bytes_to_batch_projected_only_experimental(
-            otlp_data.payload_bytes.clone(),
-        )
-        .expect("view fixture decodes");
-        let detached_view = logfwd_arrow::materialize::detach(&view);
-        assert_batch_matches(&batch, &detached_view, profile.name);
-        assert_encode_paths_match(&view, profile.name);
-    }
+    let projected = decode_protobuf_to_batch_projected_detached_experimental(&otlp_data.payload)
+        .expect("projected fixture decodes");
+    assert_batch_matches(&batch, &projected, profile.name);
+    assert_encode_paths_match(&projected, profile.name);
+    let view =
+        decode_protobuf_bytes_to_batch_projected_only_experimental(otlp_data.payload_bytes.clone())
+            .expect("view fixture decodes");
+    let detached_view = logfwd_arrow::materialize::detach(&view);
+    assert_batch_matches(&batch, &detached_view, profile.name);
+    assert_encode_paths_match(&view, profile.name);
 
     let zstd_payload =
         zstd::encode_all(otlp_data.payload.as_slice(), 1).expect("fixture zstd compresses");


### PR DESCRIPTION
## Summary

- Validate projected detached/view OTLP decode for complex `AnyValue` fixtures in the benchmark setup.
- Include complex `AnyValue` fixtures in `otlp_input_decode_materialize` projected detached/view Criterion cases instead of skipping them.
- Include complex `AnyValue` fixtures in the `otlp_io_profile` release profiling binary parity checks.

## Validation

- `cargo fmt --check -p logfwd-bench`
- `cargo check -p logfwd-bench --bin otlp_io_profile --bench otlp_io`
- `cargo clippy -p logfwd-bench --bin otlp_io_profile --bench otlp_io -- -D warnings`

## Profile Results

Release-mode `otlp_io_profile`, `complex-anyvalue`, 100 iterations, 200,000 rows total. Environment: Darwin arm64, Apple M4.

| Mode | Elapsed | ns/row | vs production |
| --- | ---: | ---: | ---: |
| `prost_reference_to_batch` | 1149.928 ms | 5749.6 | 36.1% faster |
| `production_current_to_batch` | 1798.263 ms | 8991.3 | baseline |
| `projected_detached_to_batch` | 1153.593 ms | 5768.0 | 35.9% faster |
| `projected_view_to_batch` | 929.315 ms | 4646.6 | 48.3% faster |
| `projected_fallback_to_batch` | 1054.809 ms | 5274.0 | 41.3% faster |

Notes:

- These are release profile timings from the repo profile binary, not Criterion statistics.
- Allocation counters are zero because `otlp-profile-alloc` was not enabled for this run.
- `cargo bench -p logfwd-bench --bench otlp_io -- otlp_input_decode_materialize` still tries to compile unrelated bench-crate binaries on this workspace; that is separate bench harness cleanup work.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cover complex OTLP projection profiles in bench fixtures and benchmark suites
> - Removes the `has_complex_any` guard in `build_fixture` in both [otlp_io.rs](https://github.com/strawgate/fastforward/pull/2440/files#diff-2b94a188409548d0ab41bdf5b456128dcd109a21ff082e68a68470abfa9e0bb0) and [otlp_io_profile.rs](https://github.com/strawgate/fastforward/pull/2440/files#diff-4632d75c09da49be46a9a165529e968a190a39e9350a1addcfdbd702e225cc71), so projected-detached and projected-view decoding always runs for every profile.
> - `bench_decode_materialize` and `bench_end_to_end` now always register and run `projected_detached_to_batch`, `projected_view_to_batch`, and their encode counterparts for all profiles.
> - Risk: fixture construction and benchmarks will panic if `decode_protobuf_to_batch_projected_detached_experimental` or `decode_protobuf_bytes_to_batch_projected_only_experimental` fail for any profile, including those with complex Any fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d172f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->