### PR TITLE
bench: gate logfwd bench profiling binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3143,7 +3143,6 @@ dependencies = [
 name = "logfwd-lint-attrs"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +676,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +717,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1945,6 +1987,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2614,6 +2657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +2982,7 @@ dependencies = [
  "logfwd-types",
  "memchr",
  "opentelemetry-proto",
+ "parquet",
  "pprof",
  "prost 0.14.3",
  "reqwest",
@@ -3688,6 +3738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,6 +3767,39 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.16.1",
+ "lz4_flex",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -4724,6 +4816,12 @@ name = "sensor-ebpf-common"
 version = "0.1.0"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5194,6 +5292,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
 ]
 
 [[package]]
@@ -6563,6 +6672,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ clap_complete = "4.5"
 clap_complete_nushell = "4.6"
 config = { version = "0.15.22", default-features = false }
 arrow-json = "58"
+parquet = { version = "58", features = ["zstd"] }
 datafusion = { version = "53", default-features = false, features = [
     "sql",
     "string_expressions",

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -278,8 +278,11 @@ artifact to back it.
 1. **Baseline.** Before touching code, run the relevant `criterion`
    bench on `main` and save the report. `just bench` runs the Tier 1
    suite (`pipeline`, `output_encode`, `full_chain`). For more
-   targeted runs, invoke the specific bench binary directly (see
-   `crates/logfwd-bench/src/bin/`).
+   targeted Criterion runs, invoke the specific `--bench` target directly.
+   Helper and profiling binaries in `logfwd-bench` are gated behind
+   `--features bench-tools`; prefer the `just profile-*` recipes, or pass
+   that feature explicitly for direct `cargo run -p logfwd-bench --bin ...`
+   commands.
 2. **Profile to find the actual hotspot.** On macOS: `just profile-otlp-local`
    produces a flamegraph. For FramedInput-specific work:
    `just bench-framed-input -- --flamegraph /tmp/framed-input.svg`.

--- a/book/src/content/docs/development/benchmarking.md
+++ b/book/src/content/docs/development/benchmarking.md
@@ -27,13 +27,13 @@ just bench-competitive --lines 5000000 --docker --cpus 1 --memory 1g --markdown
 
 ```bash
 # Stage-by-stage profile
-cargo run -p logfwd-bench --release --bin e2e-profile
+cargo run -p logfwd-bench --release --features bench-tools --bin e2e_profile
 
 # Memory analysis
-cargo run -p logfwd-bench --release --bin sizes
+cargo run -p logfwd-bench --release --features bench-tools --bin sizes
 
 # Real RSS measurement
-cargo run -p logfwd-bench --release --bin rss
+cargo run -p logfwd-bench --release --features bench-tools --bin rss
 ```
 
 ## Nightly benchmarks

--- a/crates/logfwd-bench/Cargo.toml
+++ b/crates/logfwd-bench/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false
+# Keep tool/report binaries from being built implicitly during `cargo bench`.
+# Those binaries are opted into explicitly via `--features bench-tools`.
 autobins = false
 
 [features]
+# Empty gate used only to enable bench helper/profiling binaries on demand.
 bench-tools = []
 dhat-heap = ["dep:dhat"]
 otlp-profile-alloc = []
@@ -56,7 +59,7 @@ opentelemetry-proto = { version = "0.31", features = [
     "logs",
     "gen-tonic-messages",
 ] }
-parquet = { version = "58", features = ["zstd"] }
+parquet = { workspace = true }
 prost = "0.14"
 sonic-rs = "0.5"
 zstd = "0.13"

--- a/crates/logfwd-bench/Cargo.toml
+++ b/crates/logfwd-bench/Cargo.toml
@@ -56,6 +56,7 @@ opentelemetry-proto = { version = "0.31", features = [
     "logs",
     "gen-tonic-messages",
 ] }
+parquet = { version = "58", features = ["zstd"] }
 prost = "0.14"
 sonic-rs = "0.5"
 zstd = "0.13"
@@ -206,6 +207,30 @@ path = "src/bin/source_metadata_profile.rs"
 bench = false
 test = false
 required-features = ["bench-tools"]
+
+[[bin]]
+name = "e2e_profile"
+path = "src/e2e_profile.rs"
+bench = false
+test = false
+
+[[bin]]
+name = "explore"
+path = "src/explore.rs"
+bench = false
+test = false
+
+[[bin]]
+name = "rss"
+path = "src/rss.rs"
+bench = false
+test = false
+
+[[bin]]
+name = "sizes"
+path = "src/sizes.rs"
+bench = false
+test = false
 
 [lints]
 workspace = true

--- a/crates/logfwd-bench/Cargo.toml
+++ b/crates/logfwd-bench/Cargo.toml
@@ -213,24 +213,28 @@ name = "e2e_profile"
 path = "src/e2e_profile.rs"
 bench = false
 test = false
+required-features = ["bench-tools"]
 
 [[bin]]
 name = "explore"
 path = "src/explore.rs"
 bench = false
 test = false
+required-features = ["bench-tools"]
 
 [[bin]]
 name = "rss"
 path = "src/rss.rs"
 bench = false
 test = false
+required-features = ["bench-tools"]
 
 [[bin]]
 name = "sizes"
 path = "src/sizes.rs"
 bench = false
 test = false
+required-features = ["bench-tools"]
 
 [lints]
 workspace = true

--- a/crates/logfwd-bench/Cargo.toml
+++ b/crates/logfwd-bench/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 autobins = false
 
 [features]
-# Empty gate used only to enable bench helper/profiling binaries on demand.
-bench-tools = []
+# Enables helper/profiling binaries and their non-benchmark dependency graph.
+bench-tools = ["dep:parquet"]
 dhat-heap = ["dep:dhat"]
 otlp-profile-alloc = []
 
@@ -59,7 +59,7 @@ opentelemetry-proto = { version = "0.31", features = [
     "logs",
     "gen-tonic-messages",
 ] }
-parquet = { workspace = true }
+parquet = { workspace = true, optional = true }
 prost = "0.14"
 sonic-rs = "0.5"
 zstd = "0.13"

--- a/crates/logfwd-bench/Cargo.toml
+++ b/crates/logfwd-bench/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false
+autobins = false
 
 [features]
+bench-tools = []
 dhat-heap = ["dep:dhat"]
 otlp-profile-alloc = []
 
@@ -115,20 +117,95 @@ name = "source_metadata"
 harness = false
 
 [[bin]]
-name = "es-throughput"
-path = "src/es_throughput.rs"
+name = "logfwd-bench"
+path = "src/main.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
 
 [[bin]]
-name = "memory-profile"
-path = "src/memory_profile.rs"
+name = "cloudtrail_profile"
+path = "src/bin/cloudtrail_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "es-throughput"
+path = "src/es_throughput.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
 
 [[bin]]
 name = "file_output_profile"
 path = "src/file_output_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "framed_input_profile"
+path = "src/bin/framed_input_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "generator_profile"
+path = "src/bin/generator_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "http_receiver_apples"
+path = "src/bin/http_receiver_apples.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
 
 [[bin]]
 name = "library-eval"
 path = "src/library_eval.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "memory-profile"
+path = "src/memory_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "otlp_e2e_profile"
+path = "src/bin/otlp_e2e_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "otlp_encode_profile"
+path = "src/bin/otlp_encode_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "otlp_io_profile"
+path = "src/bin/otlp_io_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
+name = "source_metadata_profile"
+path = "src/bin/source_metadata_profile.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
 
 [lints]
 workspace = true

--- a/crates/logfwd-bench/README.md
+++ b/crates/logfwd-bench/README.md
@@ -12,7 +12,7 @@ just bench
 just bench-framed-input -- --lines 200000 --iterations 5 --flamegraph /tmp/framed-input.svg
 
 # Run the CloudTrail realism profile (nested structure + cardinality + compression)
-cargo run -p logfwd-bench --release --bin cloudtrail_profile -- --lines 20000
+cargo run -p logfwd-bench --release --features bench-tools --bin cloudtrail_profile -- --lines 20000
 
 # Run the allocation-only FramedInput report (dhat-backed, slower)
 just bench-framed-input-alloc -- --lines 200000
@@ -34,7 +34,7 @@ just profile-otlp-io -- --case attrs-heavy --mode projected_view_decode --iterat
 just profile-otlp-io-alloc -- --case attrs-heavy --iterations 100
 
 # Profile source metadata attachment CPU and allocation counts
-cargo run -p logfwd-bench --release --bin source_metadata_profile -- --rows 50000 --sources 300 --iterations 200
+cargo run -p logfwd-bench --release --features bench-tools --bin source_metadata_profile -- --rows 50000 --sources 300 --iterations 200
 
 # Run all Criterion benchmarks (Tier 1 + 2, includes file_io, batch_formation)
 just bench-full

--- a/crates/logfwd-bench/README.md
+++ b/crates/logfwd-bench/README.md
@@ -132,7 +132,7 @@ allocation counting begins after warmup completes.
 | File | Binary | What it does |
 |------|--------|-------------|
 | `main.rs` | `logfwd-bench` | Reads Criterion JSON, emits markdown tables |
-| `e2e_profile.rs` | *(lib)* | Per-stage timing breakdown (scan → transform → encode → compress) |
+| `e2e_profile.rs` | `e2e_profile` | Per-stage timing breakdown (scan → transform → encode → compress) |
 | `bin/cloudtrail_profile.rs` | `cloudtrail_profile` | CloudTrail-like generator profile (NDJSON vs direct RecordBatch generation, cardinality, compression) |
 | `es_throughput.rs` | `es-throughput` | Elasticsearch output throughput with worker scaling |
 | `bin/framed_input_profile.rs` | `framed_input_profile` | FramedInput stage timings, RSS, optional flamegraph, optional dhat allocation report |

--- a/crates/logfwd-bench/src/e2e_profile.rs
+++ b/crates/logfwd-bench/src/e2e_profile.rs
@@ -17,8 +17,8 @@ fn main() {
     let lines = 100_000;
     let data = generate_simple(lines);
     let raw_mb = data.len() as f64 / 1_048_576.0;
-    
-    println!("=== End-to-End Stage Profiling ({} lines, {:.1} MB) ===\n", lines, raw_mb);
+
+    println!("=== End-to-End Stage Profiling ({lines} lines, {raw_mb:.1} MB) ===\n");
 
     // Stage 1: Scan
     let t0 = Instant::now();
@@ -32,20 +32,7 @@ fn main() {
     let result = transform.execute_blocking(batch).unwrap();
     let transform_ms = t1.elapsed().as_millis();
 
-    // Stage 3: JSON serialization (simulating HTTP JSON lines output)
-    let t2 = Instant::now();
-    let mut json_sink = logfwd_output::JsonLinesSink::new(
-        "bench".to_string(),
-        "http://localhost:19877".to_string(),
-        vec![],
-        logfwd_output::Compression::None,
-        std::sync::Arc::new(ComponentStats::new()),
-    );
-    json_sink.serialize_batch(&result);
-    let json_ms = t2.elapsed().as_millis();
-    let json_mb = json_sink.batch_buf.len() as f64 / 1_048_576.0;
-
-    // Stage 4: OTLP protobuf encoding
+    // Stage 3: OTLP protobuf encoding
     let t3 = Instant::now();
     let mut otlp_sink = logfwd_output::OtlpSink::new(
         "bench".to_string(),
@@ -54,79 +41,132 @@ fn main() {
         logfwd_output::Compression::None,
         vec![],
         reqwest::Client::new(),
-        std::sync::Arc::new(ComponentStats::new()),
-    );
+        Arc::new(ComponentStats::new()),
+    )
+    .unwrap();
     let metadata = BatchMetadata {
         resource_attrs: Arc::new(vec![]),
         observed_time_ns: 0,
     };
     otlp_sink.encode_batch(&result, &metadata);
     let otlp_ms = t3.elapsed().as_millis();
-    let otlp_mb = otlp_sink.encoder_buf.len() as f64 / 1_048_576.0;
+    let otlp_mb = otlp_sink.encoded_payload().len() as f64 / 1_048_576.0;
 
-    // Stage 5: zstd compression of OTLP payload
+    // Stage 4: zstd compression of OTLP payload
     let t4 = Instant::now();
     let mut compressor = ChunkCompressor::new(1).unwrap();
-    let compressed = compressor.compress(&otlp_sink.encoder_buf).unwrap();
+    let compressed = compressor.compress(otlp_sink.encoded_payload()).unwrap();
     let zstd_ms = t4.elapsed().as_millis();
     let zstd_mb = compressed.data.len() as f64 / 1_048_576.0;
 
-    // Stage 6: Simulated HTTP send (just measure the overhead of ureq setup, no actual network)
-    // Skip actual send — we want CPU time only
+    let total_ms = scan_ms + transform_ms + otlp_ms + zstd_ms;
+    let lps = if total_ms > 0 {
+        lines as u64 * 1000 / total_ms as u64
+    } else {
+        0
+    };
 
-    let total_ms = scan_ms + transform_ms + json_ms + otlp_ms + zstd_ms;
-    let lps = if total_ms > 0 { lines as u64 * 1000 / total_ms as u64 } else { 0 };
-
-    println!("  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%", "1. Scan (JSON→Arrow)", scan_ms, raw_mb, scan_ms as f64 / total_ms as f64 * 100.0);
-    println!("  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%", "2. Transform (SQL)", transform_ms, 0.0, transform_ms as f64 / total_ms as f64 * 100.0);
-    println!("  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%", "3. JSON serialize", json_ms, json_mb, json_ms as f64 / total_ms as f64 * 100.0);
-    println!("  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%", "4. OTLP protobuf encode", otlp_ms, otlp_mb, otlp_ms as f64 / total_ms as f64 * 100.0);
-    println!("  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%", "5. zstd compress", zstd_ms, zstd_mb, zstd_ms as f64 / total_ms as f64 * 100.0);
+    println!(
+        "  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%",
+        "1. Scan (JSON→Arrow)",
+        scan_ms,
+        raw_mb,
+        scan_ms as f64 / total_ms as f64 * 100.0
+    );
+    println!(
+        "  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%",
+        "2. Transform (SQL)",
+        transform_ms,
+        0.0,
+        transform_ms as f64 / total_ms as f64 * 100.0
+    );
+    println!(
+        "  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%",
+        "3. OTLP protobuf encode",
+        otlp_ms,
+        otlp_mb,
+        otlp_ms as f64 / total_ms as f64 * 100.0
+    );
+    println!(
+        "  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%",
+        "4. zstd compress",
+        zstd_ms,
+        zstd_mb,
+        zstd_ms as f64 / total_ms as f64 * 100.0
+    );
     println!("  {:<25} {:>6}ms", "───────────────────────", 0);
-    println!("  {:<25} {:>6}ms                {:>10} lines/sec", "TOTAL (CPU only)", total_ms, lps);
+    println!(
+        "  {:<25} {:>6}ms                {:>10} lines/sec",
+        "TOTAL (CPU only)", total_ms, lps
+    );
     println!();
-    
-    println!("  Size pipeline: {:.1}MB JSON → {:.1}MB OTLP → {:.1}MB zstd ({:.1}x compression)", 
-        raw_mb, otlp_mb, zstd_mb, raw_mb / zstd_mb);
+
+    println!(
+        "  Size pipeline: {raw_mb:.1}MB raw → {otlp_mb:.1}MB OTLP → {zstd_mb:.1}MB zstd ({:.1}x compression)",
+        raw_mb / zstd_mb
+    );
 
     // Now repeat at scale
     println!("\n=== Scaling to 1M lines ===\n");
     for n in [100_000, 500_000, 1_000_000] {
         let data = generate_simple(n);
-        
+
         let t = Instant::now();
         let mut s = Scanner::new(ScanConfig::default());
         let batch = s.scan(bytes::Bytes::from(data)).unwrap();
         let scan = t.elapsed().as_millis();
-        
+
         let t = Instant::now();
         let mut xf = SqlTransform::new("SELECT * FROM logs").unwrap();
         let result = xf.execute_blocking(batch).unwrap();
         let xform = t.elapsed().as_millis();
-        
+
         let t = Instant::now();
-        let mut sink = logfwd_output::OtlpSink::new("b".into(), "http://x".into(), logfwd_output::OtlpProtocol::Http, logfwd_output::Compression::None, vec![], reqwest::Client::new(), std::sync::Arc::new(ComponentStats::new()));
-        let meta = BatchMetadata { resource_attrs: Arc::new(vec![]), observed_time_ns: 0 };
+        let mut sink = logfwd_output::OtlpSink::new(
+            "b".into(),
+            "http://x".into(),
+            logfwd_output::OtlpProtocol::Http,
+            logfwd_output::Compression::None,
+            vec![],
+            reqwest::Client::new(),
+            Arc::new(ComponentStats::new()),
+        )
+        .unwrap();
+        let meta = BatchMetadata {
+            resource_attrs: Arc::new(vec![]),
+            observed_time_ns: 0,
+        };
         sink.encode_batch(&result, &meta);
         let encode = t.elapsed().as_millis();
-        
+
         let t = Instant::now();
         let mut c = ChunkCompressor::new(1).unwrap();
-        let _ = c.compress(&sink.encoder_buf).unwrap();
+        let _ = c.compress(sink.encoded_payload()).unwrap();
         let compress = t.elapsed().as_millis();
-        
+
         let total = scan + xform + encode + compress;
-        let lps = if total > 0 { n as u64 * 1000 / total as u64 } else { 0 };
-        
-        println!("  {:>7} lines: scan={:>5}ms  xform={:>4}ms  otlp={:>5}ms  zstd={:>4}ms  total={:>5}ms  {:>8} lines/sec",
-            n, scan, xform, encode, compress, total, lps);
+        let lps = if total > 0 {
+            n as u64 * 1000 / total as u64
+        } else {
+            0
+        };
+
+        println!(
+            "  {n:>7} lines: scan={scan:>5}ms  xform={xform:>4}ms  otlp={encode:>5}ms  zstd={compress:>4}ms  total={total:>5}ms  {lps:>8} lines/sec"
+        );
     }
 }
 
 fn generate_simple(n: usize) -> Vec<u8> {
     let mut buf = Vec::with_capacity(n * 180);
     let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let paths = ["/api/v1/users", "/api/v1/orders", "/api/v2/products", "/health", "/api/v1/auth"];
+    let paths = [
+        "/api/v1/users",
+        "/api/v1/orders",
+        "/api/v2/products",
+        "/health",
+        "/api/v1/auth",
+    ];
     for i in 0..n {
         write!(buf, r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{:016x}","service":"myapp"}}"#,
             i % 1000, levels[i % 4], paths[i % 5], 10000 + (i * 7) % 90000,

--- a/crates/logfwd-bench/src/e2e_profile.rs
+++ b/crates/logfwd-bench/src/e2e_profile.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 //! Profile each stage of the full pipeline: read → scan → transform → encode → "send"
-//! Run with: cargo run -p logfwd-bench --release --bin e2e-profile
+//! Run with: cargo run -p logfwd-bench --release --features bench-tools --bin e2e_profile
 
 use std::io::Write;
 use std::sync::Arc;
@@ -65,34 +65,41 @@ fn main() {
     } else {
         0
     };
+    let pct = |stage_ms: u128| {
+        if total_ms > 0 {
+            stage_ms as f64 / total_ms as f64 * 100.0
+        } else {
+            0.0
+        }
+    };
 
     println!(
         "  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%",
         "1. Scan (JSON→Arrow)",
         scan_ms,
         raw_mb,
-        scan_ms as f64 / total_ms as f64 * 100.0
+        pct(scan_ms)
     );
     println!(
         "  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%",
         "2. Transform (SQL)",
         transform_ms,
         0.0,
-        transform_ms as f64 / total_ms as f64 * 100.0
+        pct(transform_ms)
     );
     println!(
         "  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%",
         "3. OTLP protobuf encode",
         otlp_ms,
         otlp_mb,
-        otlp_ms as f64 / total_ms as f64 * 100.0
+        pct(otlp_ms)
     );
     println!(
         "  {:<25} {:>6}ms  {:>6.1} MB output  {:>5.1}%",
         "4. zstd compress",
         zstd_ms,
         zstd_mb,
-        zstd_ms as f64 / total_ms as f64 * 100.0
+        pct(zstd_ms)
     );
     println!("  {:<25} {:>6}ms", "───────────────────────", 0);
     println!(

--- a/crates/logfwd-bench/src/explore.rs
+++ b/crates/logfwd-bench/src/explore.rs
@@ -18,7 +18,9 @@ fn main() {
     }
     let quick = args.iter().any(|a| a == "--quick");
 
-    println!("dataset,lines,fields,query,scan_ms,transform_ms,total_ms,lines_per_sec,scan_lines_per_sec");
+    println!(
+        "dataset,lines,fields,query,scan_ms,transform_ms,total_ms,lines_per_sec,scan_lines_per_sec"
+    );
 
     let sizes: Vec<usize> = if quick {
         vec![10_000, 100_000]
@@ -65,26 +67,110 @@ fn main() {
     // === Dimension 4: Projection pushdown on wide data ===
     eprintln!("\n=== Dimension 4: Projection Pushdown (wide 20-field, 100K) ===");
     bench("wide", 100_000, 20, "SELECT * FROM logs", &data_wide);
-    bench("wide", 100_000, 20, "SELECT timestamp_str, level_str FROM logs", &data_wide);
-    bench("wide", 100_000, 20, "SELECT timestamp_str, level_str, message_str, duration_ms_int FROM logs", &data_wide);
-    bench("wide", 100_000, 20, "SELECT * FROM logs WHERE level_str = 'ERROR'", &data_wide);
-    bench("wide", 100_000, 20, "SELECT level_str FROM logs WHERE status_code_int > 400", &data_wide);
+    bench(
+        "wide",
+        100_000,
+        20,
+        "SELECT timestamp_str, level_str FROM logs",
+        &data_wide,
+    );
+    bench(
+        "wide",
+        100_000,
+        20,
+        "SELECT timestamp_str, level_str, message_str, duration_ms_int FROM logs",
+        &data_wide,
+    );
+    bench(
+        "wide",
+        100_000,
+        20,
+        "SELECT * FROM logs WHERE level_str = 'ERROR'",
+        &data_wide,
+    );
+    bench(
+        "wide",
+        100_000,
+        20,
+        "SELECT level_str FROM logs WHERE status_code_int > 400",
+        &data_wide,
+    );
 
     // === Dimension 5: Aggregations ===
     eprintln!("\n=== Dimension 5: Aggregations (100K) ===");
-    bench("simple", 100_000, 6, "SELECT COUNT(*) FROM logs", &data_100k);
-    bench("simple", 100_000, 6, "SELECT level_str, COUNT(*) FROM logs GROUP BY level_str", &data_100k);
-    bench("simple", 100_000, 6, "SELECT level_str, AVG(duration_ms_int), MIN(duration_ms_int), MAX(duration_ms_int) FROM logs GROUP BY level_str", &data_100k);
-    bench("wide", 100_000, 20, "SELECT region_str, namespace_str, COUNT(*) FROM logs GROUP BY region_str, namespace_str", &data_wide);
-    bench("wide", 100_000, 20, "SELECT method_str, AVG(duration_ms_int), COUNT(*) FROM logs GROUP BY method_str", &data_wide);
+    bench(
+        "simple",
+        100_000,
+        6,
+        "SELECT COUNT(*) FROM logs",
+        &data_100k,
+    );
+    bench(
+        "simple",
+        100_000,
+        6,
+        "SELECT level_str, COUNT(*) FROM logs GROUP BY level_str",
+        &data_100k,
+    );
+    bench(
+        "simple",
+        100_000,
+        6,
+        "SELECT level_str, AVG(duration_ms_int), MIN(duration_ms_int), MAX(duration_ms_int) FROM logs GROUP BY level_str",
+        &data_100k,
+    );
+    bench(
+        "wide",
+        100_000,
+        20,
+        "SELECT region_str, namespace_str, COUNT(*) FROM logs GROUP BY region_str, namespace_str",
+        &data_wide,
+    );
+    bench(
+        "wide",
+        100_000,
+        20,
+        "SELECT method_str, AVG(duration_ms_int), COUNT(*) FROM logs GROUP BY method_str",
+        &data_wide,
+    );
 
     // === Dimension 6: String operations ===
     eprintln!("\n=== Dimension 6: String Operations (100K) ===");
-    bench("simple", 100_000, 6, "SELECT *, UPPER(level_str) as level_upper FROM logs", &data_100k);
-    bench("simple", 100_000, 6, "SELECT *, LENGTH(message_str) as msg_len FROM logs", &data_100k);
-    bench("simple", 100_000, 6, "SELECT *, CONCAT(level_str, ':', service_str) as tag FROM logs", &data_100k);
-    bench("simple", 100_000, 6, "SELECT * FROM logs WHERE message_str LIKE '%orders%'", &data_100k);
-    bench("simple", 100_000, 6, "SELECT * FROM logs WHERE LOWER(level_str) = 'error'", &data_100k);
+    bench(
+        "simple",
+        100_000,
+        6,
+        "SELECT *, UPPER(level_str) as level_upper FROM logs",
+        &data_100k,
+    );
+    bench(
+        "simple",
+        100_000,
+        6,
+        "SELECT *, LENGTH(message_str) as msg_len FROM logs",
+        &data_100k,
+    );
+    bench(
+        "simple",
+        100_000,
+        6,
+        "SELECT *, CONCAT(level_str, ':', service_str) as tag FROM logs",
+        &data_100k,
+    );
+    bench(
+        "simple",
+        100_000,
+        6,
+        "SELECT * FROM logs WHERE message_str LIKE '%orders%'",
+        &data_100k,
+    );
+    bench(
+        "simple",
+        100_000,
+        6,
+        "SELECT * FROM logs WHERE LOWER(level_str) = 'error'",
+        &data_100k,
+    );
 
     // === Dimension 7: Scan-only (no transform overhead) ===
     eprintln!("\n=== Dimension 7: Scan-Only (no SQL) ===");
@@ -105,15 +191,56 @@ fn main() {
     for (path, expected_lines) in &nginx_paths {
         if let Ok(data) = std::fs::read(path) {
             let lines = memchr::memchr_iter(b'\n', &data).count();
-            bench_scan_only(&format!("nginx({})", fmt_count(*expected_lines)), lines, 8, &data);
-            bench(&format!("nginx({})", fmt_count(*expected_lines)), lines, 8, "SELECT * FROM logs", &data);
-            bench(&format!("nginx({})", fmt_count(*expected_lines)), lines, 8, "SELECT time_str, remote_ip_str, request_str, response_int FROM logs", &data);
-            bench(&format!("nginx({})", fmt_count(*expected_lines)), lines, 8, "SELECT * FROM logs WHERE response_int >= 400", &data);
-            bench(&format!("nginx({})", fmt_count(*expected_lines)), lines, 8, "SELECT remote_ip_str, COUNT(*) as cnt FROM logs GROUP BY remote_ip_str ORDER BY cnt DESC LIMIT 10", &data);
-            bench(&format!("nginx({})", fmt_count(*expected_lines)), lines, 8, "SELECT response_int, COUNT(*) FROM logs GROUP BY response_int", &data);
-            bench(&format!("nginx({})", fmt_count(*expected_lines)), lines, 8, "SELECT * FROM logs WHERE request_str LIKE '%product_1%'", &data);
+            bench_scan_only(
+                &format!("nginx({})", fmt_count(*expected_lines)),
+                lines,
+                8,
+                &data,
+            );
+            bench(
+                &format!("nginx({})", fmt_count(*expected_lines)),
+                lines,
+                8,
+                "SELECT * FROM logs",
+                &data,
+            );
+            bench(
+                &format!("nginx({})", fmt_count(*expected_lines)),
+                lines,
+                8,
+                "SELECT time_str, remote_ip_str, request_str, response_int FROM logs",
+                &data,
+            );
+            bench(
+                &format!("nginx({})", fmt_count(*expected_lines)),
+                lines,
+                8,
+                "SELECT * FROM logs WHERE response_int >= 400",
+                &data,
+            );
+            bench(
+                &format!("nginx({})", fmt_count(*expected_lines)),
+                lines,
+                8,
+                "SELECT remote_ip_str, COUNT(*) as cnt FROM logs GROUP BY remote_ip_str ORDER BY cnt DESC LIMIT 10",
+                &data,
+            );
+            bench(
+                &format!("nginx({})", fmt_count(*expected_lines)),
+                lines,
+                8,
+                "SELECT response_int, COUNT(*) FROM logs GROUP BY response_int",
+                &data,
+            );
+            bench(
+                &format!("nginx({})", fmt_count(*expected_lines)),
+                lines,
+                8,
+                "SELECT * FROM logs WHERE request_str LIKE '%product_1%'",
+                &data,
+            );
         } else {
-            eprintln!("  Skipping {} (not found). Run: curl -o {} <url>", path, path);
+            eprintln!("  Skipping {path} (not found). Run: curl -o {path} <url>");
         }
     }
 
@@ -123,17 +250,33 @@ fn main() {
         let data_1m = generate_simple(1_000_000);
         bench_scan_only("simple", 1_000_000, 6, &data_1m);
         bench("simple", 1_000_000, 6, "SELECT * FROM logs", &data_1m);
-        bench("simple", 1_000_000, 6, "SELECT * FROM logs WHERE level_str = 'ERROR'", &data_1m);
-        bench("simple", 1_000_000, 6, "SELECT level_str, COUNT(*) FROM logs GROUP BY level_str", &data_1m);
+        bench(
+            "simple",
+            1_000_000,
+            6,
+            "SELECT * FROM logs WHERE level_str = 'ERROR'",
+            &data_1m,
+        );
+        bench(
+            "simple",
+            1_000_000,
+            6,
+            "SELECT level_str, COUNT(*) FROM logs GROUP BY level_str",
+            &data_1m,
+        );
     }
 
     eprintln!("\nDone.");
 }
 
 fn fmt_count(n: usize) -> String {
-    if n >= 1_000_000 { format!("{}M", n / 1_000_000) }
-    else if n >= 1_000 { format!("{}K", n / 1_000) }
-    else { format!("{}", n) }
+    if n >= 1_000_000 {
+        format!("{}M", n / 1_000_000)
+    } else if n >= 1_000 {
+        format!("{}K", n / 1_000)
+    } else {
+        format!("{n}")
+    }
 }
 
 fn bench(dataset: &str, lines: usize, fields: usize, sql: &str, data: &[u8]) {
@@ -142,7 +285,8 @@ fn bench(dataset: &str, lines: usize, fields: usize, sql: &str, data: &[u8]) {
     let mut scanner = Scanner::new(config);
 
     let t0 = Instant::now();
-    let batch = scanner.scan(bytes::Bytes::from(data.to_vec()))
+    let batch = scanner
+        .scan(bytes::Bytes::from(data.to_vec()))
         .expect("scan failed");
     let scan_ms = t0.elapsed().as_millis() as u64;
 
@@ -151,11 +295,21 @@ fn bench(dataset: &str, lines: usize, fields: usize, sql: &str, data: &[u8]) {
     let transform_ms = t1.elapsed().as_millis() as u64;
 
     let total_ms = scan_ms + transform_ms;
-    let lps = if total_ms > 0 { lines as u64 * 1000 / total_ms } else { 0 };
-    let scan_lps = if scan_ms > 0 { lines as u64 * 1000 / scan_ms } else { 0 };
+    let lps = if total_ms > 0 {
+        lines as u64 * 1000 / total_ms
+    } else {
+        0
+    };
+    let scan_lps = if scan_ms > 0 {
+        lines as u64 * 1000 / scan_ms
+    } else {
+        0
+    };
 
     let short_sql: String = sql.chars().take(60).collect();
-    println!("{dataset},{lines},{fields},{short_sql},{scan_ms},{transform_ms},{total_ms},{lps},{scan_lps}");
+    println!(
+        "{dataset},{lines},{fields},{short_sql},{scan_ms},{transform_ms},{total_ms},{lps},{scan_lps}"
+    );
     eprintln!(
         "  {:<12} {:>7} lines  {:>2}f  scan={:>5}ms  xform={:>5}ms  total={:>5}ms  {:>8} lines/sec  {}",
         dataset, lines, fields, scan_ms, transform_ms, total_ms, lps, &short_sql
@@ -167,15 +321,25 @@ fn bench_scan_only(dataset: &str, lines: usize, fields: usize, data: &[u8]) {
     let mut scanner = Scanner::new(config);
 
     let t0 = Instant::now();
-    let batch = scanner.scan(bytes::Bytes::from(data.to_vec()))
+    let batch = scanner
+        .scan(bytes::Bytes::from(data.to_vec()))
         .expect("scan failed");
     let scan_ms = t0.elapsed().as_millis() as u64;
-    let lps = if scan_ms > 0 { lines as u64 * 1000 / scan_ms } else { 0 };
+    let lps = if scan_ms > 0 {
+        lines as u64 * 1000 / scan_ms
+    } else {
+        0
+    };
 
     println!("{dataset},{lines},{fields},SCAN_ONLY,{scan_ms},0,{scan_ms},{lps},{lps}");
     eprintln!(
         "  {:<12} {:>7} lines  {:>2}f  scan={:>5}ms  {:>8} lines/sec  ({} rows)",
-        dataset, lines, fields, scan_ms, lps, batch.num_rows()
+        dataset,
+        lines,
+        fields,
+        scan_ms,
+        lps,
+        batch.num_rows()
     );
 }
 
@@ -184,7 +348,13 @@ fn bench_scan_only(dataset: &str, lines: usize, fields: usize, data: &[u8]) {
 fn generate_simple(n: usize) -> Vec<u8> {
     let mut buf = Vec::with_capacity(n * 180);
     let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let paths = ["/api/v1/users", "/api/v1/orders", "/api/v2/products", "/health", "/api/v1/auth"];
+    let paths = [
+        "/api/v1/users",
+        "/api/v1/orders",
+        "/api/v2/products",
+        "/health",
+        "/api/v1/auth",
+    ];
     for i in 0..n {
         write!(
             buf,
@@ -216,7 +386,7 @@ fn generate_wide(n: usize) -> Vec<u8> {
             [200, 201, 400, 404, 500][i % 5], regions[i % 4],
             i % 1000, (i as u64).wrapping_mul(0x517cc1b727220a95),
             100 + (i * 37) % 10000, 10 + (i * 11) % 1000,
-            if i % 20 == 0 { 1 } else { 0 },
+            i32::from(i % 20 == 0),
             if i % 3 == 0 { "true" } else { "false" },
             (i * 7) % 200, i % 4, 1 + i % 5, i % 10,
         ).unwrap();
@@ -229,7 +399,14 @@ fn generate_narrow(n: usize) -> Vec<u8> {
     let mut buf = Vec::with_capacity(n * 60);
     let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
     for i in 0..n {
-        write!(buf, r#"{{"ts":"{}","lvl":"{}","msg":"event {}"}}"#, i, levels[i % 4], i).unwrap();
+        write!(
+            buf,
+            r#"{{"ts":"{}","lvl":"{}","msg":"event {}"}}"#,
+            i,
+            levels[i % 4],
+            i
+        )
+        .unwrap();
         buf.push(b'\n');
     }
     buf

--- a/crates/logfwd-bench/src/rss.rs
+++ b/crates/logfwd-bench/src/rss.rs
@@ -16,17 +16,21 @@ fn rss_mb() -> f64 {
         // SAFETY: `zeroed()` is valid for `mach_task_basic_info_data_t`
         // (all-zero is a valid bit pattern for this plain-data struct).
         let mut info: libc::mach_task_basic_info_data_t = unsafe { mem::zeroed() };
-        let mut count = (mem::size_of::<libc::mach_task_basic_info_data_t>()
-            / mem::size_of::<libc::natural_t>()) as libc::mach_msg_type_number_t;
-        // SAFETY: `mach_task_self_` is always a valid task port. `info` is a
-        // mutable reference to a zeroed struct of the correct type and `count`
-        // holds the matching element count. `task_info` only writes into `info`.
+        let mut count = (size_of::<libc::mach_task_basic_info_data_t>()
+            / size_of::<libc::natural_t>()) as libc::mach_msg_type_number_t;
+        // SAFETY: accessing the mach task self port is always valid for the
+        // current process.
+        #[allow(deprecated)]
+        let task = unsafe { libc::mach_task_self_ };
+        // SAFETY: `task` is a valid task port. `info` is a properly-sized
+        // zeroed struct and `count` holds the matching element count.
+        // `task_info` only writes into `info`.
         let kr = unsafe {
             libc::task_info(
-                libc::mach_task_self_,
+                task,
                 libc::MACH_TASK_BASIC_INFO,
-                &mut info as *mut _ as libc::task_info_t,
-                &mut count,
+                &raw mut info as libc::task_info_t,
+                &raw mut count,
             )
         };
         if kr == libc::KERN_SUCCESS {
@@ -39,8 +43,11 @@ fn rss_mb() -> f64 {
         if let Ok(status) = std::fs::read_to_string("/proc/self/status") {
             for line in status.lines() {
                 if line.starts_with("VmRSS:") {
-                    let kb: f64 = line.split_whitespace().nth(1)
-                        .and_then(|s| s.parse().ok()).unwrap_or(0.0);
+                    let kb: f64 = line
+                        .split_whitespace()
+                        .nth(1)
+                        .and_then(|s| s.parse().ok())
+                        .unwrap_or(0.0);
                     return kb / 1024.0;
                 }
             }
@@ -53,36 +60,47 @@ fn main() {
     println!("=== RSS Measurement at Each Pipeline Stage ===\n");
 
     for (label, lines) in [("100K", 100_000), ("500K", 500_000), ("1M", 1_000_000)] {
-        println!("--- {} lines ---", label);
+        println!("--- {label} lines ---");
 
         let baseline = rss_mb();
-        println!("  Baseline RSS:            {:.1} MB", baseline);
+        println!("  Baseline RSS:            {baseline:.1} MB");
 
         // Generate data
         let data = generate_simple(lines);
         let after_gen = rss_mb();
-        println!("  After generate ({:.1}MB):  {:.1} MB  (+{:.1} MB)",
-            data.len() as f64 / 1_048_576.0, after_gen, after_gen - baseline);
+        println!(
+            "  After generate ({:.1}MB):  {after_gen:.1} MB  (+{:.1} MB)",
+            data.len() as f64 / 1_048_576.0,
+            after_gen - baseline
+        );
 
         // Scan
         let mut scanner = Scanner::new(ScanConfig::default());
         let batch = scanner.scan(bytes::Bytes::from(data.clone())).unwrap();
         let after_scan = rss_mb();
-        println!("  After scan ({} rows):    {:.1} MB  (+{:.1} MB)",
-            batch.num_rows(), after_scan, after_scan - after_gen);
+        println!(
+            "  After scan ({} rows):    {after_scan:.1} MB  (+{:.1} MB)",
+            batch.num_rows(),
+            after_scan - after_gen
+        );
 
         // Drop the input data
         drop(data);
         let after_drop_input = rss_mb();
-        println!("  After drop input:        {:.1} MB  (+{:.1} MB)",
-            after_drop_input, after_drop_input - after_scan);
+        println!(
+            "  After drop input:        {after_drop_input:.1} MB  (+{:.1} MB)",
+            after_drop_input - after_scan
+        );
 
         // Transform
         let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         let result = transform.execute_blocking(batch.clone()).unwrap();
         let after_transform = rss_mb();
-        println!("  After transform ({} rows): {:.1} MB  (+{:.1} MB)",
-            result.num_rows(), after_transform, after_transform - after_drop_input);
+        println!(
+            "  After transform ({} rows): {after_transform:.1} MB  (+{:.1} MB)",
+            result.num_rows(),
+            after_transform - after_drop_input
+        );
 
         // Drop everything
         drop(batch);
@@ -90,11 +108,19 @@ fn main() {
         drop(scanner);
         drop(transform);
         let after_drop_all = rss_mb();
-        println!("  After drop all:          {:.1} MB  (freed {:.1} MB)",
-            after_drop_all, after_transform - after_drop_all);
+        println!(
+            "  After drop all:          {after_drop_all:.1} MB  (freed {:.1} MB)",
+            after_transform - after_drop_all
+        );
 
-        println!("  Peak delta from baseline: {:.1} MB", after_transform - baseline);
-        println!("  Per line at peak:         {:.0} bytes", (after_transform - baseline) * 1_048_576.0 / lines as f64);
+        println!(
+            "  Peak delta from baseline: {:.1} MB",
+            after_transform - baseline
+        );
+        println!(
+            "  Per line at peak:         {:.0} bytes",
+            (after_transform - baseline) * 1_048_576.0 / lines as f64
+        );
         println!();
     }
 
@@ -106,7 +132,9 @@ fn main() {
 
         let before = rss_mb();
         let mut detached_scanner = Scanner::new(ScanConfig::default());
-        let batch = detached_scanner.scan_detached(bytes::Bytes::from(data.clone())).unwrap();
+        let batch = detached_scanner
+            .scan_detached(bytes::Bytes::from(data.clone()))
+            .unwrap();
         let after_detached = rss_mb();
         let detached_cols = batch.num_columns();
         let detached_reported = batch.get_array_memory_size() as f64 / 1_048_576.0;
@@ -122,14 +150,20 @@ fn main() {
         drop(batch);
         drop(streaming_scanner);
 
-        println!("  Raw JSON:         {:.1} MB", raw_mb);
-        println!("  scan_detached:    RSS +{:.1} MB  (reported {:.1} MB)  {} cols",
-            after_detached - before, detached_reported, detached_cols);
-        println!("  scan (zero-copy): RSS +{:.1} MB  (reported {:.1} MB)  {} cols",
-            after_streaming - mid, streaming_reported, streaming_cols);
-        println!("  Savings:          {:.1} MB ({:.0}% less RSS)",
+        println!("  Raw JSON:         {raw_mb:.1} MB");
+        println!(
+            "  scan_detached:    RSS +{:.1} MB  (reported {detached_reported:.1} MB)  {detached_cols} cols",
+            after_detached - before
+        );
+        println!(
+            "  scan (zero-copy): RSS +{:.1} MB  (reported {streaming_reported:.1} MB)  {streaming_cols} cols",
+            after_streaming - mid
+        );
+        println!(
+            "  Savings:          {:.1} MB ({:.0}% less RSS)",
             (after_detached - before) - (after_streaming - mid),
-            100.0 * (1.0 - (after_streaming - mid) / (after_detached - before)));
+            100.0 * (1.0 - (after_streaming - mid) / (after_detached - before))
+        );
         println!();
     }
 
@@ -139,31 +173,41 @@ fn main() {
     let gen_mb = data.len() as f64 / 1_048_576.0;
 
     let baseline = rss_mb();
-    println!("  Baseline:                {:.1} MB", baseline);
-    println!("  Wide data generated:     {:.1} MB", gen_mb);
+    println!("  Baseline:                {baseline:.1} MB");
+    println!("  Wide data generated:     {gen_mb:.1} MB");
 
     // SELECT * (all 20 fields)
     {
-        let mut transform = SqlTransform::new("SELECT * FROM logs").unwrap();
+        let transform = SqlTransform::new("SELECT * FROM logs").unwrap();
         let config = transform.scan_config();
         let mut scanner = Scanner::new(config);
         let batch = scanner.scan(bytes::Bytes::from(data.clone())).unwrap();
         let after = rss_mb();
-        println!("  SELECT * (20 fields):    {:.1} MB  (delta {:.1} MB)", after, after - baseline);
-        drop(batch); drop(scanner); drop(transform);
+        println!(
+            "  SELECT * (20 fields):    {after:.1} MB  (delta {:.1} MB)",
+            after - baseline
+        );
+        drop(batch);
+        drop(scanner);
+        drop(transform);
     }
 
     let mid = rss_mb();
 
     // SELECT 2 fields (pushdown)
     {
-        let mut transform = SqlTransform::new("SELECT timestamp_str, level_str FROM logs").unwrap();
+        let transform = SqlTransform::new("SELECT timestamp_str, level_str FROM logs").unwrap();
         let config = transform.scan_config();
         let mut scanner = Scanner::new(config);
         let batch = scanner.scan(bytes::Bytes::from(data.clone())).unwrap();
         let after = rss_mb();
-        println!("  SELECT 2 fields:         {:.1} MB  (delta {:.1} MB)", after, after - mid);
-        drop(batch); drop(scanner); drop(transform);
+        println!(
+            "  SELECT 2 fields:         {after:.1} MB  (delta {:.1} MB)",
+            after - mid
+        );
+        drop(batch);
+        drop(scanner);
+        drop(transform);
     }
 
     drop(data);
@@ -173,7 +217,13 @@ fn main() {
 fn generate_simple(n: usize) -> Vec<u8> {
     let mut buf = Vec::with_capacity(n * 180);
     let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let paths = ["/api/v1/users", "/api/v1/orders", "/api/v2/products", "/health", "/api/v1/auth"];
+    let paths = [
+        "/api/v1/users",
+        "/api/v1/orders",
+        "/api/v2/products",
+        "/health",
+        "/api/v1/auth",
+    ];
     for i in 0..n {
         write!(buf, r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{:016x}","service":"myapp"}}"#,
             i % 1000, levels[i % 4], paths[i % 5], 10000 + (i * 7) % 90000,
@@ -196,7 +246,7 @@ fn generate_wide(n: usize) -> Vec<u8> {
             [200, 201, 400, 404, 500][i % 5], regions[i % 4],
             i % 1000, (i as u64).wrapping_mul(0x517cc1b727220a95),
             100 + (i * 37) % 10000, 10 + (i * 11) % 1000,
-            if i % 20 == 0 { 1 } else { 0 },
+            i32::from(i % 20 == 0),
             if i % 3 == 0 { "true" } else { "false" },
             (i * 7) % 200, i % 4, 1 + i % 5, i % 10).unwrap();
         buf.push(b'\n');

--- a/crates/logfwd-bench/src/rss.rs
+++ b/crates/logfwd-bench/src/rss.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 //! Measure actual RSS (resident set size) at each pipeline stage.
-//! Run with: cargo run -p logfwd-bench --release --bin rss
+//! Run with: cargo run -p logfwd-bench --release --features bench-tools --bin rss
 
 use std::io::Write;
 
@@ -12,7 +12,7 @@ fn rss_mb() -> f64 {
     // macOS: use mach API via libc
     #[cfg(target_os = "macos")]
     {
-        use std::mem;
+        use std::mem::{self, size_of};
         // SAFETY: `zeroed()` is valid for `mach_task_basic_info_data_t`
         // (all-zero is a valid bit pattern for this plain-data struct).
         let mut info: libc::mach_task_basic_info_data_t = unsafe { mem::zeroed() };

--- a/crates/logfwd-bench/src/sizes.rs
+++ b/crates/logfwd-bench/src/sizes.rs
@@ -3,7 +3,6 @@
 //! Run with: cargo run -p logfwd-bench --release --bin sizes
 
 use std::io::Write;
-use std::time::Instant;
 
 use arrow::ipc::writer::{FileWriter, IpcWriteOptions};
 use arrow::record_batch::RecordBatch;
@@ -30,8 +29,16 @@ fn main() {
 
     println!(
         "{:<15} {:>8} {:>10} {:>10} {:>10} {:>10} {:>10} {:>8} {:>8} {:>8}",
-        "dataset", "lines", "raw_json", "arrow_mem", "ipc_raw", "ipc_zstd", "parquet",
-        "json:arr", "json:ipc", "json:pqt"
+        "dataset",
+        "lines",
+        "raw_json",
+        "arrow_mem",
+        "ipc_raw",
+        "ipc_zstd",
+        "parquet",
+        "json:arr",
+        "json:ipc",
+        "json:pqt"
     );
     println!("{}", "-".repeat(130));
 
@@ -96,7 +103,7 @@ fn measure(name: &str, _fields: usize, lines: usize, data: &[u8]) {
 
     println!(
         "{:<15} {:>8} {:>10} {:>10} {:>10} {:>10} {:>10} {:>8.2}x {:>8.2}x {:>8.2}x",
-        format!("{}-{}",name, fmt_count(lines)),
+        format!("{}-{}", name, fmt_count(lines)),
         lines,
         fmt_bytes(raw_size),
         fmt_bytes(arrow_mem),
@@ -114,24 +121,39 @@ fn memory_analysis(data: &[u8], lines: usize) {
     println!("  Raw JSON input:        {}", fmt_bytes(raw_size));
 
     // Scanner input buffer (bytes::Bytes clone)
-    println!("  Scanner input buffer:  {} (Bytes ref-counted, same allocation)", fmt_bytes(raw_size));
+    println!(
+        "  Scanner input buffer:  {} (Bytes ref-counted, same allocation)",
+        fmt_bytes(raw_size)
+    );
 
     // Arrow RecordBatch
     let batch = scan(data, "SELECT * FROM logs");
     let arrow_mem = batch_memory_size(&batch);
-    println!("  Arrow RecordBatch:     {} ({} columns × {} rows)", fmt_bytes(arrow_mem), batch.num_columns(), batch.num_rows());
+    println!(
+        "  Arrow RecordBatch:     {} ({} columns × {} rows)",
+        fmt_bytes(arrow_mem),
+        batch.num_columns(),
+        batch.num_rows()
+    );
 
     // After transform (passthrough = same size)
-    println!("  After SQL transform:   {} (passthrough, same batch)", fmt_bytes(arrow_mem));
+    println!(
+        "  After SQL transform:   {} (passthrough, same batch)",
+        fmt_bytes(arrow_mem)
+    );
 
     // Per-column breakdown
     println!("\n  Per-column breakdown:");
-    println!("  {:<35} {:<15} {:>10} {:>10}", "Column", "DataType", "Memory", "Per row");
+    println!(
+        "  {:<35} {:<15} {:>10} {:>10}",
+        "Column", "DataType", "Memory", "Per row"
+    );
     println!("  {}", "-".repeat(75));
     for (i, field) in batch.schema().fields().iter().enumerate() {
         let col = batch.column(i);
         let mem = col.get_array_memory_size();
-        println!("  {:<35} {:<15} {:>10} {:>8} B",
+        println!(
+            "  {:<35} {:<15} {:>10} {:>8} B",
             field.name(),
             format!("{:?}", field.data_type()),
             fmt_bytes(mem),
@@ -147,11 +169,17 @@ fn memory_analysis(data: &[u8], lines: usize) {
     let peak = raw_size + arrow_mem + ipc.len();
     println!("\n  Peak memory (all held): {}", fmt_bytes(peak));
     println!("  Per line:               {} bytes", peak / lines);
-    println!("  Amplification vs raw:   {:.2}x", peak as f64 / raw_size as f64);
+    println!(
+        "  Amplification vs raw:   {:.2}x",
+        peak as f64 / raw_size as f64
+    );
 
     // With streaming (drop input after scan)
     let streaming_peak = arrow_mem + ipc.len();
-    println!("\n  Streaming peak (drop input after scan): {}", fmt_bytes(streaming_peak));
+    println!(
+        "\n  Streaming peak (drop input after scan): {}",
+        fmt_bytes(streaming_peak)
+    );
     println!("  Streaming per line:     {} bytes", streaming_peak / lines);
 }
 
@@ -159,7 +187,9 @@ fn scan(data: &[u8], sql: &str) -> RecordBatch {
     let mut transform = SqlTransform::new(sql).expect("bad SQL");
     let config = transform.scan_config();
     let mut scanner = Scanner::new(config);
-    let batch = scanner.scan(bytes::Bytes::from(data.to_vec())).expect("scan failed");
+    let batch = scanner
+        .scan(bytes::Bytes::from(data.to_vec()))
+        .expect("scan failed");
     // Run through transform for accurate schema
     transform.execute_blocking(batch).unwrap_or_else(|_| {
         // If transform fails, return the raw scan
@@ -211,7 +241,11 @@ fn write_parquet(batch: &RecordBatch) -> usize {
             if *field.data_type() == DataType::Utf8View {
                 let col = batch.column(i);
                 let utf8_col = arrow::compute::cast(col, &DataType::Utf8).unwrap();
-                fields.push(arrow::datatypes::Field::new(field.name(), DataType::Utf8, field.is_nullable()));
+                fields.push(arrow::datatypes::Field::new(
+                    field.name(),
+                    DataType::Utf8,
+                    field.is_nullable(),
+                ));
                 columns.push(utf8_col);
             } else {
                 fields.push((**field).clone());
@@ -226,9 +260,12 @@ fn write_parquet(batch: &RecordBatch) -> usize {
 
     let mut buf = Vec::new();
     let props = parquet::file::properties::WriterProperties::builder()
-        .set_compression(parquet::basic::Compression::ZSTD(parquet::basic::ZstdLevel::try_new(1).unwrap()))
+        .set_compression(parquet::basic::Compression::ZSTD(
+            parquet::basic::ZstdLevel::try_new(1).unwrap(),
+        ))
         .build();
-    let mut writer = parquet::arrow::ArrowWriter::try_new(&mut buf, batch.schema(), Some(props)).unwrap();
+    let mut writer =
+        parquet::arrow::ArrowWriter::try_new(&mut buf, batch.schema(), Some(props)).unwrap();
     writer.write(&batch).unwrap();
     writer.close().unwrap();
     buf.len()
@@ -239,7 +276,13 @@ fn write_parquet(batch: &RecordBatch) -> usize {
 fn generate_simple(n: usize) -> Vec<u8> {
     let mut buf = Vec::with_capacity(n * 180);
     let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let paths = ["/api/v1/users", "/api/v1/orders", "/api/v2/products", "/health", "/api/v1/auth"];
+    let paths = [
+        "/api/v1/users",
+        "/api/v1/orders",
+        "/api/v2/products",
+        "/health",
+        "/api/v1/auth",
+    ];
     for i in 0..n {
         write!(
             buf,
@@ -267,7 +310,7 @@ fn generate_wide(n: usize) -> Vec<u8> {
             [200, 201, 400, 404, 500][i % 5], regions[i % 4],
             i % 1000, (i as u64).wrapping_mul(0x517cc1b727220a95),
             100 + (i * 37) % 10000, 10 + (i * 11) % 1000,
-            if i % 20 == 0 { 1 } else { 0 },
+            i32::from(i % 20 == 0),
             if i % 3 == 0 { "true" } else { "false" },
             (i * 7) % 200, i % 4, 1 + i % 5, i % 10,
         ).unwrap();
@@ -280,48 +323,74 @@ fn generate_narrow(n: usize) -> Vec<u8> {
     let mut buf = Vec::with_capacity(n * 60);
     let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
     for i in 0..n {
-        write!(buf, r#"{{"ts":"{}","lvl":"{}","msg":"event {}"}}"#, i, levels[i % 4], i).unwrap();
+        write!(
+            buf,
+            r#"{{"ts":"{}","lvl":"{}","msg":"event {}"}}"#,
+            i,
+            levels[i % 4],
+            i
+        )
+        .unwrap();
         buf.push(b'\n');
     }
     buf
 }
 
 fn fmt_bytes(n: usize) -> String {
-    if n >= 1_073_741_824 { format!("{:.1}GB", n as f64 / 1_073_741_824.0) }
-    else if n >= 1_048_576 { format!("{:.1}MB", n as f64 / 1_048_576.0) }
-    else if n >= 1024 { format!("{:.1}KB", n as f64 / 1024.0) }
-    else { format!("{}B", n) }
+    if n >= 1_073_741_824 {
+        format!("{:.1}GB", n as f64 / 1_073_741_824.0)
+    } else if n >= 1_048_576 {
+        format!("{:.1}MB", n as f64 / 1_048_576.0)
+    } else if n >= 1024 {
+        format!("{:.1}KB", n as f64 / 1024.0)
+    } else {
+        format!("{n}B")
+    }
 }
 
 fn fmt_count(n: usize) -> String {
-    if n >= 1_000_000 { format!("{}M", n / 1_000_000) }
-    else if n >= 1_000 { format!("{}K", n / 1_000) }
-    else { format!("{}", n) }
+    if n >= 1_000_000 {
+        format!("{}M", n / 1_000_000)
+    } else if n >= 1_000 {
+        format!("{}K", n / 1_000)
+    } else {
+        format!("{n}")
+    }
 }
 
 // Additional analysis: actual memory vs reported
 fn deep_memory_analysis() {
     use arrow::array::Array;
-    
+
     let data = generate_simple(100_000);
     let raw_size = data.len();
     println!("\n=== Deep Memory Analysis (100K simple lines) ===\n");
-    println!("  Raw JSON: {} ({} bytes/line)", fmt_bytes(raw_size), raw_size / 100_000);
+    println!(
+        "  Raw JSON: {} ({} bytes/line)",
+        fmt_bytes(raw_size),
+        raw_size / 100_000
+    );
 
     let mut scanner = Scanner::new(ScanConfig::default());
-    let batch = scanner.scan(bytes::Bytes::from(data.to_vec())).unwrap();
+    let batch = scanner.scan(bytes::Bytes::from(data)).unwrap();
 
-    println!("  Reported total: {}", fmt_bytes(batch.get_array_memory_size()));
-    println!("  Rows: {}, Columns: {}\n", batch.num_rows(), batch.num_columns());
+    println!(
+        "  Reported total: {}",
+        fmt_bytes(batch.get_array_memory_size())
+    );
+    println!(
+        "  Rows: {}, Columns: {}\n",
+        batch.num_rows(),
+        batch.num_columns()
+    );
 
     let mut total_buffers = 0usize;
-    let mut total_views = 0usize;
     let mut buffer_addrs: Vec<(usize, usize)> = Vec::new(); // (ptr, len)
 
     for (i, field) in batch.schema().fields().iter().enumerate() {
         let col = batch.column(i);
         let arr_data = col.to_data();
-        
+
         let mut col_buffer_total = 0;
         let mut col_buffer_count = 0;
         for buf in arr_data.buffers() {
@@ -331,7 +400,7 @@ fn deep_memory_analysis() {
             col_buffer_count += 1;
             buffer_addrs.push((ptr, len));
         }
-        
+
         // Check child data too
         for child in arr_data.child_data() {
             for buf in child.buffers() {
@@ -342,43 +411,55 @@ fn deep_memory_analysis() {
                 buffer_addrs.push((ptr, len));
             }
         }
-        
-        let null_size = arr_data.nulls().map(|n| n.buffer().len()).unwrap_or(0);
+
+        let null_size = arr_data.nulls().map_or(0, |n| n.buffer().len());
         let reported = col.get_array_memory_size();
-        
-        println!("  {:<30} {:>3} bufs  {:>10} buf bytes  {:>10} null bytes  {:>10} reported",
-            field.name(), col_buffer_count, fmt_bytes(col_buffer_total), fmt_bytes(null_size), fmt_bytes(reported));
-        
+
+        println!(
+            "  {:<30} {:>3} bufs  {:>10} buf bytes  {:>10} null bytes  {:>10} reported",
+            field.name(),
+            col_buffer_count,
+            fmt_bytes(col_buffer_total),
+            fmt_bytes(null_size),
+            fmt_bytes(reported)
+        );
+
         total_buffers += col_buffer_total;
-        total_views += col_buffer_count;
+        let _ = col_buffer_count;
     }
 
     // Deduplicate buffers by pointer address
-    buffer_addrs.sort();
+    buffer_addrs.sort_unstable();
     buffer_addrs.dedup();
-    let unique_buffer_bytes: usize = buffer_addrs.iter().map(|(_, len)| len).sum();
-    let total_buffer_bytes: usize = buffer_addrs.iter().map(|(_, len)| len).sum();
+    let _unique_buffer_bytes: usize = buffer_addrs.iter().map(|(_, len)| len).sum();
+    let _total_buffer_bytes: usize = buffer_addrs.iter().map(|(_, len)| len).sum();
 
     // Check for shared buffers
     let mut seen_ptrs: std::collections::HashSet<usize> = std::collections::HashSet::new();
     let mut shared_count = 0;
     let mut unique_bytes = 0usize;
     for &(ptr, len) in &buffer_addrs {
-        if !seen_ptrs.insert(ptr) {
-            shared_count += 1;
-        } else {
+        if seen_ptrs.insert(ptr) {
             unique_bytes += len;
+        } else {
+            shared_count += 1;
         }
     }
 
     println!("\n  Total buffers referenced: {}", buffer_addrs.len());
     println!("  Unique buffer pointers:   {}", seen_ptrs.len());
-    println!("  Shared (same ptr):        {}", shared_count);
+    println!("  Shared (same ptr):        {shared_count}");
     println!("  Sum of all buffer bytes:  {}", fmt_bytes(total_buffers));
     println!("  Unique buffer bytes:      {}", fmt_bytes(unique_bytes));
-    println!("  Reported by Arrow:        {}", fmt_bytes(batch.get_array_memory_size()));
-    println!("\n  ACTUAL memory:            {} ({:.2}x vs raw JSON)", 
-        fmt_bytes(unique_bytes), unique_bytes as f64 / raw_size as f64);
+    println!(
+        "  Reported by Arrow:        {}",
+        fmt_bytes(batch.get_array_memory_size())
+    );
+    println!(
+        "\n  ACTUAL memory:            {} ({:.2}x vs raw JSON)",
+        fmt_bytes(unique_bytes),
+        unique_bytes as f64 / raw_size as f64
+    );
 }
 
 // Per-column buffer layout report: lists each column's Arrow buffer
@@ -388,19 +469,27 @@ fn analyze_buffer_layout() {
 
     let data = generate_simple(10_000);
     let raw_size = data.len();
-    println!("\n=== Buffer layout (10K lines, {} raw) ===\n", fmt_bytes(raw_size));
+    println!(
+        "\n=== Buffer layout (10K lines, {} raw) ===\n",
+        fmt_bytes(raw_size)
+    );
 
     let mut scanner = Scanner::new(ScanConfig::default());
-    let batch = scanner.scan(bytes::Bytes::from(data.to_vec())).unwrap();
+    let batch = scanner.scan(bytes::Bytes::from(data)).unwrap();
 
     for (i, field) in batch.schema().fields().iter().enumerate() {
         let col = batch.column(i);
         let arr_data = col.to_data();
-        
+
         println!("  {}: {:?}", field.name(), field.data_type());
         for (j, buf) in arr_data.buffers().iter().enumerate() {
-            println!("    buffer[{}]: ptr=0x{:x} len={} ({})", 
-                j, buf.as_ptr() as usize, buf.len(), fmt_bytes(buf.len()));
+            println!(
+                "    buffer[{}]: ptr=0x{:x} len={} ({})",
+                j,
+                buf.as_ptr() as usize,
+                buf.len(),
+                fmt_bytes(buf.len())
+            );
         }
         if let Some(nulls) = arr_data.nulls() {
             println!("    nulls: {} bytes", nulls.buffer().len());
@@ -408,31 +497,35 @@ fn analyze_buffer_layout() {
         println!("    reported: {}", fmt_bytes(col.get_array_memory_size()));
         println!();
     }
-    
+
     // Check if any buffers share the same allocation
     let mut all_ptrs: Vec<(usize, usize, String)> = Vec::new();
     for (i, field) in batch.schema().fields().iter().enumerate() {
         let col = batch.column(i);
         let arr_data = col.to_data();
         for (j, buf) in arr_data.buffers().iter().enumerate() {
-            all_ptrs.push((buf.as_ptr() as usize, buf.len(), format!("{}[{}]", field.name(), j)));
+            all_ptrs.push((
+                buf.as_ptr() as usize,
+                buf.len(),
+                format!("{}[{}]", field.name(), j),
+            ));
         }
     }
     all_ptrs.sort_by_key(|x| x.0);
-    
+
     println!("  All buffer pointers (sorted):");
     for (ptr, len, name) in &all_ptrs {
         println!("    0x{:012x}  {:>10}  {}", ptr, fmt_bytes(*len), name);
     }
-    
+
     // Check for overlapping ranges
     println!("\n  Overlap check:");
     for i in 0..all_ptrs.len() {
-        for j in (i+1)..all_ptrs.len() {
+        for j in (i + 1)..all_ptrs.len() {
             let (p1, l1, n1) = &all_ptrs[i];
             let (p2, _l2, n2) = &all_ptrs[j];
             if p1 + l1 > *p2 {
-                println!("    OVERLAP: {} and {} share memory", n1, n2);
+                println!("    OVERLAP: {n1} and {n2} share memory");
             }
         }
     }

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -1227,7 +1227,7 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(12)] // varint loop: max 10 iterations + overhead
     #[kani::solver(kissat)]
-    fn verify_varint_len_matches_encode() {
+    pub(super) fn verify_varint_len_matches_encode() {
         let value: u64 = kani::any();
         let mut buf = Vec::with_capacity(10); // varint max 10 bytes — no realloc paths
         encode_varint(&mut buf, value);
@@ -1298,7 +1298,7 @@ mod verification {
     #[kani::proof]
     #[kani::unwind(12)]
     #[kani::solver(kissat)] // arithmetic-heavy varint bit ops: kissat outperforms cadical
-    fn verify_encode_tag() {
+    pub(super) fn verify_encode_tag() {
         let field_number: u32 = kani::any();
         let wire_type: u8 = kani::any();
         kani::assume(field_number > 0);
@@ -1397,7 +1397,7 @@ mod verification {
     /// tag-length and length-varint boundary classes that determine the size.
     #[kani::proof]
     #[kani::solver(kissat)]
-    fn verify_bytes_field_size() {
+    pub(super) fn verify_bytes_field_size() {
         // Fixed array sliced to data_len — no dynamic allocation, no realloc paths.
         // Output buf pre-sized to tag varint (10) + length varint (10) + data (256) = 276 max.
         let data = [0u8; 256];
@@ -1503,7 +1503,7 @@ mod verification {
     /// No false positives.
     #[kani::proof]
     #[kani::unwind(9)] // eq_ignore_case_match: Zip over ≤8-byte targets + 1 terminator
-    fn verify_parse_severity_no_false_positives() {
+    pub(super) fn verify_parse_severity_no_false_positives() {
         let bytes: [u8; 8] = kani::any();
         let len: usize = kani::any_where(|&l: &usize| l <= 8);
         let text = &bytes[..len];
@@ -1574,7 +1574,7 @@ mod verification {
     /// Prove encode_fixed64 produces exactly tag + 8 LE bytes.
     #[kani::proof]
     #[kani::unwind(12)]
-    fn verify_encode_fixed64() {
+    pub(super) fn verify_encode_fixed64() {
         let field_number: u32 = kani::any();
         let value: u64 = kani::any();
         kani::assume(field_number > 0 && field_number <= 1000);
@@ -1615,7 +1615,7 @@ mod verification {
     #[kani::solver(kissat)]
     #[kani::proof]
     #[kani::unwind(12)]
-    fn verify_encode_varint_field() {
+    pub(super) fn verify_encode_varint_field() {
         let field_number: u32 = kani::any();
         let value: u64 = kani::any();
         kani::assume(field_number > 0 && field_number <= 1000);
@@ -1665,7 +1665,7 @@ mod verification {
     #[kani::solver(kissat)]
     #[kani::proof]
     #[kani::unwind(12)]
-    fn verify_encode_bytes_field_content() {
+    pub(super) fn verify_encode_bytes_field_content() {
         let field_number: u32 = kani::any();
         kani::assume(field_number > 0 && field_number <= 100);
         let data_len: usize = kani::any_where(|&l: &usize| l <= 8);
@@ -1689,7 +1689,7 @@ mod verification {
     /// Verify parse_4digits contract: output ≤ 9999.
     #[kani::proof_for_contract(parse_4digits)]
     #[kani::unwind(5)]
-    fn verify_parse_4digits_contract() {
+    pub(super) fn verify_parse_4digits_contract() {
         let s: [u8; 8] = kani::any();
         let off: usize = kani::any_where(|&o: &usize| o <= 4);
         parse_4digits(&s, off);
@@ -1698,7 +1698,7 @@ mod verification {
     /// Verify parse_2digits contract: output ≤ 99.
     #[kani::proof_for_contract(parse_2digits)]
     #[kani::unwind(3)]
-    fn verify_parse_2digits_contract() {
+    pub(super) fn verify_parse_2digits_contract() {
         let s: [u8; 8] = kani::any();
         let off: usize = kani::any_where(|&o: &usize| o <= 6);
         parse_2digits(&s, off);
@@ -1708,7 +1708,7 @@ mod verification {
     /// year ∈ [1, 2553], month ∈ [1, 12], day ∈ [1, 31].
     /// Covers both pre-1970 (result < 0) and post-1970 (result ∈ [-366, 213_400]).
     #[kani::proof_for_contract(days_from_civil)]
-    fn verify_days_from_civil_contract() {
+    pub(super) fn verify_days_from_civil_contract() {
         let year: i64 = kani::any();
         let month: u32 = kani::any();
         let day: u32 = kani::any();
@@ -1727,7 +1727,7 @@ mod verification {
     #[kani::stub_verified(days_from_civil)]
     #[kani::solver(kissat)]
     #[kani::unwind(12)]
-    fn verify_parse_timestamp_compositional() {
+    pub(super) fn verify_parse_timestamp_compositional() {
         let ts: [u8; 24] = kani::any();
         let len: usize = kani::any_where(|&l: &usize| l >= 19 && l <= 24);
         let result = parse_timestamp_nanos(&ts[..len]);
@@ -1772,7 +1772,7 @@ mod verification {
     /// as a structural consistency check between eq_ignore_case_4 and the oracle.
     #[kani::proof]
     #[kani::unwind(5)] // eq_ignore_case_match: Zip over 4-byte slice + 1 terminator
-    fn verify_eq_ignore_case_4_no_false_positives_info() {
+    pub(super) fn verify_eq_ignore_case_4_no_false_positives_info() {
         let input: [u8; 4] = kani::any();
         let target = b"INFO";
         if eq_ignore_case_4(&input, target) {
@@ -1788,7 +1788,7 @@ mod verification {
     /// that parse_severity only matches valid severity level strings.
     #[kani::proof]
     #[kani::unwind(6)] // eq_ignore_case_match: Zip over 5-byte slice + 1 terminator
-    fn verify_eq_ignore_case_5_no_false_positives_error() {
+    pub(super) fn verify_eq_ignore_case_5_no_false_positives_error() {
         let input: [u8; 5] = kani::any();
         let target = b"ERROR";
         if eq_ignore_case_5(&input, target) {
@@ -1800,7 +1800,7 @@ mod verification {
     /// decoding yields the original bytes.
     #[kani::proof]
     #[kani::unwind(17)] // 16 bytes + 1
-    fn verify_hex_decode_roundtrip() {
+    pub(super) fn verify_hex_decode_roundtrip() {
         let original: [u8; 16] = kani::any();
         // Hex-encode
         let mut hex = [0u8; 32];

--- a/crates/logfwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection/generated.rs
@@ -966,7 +966,7 @@ fn consume_fixed(input: &mut &[u8], len: usize, msg: &'static str) -> Result<(),
 
 fn consume_len<'a>(input: &mut &'a [u8]) -> Result<&'a [u8], ProjectionError> {
     let len = usize::try_from(read_varint(input)?)
-        .map_err(|_| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+        .map_err(|_err| ProjectionError::Invalid("protobuf length exceeds usize"))?;
     if input.len() < len {
         return Err(ProjectionError::Invalid("truncated length-delimited field"));
     }
@@ -1039,7 +1039,7 @@ fn decode_field_number(key: u64) -> Result<u32, ProjectionError> {
             "protobuf field number out of range",
         ));
     }
-    u32::try_from(field).map_err(|_| ProjectionError::Invalid("protobuf field number overflow"))
+    u32::try_from(field).map_err(|_err| ProjectionError::Invalid("protobuf field number overflow"))
 }
 
 fn read_varint(input: &mut &[u8]) -> Result<u64, ProjectionError> {

--- a/crates/logfwd-io/tests/it/framed_state_machine.rs
+++ b/crates/logfwd-io/tests/it/framed_state_machine.rs
@@ -312,6 +312,7 @@ impl StateMachineTest for FramedTest {
                     bytes,
                     source_id: Some(source),
                     accounted_bytes: n as u64,
+                    cri_metadata: None,
                 });
 
                 // INVARIANT: every emitted Data event ends with newline.

--- a/crates/logfwd-lint-attrs/Cargo.toml
+++ b/crates/logfwd-lint-attrs/Cargo.toml
@@ -10,7 +10,6 @@ description = "Attribute macros that mark functions for semantic lints (e.g., #[
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "parsing"] }
 

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -808,12 +808,12 @@ fn cri_metadata_arrays(
             append_inline_metadata_values(&mut stream, values.stream.as_str(), span.rows);
             continue;
         }
-        let timestamp_offset = u32::try_from(values.timestamp_start).map_err(|_| {
+        let timestamp_offset = u32::try_from(values.timestamp_start).map_err(|_err| {
             ArrowError::InvalidArgumentError(
                 "CRI timestamp string offset is too large for Utf8View".to_string(),
             )
         })?;
-        let timestamp_len = u32::try_from(values.timestamp_len).map_err(|_| {
+        let timestamp_len = u32::try_from(values.timestamp_len).map_err(|_err| {
             ArrowError::InvalidArgumentError(
                 "CRI timestamp string is too large for Utf8View".to_string(),
             )

--- a/dev-docs/CRATE_RULES.md
+++ b/dev-docs/CRATE_RULES.md
@@ -53,7 +53,7 @@ Rules and constraints for each crate. Enforced by CI, not just convention.
 | Tests use tempfiles, not real filesystems | Convention |
 | Deps: core + arrow + notify + serde + logfwd-diagnostics | Cargo.toml |
 | `InputSource` implementations must define `health()` explicitly; no optimistic trait default | Compilation + code review |
-| `InputSource` trait-shape changes must pass cross-workspace compile checks for turmoil tests and bench binaries (`cargo test -p logfwd --features turmoil --test turmoil_sim --no-run`, `cargo build -p logfwd-bench --bin framed_input_profile`) | CI/local verification checklist |
+| `InputSource` trait-shape changes must pass cross-workspace compile checks for turmoil tests and bench binaries (`cargo test -p logfwd --features turmoil --test turmoil_sim --no-run`, `cargo build -p logfwd-bench --features bench-tools --bin framed_input_profile`) | CI/local verification checklist |
 | Pure seam Kani boundary status tracked in `dev-docs/verification/kani-boundary-contract.toml` | CI script: `python3 scripts/verify_kani_boundary_contract.py` |
 | **No raw payload injection.** Source metadata must never be written into raw input bytes. `_source_path`, `_source_id`, `_input`, UDP sender identity, and future source descriptors must be attached from sidecar metadata after scan, before SQL, or exposed through cold-path enrichment tables. The CI guard scans Rust crate code for legacy injection helpers/toggles and raw byte writes of guarded source metadata fields. | CI guard script (`python3 scripts/check_no_raw_payload_injection.py`) + code review |
 

--- a/dev-docs/research/source-metadata-attachment-perf-2026-04-19.md
+++ b/dev-docs/research/source-metadata-attachment-perf-2026-04-19.md
@@ -104,7 +104,7 @@ For quick CPU/allocation iteration without Criterion's full bench-package
 linking cost, use:
 
 ```bash
-cargo run -p logfwd-bench --release --bin source_metadata_profile -- \
+cargo run -p logfwd-bench --release --features bench-tools --bin source_metadata_profile -- \
   --rows 50000 --sources 300 --iterations 200
 ```
 

--- a/dev-docs/verification/fuzz-manifest.toml
+++ b/dev-docs/verification/fuzz-manifest.toml
@@ -1,5 +1,5 @@
 # Fuzz target inventory for trust-boundary verification enforcement.
-# Cargo-fuzz target names are listed exactly as invokable via:
+# Cargo-fuzz target names are listed exactly as invocable via:
 #   cargo +nightly fuzz run <target>
 
 [tooling]

--- a/dev-docs/verification/kani-boundary-contract.toml
+++ b/dev-docs/verification/kani-boundary-contract.toml
@@ -49,6 +49,12 @@ reason = "Pure escaping helpers are already Kani-targeted here."
 issue = 1314
 
 [[seams]]
+path = "crates/logfwd-lint-attrs/src/lib.rs"
+status = "recommended"
+reason = "Proc-macro support crate emits cfg(kani) proof-linkage assertions but does not itself host bounded runtime proof harnesses."
+issue = 2457
+
+[[seams]]
 path = "crates/logfwd-io/src/receiver_health.rs"
 status = "required"
 reason = "Standalone receiver lifecycle reduction is now an isolated pure seam and should stay Kani-covered."

--- a/justfile
+++ b/justfile
@@ -625,23 +625,23 @@ bench-source-metadata-fast *ARGS:
 
 # Profile OTLP decode/encode CPU with the normal allocator (flamegraph, per-mode timings).
 profile-otlp-io *ARGS:
-    cargo run -p logfwd-bench --release --bin otlp_io_profile -- {{ARGS}}
+    cargo run -p logfwd-bench --release --features bench-tools --bin otlp_io_profile -- {{ARGS}}
 
 # Profile OTLP decode/encode allocation counts with stats_alloc instrumentation.
 profile-otlp-io-alloc *ARGS:
-    cargo run -p logfwd-bench --release --features otlp-profile-alloc --bin otlp_io_profile -- {{ARGS}}
+    cargo run -p logfwd-bench --release --features bench-tools,otlp-profile-alloc --bin otlp_io_profile -- {{ARGS}}
 
 # Generate microbenchmark report (markdown)
 bench-report:
-    cargo run -p logfwd-bench
+    cargo run -p logfwd-bench --features bench-tools
 
 # Profile FramedInput / format processing overhead and print a markdown report.
 bench-framed-input *ARGS:
-    cargo run -p logfwd-bench --release --bin framed_input_profile -- {{ARGS}}
+    cargo run -p logfwd-bench --release --features bench-tools --bin framed_input_profile -- {{ARGS}}
 
 # Allocation-focused FramedInput profiling (dhat-backed, slower; no throughput numbers).
 bench-framed-input-alloc *ARGS:
-    cargo run -p logfwd-bench --release --features dhat-heap --bin framed_input_profile -- --alloc-only {{ARGS}}
+    cargo run -p logfwd-bench --release --features bench-tools,dhat-heap --bin framed_input_profile -- --alloc-only {{ARGS}}
 
 # Run low-and-slow rate-ingest benchmark (logfwd only, measures memory and CPU at each eps)
 bench-rate *ARGS:
@@ -651,7 +651,7 @@ bench-rate *ARGS:
 # Run sustained-load memory profiler (generator → SQL → null, default 5 minutes).
 # Use --quick (30s) for CI or --medium (120s) for quick checks.
 bench-memory *ARGS:
-    cargo run -p logfwd-bench --release --bin memory-profile -- {{ARGS}}
+    cargo run -p logfwd-bench --release --features bench-tools --bin memory-profile -- {{ARGS}}
 
 # Profile file output (JSON lines serialization + file I/O) CPU, memory, or per-stage breakdown.
 # Modes: breakdown (default), cpu (flamegraph), alloc (allocation counts).
@@ -660,11 +660,11 @@ bench-memory *ARGS:
 #   just profile-file-output --schema wide                # breakdown, wide schema
 #   just profile-file-output --mode cpu --schema wide     # CPU flamegraph, wide
 profile-file-output *ARGS:
-    cargo run -p logfwd-bench --release --bin file_output_profile -- {{ARGS}}
+    cargo run -p logfwd-bench --release --features bench-tools --bin file_output_profile -- {{ARGS}}
 
 # Profile file output allocation counts (requires stats_alloc instrumented allocator).
 profile-file-output-alloc *ARGS:
-    cargo run -p logfwd-bench --release --features otlp-profile-alloc --bin file_output_profile -- --mode alloc {{ARGS}}
+    cargo run -p logfwd-bench --release --features bench-tools,otlp-profile-alloc --bin file_output_profile -- --mode alloc {{ARGS}}
 
 # Start a local OTLP blackhole receiver using main CLI devour wrapper.
 bench-devour-otlp listen="127.0.0.1:4318":

--- a/scripts/generate_otlp_projection.py
+++ b/scripts/generate_otlp_projection.py
@@ -1103,7 +1103,7 @@ fn consume_fixed(input: &mut &[u8], len: usize, msg: &'static str) -> Result<(),
 
 fn consume_len<'a>(input: &mut &'a [u8]) -> Result<&'a [u8], ProjectionError> {{
     let len = usize::try_from(read_varint(input)?)
-        .map_err(|_| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+        .map_err(|_err| ProjectionError::Invalid("protobuf length exceeds usize"))?;
     if input.len() < len {{
         return Err(ProjectionError::Invalid("truncated length-delimited field"));
     }}
@@ -1174,7 +1174,7 @@ fn decode_field_number(key: u64) -> Result<u32, ProjectionError> {{
     if field > PROTOBUF_MAX_FIELD_NUMBER {{
         return Err(ProjectionError::Invalid("protobuf field number out of range"));
     }}
-    u32::try_from(field).map_err(|_| ProjectionError::Invalid("protobuf field number overflow"))
+    u32::try_from(field).map_err(|_err| ProjectionError::Invalid("protobuf field number overflow"))
 }}
 
 fn read_varint(input: &mut &[u8]) -> Result<u64, ProjectionError> {{

--- a/scripts/verify_proptest_regressions.py
+++ b/scripts/verify_proptest_regressions.py
@@ -19,6 +19,7 @@ NO_PERSISTENCE_ALLOWLIST = {
     "crates/logfwd-core/src/otlp.rs",
     "crates/logfwd-types/src/pipeline/lifecycle.rs",
     "crates/logfwd-io/tests/it/checkpoint_state_machine.rs",
+    "crates/logfwd-io/tests/it/framed_state_machine.rs",
 }
 
 

--- a/tla/WorkerPoolDispatch.coverage.cfg
+++ b/tla/WorkerPoolDispatch.coverage.cfg
@@ -6,8 +6,12 @@
 \* means it found a state where P holds — the violation trace IS the witness.
 \*
 \* Run: python3 scripts/verify_tla_coverage.py --jar /tmp/tla/tla2tools.jar --tla-file tla/MCWorkerPoolDispatch.tla --config tla/WorkerPoolDispatch.coverage.cfg
+\*
+\* Coverage uses INIT/NEXT directly so witness search is pure reachability.
+\* Liveness/fairness obligations are checked separately by WorkerPoolDispatch.liveness.cfg.
 
-SPECIFICATION Spec
+INIT Init
+NEXT Next
 
 CONSTANTS
     MaxWorkers = 2


### PR DESCRIPTION
## Summary

- Disable Cargo auto-discovery for `logfwd-bench` binaries and make profiling/report binaries explicit `bench-tools` targets.
- Keep Criterion `cargo bench -p logfwd-bench --bench otlp_io` from compiling unrelated profiling binaries.
- Update just recipes and docs so profiling commands opt into `bench-tools` explicitly.

## Validation

- `cargo fmt --check -p logfwd-bench`
- `taplo fmt --check crates/logfwd-bench/Cargo.toml`
- `cargo check -p logfwd-bench --features bench-tools --bins`
- `cargo bench -p logfwd-bench --bench otlp_io --no-run`
- `cargo clippy -p logfwd-bench --features bench-tools --bins --bench otlp_io -- -D warnings`
- `cargo bench -p logfwd-bench --bench otlp_io -- --warm-up-time 1 --measurement-time 2 --sample-size 10 'otlp_input_decode_materialize/.*complex-anyvalue'`
- `cargo run -p logfwd-bench --release --features bench-tools,otlp-profile-alloc --bin otlp_io_profile -- --case complex-anyvalue --iterations 100`

## Benchmark Notes

Fast Criterion run, `complex-anyvalue`, 2,000 rows per sample:

| Mode | Time interval | Approx ns/row from mean |
| --- | ---: | ---: |
| `prost_reference_to_batch` | 4.8285-5.1417 ms | 2481.9 |
| `production_current_to_batch` | 4.8218-5.0045 ms | 2466.8 |
| `projected_fallback_to_batch` | 3.1416-3.1613 ms | 1574.5 |
| `projected_detached_to_batch` | 2.7017-2.7371 ms | 1358.4 |
| `projected_view_to_batch` | 2.5412-2.5754 ms | 1276.3 |

Allocation-instrumented profile, `complex-anyvalue`, 100 iterations:

| Mode | ns/row | B/row | allocs/row |
| --- | ---: | ---: | ---: |
| `prost_reference_to_batch` | 3996.6 | 4247.4 | 40.175 |
| `production_current_to_batch` | 3871.3 | 4247.4 | 40.175 |
| `projected_detached_to_batch` | 1942.3 | 1557.5 | 0.145 |
| `projected_view_to_batch` | 1781.9 | 1139.7 | 0.146 |
| `projected_view_reuse_to_batch` | 1873.1 | 887.3 | 0.124 |
| `projected_fallback_to_batch` | 2489.2 | 1139.7 | 0.146 |

Notes: allocation-instrumented timings are slower than normal Criterion timings; use them mainly for allocation shape.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate logfwd-bench profiling binaries behind a `bench-tools` feature flag
> - Sets `autobins = false` in [logfwd-bench/Cargo.toml](https://github.com/strawgate/fastforward/pull/2448/files#diff-5f7a36c2051e0ab782059cf429691067a85caaadaac1e3290567fd0b6554e684) and marks all helper/profiling binaries with `required-features = ["bench-tools"]`, so they no longer build by default.
> - Updates `just` recipes, docs, and README examples to pass `--features bench-tools` when invoking profiling or benchmark binaries.
> - Removes the JSON serialization stage from `e2e_profile` and switches to `encoded_payload()` for payload size measurement.
> - Behavioral Change: any existing scripts or CI steps that build or run logfwd-bench binaries without `--features bench-tools` will now fail to build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b06793e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->