### PR TITLE
[codex] Fix logfwd-output Kani proof imports

### DIFF
--- a/crates/logfwd-output/src/elasticsearch/kani_proofs.rs
+++ b/crates/logfwd-output/src/elasticsearch/kani_proofs.rs
@@ -1,7 +1,7 @@
 //! Kani formal verification proofs for the Elasticsearch timestamp utilities.
 #![cfg(kani)]
 
-use super::*;
+use crate::elasticsearch::timestamp::{is_leap_year, write_ts_suffix};
 
 /// Prove is_leap_year satisfies all four cases of the Gregorian calendar rule
 /// exhaustively for every possible u32 year value.


### PR DESCRIPTION
## Summary
- import `is_leap_year` and `write_ts_suffix` directly into `elasticsearch/kani_proofs.rs`
- restore `logfwd-output` Kani proof compilation on `main`

## Why
`Kani proofs (io + output)` is red on `main` because `crates/logfwd-output/src/elasticsearch/kani_proofs.rs` no longer resolves the timestamp helpers through `super::*`.

## Validation
- `RUSTC_WRAPPER="" cargo kani -p logfwd-output --harness verify_is_leap_year_gregorian_rules -Z function-contracts -Z mem-predicates -Z stubbing`
- Kani compile reached `verify_write_ts_suffix_ascii` successfully before I stopped the longer solver run

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix glob import in `kani_proofs` for `logfwd-output` elasticsearch module
> Replaces `use super::*;` with an explicit import of `is_leap_year` and `write_ts_suffix` from `crate::elasticsearch::timestamp` in [kani_proofs.rs](https://github.com/strawgate/fastforward/pull/2481/files#diff-cf20fb5df3041a5006354e630def5b5075a089da77fcaf22357f8ba1f72b9dc5). This makes the proof's dependencies explicit and avoids unintended name pollution from the glob import.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e1ee26b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->