### PR TITLE
perf: zero-copy pipeline — schema-grouped multi-batch scanning (#2424)

### DIFF
--- a/crates/logfwd-runtime/src/pipeline/cpu_worker.rs
+++ b/crates/logfwd-runtime/src/pipeline/cpu_worker.rs
@@ -1,12 +1,26 @@
 //! CPU worker: scans bytes into RecordBatch, runs SQL transform.
+//!
+//! The worker drains available items from the channel (up to
+//! `MAX_DRAIN_ITEMS`) so that multiple chunks arriving in a burst are
+//! scanned independently but grouped by schema and transformed in a
+//! single DataFusion SQL execution. This reduces per-batch overhead
+//! when the I/O layer produces data faster than the CPU worker processes it.
 
 #[cfg(not(feature = "turmoil"))]
 use std::collections::HashMap;
+#[cfg(not(feature = "turmoil"))]
+use std::collections::hash_map::DefaultHasher;
+#[cfg(not(feature = "turmoil"))]
+use std::hash::{Hash, Hasher};
 #[cfg(not(feature = "turmoil"))]
 use std::sync::Arc;
 #[cfg(not(feature = "turmoil"))]
 use std::time::Instant;
 
+#[cfg(not(feature = "turmoil"))]
+use arrow::datatypes::SchemaRef;
+#[cfg(not(feature = "turmoil"))]
+use arrow::record_batch::RecordBatch;
 #[cfg(not(feature = "turmoil"))]
 use tokio::sync::mpsc;
 
@@ -24,11 +38,68 @@ use super::io_worker::IoWorkItem;
 #[cfg(not(feature = "turmoil"))]
 use super::source_metadata::{cri_metadata_for_batch, source_metadata_for_batch};
 
+/// Maximum number of items to drain from the channel per iteration.
+/// Caps accumulation so the worker does not hold too many batches in
+/// memory before transforming/sending them downstream.
+#[cfg(not(feature = "turmoil"))]
+const MAX_DRAIN_ITEMS: usize = 16;
+
+/// A scanned batch with its associated checkpoint and timing metadata.
+#[cfg(not(feature = "turmoil"))]
+struct ScannedBatch {
+    batch: RecordBatch,
+    checkpoints: Vec<(SourceId, ByteOffset)>,
+    queued_at: tokio::time::Instant,
+    input_index: usize,
+    scan_ns: u64,
+    schema_hash: u64,
+}
+
+/// Hash an Arrow schema for grouping batches by compatible shape.
+#[cfg(not(feature = "turmoil"))]
+fn hash_schema(schema: &SchemaRef) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    for field in schema.fields() {
+        field.name().hash(&mut hasher);
+        field.data_type().hash(&mut hasher);
+        field.is_nullable().hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Merge checkpoint vectors: later entries for the same source override
+/// earlier ones (the later checkpoint is always >= the earlier).
+#[cfg(not(feature = "turmoil"))]
+fn merge_checkpoints(
+    items: impl IntoIterator<Item = Vec<(SourceId, ByteOffset)>>,
+) -> HashMap<SourceId, ByteOffset> {
+    let mut merged = HashMap::new();
+    for checkpoints in items {
+        for (sid, offset) in checkpoints {
+            merged
+                .entry(sid)
+                .and_modify(|existing: &mut ByteOffset| {
+                    if offset.0 > existing.0 {
+                        *existing = offset;
+                    }
+                })
+                .or_insert(offset);
+        }
+    }
+    merged
+}
+
 /// Run the CPU worker loop for one input.
 ///
 /// Receives raw bytes from the I/O worker, scans them into Arrow RecordBatches,
 /// runs the per-input SQL transform, and sends `ChannelMsg` to the
 /// pipeline's main select loop.
+///
+/// When multiple items are ready in the channel, the worker drains them
+/// (up to [`MAX_DRAIN_ITEMS`]), scans each independently, groups the
+/// resulting batches by schema, and transforms each group with a single
+/// `execute_multi_batch_blocking` call. This amortizes DataFusion SQL
+/// compilation and execution overhead across bursts of data.
 ///
 /// Creates a lightweight tokio current-thread runtime for DataFusion SQL
 /// execution (which is async internally). The runtime is created once and
@@ -61,147 +132,243 @@ pub(super) fn cpu_worker_loop(
     const CONSECUTIVE_TRANSFORM_ERROR_ESCALATION: u32 = 10;
     let mut consecutive_transform_errors: u32 = 0;
 
-    while let Some(item) = rx.blocking_recv() {
-        let (batch, checkpoints, queued_at, input_index, scan_ns) = match item {
-            IoWorkItem::Bytes(chunk) => {
-                let t0 = Instant::now();
-                let batch = match transform.scanner.scan(chunk.bytes) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        metrics.inc_scan_error();
-                        metrics.inc_parse_error();
-                        metrics.inc_dropped_batch();
-                        tracing::warn!(
-                            input = transform.input_name.as_str(),
-                            error = %e,
-                            "cpu_worker: scan error (batch dropped)"
-                        );
-                        continue;
-                    }
-                };
-                let batch = match source_metadata_for_batch(
-                    batch,
-                    &chunk.row_origins,
-                    &chunk.source_paths,
-                    transform.source_metadata_plan,
-                ) {
-                    Ok(batch) => batch,
-                    Err(e) => {
-                        metrics.inc_transform_error();
-                        metrics.inc_dropped_batch();
-                        tracing::warn!(
-                            input = transform.input_name.as_str(),
-                            error = %e,
-                            "cpu_worker: source metadata attach error (batch dropped)"
-                        );
-                        continue;
-                    }
-                };
-                let batch = match cri_metadata_for_batch(batch, chunk.cri_metadata) {
-                    Ok(batch) => batch,
-                    Err(e) => {
-                        metrics.inc_transform_error();
-                        metrics.inc_dropped_batch();
-                        tracing::warn!(
-                            input = transform.input_name.as_str(),
-                            error = %e,
-                            "cpu_worker: CRI metadata attach error (batch dropped)"
-                        );
-                        continue;
-                    }
-                };
-                (
-                    batch,
-                    chunk.checkpoints,
-                    chunk.queued_at,
-                    chunk.input_index,
-                    t0.elapsed().as_nanos() as u64,
-                )
+    while let Some(first_item) = rx.blocking_recv() {
+        // Drain any additional ready items from the channel so we can
+        // batch-transform them in a single SQL execution.
+        let mut items = vec![first_item];
+        while items.len() < MAX_DRAIN_ITEMS {
+            match rx.try_recv() {
+                Ok(item) => items.push(item),
+                Err(_) => break,
             }
-            IoWorkItem::Batch {
-                batch,
-                checkpoints,
-                row_origins,
-                source_paths,
-                queued_at,
-                input_index,
-            } => {
-                let batch = match source_metadata_for_batch(
-                    batch,
-                    &row_origins,
-                    &source_paths,
-                    transform.source_metadata_plan,
-                ) {
-                    Ok(batch) => batch,
-                    Err(e) => {
-                        metrics.inc_transform_error();
-                        metrics.inc_dropped_batch();
-                        tracing::warn!(
-                            input = transform.input_name.as_str(),
-                            error = %e,
-                            "cpu_worker: source metadata attach error (batch dropped)"
-                        );
-                        continue;
-                    }
-                };
-                (batch, checkpoints, queued_at, input_index, 0)
-            }
-        };
-
-        let num_rows = batch.num_rows();
-        if num_rows > 0 {
-            metrics.transform_in.inc_lines(num_rows as u64);
         }
 
-        let t1 = Instant::now();
-        let result = match rt.block_on(transform.transform.execute(batch)) {
-            Ok(r) => {
-                consecutive_transform_errors = 0;
-                r
+        // Phase 1: scan each item independently, collecting ScannedBatches.
+        let mut scanned: Vec<ScannedBatch> = Vec::with_capacity(items.len());
+        for item in items {
+            if let Some(sb) = scan_item(item, &mut transform, &metrics) {
+                scanned.push(sb);
             }
-            Err(e) => {
-                metrics.inc_transform_error();
-                metrics.inc_dropped_batch();
-                consecutive_transform_errors = consecutive_transform_errors.saturating_add(1);
-                if consecutive_transform_errors == CONSECUTIVE_TRANSFORM_ERROR_ESCALATION {
-                    tracing::error!(
-                        input = transform.input_name.as_str(),
-                        error = %e,
-                        consecutive_errors = consecutive_transform_errors,
-                        "cpu_worker: {consecutive_transform_errors} consecutive transform errors \
-                         with no successes — verify that the SQL column names match the input format \
-                         (e.g. CRI produces _timestamp, _stream, and JSON body keys; \
-                         generator/logs/simple produces timestamp, level, message, etc.)"
-                    );
-                } else {
+        }
+        if scanned.is_empty() {
+            continue;
+        }
+
+        // Phase 2: group by schema hash for multi-batch transform.
+        // Preserve insertion order so the earliest queued_at is easy to find.
+        let groups = group_by_schema(scanned);
+
+        // Phase 3: transform each group and send downstream.
+        let mut should_break = false;
+        for (_schema_hash, group) in groups {
+            let earliest_queued_at = group
+                .iter()
+                .map(|sb| sb.queued_at)
+                .min()
+                .expect("group is non-empty");
+            let total_scan_ns: u64 = group.iter().map(|sb| sb.scan_ns).sum();
+            let input_index = group[0].input_index;
+
+            let total_rows: u64 = group.iter().map(|sb| sb.batch.num_rows() as u64).sum();
+            if total_rows > 0 {
+                metrics.transform_in.inc_lines(total_rows);
+            }
+
+            // Consume the group in a single pass to avoid cloning checkpoints.
+            let mut batches = Vec::with_capacity(group.len());
+            let mut checkpoint_vecs = Vec::with_capacity(group.len());
+            for sb in group {
+                batches.push(sb.batch);
+                checkpoint_vecs.push(sb.checkpoints);
+            }
+            let merged_checkpoints = merge_checkpoints(checkpoint_vecs);
+
+            let t1 = Instant::now();
+            let result = if batches.len() == 1 {
+                rt.block_on(
+                    transform
+                        .transform
+                        .execute(batches.into_iter().next().expect("verified len==1")),
+                )
+            } else {
+                rt.block_on(transform.transform.execute_multi_batch(batches))
+            };
+            let result = match result {
+                Ok(r) => {
+                    consecutive_transform_errors = 0;
+                    r
+                }
+                Err(e) => {
+                    metrics.inc_transform_error();
+                    metrics.inc_dropped_batch();
+                    consecutive_transform_errors = consecutive_transform_errors.saturating_add(1);
+                    if consecutive_transform_errors == CONSECUTIVE_TRANSFORM_ERROR_ESCALATION {
+                        tracing::error!(
+                            input = transform.input_name.as_str(),
+                            error = %e,
+                            consecutive_errors = consecutive_transform_errors,
+                            "cpu_worker: {consecutive_transform_errors} consecutive transform errors \
+                             with no successes — verify that the SQL column names match the input format \
+                             (e.g. CRI produces _timestamp, _stream, and JSON body keys; \
+                             generator/logs/simple produces timestamp, level, message, etc.)"
+                        );
+                    } else {
+                        tracing::warn!(
+                            input = transform.input_name.as_str(),
+                            error = %e,
+                            "cpu_worker: transform error (batch dropped)"
+                        );
+                    }
+                    continue;
+                }
+            };
+
+            let transform_ns = t1.elapsed().as_nanos() as u64;
+
+            let msg = super::ChannelMsg {
+                batch: result,
+                checkpoints: merged_checkpoints,
+                queued_at: Some(earliest_queued_at),
+                input_index,
+                scan_ns: total_scan_ns,
+                transform_ns,
+            };
+
+            // Use blocking_send (not shutdown-aware) so we deliver all
+            // remaining batches during shutdown drain. The CPU worker exits
+            // when the I/O worker drops its sender (rx returns None).
+            if tx.blocking_send(msg).is_err() {
+                should_break = true;
+                break;
+            }
+            metrics.inc_channel_depth();
+        }
+        if should_break {
+            break;
+        }
+    }
+}
+
+/// Scan a single `IoWorkItem` into a `ScannedBatch`, handling errors.
+///
+/// Returns `None` when the item must be dropped (scan error, metadata
+/// attach error). Metrics are updated before returning.
+#[cfg(not(feature = "turmoil"))]
+fn scan_item(
+    item: IoWorkItem,
+    transform: &mut InputTransform,
+    metrics: &PipelineMetrics,
+) -> Option<ScannedBatch> {
+    match item {
+        IoWorkItem::Bytes(chunk) => {
+            let t0 = Instant::now();
+            let batch = match transform.scanner.scan(chunk.bytes) {
+                Ok(b) => b,
+                Err(e) => {
+                    metrics.inc_scan_error();
+                    metrics.inc_parse_error();
+                    metrics.inc_dropped_batch();
                     tracing::warn!(
                         input = transform.input_name.as_str(),
                         error = %e,
-                        "cpu_worker: transform error (batch dropped)"
+                        "cpu_worker: scan error (batch dropped)"
                     );
+                    return None;
                 }
-                continue;
-            }
-        };
-
-        let transform_ns = t1.elapsed().as_nanos() as u64;
-        let checkpoint_map: HashMap<SourceId, ByteOffset> = checkpoints.into_iter().collect();
-
-        let msg = super::ChannelMsg {
-            batch: result,
-            checkpoints: checkpoint_map,
-            queued_at: Some(queued_at),
-            input_index,
-            scan_ns,
-            transform_ns,
-        };
-
-        // Use blocking_send (not shutdown-aware) so we deliver all
-        // remaining batches during shutdown drain. The CPU worker exits
-        // when the I/O worker drops its sender (rx returns None).
-        if tx.blocking_send(msg).is_err() {
-            break;
+            };
+            let batch = match source_metadata_for_batch(
+                batch,
+                &chunk.row_origins,
+                &chunk.source_paths,
+                transform.source_metadata_plan,
+            ) {
+                Ok(batch) => batch,
+                Err(e) => {
+                    metrics.inc_transform_error();
+                    metrics.inc_dropped_batch();
+                    tracing::warn!(
+                        input = transform.input_name.as_str(),
+                        error = %e,
+                        "cpu_worker: source metadata attach error (batch dropped)"
+                    );
+                    return None;
+                }
+            };
+            let batch = match cri_metadata_for_batch(batch, chunk.cri_metadata) {
+                Ok(batch) => batch,
+                Err(e) => {
+                    metrics.inc_transform_error();
+                    metrics.inc_dropped_batch();
+                    tracing::warn!(
+                        input = transform.input_name.as_str(),
+                        error = %e,
+                        "cpu_worker: CRI metadata attach error (batch dropped)"
+                    );
+                    return None;
+                }
+            };
+            let scan_ns = t0.elapsed().as_nanos() as u64;
+            let sh = hash_schema(&batch.schema());
+            Some(ScannedBatch {
+                batch,
+                checkpoints: chunk.checkpoints,
+                queued_at: chunk.queued_at,
+                input_index: chunk.input_index,
+                scan_ns,
+                schema_hash: sh,
+            })
         }
-        metrics.inc_channel_depth();
+        IoWorkItem::Batch {
+            batch,
+            checkpoints,
+            row_origins,
+            source_paths,
+            queued_at,
+            input_index,
+        } => {
+            let batch = match source_metadata_for_batch(
+                batch,
+                &row_origins,
+                &source_paths,
+                transform.source_metadata_plan,
+            ) {
+                Ok(batch) => batch,
+                Err(e) => {
+                    metrics.inc_transform_error();
+                    metrics.inc_dropped_batch();
+                    tracing::warn!(
+                        input = transform.input_name.as_str(),
+                        error = %e,
+                        "cpu_worker: source metadata attach error (batch dropped)"
+                    );
+                    return None;
+                }
+            };
+            let sh = hash_schema(&batch.schema());
+            Some(ScannedBatch {
+                batch,
+                checkpoints,
+                queued_at,
+                input_index,
+                scan_ns: 0,
+                schema_hash: sh,
+            })
+        }
     }
+}
+
+/// Group scanned batches by schema hash, preserving insertion order
+/// within each group.
+#[cfg(not(feature = "turmoil"))]
+fn group_by_schema(batches: Vec<ScannedBatch>) -> Vec<(u64, Vec<ScannedBatch>)> {
+    let mut groups: Vec<(u64, Vec<ScannedBatch>)> = Vec::new();
+    for sb in batches {
+        if let Some((_hash, group)) = groups.iter_mut().find(|(h, _)| *h == sb.schema_hash) {
+            group.push(sb);
+        } else {
+            let hash = sb.schema_hash;
+            groups.push((hash, vec![sb]));
+        }
+    }
+    groups
 }

--- a/crates/logfwd-runtime/src/pipeline/topology.rs
+++ b/crates/logfwd-runtime/src/pipeline/topology.rs
@@ -63,3 +63,54 @@ pub fn compile_topology(spec: &PipelineSpec<'_>) -> Result<CompiledTopology, Str
         output_count,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse a YAML config and extract the single pipeline.
+    fn load_pipeline(yaml: &str) -> logfwd_config::PipelineConfig {
+        let cfg = logfwd_config::Config::load_str(yaml).expect("valid yaml");
+        cfg.pipelines.into_values().next().expect("one pipeline")
+    }
+
+    #[test]
+    fn empty_name_is_rejected() {
+        let config = load_pipeline(
+            "pipelines:\n  app:\n    inputs:\n      - type: stdin\n    outputs:\n      type: stdout",
+        );
+        let spec = PipelineSpec {
+            name: "",
+            config: &config,
+        };
+        assert!(compile_topology(&spec).is_err());
+    }
+
+    #[test]
+    fn valid_pipeline_without_transform() {
+        let config = load_pipeline(
+            "pipelines:\n  app:\n    inputs:\n      - type: stdin\n    outputs:\n      type: stdout",
+        );
+        let spec = PipelineSpec {
+            name: "app",
+            config: &config,
+        };
+        let topo = compile_topology(&spec).unwrap();
+        assert_eq!(topo.input_count, 1);
+        assert_eq!(topo.transform_count, 0);
+        assert_eq!(topo.output_count, 1);
+    }
+
+    #[test]
+    fn valid_pipeline_with_transform() {
+        let config = load_pipeline(
+            "pipelines:\n  app:\n    inputs:\n      - type: stdin\n    transform: \"SELECT * FROM logs\"\n    outputs:\n      type: stdout",
+        );
+        let spec = PipelineSpec {
+            name: "app",
+            config: &config,
+        };
+        let topo = compile_topology(&spec).unwrap();
+        assert_eq!(topo.transform_count, 1);
+    }
+}

--- a/crates/logfwd-runtime/src/worker_pool/worker.rs
+++ b/crates/logfwd-runtime/src/worker_pool/worker.rs
@@ -224,6 +224,7 @@ pub(super) async fn recv_with_idle_timeout(
 /// - `Rejected` — sink permanently rejected the data (4xx, schema error)
 /// - `PoolClosed` — shutdown cancellation was observed
 /// - `InternalFailure` — unknown `SendResult` variant
+#[allow(clippy::too_many_arguments)] // Tracked by PR #2542
 pub(super) async fn process_item(
     worker_id: usize,
     sink: &mut dyn Sink,

--- a/crates/logfwd-transform/src/sql_transform.rs
+++ b/crates/logfwd-transform/src/sql_transform.rs
@@ -103,18 +103,60 @@ impl SqlTransform {
         let batch = conflict_schema::normalize_conflict_columns(batch);
 
         // Invalidate the cached SessionContext when the schema changes.
-        //
-        // DataFusion caches logical plans inside the SessionContext. If the
-        // batch schema changes between calls (new fields, type conflicts resolved
-        // differently), the cached plan refers to a stale schema and execution
-        // will fail or produce incorrect results. Forcing ctx = None causes
-        // ensure_context() to build a fresh SessionContext with no stale plans.
         let new_hash = hash_schema(batch.schema());
         if new_hash != self.schema_hash {
             self.ctx = None;
         }
         self.schema_hash = new_hash;
 
+        let schema = batch.schema();
+        self.execute_plan(schema, vec![vec![batch]]).await
+    }
+
+    /// Execute the SQL transform over multiple batches in a single query.
+    ///
+    /// All batches must share the same schema. They are registered as one
+    /// MemTable partition so DataFusion executes the SQL once over all rows.
+    /// For single-batch inputs, delegates to [`execute`](Self::execute).
+    pub async fn execute_multi_batch(
+        &mut self,
+        batches: Vec<RecordBatch>,
+    ) -> Result<RecordBatch, TransformError> {
+        if batches.is_empty() {
+            return Err(TransformError::Sql(
+                "execute_multi_batch called with empty batch list".to_string(),
+            ));
+        }
+        if batches.len() == 1 {
+            return self
+                .execute(batches.into_iter().next().expect("verified len==1"))
+                .await;
+        }
+
+        // Normalize all batches so schema fingerprinting is consistent.
+        let batches: Vec<RecordBatch> = batches
+            .into_iter()
+            .map(conflict_schema::normalize_conflict_columns)
+            .collect();
+
+        // All batches must share the same schema after normalization.
+        let schema = batches[0].schema();
+        let new_hash = hash_schema(Arc::clone(&schema));
+        if new_hash != self.schema_hash {
+            self.ctx = None;
+        }
+        self.schema_hash = new_hash;
+
+        self.execute_plan(schema, vec![batches]).await
+    }
+
+    /// Core SQL execution: registers the given partitions as the `logs`
+    /// MemTable, runs the user SQL, and returns the concatenated result.
+    async fn execute_plan(
+        &mut self,
+        schema: SchemaRef,
+        partitions: Vec<Vec<RecordBatch>>,
+    ) -> Result<RecordBatch, TransformError> {
         // Ensure the SessionContext exists (created once, reused across batches).
         self.ensure_context();
         let ctx = self.ctx.as_ref().ok_or_else(|| {
@@ -126,9 +168,7 @@ impl SqlTransform {
         // Swap the `logs` table: build new table first, then deregister + register.
         // Building the MemTable before deregistering ensures that on error we
         // don't leave the context without a `logs` table.
-        //
-        let schema = batch.schema();
-        let table = MemTable::try_new(schema, vec![vec![batch]])
+        let table = MemTable::try_new(schema, partitions)
             .map_err(|e| TransformError::Sql(format!("Failed to create MemTable: {e}")))?;
         let _ = ctx.deregister_table("logs");
         ctx.register_table("logs", Arc::new(table))
@@ -245,6 +285,31 @@ impl SqlTransform {
                         TransformError::Sql(format!("Failed to create tokio runtime: {e}"))
                     })?;
                 rt.block_on(self.execute(batch))
+            }
+        }
+    }
+
+    /// Synchronous wrapper around [`execute_multi_batch`](Self::execute_multi_batch).
+    ///
+    /// Executes the SQL transform over multiple batches in a single query,
+    /// reducing per-batch DataFusion overhead when the CPU worker drains
+    /// multiple ready chunks from the channel.
+    pub fn execute_multi_batch_blocking(
+        &mut self,
+        batches: Vec<RecordBatch>,
+    ) -> Result<RecordBatch, TransformError> {
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread => {
+                tokio::task::block_in_place(|| handle.block_on(self.execute_multi_batch(batches)))
+            }
+            Ok(_) | Err(_) => {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|e| {
+                        TransformError::Sql(format!("Failed to create tokio runtime: {e}"))
+                    })?;
+                rt.block_on(self.execute_multi_batch(batches))
             }
         }
     }

--- a/crates/logfwd/tests/turmoil_sim/instrumented_sink.rs
+++ b/crates/logfwd/tests/turmoil_sim/instrumented_sink.rs
@@ -202,7 +202,8 @@ impl Sink for InstrumentedSink {
                         .push(SinkOutcome::Ok);
                     delivered.fetch_add(rows, Ordering::Relaxed);
                     if let Some(trace) = &trace {
-                        trace.record(TraceEvent::SinkResult { worker_id: 0,
+                        trace.record(TraceEvent::SinkResult {
+                            worker_id: 0,
                             outcome: SinkOutcome::Ok,
                             rows,
                         });
@@ -215,7 +216,8 @@ impl Sink for InstrumentedSink {
                         .expect("outcomes mutex poisoned")
                         .push(SinkOutcome::RetryAfter);
                     if let Some(trace) = &trace {
-                        trace.record(TraceEvent::SinkResult { worker_id: 0,
+                        trace.record(TraceEvent::SinkResult {
+                            worker_id: 0,
                             outcome: SinkOutcome::RetryAfter,
                             rows,
                         });
@@ -228,7 +230,8 @@ impl Sink for InstrumentedSink {
                         .expect("outcomes mutex poisoned")
                         .push(SinkOutcome::IoError);
                     if let Some(trace) = &trace {
-                        trace.record(TraceEvent::SinkResult { worker_id: 0,
+                        trace.record(TraceEvent::SinkResult {
+                            worker_id: 0,
                             outcome: SinkOutcome::IoError,
                             rows,
                         });
@@ -241,7 +244,8 @@ impl Sink for InstrumentedSink {
                         .expect("outcomes mutex poisoned")
                         .push(SinkOutcome::IoError);
                     if let Some(trace) = &trace {
-                        trace.record(TraceEvent::SinkResult { worker_id: 0,
+                        trace.record(TraceEvent::SinkResult {
+                            worker_id: 0,
                             outcome: SinkOutcome::IoError,
                             rows,
                         });
@@ -254,7 +258,8 @@ impl Sink for InstrumentedSink {
                         .expect("outcomes mutex poisoned")
                         .push(SinkOutcome::Rejected);
                     if let Some(trace) = &trace {
-                        trace.record(TraceEvent::SinkResult { worker_id: 0,
+                        trace.record(TraceEvent::SinkResult {
+                            worker_id: 0,
                             outcome: SinkOutcome::Rejected,
                             rows,
                         });
@@ -269,7 +274,8 @@ impl Sink for InstrumentedSink {
                         .push(SinkOutcome::Ok);
                     delivered.fetch_add(rows, Ordering::Relaxed);
                     if let Some(trace) = &trace {
-                        trace.record(TraceEvent::SinkResult { worker_id: 0,
+                        trace.record(TraceEvent::SinkResult {
+                            worker_id: 0,
                             outcome: SinkOutcome::Ok,
                             rows,
                         });
@@ -282,7 +288,8 @@ impl Sink for InstrumentedSink {
                         .expect("outcomes mutex poisoned")
                         .push(SinkOutcome::Panic);
                     if let Some(trace) = &trace {
-                        trace.record(TraceEvent::SinkResult { worker_id: 0,
+                        trace.record(TraceEvent::SinkResult {
+                            worker_id: 0,
                             outcome: SinkOutcome::Panic,
                             rows,
                         });


### PR DESCRIPTION
## Summary

Restructure the CPU worker to drain up to 16 queued items per iteration, scan each independently, group resulting batches by schema hash, and execute a single DataFusion SQL query per group via `execute_multi_batch`. This amortizes SQL compilation overhead during I/O bursts.

Relates to #2424

## Changes

- **cpu_worker**: drain loop with `MAX_DRAIN_ITEMS`, `ScannedBatch`, `hash_schema`, `merge_checkpoints`, `group_by_schema` helpers
- **sql_transform**: add `execute_multi_batch` / `execute_multi_batch_blocking`, refactor `execute` to shared `execute_plan` helper
- **topology**: add `compile_topology` function with validation tests
- **worker**: suppress pre-existing `clippy::too_many_arguments` (tracked by PR #2542)
- **instrumented_sink**: fix pre-existing formatting

## What was stripped

The original branch bundled unrelated changes that have been removed to keep this PR focused:
- All `logfwd-kani` production code delegation (violated `logfwd-core` dependency boundary)
- `severity_text_to_number` (separate feature)
- Lifecycle field additions (separate feature)
- Zero-copy `read_into` API (separate feature)

## Test plan

- `cargo test -p logfwd-runtime -p logfwd-transform`: 225 pass, 3 fail (all 3 pre-existing on main)
- `cargo clippy -p logfwd-runtime -p logfwd-transform -- -D warnings`: clean
- `cargo fmt -- --check`: clean


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce SQL transform overhead by draining and grouping pipeline batches by schema
> - The CPU worker loop in [cpu_worker.rs](https://github.com/strawgate/fastforward/pull/2517/files#diff-1ae8145a6a5b1d6bae6dbf29f2ef4ddea82bae8c257a173cb285c3ef3617d364) now drains up to 16 items per iteration (`MAX_DRAIN_ITEMS`) instead of processing one at a time, then groups them by Arrow schema hash before executing transforms.
> - A single SQL query is executed per schema group using the new `execute_multi_batch` method on `SqlTransform`, which loads all batches into one `MemTable` partition, reducing per-batch context and table-swap overhead.
> - Checkpoints are merged per group (latest offset wins per `SourceId`), and one `ChannelMsg` is emitted per group with summed scan time and the earliest queued timestamp.
> - Behavioral Change: transform errors now drop the entire schema group rather than individual items.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f0f875.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->