### PR TITLE
fix: rename binary references from logfwd to ff across bench, e2e, deploy, and dashboard

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -205,7 +205,7 @@ jobs:
             --json-file rate-bench-result.json \
             --gh-bench-file rate-gh-bench.json
         env:
-          LOGFWD: ./bin/ff
+          FF: ./bin/ff
 
       - uses: actions/upload-artifact@v7
         with:
@@ -309,7 +309,7 @@ jobs:
       - run: chmod +x bin/*
 
       - uses: ./.github/actions/setup-rust
-      - name: Build logfwd with profiling
+      - name: Build ff with profiling
         env:
           RUSTFLAGS: ${{ env.BENCH_RUSTFLAGS }}
         run: |

--- a/bench/dashboard/competitive.html
+++ b/bench/dashboard/competitive.html
@@ -73,7 +73,7 @@ function getScenarioTitle(sn) {
 }
 
 const AGENT_COLORS = {
-  'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
+  'ff': '#2563eb', 'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
   'filebeat': '#d97706', 'otelcol': '#dc2626', 'vlagent': '#64748b'
 };
 

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -11,7 +11,7 @@
 <body>
 <div class="container">
   <header class="hero">
-    <p class="eyebrow">logfwd benchmark suite</p>
+    <p class="eyebrow">ff benchmark suite</p>
     <h1>Benchmark Control Room</h1>
     <p class="lede">Track competitive throughput, development resource curves, and run-level details from nightly data in one view.</p>
     <div class="hero-tags">
@@ -79,7 +79,7 @@ function getScenarioTitle(sn) {
 }
 
 const AGENT_COLORS = {
-  'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
+  'ff': '#2563eb', 'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
   'filebeat': '#d97706', 'otelcol': '#dc2626', 'vlagent': '#64748b'
 };
 
@@ -249,14 +249,15 @@ async function main() {
   if (latestRun && latestRun.scenarios) {
     for (const sn of (latestRun.scenario_names || Object.keys(latestRun.scenarios))) {
       const sc = latestRun.scenarios[sn];
-      if (!sc?.logfwd) continue;
-      const scenarioLogfwdLps = averageLps(sc.logfwd);
-      if (!(scenarioLogfwdLps > 0)) continue;
+      const ffData = sc?.ff || sc?.logfwd;
+      if (!ffData) continue;
+      const scenarioFfLps = averageLps(ffData);
+      if (!(scenarioFfLps > 0)) continue;
       for (const agent of Object.keys(sc)) {
-        if (agent === 'logfwd') continue;
+        if (agent === 'ff' || agent === 'logfwd') continue;
         const competitorLps = averageLps(sc[agent]) || 0;
         if (!(competitorLps > 0)) continue;
-        const ratio = scenarioLogfwdLps / competitorLps;
+        const ratio = scenarioFfLps / competitorLps;
         if (!bestRatio || ratio > bestRatio.value) bestRatio = { value: ratio, vs: agent, scenario: sn };
       }
     }

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -249,9 +249,9 @@ async function main() {
   if (latestRun && latestRun.scenarios) {
     for (const sn of (latestRun.scenario_names || Object.keys(latestRun.scenarios))) {
       const sc = latestRun.scenarios[sn];
-      const ffData = sc?.ff || sc?.logfwd;
-      if (!ffData) continue;
-      const scenarioFfLps = averageLps(ffData);
+      const ffLps = averageLps(sc?.ff);
+      const logfwdLps = averageLps(sc?.logfwd);
+      const scenarioFfLps = ffLps > 0 ? ffLps : logfwdLps;
       if (!(scenarioFfLps > 0)) continue;
       for (const agent of Object.keys(sc)) {
         if (agent === 'ff' || agent === 'logfwd') continue;

--- a/bench/dashboard/run.html
+++ b/bench/dashboard/run.html
@@ -81,7 +81,7 @@ function getScenarioTitle(sn) {
 }
 
 const AGENT_COLORS = {
-  'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
+  'ff': '#2563eb', 'logfwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
   'filebeat': '#d97706', 'otelcol': '#dc2626', 'vlagent': '#64748b'
 };
 

--- a/crates/logfwd-competitive-bench/src/main.rs
+++ b/crates/logfwd-competitive-bench/src/main.rs
@@ -404,11 +404,11 @@ fn main() {
 
 /// Run the low-and-slow rate-ingest benchmark (non-competitive, ff only).
 fn run_rate_bench_main(args: &Args) {
-    // Locate ff binary via LOGFWD env var or PATH.
+    // Locate ff binary via FF env var (or legacy LOGFWD) or PATH.
     let logfwd_binary = find_logfwd_binary().unwrap_or_else(|| {
         eprintln!(
             "ERROR: ff binary not found. \
-             Set the LOGFWD env var or ensure ff is on PATH."
+             Set the FF env var (or legacy LOGFWD) or ensure ff is on PATH."
         );
         process::exit(1);
     });
@@ -469,12 +469,15 @@ fn run_rate_bench_main(args: &Args) {
     }
 }
 
-/// Locate the logfwd binary.  Checks `LOGFWD` env var first, then `PATH`.
+/// Locate the ff binary.  Checks `FF` env var first, then `LOGFWD` (legacy),
+/// then `PATH`.
 fn find_logfwd_binary() -> Option<PathBuf> {
-    if let Ok(val) = std::env::var("LOGFWD") {
-        let p = PathBuf::from(&val);
-        if p.exists() {
-            return Some(p);
+    for var in ["FF", "LOGFWD"] {
+        if let Ok(val) = std::env::var(var) {
+            let p = PathBuf::from(&val);
+            if p.exists() {
+                return Some(p);
+            }
         }
     }
     if let Ok(output) = process::Command::new("which").arg("ff").output()

--- a/crates/logfwd-competitive-bench/src/main.rs
+++ b/crates/logfwd-competitive-bench/src/main.rs
@@ -574,12 +574,19 @@ fn resolve_binary(
     bin_dir: &std::path::Path,
     no_download: bool,
 ) -> Option<PathBuf> {
-    // Check env override.
+    // Check env override.  For `ff`, also check legacy `LOGFWD`.
     let env_var = agent.name().to_uppercase().replace('-', "_");
-    if let Ok(val) = std::env::var(&env_var) {
-        let p = PathBuf::from(&val);
-        if p.exists() {
-            return Some(p);
+    let env_vars: Vec<&str> = if env_var == "FF" {
+        vec!["FF", "LOGFWD"]
+    } else {
+        vec![&env_var]
+    };
+    for var in env_vars {
+        if let Ok(val) = std::env::var(var) {
+            let p = PathBuf::from(&val);
+            if p.exists() {
+                return Some(p);
+            }
         }
     }
 

--- a/deploy/configmap.yml
+++ b/deploy/configmap.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: logfwd-config
+  name: ff-config
   namespace: collectors
 data:
   pipeline.yaml: |

--- a/deploy/daemonset.yml
+++ b/deploy/daemonset.yml
@@ -87,7 +87,7 @@ spec:
               mountPath: /etc/ff
               readOnly: true
             - name: data
-              mountPath: /var/lib/ff
+              mountPath: /var/lib/logfwd
       volumes:
         - name: varlog
           hostPath:
@@ -97,5 +97,5 @@ spec:
             name: ff-config
         - name: data
           hostPath:
-            path: /var/lib/ff
+            path: /var/lib/logfwd
             type: DirectoryOrCreate

--- a/deploy/daemonset.yml
+++ b/deploy/daemonset.yml
@@ -34,7 +34,7 @@ spec:
           args:
             - "run"
             - "--config"
-            - "/etc/logfwd/pipeline.yaml"
+            - "/etc/ff/pipeline.yaml"
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -84,18 +84,18 @@ spec:
               mountPath: /var/log
               readOnly: true
             - name: config
-              mountPath: /etc/logfwd
+              mountPath: /etc/ff
               readOnly: true
             - name: data
-              mountPath: /var/lib/logfwd
+              mountPath: /var/lib/ff
       volumes:
         - name: varlog
           hostPath:
             path: /var/log
         - name: config
           configMap:
-            name: logfwd-config
+            name: ff-config
         - name: data
           hostPath:
-            path: /var/lib/logfwd
+            path: /var/lib/ff
             type: DirectoryOrCreate

--- a/justfile
+++ b/justfile
@@ -452,7 +452,7 @@ bench-e2e seconds="10":
 
 [private]
 bench-pipelines seconds="10":
-    @echo "logfwd pipeline benchmarks ({{seconds}}s each)"
+    @echo "ff pipeline benchmarks ({{seconds}}s each)"
     @echo "================================================"
     cargo build --release -p logfwd
     just bench-self {{seconds}}
@@ -518,7 +518,7 @@ bench-docker:
 profile-otlp-local lines="500000" seconds="6":
     #!/usr/bin/env bash
     set -euo pipefail
-    ROOT=$(mktemp -d /tmp/logfwd-pprof.XXXXXX)
+    ROOT=$(mktemp -d /tmp/ff-pprof.XXXXXX)
     PORT=$(python3 -c 'import socket; s = socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')
 
     echo "==> Build cpu-profiling binary"
@@ -598,10 +598,10 @@ bench-framed-input *ARGS:
 bench-framed-input-alloc *ARGS:
     cargo run -p logfwd-bench --release --features dhat-heap --bin framed_input_profile -- --alloc-only {{ARGS}}
 
-# Run low-and-slow rate-ingest benchmark (logfwd only, measures memory and CPU at each eps)
+# Run low-and-slow rate-ingest benchmark (ff only, measures memory and CPU at each eps)
 bench-rate *ARGS:
     cargo build --release -p logfwd
-    LOGFWD=./target/release/ff cargo run -p logfwd-competitive-bench --release -- --rate-bench {{ARGS}}
+    FF=./target/release/ff cargo run -p logfwd-competitive-bench --release -- --rate-bench {{ARGS}}
 
 # Run sustained-load memory profiler (generator → SQL → null, default 5 minutes).
 # Use --quick (30s) for CI or --medium (120s) for quick checks.

--- a/justfile
+++ b/justfile
@@ -304,8 +304,8 @@ build-dev-lite:
 _bench-run name config seconds="10" diag="http://127.0.0.1:9090":
     #!/usr/bin/env bash
     set -euo pipefail
-    LOGFWD=./target/release/ff
-    $LOGFWD run --config {{config}} &
+    FF=./target/release/ff
+    $FF run --config {{config}} &
     PID=$!
     sleep {{seconds}}
     STATS=$(curl -s {{diag}}/admin/v1/stats 2>/dev/null || echo '{}')
@@ -323,8 +323,8 @@ _bench-run name config seconds="10" diag="http://127.0.0.1:9090":
 _bench-pair name rx_config tx_config seconds="10":
     #!/usr/bin/env bash
     set -euo pipefail
-    LOGFWD=./target/release/ff
-    $LOGFWD run --config {{rx_config}} &
+    FF=./target/release/ff
+    $FF run --config {{rx_config}} &
     RX=$!;
 
     # Poll /ready until the diagnostics HTTP server is up (503 → 200).
@@ -349,7 +349,7 @@ _bench-pair name rx_config tx_config seconds="10":
     # Give run_async() time to bind receiver sockets after /ready returns.
     sleep 1
 
-    $LOGFWD run --config {{tx_config}} &
+    $FF run --config {{tx_config}} &
     TX=$!; sleep {{seconds}}
     STATS=$(curl -s http://127.0.0.1:9091/admin/v1/stats 2>/dev/null || echo '{}')
     kill $TX $RX 2>/dev/null; wait $TX $RX 2>/dev/null || true

--- a/tests/e2e/manifests/ff-config.yaml
+++ b/tests/e2e/manifests/ff-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: logfwd-config
+  name: ff-config
 data:
   config.yaml: |
     server:

--- a/tests/e2e/manifests/ff-daemonset.yaml
+++ b/tests/e2e/manifests/ff-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         - name: ff
           image: ff:e2e
           imagePullPolicy: IfNotPresent
-          args: ["run", "--config", "/etc/logfwd/config.yaml"]
+          args: ["run", "--config", "/etc/ff/config.yaml"]
           securityContext:
             runAsNonRoot: false
             runAsUser: 0
@@ -74,7 +74,7 @@ spec:
               mountPath: /var/log
               readOnly: true
             - name: config
-              mountPath: /etc/logfwd
+              mountPath: /etc/ff
               readOnly: true
       volumes:
         - name: varlog
@@ -83,4 +83,4 @@ spec:
             type: Directory
         - name: config
           configMap:
-            name: logfwd-config
+            name: ff-config


### PR DESCRIPTION
# Summary  Complete the `logfwd` → `ff` binary rename across all remaining infrastructure that still referenced the old binary name. Main already had partial renames; this finishes the job.  **What changed (10 files):** - `.github/workflows/bench.yml` — env var `LOGFWD` → `FF` - `crates/logfwd-competitive-bench/src/main.rs` — `find_logfwd_binary()` checks `FF` env var first (with `LOGFWD` fallback), error messages updated - `bench/dashboard/index.html` — backward-compat: accepts both `ff` and `logfwd` agent data, best-ratio fallback - `bench/dashboard/competitive.html` — `AGENT_COLORS` includes both `ff` and `logfwd` - `bench/dashboard/run.html` — `AGENT_COLORS` includes both `ff` and `logfwd` - `deploy/configmap.yml` — ConfigMap name `ff-config` - `deploy/daemonset.yml` — DaemonSet, labels, service account, config mount paths - `justfile` — env var `LOGFWD` → `FF` in rate-bench and other recipes - `tests/e2e/manifests/ff-config.yaml` — service DNS namespace - `tests/e2e/manifests/ff-daemonset.yaml` — container name, image, config path  **Backward compatibility:** - Dashboard `AGENT_COLORS` includes both `ff` and `logfwd` entries (historical bench data uses `logfwd`) - Best-ratio calculation falls back: `sc?.ff || sc?.logfwd` - Competitive bench checks both `FF` and `LOGFWD` env vars  ## Closes  Relates to binary rename effort.  ## Test plan  - [x] `cargo check -p logfwd-competitive-bench` — clean - [x] `just fmt` — passed - [x] `just clippy` — zero warnings - [ ] CI passes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename binary references from `logfwd` to `ff` across bench, deploy, and e2e manifests
> - Updates benchmark workflows, justfile recipes, and the competitive bench harness to read the binary path from the `FF` env var, falling back to `LOGFWD` for legacy compatibility.
> - Renames the Kubernetes ConfigMap from `logfwd-config` to `ff-config` and updates mount paths from `/etc/logfwd` to `/etc/ff` in both deploy and e2e manifests.
> - Updates benchmark dashboard HTML to recognize `ff` as an agent name for chart colorization and ratio computation, with fallback to `logfwd` data when `ff` is absent.
> - Risk: any external tooling or scripts that reference `logfwd-config` or `/etc/logfwd` will break without a corresponding update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6dcf4ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->