### PR TITLE
perf: re-enable sccache for local development builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
-# [build]
-# rustc-wrapper = "sccache"
+[build]
+rustc-wrapper = "sccache"
 
 # Deny common mistakes in all builds (not just CI).
 [target.'cfg(all())']


### PR DESCRIPTION
## Summary

- Uncomment `rustc-wrapper = "sccache"` in `.cargo/config.toml`
- CI already sets `RUSTC_WRAPPER=""` in `ci.yml` to disable sccache in workflows, so this only affects local development

## Test plan

- [x] `just ci` passes locally (1,937 tests)
- [x] CI workflows unaffected (already override with `RUSTC_WRAPPER=""`)
- [x] Developers with sccache installed get automatic build caching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-enable sccache as the `rustc-wrapper` for local development builds
> Uncomments the `[build]` section in [.cargo/config.toml](https://github.com/strawgate/fastforward/pull/2478/files#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268) and sets `rustc-wrapper = "sccache"`, so local Cargo builds route compilation through sccache for faster incremental rebuilds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4615780.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->