### PR TITLE
test(output): add proptest coverage for row_json.rs and json_lines.rs

### DIFF
--- a/crates/logfwd-output/src/json_lines.rs
+++ b/crates/logfwd-output/src/json_lines.rs
@@ -296,6 +296,14 @@ mod tests {
     use arrow::array::StringArray;
     use arrow::datatypes::{DataType, Field, Schema};
     use logfwd_types::diagnostics::ComponentStats;
+    use proptest::prelude::*;
+
+    mod arrow_test_utils {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../logfwd-test-utils/src/arrow.rs"
+        ));
+    }
 
     fn make_sink() -> JsonLinesSink {
         let client = Arc::new(
@@ -444,6 +452,43 @@ mod tests {
             sink.batch_buf.is_empty(),
             "buf should be cleared between calls"
         );
+    }
+
+    proptest! {
+        #[test]
+        fn ndjson_lines_are_valid_json(batch in arrow_test_utils::arb_record_batch()) {
+            let mut sink = make_sink();
+            sink.serialize_batch(&batch).expect("serialize_batch must succeed");
+
+            let output = String::from_utf8(sink.batch_buf.clone()).expect("ndjson should be utf8");
+            let lines = output.lines().collect::<Vec<_>>();
+            prop_assert_eq!(lines.len(), batch.num_rows());
+
+            for line in lines {
+                let value: serde_json::Value = serde_json::from_str(line).expect("line must be valid json");
+                prop_assert!(value.is_object(), "each ndjson line must be a JSON object");
+            }
+        }
+
+        #[test]
+        fn ndjson_no_embedded_newlines(batch in arrow_test_utils::arb_record_batch()) {
+            let mut sink = make_sink();
+            sink.serialize_batch(&batch).expect("serialize_batch must succeed");
+
+            let newline_count = sink.batch_buf.iter().filter(|b| **b == b'\n').count();
+            prop_assert_eq!(newline_count, batch.num_rows(), "expected exactly one newline delimiter per row");
+
+            let mut lines = sink.batch_buf.split(|b| *b == b'\n').peekable();
+            while let Some(line) = lines.next() {
+                if line.is_empty() {
+                    prop_assert!(lines.peek().is_none(), "only trailing newline can produce empty segment");
+                    continue;
+                }
+
+                prop_assert!(!line.contains(&b'\n'), "ndjson line must not contain raw newline bytes");
+                serde_json::from_slice::<serde_json::Value>(line).expect("line must parse as JSON");
+            }
+        }
     }
 
     #[test]

--- a/crates/logfwd-output/src/row_json.rs
+++ b/crates/logfwd-output/src/row_json.rs
@@ -482,3 +482,190 @@ pub fn write_row_json(
     out.push(b'}');
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use arrow::array::{Float64Array, Int64Array, StringArray, StructArray};
+    use arrow::buffer::NullBuffer;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use proptest::prelude::*;
+
+    use crate::{build_col_infos, resolve_col_infos};
+
+    mod arrow_test_utils {
+        include!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../logfwd-test-utils/src/arrow.rs"
+        ));
+    }
+
+    fn serialize_row_via_default(batch: &RecordBatch, row: usize) -> String {
+        let cols = build_col_infos(batch);
+        let mut out = Vec::new();
+        write_row_json(batch, row, &cols, &mut out).expect("row serialization must succeed");
+        String::from_utf8(out).expect("row json must be utf8")
+    }
+
+    fn serialize_row_via_resolved(batch: &RecordBatch, row: usize) -> String {
+        let cols = build_col_infos(batch);
+        let resolved = resolve_col_infos(batch, &cols);
+        let mut out = Vec::new();
+        write_row_json_resolved(row, &resolved, &mut out)
+            .expect("resolved row serialization must succeed");
+        String::from_utf8(out).expect("row json must be utf8")
+    }
+
+    fn scalar_batch(rows: Vec<(String, i64, f64, bool)>) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("text", DataType::Utf8, false),
+            Field::new("count", DataType::Int64, false),
+            Field::new("ratio", DataType::Float64, false),
+            Field::new("ok", DataType::Boolean, false),
+        ]));
+
+        let text = rows.iter().map(|row| row.0.as_str()).collect::<Vec<_>>();
+        let count = rows.iter().map(|row| row.1).collect::<Vec<_>>();
+        let ratio = rows.iter().map(|row| row.2).collect::<Vec<_>>();
+        let ok = rows.iter().map(|row| row.3).collect::<Vec<_>>();
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(text)),
+                Arc::new(Int64Array::from(count)),
+                Arc::new(Float64Array::from(ratio)),
+                Arc::new(arrow::array::BooleanArray::from(ok)),
+            ],
+        )
+        .expect("scalar batch must be valid")
+    }
+
+    proptest! {
+        #[test]
+        fn row_json_produces_valid_json(batch in arrow_test_utils::arb_record_batch()) {
+            let cols = build_col_infos(&batch);
+            for row in 0..batch.num_rows() {
+                let mut out = Vec::new();
+                write_row_json(&batch, row, &cols, &mut out).expect("serialize");
+                let text = String::from_utf8(out).expect("utf8");
+                let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+                prop_assert!(value.is_object(), "row json must be an object: {text}");
+            }
+        }
+
+        #[test]
+        fn row_json_field_count_matches_schema(
+            rows in proptest::collection::vec(
+                (
+                    proptest::collection::vec(any::<char>(), 0..=10).prop_map(|chars| chars.into_iter().collect::<String>()),
+                    any::<i64>(),
+                    (-1_000_000i64..1_000_000i64).prop_map(|n| n as f64 / 10.0),
+                    any::<bool>(),
+                ),
+                0..20,
+            )
+        ) {
+            let batch = scalar_batch(rows);
+            for row in 0..batch.num_rows() {
+                let text = serialize_row_via_default(&batch, row);
+                let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+                let object = value.as_object().expect("must be object");
+                prop_assert_eq!(object.len(), batch.schema().fields().len());
+            }
+        }
+
+        #[test]
+        fn row_json_null_handling(
+            text_values in proptest::collection::vec(prop::option::of(any::<String>()), 0..20),
+            int_values in proptest::collection::vec(prop::option::of(any::<i64>()), 0..20),
+        ) {
+            let row_count = text_values.len().min(int_values.len());
+            let text_values = text_values.into_iter().take(row_count).collect::<Vec<_>>();
+            let int_values = int_values.into_iter().take(row_count).collect::<Vec<_>>();
+
+            let struct_fields = vec![
+                Arc::new(Field::new("inner_text", DataType::Utf8, true)),
+                Arc::new(Field::new("inner_int", DataType::Int64, true)),
+            ];
+            let struct_array = StructArray::new(
+                struct_fields.clone().into(),
+                vec![
+                    Arc::new(StringArray::from(text_values.iter().map(|v| v.as_deref()).collect::<Vec<_>>())),
+                    Arc::new(Int64Array::from(int_values.clone())),
+                ],
+                Some(NullBuffer::from(vec![true; row_count])),
+            );
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "nested",
+                DataType::Struct(struct_fields.into()),
+                true,
+            )]));
+            let batch = RecordBatch::try_new(schema, vec![Arc::new(struct_array)]).expect("valid nested batch");
+
+            for row in 0..batch.num_rows() {
+                let text = serialize_row_via_default(&batch, row);
+                let value: serde_json::Value = serde_json::from_str(&text).expect("valid json");
+                let nested = value
+                    .get("nested")
+                    .and_then(serde_json::Value::as_object)
+                    .expect("nested object should be present");
+
+                let inner_text = nested.get("inner_text").expect("inner_text key present");
+                let inner_int = nested.get("inner_int").expect("inner_int key present");
+                prop_assert_ne!(inner_text, "null", "inner_text must not serialize as string literal 'null'");
+                prop_assert_ne!(inner_int, "null", "inner_int must not serialize as string literal 'null'");
+
+                if text_values[row].is_none() {
+                    prop_assert!(inner_text.is_null(), "null inner_text must serialize as JSON null");
+                }
+                if int_values[row].is_none() {
+                    prop_assert!(inner_int.is_null(), "null inner_int must serialize as JSON null");
+                }
+            }
+        }
+
+        #[test]
+        fn row_json_paths_agree(batch in arrow_test_utils::arb_record_batch_without_null_column()) {
+            for row in 0..batch.num_rows() {
+                let direct = serialize_row_via_default(&batch, row);
+                let resolved = serialize_row_via_resolved(&batch, row);
+                prop_assert_eq!(resolved, direct, "resolved and default row serializers diverged");
+            }
+        }
+    }
+
+    #[test]
+    fn row_json_special_floats() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "ratio",
+            DataType::Float64,
+            true,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Float64Array::from(vec![
+                Some(f64::NAN),
+                Some(f64::INFINITY),
+                Some(f64::NEG_INFINITY),
+                Some(1.5),
+            ]))],
+        )
+        .expect("valid float batch");
+
+        let cols = build_col_infos(&batch);
+        for row in 0..batch.num_rows() {
+            let mut out = Vec::new();
+            write_row_json(&batch, row, &cols, &mut out).expect("serialize");
+            let value: serde_json::Value = serde_json::from_slice(&out).expect("valid json");
+            let ratio = value.get("ratio").expect("ratio field present");
+            if row < 3 {
+                assert!(ratio.is_null(), "NaN and infinities must serialize as null");
+            } else {
+                assert_eq!(ratio.as_f64(), Some(1.5));
+            }
+        }
+    }
+}

--- a/crates/logfwd-test-utils/src/arrow.rs
+++ b/crates/logfwd-test-utils/src/arrow.rs
@@ -1,0 +1,161 @@
+/// Reusable Arrow `RecordBatch` generators for property-based tests.
+use std::sync::Arc;
+
+use arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int64Array, ListArray, ListBuilder, NullArray,
+    StringArray, StructArray, TimestampNanosecondArray,
+};
+use arrow::buffer::NullBuffer;
+use arrow::datatypes::{DataType, Field, Fields, TimeUnit};
+use arrow::record_batch::RecordBatch;
+use proptest::prelude::*;
+
+fn unicode_string(max_len: usize) -> impl Strategy<Value = String> {
+    proptest::collection::vec(any::<char>(), 0..=max_len)
+        .prop_map(|chars| chars.into_iter().collect())
+}
+
+fn list_i64_array(values: Vec<Option<Vec<Option<i64>>>>) -> ListArray {
+    let mut builder = ListBuilder::new(arrow::array::Int64Builder::new());
+    for row in values {
+        match row {
+            Some(items) => {
+                for item in items {
+                    builder.values().append_option(item);
+                }
+                builder.append(true);
+            }
+            None => builder.append(false),
+        }
+    }
+    builder.finish()
+}
+
+fn struct_array(
+    utf8_values: Vec<Option<String>>,
+    int_values: Vec<Option<i64>>,
+    valid_rows: Vec<bool>,
+) -> StructArray {
+    let fields: Fields = vec![
+        Arc::new(Field::new("inner_text", DataType::Utf8, true)),
+        Arc::new(Field::new("inner_int", DataType::Int64, true)),
+    ]
+    .into();
+    let arrays: Vec<ArrayRef> = vec![
+        Arc::new(StringArray::from(
+            utf8_values.iter().map(Option::as_deref).collect::<Vec<_>>(),
+        )),
+        Arc::new(Int64Array::from(int_values)),
+    ];
+    let validity = Some(NullBuffer::from(valid_rows));
+    StructArray::new(fields, arrays, validity)
+}
+
+fn arb_record_batch_impl(include_null_column: bool) -> impl Strategy<Value = RecordBatch> {
+    (0usize..=20).prop_flat_map(move |rows| {
+        let utf8 = proptest::collection::vec(prop::option::of(unicode_string(12)), rows);
+        let ints = proptest::collection::vec(prop::option::of(any::<i64>()), rows);
+        let floats = proptest::collection::vec(prop::option::of(any::<f64>()), rows);
+        let bools = proptest::collection::vec(prop::option::of(any::<bool>()), rows);
+        let ts_nanos = proptest::collection::vec(prop::option::of(any::<i64>()), rows);
+        let list_values = proptest::collection::vec(
+            prop::option::of(proptest::collection::vec(
+                prop::option::of(any::<i64>()),
+                0..=4,
+            )),
+            rows,
+        );
+        let struct_text = proptest::collection::vec(prop::option::of(unicode_string(8)), rows);
+        let struct_int = proptest::collection::vec(prop::option::of(any::<i64>()), rows);
+        let struct_valid = proptest::collection::vec(any::<bool>(), rows);
+
+        (
+            Just(rows),
+            utf8,
+            ints,
+            floats,
+            bools,
+            ts_nanos,
+            list_values,
+            struct_text,
+            struct_int,
+            struct_valid,
+            Just(include_null_column),
+        )
+            .prop_map(
+                |(
+                    rows,
+                    utf8,
+                    ints,
+                    floats,
+                    bools,
+                    ts_nanos,
+                    list_values,
+                    struct_text,
+                    struct_int,
+                    struct_valid,
+                    include_null_column,
+                )| {
+                    let mut fields = vec![
+                        Field::new("text", DataType::Utf8, true),
+                        Field::new("count", DataType::Int64, true),
+                        Field::new("ratio", DataType::Float64, true),
+                        Field::new("ok", DataType::Boolean, true),
+                    ];
+                    if include_null_column {
+                        fields.push(Field::new("always_null", DataType::Null, true));
+                    }
+                    fields.extend([
+                        Field::new("ts", DataType::Timestamp(TimeUnit::Nanosecond, None), true),
+                        Field::new(
+                            "items",
+                            DataType::List(Arc::new(Field::new("item", DataType::Int64, true))),
+                            true,
+                        ),
+                        Field::new(
+                            "nested",
+                            DataType::Struct(
+                                vec![
+                                    Arc::new(Field::new("inner_text", DataType::Utf8, true)),
+                                    Arc::new(Field::new("inner_int", DataType::Int64, true)),
+                                ]
+                                .into(),
+                            ),
+                            true,
+                        ),
+                    ]);
+
+                    let mut columns: Vec<ArrayRef> = vec![
+                        Arc::new(StringArray::from(
+                            utf8.iter().map(Option::as_deref).collect::<Vec<_>>(),
+                        )),
+                        Arc::new(Int64Array::from(ints)),
+                        Arc::new(Float64Array::from(floats)),
+                        Arc::new(BooleanArray::from(bools)),
+                    ];
+                    if include_null_column {
+                        columns.push(Arc::new(NullArray::new(rows)));
+                    }
+                    columns.extend([
+                        Arc::new(TimestampNanosecondArray::from(ts_nanos)) as ArrayRef,
+                        Arc::new(list_i64_array(list_values)) as ArrayRef,
+                        Arc::new(struct_array(struct_text, struct_int, struct_valid)) as ArrayRef,
+                    ]);
+
+                    let schema = Arc::new(arrow::datatypes::Schema::new(fields));
+                    RecordBatch::try_new(schema, columns).expect("generated batch must be valid")
+                },
+            )
+    })
+}
+
+/// Strategy for batches including a `Null`-typed column.
+pub fn arb_record_batch() -> impl Strategy<Value = RecordBatch> {
+    arb_record_batch_impl(true)
+}
+
+/// Strategy for batches excluding the `Null`-typed column.
+#[allow(dead_code)]
+pub fn arb_record_batch_without_null_column() -> impl Strategy<Value = RecordBatch> {
+    arb_record_batch_impl(false)
+}

--- a/crates/logfwd-test-utils/src/lib.rs
+++ b/crates/logfwd-test-utils/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides reusable proptest strategies for JSON generation, test sink
 //! implementations, and common helpers used across multiple test suites.
 
+pub mod arrow;
 pub mod json;
 pub mod sinks;
 


### PR DESCRIPTION
## Summary
- **row_json.rs**: 0 tests → 5 proptests (valid JSON, field count, null handling, special floats, dual-path agreement)
- **json_lines.rs**: 9 unit tests → +2 proptests (valid JSON per line, no embedded newlines)
- Shared `arb_record_batch` generator in `logfwd-test-utils/src/arrow.rs`

Closes #2413.

## Test plan
- [x] `cargo test -p logfwd-output -- row_json` — 5 pass
- [x] `cargo test -p logfwd-output -- json_lines` — 14 pass (12 existing + 2 new)
- [x] `cargo test -p logfwd-test-utils` — 8 pass
- [x] `just clippy` — clean
- [x] `just fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add proptest coverage for `row_json.rs` and `json_lines.rs` output serialization
> - Adds property-based tests to [`row_json.rs`](https://github.com/strawgate/fastforward/pull/2454/files#diff-52251238e3d45cad7a8da16b9b815d0dc8b6429621b6712d05140d96919832e2) covering valid JSON output, field count matching schema, null handling in nested structs, and agreement between default and resolved serialization paths.
> - Adds property-based tests to [`json_lines.rs`](https://github.com/strawgate/fastforward/pull/2454/files#diff-77f2dc61b4df0d76b588129b7bba4fc90ee24578787a681301266b53cfd0481c) verifying each NDJSON line is valid JSON and contains no embedded newlines.
> - Introduces a reusable [`arrow.rs`](https://github.com/strawgate/fastforward/pull/2454/files#diff-77dac48be7aa47c21f024c2534962ddbb44c33ef093997efeada8d3dea98e53c) test utility module in `logfwd-test-utils` with Arrow `RecordBatch` generators for various column types, nullability, and struct nesting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 83e9a6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->