### PR TITLE
fix(ci): add RUSTC_WRAPPER override to docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,10 @@ concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Disable sccache in CI — config.toml enables it for local dev builds.
+  RUSTC_WRAPPER: ""
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -466,13 +466,13 @@ fn scan_line_with_predicate<B: ScanBuilder>(
     // If the predicate references the line-capture field, store the line
     // content in the predicate scratch so IS NOT NULL and string comparisons
     // on the synthetic line column work correctly.
-    if let Some(ref line_name) = config.line_field_name {
-        if predicate.references_field(line_name.as_bytes()) {
-            pred_scratch.insert(
-                line_name.as_bytes(),
-                PredicateFieldValue::Str(buf[start..end].to_vec()),
-            );
-        }
+    if let Some(ref line_name) = config.line_field_name
+        && predicate.references_field(line_name.as_bytes())
+    {
+        pred_scratch.insert(
+            line_name.as_bytes(),
+            PredicateFieldValue::Str(buf[start..end].to_vec()),
+        );
     }
     let has_line_capture = config.captures_line();
 

--- a/dev-docs/verification/kani-boundary-contract.toml
+++ b/dev-docs/verification/kani-boundary-contract.toml
@@ -43,6 +43,11 @@ reason = "Registry ordering and apply-ack helpers are bounded pure logic with ex
 issue = 1314
 
 [[seams]]
+path = "crates/logfwd-types/src/diagnostics.rs"
+status = "recommended"
+reason = "Contains cfg(kani) stubs for atomic counter operations (inc_send, send_ns_total, send_count) that Kani cannot model; no proof harnesses, only Kani-compatible no-op implementations."
+
+[[seams]]
 path = "crates/logfwd-types/src/diagnostics/health.rs"
 status = "required"
 reason = "Shared control-plane health lattice is an isolated pure seam and should stay Kani-covered."


### PR DESCRIPTION
## Summary
- Add `RUSTC_WRAPPER: ""` to the Deploy Docs workflow to match `ci.yml`
- Fixes `wasm-pack` build failure caused by `.cargo/config.toml` setting `rustc-wrapper = "sccache"` (added in #2480) without sccache being installed in the docs CI runner

## Test plan
- [ ] Deploy Docs workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable sccache in the docs CI workflow by overriding `RUSTC_WRAPPER`
> Sets `RUSTC_WRAPPER` to an empty string at the workflow level in [docs.yml](.github/workflows/docs.yml) to prevent sccache from being invoked during docs builds. Also refactors a nested `if` in `json_scanner.scan_line_with_predicate` into a single combined `if let` condition, and adds a Kani seam entry for `diagnostics.rs` in the verification boundary contract.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0cd07d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->