### PR TITLE
Add Tier 3 restriction-group correctness lints to Clippy config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,15 @@ implicit_clone = "warn"
 needless_for_each = "warn"
 or_fun_call = "warn"
 checked_conversions = "warn"
+# Tier 3: restriction-group correctness lints (opt-in, not in pedantic).
+unimplemented = "warn"
+todo = "warn"
+rc_mutex = "deny"
+lossy_float_literal = "warn"
+float_cmp_const = "warn"
+fn_to_numeric_cast_any = "warn"
+verbose_file_reads = "warn"
+unnecessary_self_imports = "warn"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [


### PR DESCRIPTION
# Summary

Adds a new set of Tier 3 restriction-group correctness lints to the workspace Clippy configuration. These lints are opt-in and not included in the pedantic group, helping catch common correctness issues and code quality problems:

- `unimplemented` and `todo`: Warn on unfinished code markers
- `rc_mutex`: Deny use of `Rc<Mutex<T>>` (performance anti-pattern)
- `lossy_float_literal` and `float_cmp_const`: Warn on floating-point precision issues
- `fn_to_numeric_cast_any`: Warn on function pointer to numeric casts
- `verbose_file_reads`: Warn on unnecessarily verbose file reading patterns
- `unnecessary_self_imports`: Warn on redundant self imports

## Closes

<!-- Link issues this PR resolves -->

## Test plan

N/A - Configuration change only. `just ci` will validate the Clippy configuration is valid.

https://claude.ai/code/session_013MnRmFkRHyoA52SQJ5tRTk

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Tier 3 Clippy restriction-group lints to workspace configuration
> Adds eight Clippy lints to [Cargo.toml](https://github.com/strawgate/fastforward/pull/2500/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) under the workspace `[lints.clippy]` section. Lints like `todo`, `unimplemented`, `lossy_float_literal`, and `float_cmp_const` are set to `warn`; `rc_mutex` is set to `deny`. Risk: existing code violating these lints will now fail `clippy` checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5047e9b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->