### PR TITLE
[codex] Write OTLP hex fields directly into the builder

### DIFF
--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -434,6 +434,63 @@ impl ColumnarBatchBuilder {
         Ok(())
     }
 
+    /// Write lowercase hexadecimal text for `value` into the generated string buffer.
+    ///
+    /// This avoids a temporary scratch `Vec<u8>` for producers that need hex
+    /// strings but already have the raw bytes.
+    #[inline]
+    pub fn write_hex_bytes_lower(
+        &mut self,
+        handle: FieldHandle,
+        value: &[u8],
+    ) -> Result<(), BuilderError> {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+
+        debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
+        debug_assert!(handle.index() < self.columns.len());
+        if !self.columns[handle.index()].accepts_str() {
+            return Ok(());
+        }
+        if self.dedup_enabled && self.is_duplicate(handle) {
+            return Ok(());
+        }
+
+        let encoded_len = value
+            .len()
+            .checked_mul(2)
+            .ok_or(BuilderError::StringBufferOverflow {
+                buffer_len: self.string_buf.len(),
+                value_len: value.len(),
+            })?;
+        let raw_offset = self
+            .original_buf
+            .len()
+            .checked_add(self.string_buf.len())
+            .ok_or(BuilderError::StringBufferOverflow {
+                buffer_len: self.string_buf.len(),
+                value_len: encoded_len,
+            })?;
+        let offset =
+            u32::try_from(raw_offset).map_err(|_e| BuilderError::StringBufferOverflow {
+                buffer_len: self.string_buf.len(),
+                value_len: encoded_len,
+            })?;
+        let len = u32::try_from(encoded_len).map_err(|_e| BuilderError::StringBufferOverflow {
+            buffer_len: self.string_buf.len(),
+            value_len: encoded_len,
+        })?;
+
+        self.string_buf.reserve(encoded_len);
+        for &byte in value {
+            self.string_buf.push(HEX[(byte >> 4) as usize]);
+            self.string_buf.push(HEX[(byte & 0x0f) as usize]);
+        }
+
+        let sref = StringRef { offset, len };
+        self.columns[handle.index()].push_str(self.lifecycle.row_count(), sref);
+        Ok(())
+    }
+
     /// Write a zero-copy reference to a subslice of the original input buffer.
     ///
     /// The `value` must be a subslice of the buffer previously set via
@@ -1606,6 +1663,21 @@ mod tests {
         let col = batch.column(0).as_string_view();
         assert_eq!(col.value(0), "original");
         assert_eq!(col.value(1), "generated");
+    }
+
+    #[test]
+    fn write_hex_bytes_lower_produces_correct_string() {
+        let mut plan = BatchPlan::new();
+        let name = plan.declare_planned("name", FieldKind::Utf8View).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+        b.begin_batch();
+        b.begin_row();
+        b.write_hex_bytes_lower(name, &[0xde, 0xad, 0xbe, 0xef])
+            .unwrap();
+        b.end_row();
+        let batch = b.finish_batch().unwrap();
+        let col = batch.column(0).as_string_view();
+        assert_eq!(col.value(0), "deadbeef");
     }
 
     #[test]

--- a/crates/logfwd-arrow/src/columnar/builder.rs
+++ b/crates/logfwd-arrow/src/columnar/builder.rs
@@ -43,6 +43,12 @@ pub enum BuilderError {
     Materialize(MaterializeError),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct StringBufferOverflow {
+    buffer_len: usize,
+    value_len: usize,
+}
+
 impl std::fmt::Display for BuilderError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -79,6 +85,84 @@ impl From<ArrowError> for BuilderError {
 impl From<MaterializeError> for BuilderError {
     fn from(e: MaterializeError) -> Self {
         BuilderError::Materialize(e)
+    }
+}
+
+impl From<StringBufferOverflow> for BuilderError {
+    fn from(e: StringBufferOverflow) -> Self {
+        BuilderError::StringBufferOverflow {
+            buffer_len: e.buffer_len,
+            value_len: e.value_len,
+        }
+    }
+}
+
+#[inline]
+fn current_buffer_len(
+    original_len: usize,
+    generated_len: usize,
+    value_len: usize,
+) -> Result<usize, StringBufferOverflow> {
+    original_len
+        .checked_add(generated_len)
+        .ok_or(StringBufferOverflow {
+            buffer_len: usize::MAX,
+            value_len,
+        })
+}
+
+#[inline]
+fn checked_generated_append_len(
+    generated_len: usize,
+    value_len: usize,
+    buffer_len: usize,
+) -> Result<(), StringBufferOverflow> {
+    generated_len
+        .checked_add(value_len)
+        .ok_or(StringBufferOverflow {
+            buffer_len,
+            value_len,
+        })?;
+    Ok(())
+}
+
+#[inline]
+fn string_ref_at_buffer_len(
+    buffer_len: usize,
+    value_len: usize,
+) -> Result<StringRef, StringBufferOverflow> {
+    let offset = u32::try_from(buffer_len).map_err(|_e| StringBufferOverflow {
+        buffer_len,
+        value_len,
+    })?;
+    let len = u32::try_from(value_len).map_err(|_e| StringBufferOverflow {
+        buffer_len,
+        value_len,
+    })?;
+    Ok(StringRef { offset, len })
+}
+
+#[inline]
+fn checked_hex_encoded_len(
+    input_len: usize,
+    buffer_len: usize,
+) -> Result<usize, StringBufferOverflow> {
+    input_len.checked_mul(2).ok_or(StringBufferOverflow {
+        buffer_len,
+        value_len: usize::MAX,
+    })
+}
+
+#[inline]
+fn encode_hex_lower_into(out: &mut Vec<u8>, value: &[u8], encoded_len: usize) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
+    let old_len = out.len();
+    out.resize(old_len + encoded_len, 0);
+    let encoded = &mut out[old_len..old_len + encoded_len];
+    for (i, &byte) in value.iter().enumerate() {
+        encoded[i * 2] = HEX[(byte >> 4) as usize];
+        encoded[i * 2 + 1] = HEX[(byte & 0x0f) as usize];
     }
 }
 
@@ -346,28 +430,13 @@ impl ColumnarBatchBuilder {
         if self.dedup_enabled && self.is_duplicate(handle) {
             return Ok(());
         }
-        // Generated string offsets are shifted by original_buf.len() so that
-        // the 2-buffer model can distinguish original vs generated at
-        // materialization time.
-        let raw_offset = self
-            .original_buf
-            .len()
-            .checked_add(self.string_buf.len())
-            .ok_or(BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: value.len(),
-            })?;
-        let offset =
-            u32::try_from(raw_offset).map_err(|_e| BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: value.len(),
-            })?;
-        let len = u32::try_from(value.len()).map_err(|_e| BuilderError::StringBufferOverflow {
-            buffer_len: self.string_buf.len(),
-            value_len: value.len(),
-        })?;
+        let buffer_len =
+            current_buffer_len(self.original_buf.len(), self.string_buf.len(), value.len())
+                .map_err(BuilderError::from)?;
+        checked_generated_append_len(self.string_buf.len(), value.len(), buffer_len)
+            .map_err(BuilderError::from)?;
+        let sref = string_ref_at_buffer_len(buffer_len, value.len()).map_err(BuilderError::from)?;
         self.string_buf.extend_from_slice(value.as_bytes());
-        let sref = StringRef { offset, len };
         self.columns[handle.index()].push_str(self.lifecycle.row_count(), sref);
         Ok(())
     }
@@ -411,25 +480,13 @@ impl ColumnarBatchBuilder {
         if self.dedup_enabled && self.is_duplicate(handle) {
             return Ok(());
         }
-        let raw_offset = self
-            .original_buf
-            .len()
-            .checked_add(self.string_buf.len())
-            .ok_or(BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: value.len(),
-            })?;
-        let offset =
-            u32::try_from(raw_offset).map_err(|_e| BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: value.len(),
-            })?;
-        let len = u32::try_from(value.len()).map_err(|_e| BuilderError::StringBufferOverflow {
-            buffer_len: self.string_buf.len(),
-            value_len: value.len(),
-        })?;
+        let buffer_len =
+            current_buffer_len(self.original_buf.len(), self.string_buf.len(), value.len())
+                .map_err(BuilderError::from)?;
+        checked_generated_append_len(self.string_buf.len(), value.len(), buffer_len)
+            .map_err(BuilderError::from)?;
+        let sref = string_ref_at_buffer_len(buffer_len, value.len()).map_err(BuilderError::from)?;
         self.string_buf.extend_from_slice(value);
-        let sref = StringRef { offset, len };
         self.columns[handle.index()].push_str(self.lifecycle.row_count(), sref);
         Ok(())
     }
@@ -438,14 +495,18 @@ impl ColumnarBatchBuilder {
     ///
     /// This avoids a temporary scratch `Vec<u8>` for producers that need hex
     /// strings but already have the raw bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the encoded hex string or its resulting offset would
+    /// exceed `u32::MAX`, or if extending the generated string buffer would
+    /// overflow addressable `usize` space.
     #[inline]
     pub fn write_hex_bytes_lower(
         &mut self,
         handle: FieldHandle,
         value: &[u8],
     ) -> Result<(), BuilderError> {
-        const HEX: &[u8; 16] = b"0123456789abcdef";
-
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
         if !self.columns[handle.index()].accepts_str() {
@@ -455,38 +516,15 @@ impl ColumnarBatchBuilder {
             return Ok(());
         }
 
-        let encoded_len = value
-            .len()
-            .checked_mul(2)
-            .ok_or(BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: value.len(),
-            })?;
-        let raw_offset = self
-            .original_buf
-            .len()
-            .checked_add(self.string_buf.len())
-            .ok_or(BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: encoded_len,
-            })?;
-        let offset =
-            u32::try_from(raw_offset).map_err(|_e| BuilderError::StringBufferOverflow {
-                buffer_len: self.string_buf.len(),
-                value_len: encoded_len,
-            })?;
-        let len = u32::try_from(encoded_len).map_err(|_e| BuilderError::StringBufferOverflow {
-            buffer_len: self.string_buf.len(),
-            value_len: encoded_len,
-        })?;
-
-        self.string_buf.reserve(encoded_len);
-        for &byte in value {
-            self.string_buf.push(HEX[(byte >> 4) as usize]);
-            self.string_buf.push(HEX[(byte & 0x0f) as usize]);
-        }
-
-        let sref = StringRef { offset, len };
+        let buffer_len =
+            current_buffer_len(self.original_buf.len(), self.string_buf.len(), value.len())
+                .map_err(BuilderError::from)?;
+        let encoded_len =
+            checked_hex_encoded_len(value.len(), buffer_len).map_err(BuilderError::from)?;
+        checked_generated_append_len(self.string_buf.len(), encoded_len, buffer_len)
+            .map_err(BuilderError::from)?;
+        let sref = string_ref_at_buffer_len(buffer_len, encoded_len).map_err(BuilderError::from)?;
+        encode_hex_lower_into(&mut self.string_buf, value, encoded_len);
         self.columns[handle.index()].push_str(self.lifecycle.row_count(), sref);
         Ok(())
     }
@@ -1681,6 +1719,21 @@ mod tests {
     }
 
     #[test]
+    fn write_hex_bytes_lower_respects_dedup() {
+        let mut plan = BatchPlan::new();
+        let name = plan.declare_planned("name", FieldKind::Utf8View).unwrap();
+        let mut b = ColumnarBatchBuilder::new(plan);
+        b.begin_batch();
+        b.begin_row();
+        b.write_hex_bytes_lower(name, &[0xde, 0xad]).unwrap();
+        b.write_hex_bytes_lower(name, &[0xbe, 0xef]).unwrap();
+        b.end_row();
+        let batch = b.finish_batch().unwrap();
+        let col = batch.column(0).as_string_view();
+        assert_eq!(col.value(0), "dead");
+    }
+
+    #[test]
     fn write_input_ref_returns_error_on_oob() {
         let mut plan = BatchPlan::new();
         let f = plan.declare_planned("field", FieldKind::Utf8View).unwrap();
@@ -1692,6 +1745,148 @@ mod tests {
         // Not a subslice of original buffer — should return error.
         let result = b.write_input_ref(f, b"external");
         assert!(result.is_err());
+    }
+}
+
+#[cfg(kani)]
+mod verification {
+    use super::*;
+
+    fn hex_oracle(bytes: &[u8]) -> Vec<u8> {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = Vec::with_capacity(bytes.len() * 2);
+        for &byte in bytes {
+            out.push(HEX[(byte >> 4) as usize]);
+            out.push(HEX[(byte & 0x0f) as usize]);
+        }
+        out
+    }
+
+    #[kani::proof]
+    fn verify_current_buffer_len_matches_checked_add() {
+        let original_len: usize = kani::any();
+        let generated_len: usize = kani::any();
+        let value_len: usize = kani::any();
+
+        let result = current_buffer_len(original_len, generated_len, value_len);
+        match original_len.checked_add(generated_len) {
+            Some(sum) => {
+                assert!(result.is_ok());
+                assert_eq!(result.unwrap(), sum);
+            }
+            None => {
+                assert!(result.is_err());
+                let err = result.unwrap_err();
+                assert_eq!(err.buffer_len, usize::MAX);
+                assert_eq!(err.value_len, value_len);
+            }
+        }
+
+        kani::cover!(original_len == 0, "zero original buffer");
+        kani::cover!(generated_len == 0, "zero generated buffer");
+        kani::cover!(
+            original_len.checked_add(generated_len).is_none(),
+            "combined buffer length overflow"
+        );
+    }
+
+    #[kani::proof]
+    fn verify_checked_generated_append_len_matches_checked_add() {
+        let generated_len: usize = kani::any();
+        let value_len: usize = kani::any();
+        let buffer_len: usize = kani::any();
+
+        let result = checked_generated_append_len(generated_len, value_len, buffer_len);
+        match generated_len.checked_add(value_len) {
+            Some(_sum) => assert!(result.is_ok()),
+            None => {
+                assert!(result.is_err());
+                let err = result.unwrap_err();
+                assert_eq!(err.buffer_len, buffer_len);
+                assert_eq!(err.value_len, value_len);
+            }
+        }
+
+        kani::cover!(generated_len == 0, "empty generated buffer");
+        kani::cover!(value_len == 0, "empty append");
+        kani::cover!(
+            generated_len.checked_add(value_len).is_none(),
+            "generated append length overflow"
+        );
+    }
+
+    #[kani::proof]
+    fn verify_string_ref_at_buffer_len_matches_u32_conversions() {
+        let buffer_len: usize = kani::any();
+        let value_len: usize = kani::any();
+
+        let result = string_ref_at_buffer_len(buffer_len, value_len);
+        match (u32::try_from(buffer_len), u32::try_from(value_len)) {
+            (Ok(offset), Ok(len)) => {
+                assert!(result.is_ok());
+                let sref = result.unwrap();
+                assert_eq!(sref.offset, offset);
+                assert_eq!(sref.len, len);
+            }
+            _ => {
+                assert!(result.is_err());
+                let err = result.unwrap_err();
+                assert_eq!(err.buffer_len, buffer_len);
+                assert_eq!(err.value_len, value_len);
+            }
+        }
+
+        kani::cover!(buffer_len <= u32::MAX as usize, "offset fits in u32");
+        kani::cover!(value_len <= u32::MAX as usize, "length fits in u32");
+        kani::cover!(buffer_len > u32::MAX as usize, "offset overflow");
+        kani::cover!(value_len > u32::MAX as usize, "length overflow");
+    }
+
+    #[kani::proof]
+    fn verify_checked_hex_encoded_len_matches_doubling() {
+        let input_len: usize = kani::any();
+        let buffer_len: usize = kani::any();
+
+        let result = checked_hex_encoded_len(input_len, buffer_len);
+        match input_len.checked_mul(2) {
+            Some(encoded_len) => {
+                assert!(result.is_ok());
+                assert_eq!(result.unwrap(), encoded_len);
+            }
+            None => {
+                assert!(result.is_err());
+                let err = result.unwrap_err();
+                assert_eq!(err.buffer_len, buffer_len);
+                assert_eq!(err.value_len, usize::MAX);
+            }
+        }
+
+        kani::cover!(input_len == 0, "empty hex input");
+        kani::cover!(input_len == 1, "single-byte hex input");
+        kani::cover!(input_len.checked_mul(2).is_none(), "hex length overflow");
+    }
+
+    #[kani::proof]
+    #[kani::unwind(6)]
+    fn verify_encode_hex_lower_into_matches_oracle() {
+        let prefix: [u8; 2] = kani::any();
+        let bytes: [u8; 2] = kani::any();
+
+        let mut out = prefix.to_vec();
+        let old_len = out.len();
+        let expected = hex_oracle(&bytes);
+        encode_hex_lower_into(&mut out, &bytes, expected.len());
+
+        assert_eq!(&out[..old_len], &prefix);
+        assert_eq!(&out[old_len..], expected.as_slice());
+        assert!(
+            out[old_len..]
+                .iter()
+                .all(|&b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        );
+
+        kani::cover!(bytes[0] == 0x00, "hex oracle covers 00");
+        kani::cover!(bytes[1] == 0xff, "hex oracle covers ff");
     }
 }
 
@@ -1948,6 +2143,28 @@ mod proptests {
                     prop_assert_eq!(strs.value(row), expected_label.as_str());
                 }
             }
+        }
+
+        #[test]
+        fn write_hex_bytes_lower_matches_oracle(
+            bytes in proptest::collection::vec(any::<u8>(), 0..128),
+        ) {
+            let mut plan = BatchPlan::new();
+            let field = plan.declare_planned("hex", FieldKind::Utf8View).unwrap();
+            let mut builder = ColumnarBatchBuilder::new(plan);
+
+            builder.begin_batch();
+            builder.begin_row();
+            builder.write_hex_bytes_lower(field, &bytes).unwrap();
+            builder.end_row();
+
+            let batch = builder.finish_batch().unwrap();
+            let col = batch.column(0).as_any().downcast_ref::<StringViewArray>().unwrap();
+            let expected = bytes
+                .iter()
+                .flat_map(|byte| [b"0123456789abcdef"[(byte >> 4) as usize] as char, b"0123456789abcdef"[(byte & 0x0f) as usize] as char])
+                .collect::<String>();
+            prop_assert_eq!(col.value(0), expected);
         }
     }
 }

--- a/crates/logfwd-io/src/otlp_receiver/projection/decode.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection/decode.rs
@@ -176,10 +176,10 @@ fn decode_log_record_wire(
         fields.write_body(builder, value, scratch, string_storage)?;
     }
     if let Some(value) = record.trace_id {
-        fields.write_trace_id(builder, value, scratch)?;
+        fields.write_trace_id(builder, value)?;
     }
     if let Some(value) = record.span_id {
-        fields.write_span_id(builder, value, scratch)?;
+        fields.write_span_id(builder, value)?;
     }
     if record.flags > 0 {
         fields.write_flags(builder, record.flags);

--- a/crates/logfwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection/generated.rs
@@ -433,18 +433,16 @@ impl OtlpFieldHandles {
         &self,
         builder: &mut ColumnarBatchBuilder,
         value: &[u8],
-        scratch: &mut WireScratch,
     ) -> Result<(), ProjectionError> {
-        super::write_hex_field(builder, self.trace_id, value, &mut scratch.hex)
+        super::write_hex_field(builder, self.trace_id, value)
     }
 
     pub(super) fn write_span_id(
         &self,
         builder: &mut ColumnarBatchBuilder,
         value: &[u8],
-        scratch: &mut WireScratch,
     ) -> Result<(), ProjectionError> {
-        super::write_hex_field(builder, self.span_id, value, &mut scratch.hex)
+        super::write_hex_field(builder, self.span_id, value)
     }
 
     pub(super) fn write_flags(&self, builder: &mut ColumnarBatchBuilder, value: i64) {
@@ -880,7 +878,7 @@ pub(super) fn write_wire_any(
         WireAny::Bool(value) => builder.write_bool(handle, value),
         WireAny::Int(value) => builder.write_i64(handle, value),
         WireAny::Double(value) => builder.write_f64(handle, value),
-        WireAny::Bytes(value) => super::write_hex_field(builder, handle, value, &mut scratch.hex)?,
+        WireAny::Bytes(value) => super::write_hex_field(builder, handle, value)?,
         WireAny::ArrayRaw(value) => {
             super::write_wire_any_complex_json(builder, handle, WireAny::ArrayRaw(value), scratch)?;
         }
@@ -935,7 +933,7 @@ pub(super) fn write_wire_any_as_string(
                 .write_str_bytes(handle, &scratch.decimal)
                 .map_err(|e| ProjectionError::Batch(e.to_string()))?;
         }
-        WireAny::Bytes(value) => super::write_hex_field(builder, handle, value, &mut scratch.hex)?,
+        WireAny::Bytes(value) => super::write_hex_field(builder, handle, value)?,
         WireAny::ArrayRaw(value) => {
             super::write_wire_any_complex_json(builder, handle, WireAny::ArrayRaw(value), scratch)?;
         }
@@ -1655,10 +1653,10 @@ mod generated_tests {
             )
             .expect("body appender should write");
         handles
-            .write_trace_id(&mut builder, &[0xab, 0xcd], &mut scratch)
+            .write_trace_id(&mut builder, &[0xab, 0xcd])
             .expect("trace id appender should write");
         handles
-            .write_span_id(&mut builder, &[0x12, 0x34], &mut scratch)
+            .write_span_id(&mut builder, &[0x12, 0x34])
             .expect("span id appender should write");
         handles.write_flags(&mut builder, 1);
         handles

--- a/crates/logfwd-io/src/otlp_receiver/projection/wire.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection/wire.rs
@@ -209,7 +209,6 @@ pub(super) fn subslice_range(
 
 #[derive(Default)]
 pub(super) struct WireScratch {
-    pub(super) hex: Vec<u8>,
     pub(super) decimal: Vec<u8>,
     pub(super) json: Vec<u8>,
     pub(super) resource_key: Vec<u8>,

--- a/crates/logfwd-io/src/otlp_receiver/projection/write.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection/write.rs
@@ -69,12 +69,10 @@ pub(super) fn write_hex_field(
     builder: &mut ColumnarBatchBuilder,
     handle: FieldHandle,
     bytes: &[u8],
-    hex_buf: &mut Vec<u8>,
+    _hex_buf: &mut Vec<u8>,
 ) -> Result<(), ProjectionError> {
-    hex_buf.clear();
-    write_hex_to_buf(hex_buf, bytes);
     builder
-        .write_str_bytes(handle, hex_buf)
+        .write_hex_bytes_lower(handle, bytes)
         .map_err(|e| ProjectionError::Batch(e.to_string()))
 }
 

--- a/crates/logfwd-io/src/otlp_receiver/projection/write.rs
+++ b/crates/logfwd-io/src/otlp_receiver/projection/write.rs
@@ -69,7 +69,6 @@ pub(super) fn write_hex_field(
     builder: &mut ColumnarBatchBuilder,
     handle: FieldHandle,
     bytes: &[u8],
-    _hex_buf: &mut Vec<u8>,
 ) -> Result<(), ProjectionError> {
     builder
         .write_hex_bytes_lower(handle, bytes)

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -377,6 +377,7 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 | `logfwd-runtime/worker_pool.rs` | MRU dispatch decision + typed delivery outcome helpers | Kani (8 dispatch/outcome proofs) + unit tests for worker-slot aggregation, drain-phase stickiness, and create-failure behavior |
 | `logfwd-arrow/storage_builder.rs` | StructArray conflict column assembly | Kani (2 proofs: duplicate name guard, row count invariant) + unit tests |
 | `logfwd-arrow/streaming_builder.rs` | StructArray conflict column assembly (StringView) | Kani (2 proofs: duplicate name guard, row count invariant) + unit tests |
+| `logfwd-arrow/columnar/builder.rs` | Generated-string offset accounting and lowercase hex append helpers | Kani recommended (5 proofs: buffer-len add, append-len add, `StringRef` conversion, hex-length doubling, hex oracle) + unit tests + proptest hex oracle |
 | `logfwd-arrow/conflict_schema.rs` | Conflict-struct detection + row-level precedence selection | Kani recommended (2 proofs) + unit tests |
 | `scanner_conformance.rs` (accumulation) | BytesMut accumulation → Bytes → Scanner equivalence | proptest (3 tests × 256 cases: random split, single chunk, per-line split; full value comparison) |
 

--- a/dev-docs/verification/kani-boundary-contract.toml
+++ b/dev-docs/verification/kani-boundary-contract.toml
@@ -227,3 +227,8 @@ path = "crates/logfwd-arrow/src/columnar/row_protocol.rs"
 status = "required"
 reason = "RowLifecycle state machine transitions are bounded pure seams with symbolic action sequence proofs."
 issue = 2072
+
+[[seams]]
+path = "crates/logfwd-arrow/src/columnar/builder.rs"
+status = "recommended"
+reason = "Generated-string offset accounting and lowercase hex emission are bounded pure seams inside the broader builder shell."

--- a/scripts/generate_otlp_projection.py
+++ b/scripts/generate_otlp_projection.py
@@ -673,9 +673,8 @@ def render_planned_handle_builder() -> str:
         &self,
         builder: &mut ColumnarBatchBuilder,
         value: &[u8],
-        scratch: &mut WireScratch,
     ) -> Result<(), ProjectionError> {{
-        super::write_hex_field(builder, self.{field_name}, value, &mut scratch.hex)
+        super::write_hex_field(builder, self.{field_name}, value)
     }}"""
             )
         elif writer == "any_string":
@@ -1002,7 +1001,7 @@ def render_wire_any_appenders(spec: dict) -> str:
         WireAny::Bool(value) => builder.write_bool(handle, value),
         WireAny::Int(value) => builder.write_i64(handle, value),
         WireAny::Double(value) => builder.write_f64(handle, value),
-        WireAny::Bytes(value) => super::write_hex_field(builder, handle, value, &mut scratch.hex)?,
+        WireAny::Bytes(value) => super::write_hex_field(builder, handle, value)?,
         WireAny::ArrayRaw(value) => {
             super::write_wire_any_complex_json(builder, handle, WireAny::ArrayRaw(value), scratch)?;
         }
@@ -1048,7 +1047,7 @@ pub(super) fn write_wire_any_as_string(
                 .write_str_bytes(handle, &scratch.decimal)
                 .map_err(|e| ProjectionError::Batch(e.to_string()))?;
         }
-        WireAny::Bytes(value) => super::write_hex_field(builder, handle, value, &mut scratch.hex)?,
+        WireAny::Bytes(value) => super::write_hex_field(builder, handle, value)?,
         WireAny::ArrayRaw(value) => {
             super::write_wire_any_complex_json(builder, handle, WireAny::ArrayRaw(value), scratch)?;
         }
@@ -1620,10 +1619,10 @@ mod generated_tests {{
             )
             .expect("body appender should write");
         handles
-            .write_trace_id(&mut builder, &[0xab, 0xcd], &mut scratch)
+            .write_trace_id(&mut builder, &[0xab, 0xcd])
             .expect("trace id appender should write");
         handles
-            .write_span_id(&mut builder, &[0x12, 0x34], &mut scratch)
+            .write_span_id(&mut builder, &[0x12, 0x34])
             .expect("span id appender should write");
         handles.write_flags(&mut builder, 1);
         handles


### PR DESCRIPTION
## Summary
- add a builder helper that writes lowercase hex directly into the generated string buffer
- route OTLP projection hex fields through that helper instead of a temporary scratch buffer
- cover the new builder path with a focused regression test

## Why
Projected OTLP decode still spends measurable time in builder-side string and hex handling. This change removes one avoidable copy for `trace_id` and `span_id` projection without widening the behavioral surface.

## Validation
- `cargo test -p logfwd-arrow write_hex_bytes_lower_produces_correct_string -- --nocapture`
- `cargo test -p logfwd-io generated_tests -- --nocapture`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Write OTLP hex fields directly into the columnar builder without a temporary buffer
> - Adds `ColumnarBatchBuilder::write_hex_bytes_lower` in [`columnar/builder.rs`](https://github.com/strawgate/fastforward/pull/2476/files#diff-d319f6a8aa2761b26f0d390a13e1169007daa93e1a5b5293271066f35b793159) to encode bytes as lowercase hex directly into the generated string buffer, eliminating a per-call `Vec<u8>` allocation.
> - Removes the `hex: Vec<u8>` scratch buffer from `WireScratch` and drops the `hex_buf` parameter from `write_hex_field`, `write_trace_id`, and `write_span_id`.
> - Adds overflow-safe helpers (`current_buffer_len`, `checked_generated_append_len`, `checked_hex_encoded_len`) with Kani proofs and property tests covering correctness and dedup semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bedbd55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->