### PR TITLE
fix: use explicit error binding in map_err to satisfy clippy

### DIFF
--- a/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline.rs
@@ -808,12 +808,12 @@ fn cri_metadata_arrays(
             append_inline_metadata_values(&mut stream, values.stream.as_str(), span.rows);
             continue;
         }
-        let timestamp_offset = u32::try_from(values.timestamp_start).map_err(|_| {
+        let timestamp_offset = u32::try_from(values.timestamp_start).map_err(|_err| {
             ArrowError::InvalidArgumentError(
                 "CRI timestamp string offset is too large for Utf8View".to_string(),
             )
         })?;
-        let timestamp_len = u32::try_from(values.timestamp_len).map_err(|_| {
+        let timestamp_len = u32::try_from(values.timestamp_len).map_err(|_err| {
             ArrowError::InvalidArgumentError(
                 "CRI timestamp string is too large for Utf8View".to_string(),
             )


### PR DESCRIPTION
## Summary
- Replace `map_err(|_| ...)` with `map_err(|_err| ...)` in `logfwd-runtime` pipeline to fix clippy `map_err_ignore` lint
- Two instances in `crates/logfwd-runtime/src/pipeline/input_pipeline.rs` (lines 811, 816)
- This was blocking all PR CI due to `-D warnings`

## Test plan
- [x] `cargo clippy -p logfwd-runtime -- -D warnings` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix unused error variable binding in `cri_metadata_arrays` to satisfy Clippy
> Renames unused `_` error parameters to `_err` in two `map_err` closures in [input_pipeline.rs](https://github.com/strawgate/fastforward/pull/2453/files#diff-8d09fe65f044c4f6e39b09d32493e940168bc73ffb42aff651f445fa90a96b9a). No logic or behavior is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43bd0e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->