### PR TITLE
[codex] docs: generate config support tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6511,6 +6511,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "logfwd-config",
  "quote",
  "regex",
  "syn",

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -384,6 +384,7 @@ Behavior:
 
 ## Input types
 
+{/* BEGIN GENERATED: input-types */}
 | Value | Status | Description |
 |-------|--------|-------------|
 | `file` | Implemented | Tail files matching a glob pattern. |
@@ -397,8 +398,10 @@ Behavior:
 | `linux_ebpf_sensor` | Implemented | Linux eBPF sensor input (Arrow-native control + signal rows). |
 | `macos_es_sensor` | Implemented | macOS EndpointSecurity sensor input (Arrow-native control + signal rows). |
 | `windows_ebpf_sensor` | Implemented | Windows eBPF sensor input (Arrow-native control + signal rows). |
+| `journald` | Beta | Read structured journal entries from systemd journald. |
 | `host_metrics` | Implemented | Host metrics input — process snapshots, CPU, memory, network stats via sysinfo (Arrow-native). |
 | `arrow_ipc` | Implemented | Receive Arrow IPC stream batches via HTTP `POST /v1/arrow`. |
+{/* END GENERATED: input-types */}
 
 ---
 
@@ -603,6 +606,7 @@ output:
 
 ## Output types
 
+{/* BEGIN GENERATED: output-types */}
 | Value | Status | Description |
 |-------|--------|-------------|
 | `otlp` | Implemented | OTLP protobuf over HTTP or gRPC. |
@@ -616,6 +620,7 @@ output:
 | `udp` | Implemented | Send records to a UDP endpoint. |
 | `arrow_ipc` | Implemented | Send Arrow IPC payloads to an HTTP endpoint. |
 | `parquet` | Not yet supported | Reserved for Parquet file output. |
+{/* END GENERATED: output-types */}
 
 ---
 

--- a/crates/logfwd-config-wasm/AGENTS.md
+++ b/crates/logfwd-config-wasm/AGENTS.md
@@ -28,6 +28,6 @@ Output lands in `book/public/wasm/logfwd-config/`. The `.js` and `.wasm` files a
 ## Key constraints
 
 - **Compile target**: `wasm32-unknown-unknown` only. No `std::fs`, no `tokio`, no `std::thread`.
-- **Template sync**: `INPUT_TEMPLATES` / `OUTPUT_TEMPLATES` in `src/lib.rs` mirror `crates/logfwd/src/config_templates.rs`. Keep in sync when adding new templates.
+- **Template source**: input/output templates come from `logfwd_config::docspec`. Keep the WASM exports aligned with that shared registry rather than reintroducing local copies.
 - **Validation parity**: only expose formats and output types that pass `Config::validate`. Check `crates/logfwd-config/src/validate.rs` before adding options.
 - **No serde-wasm-bindgen**: uses JSON round-trip via `js_sys::JSON::parse`. Static data — panics on serialization failure by design.

--- a/crates/logfwd-config-wasm/src/lib.rs
+++ b/crates/logfwd-config-wasm/src/lib.rs
@@ -1,41 +1,8 @@
-use logfwd_config::Config;
+use logfwd_config::{Config, docspec};
 use wasm_bindgen::prelude::*;
 
 // ── Template data ──────────────────────────────────────────────────────────
-// Mirrored from crates/logfwd/src/config_templates.rs.
-// Keep in sync when adding new templates.
-
-/// A single editable field in a template's config panel.
-/// `default` is the YAML value that appears in `snippet` for this field.
-/// Substitution matches `"key: default"` in the snippet and replaces with `"key: <user value>"`.
-/// `options` non-empty → render as a `<select>` dropdown; values are the literal YAML strings.
-#[derive(serde::Serialize)]
-struct FieldDef {
-    key: &'static str,
-    label: &'static str,
-    #[serde(rename = "default")]
-    default_val: &'static str,
-    placeholder: &'static str,
-    options: &'static [&'static str],
-}
-
-#[derive(serde::Serialize)]
-struct InputTemplate {
-    id: &'static str,
-    label: &'static str,
-    description: &'static str,
-    snippet: &'static str,
-    fields: &'static [FieldDef],
-}
-
-#[derive(serde::Serialize)]
-struct OutputTemplate {
-    id: &'static str,
-    label: &'static str,
-    description: &'static str,
-    snippet: &'static str,
-    fields: &'static [FieldDef],
-}
+// Shared input/output templates live in `logfwd-config::docspec`.
 
 #[derive(serde::Serialize)]
 struct UseCaseTemplate {
@@ -46,268 +13,6 @@ struct UseCaseTemplate {
     output_id: &'static str,
     transform: &'static str,
 }
-
-const INPUT_TEMPLATES: &[InputTemplate] = &[
-    InputTemplate {
-        id: "file_json",
-        label: "File (JSON logs)",
-        description: "Tail JSON log files on disk.",
-        snippet: "input:\n  type: file\n  path: /var/log/app/*.json\n  format: json\n",
-        fields: &[
-            FieldDef {
-                key: "path",
-                label: "Path",
-                default_val: "/var/log/app/*.json",
-                placeholder: "/var/log/app/*.json",
-                options: &[],
-            },
-            FieldDef {
-                key: "format",
-                label: "Format",
-                default_val: "json",
-                placeholder: "json",
-                options: &["json", "raw", "auto"],
-            },
-        ],
-    },
-    InputTemplate {
-        id: "file_cri",
-        label: "File (Kubernetes CRI)",
-        description: "Tail Kubernetes container logs from node filesystems.",
-        snippet: "input:\n  type: file\n  path: /var/log/containers/*.log\n  format: cri\n",
-        fields: &[FieldDef {
-            key: "path",
-            label: "Path",
-            default_val: "/var/log/containers/*.log",
-            placeholder: "/var/log/containers/*.log",
-            options: &[],
-        }],
-    },
-    InputTemplate {
-        id: "file_raw",
-        label: "File (raw lines)",
-        description: "Tail plain-text log files, one event per line.",
-        snippet: "input:\n  type: file\n  path: /var/log/app/*.log\n  format: raw\n",
-        fields: &[
-            FieldDef {
-                key: "path",
-                label: "Path",
-                default_val: "/var/log/app/*.log",
-                placeholder: "/var/log/app/*.log",
-                options: &[],
-            },
-            FieldDef {
-                key: "format",
-                label: "Format",
-                default_val: "raw",
-                placeholder: "raw",
-                options: &["raw", "json", "auto"],
-            },
-        ],
-    },
-    InputTemplate {
-        id: "udp_raw",
-        label: "UDP listener",
-        description: "Receive raw log lines over UDP (e.g. syslog).",
-        snippet: "input:\n  type: udp\n  listen: 0.0.0.0:5514\n  format: raw\n",
-        fields: &[
-            FieldDef {
-                key: "listen",
-                label: "Listen",
-                default_val: "0.0.0.0:5514",
-                placeholder: "0.0.0.0:5514",
-                options: &[],
-            },
-            FieldDef {
-                key: "format",
-                label: "Format",
-                default_val: "raw",
-                placeholder: "raw",
-                options: &["raw", "json"],
-            },
-        ],
-    },
-    InputTemplate {
-        id: "tcp_json",
-        label: "TCP listener (JSON)",
-        description: "Accept newline-delimited JSON logs over TCP.",
-        snippet: "input:\n  type: tcp\n  listen: 0.0.0.0:9000\n  format: json\n",
-        fields: &[
-            FieldDef {
-                key: "listen",
-                label: "Listen",
-                default_val: "0.0.0.0:9000",
-                placeholder: "0.0.0.0:9000",
-                options: &[],
-            },
-            FieldDef {
-                key: "format",
-                label: "Format",
-                default_val: "json",
-                placeholder: "json",
-                options: &["json", "raw"],
-            },
-        ],
-    },
-    InputTemplate {
-        id: "otlp_receiver",
-        label: "OTLP receiver",
-        description: "Receive logs via OpenTelemetry Protocol (OTLP/HTTP).",
-        snippet: "input:\n  type: otlp\n  listen: 0.0.0.0:4318\n",
-        fields: &[FieldDef {
-            key: "listen",
-            label: "Listen",
-            default_val: "0.0.0.0:4318",
-            placeholder: "0.0.0.0:4318",
-            options: &[],
-        }],
-    },
-    InputTemplate {
-        id: "http_json",
-        label: "HTTP endpoint (JSON)",
-        description: "Accept JSON log batches over HTTP POST.",
-        snippet: "input:\n  type: http\n  listen: 0.0.0.0:8080\n",
-        fields: &[FieldDef {
-            key: "listen",
-            label: "Listen",
-            default_val: "0.0.0.0:8080",
-            placeholder: "0.0.0.0:8080",
-            options: &[],
-        }],
-    },
-    InputTemplate {
-        id: "journald",
-        label: "systemd journald",
-        description: "Read logs from the systemd journal.",
-        snippet: "input:\n  type: journald\n",
-        fields: &[],
-    },
-    InputTemplate {
-        id: "generator",
-        label: "Generator",
-        description: "Synthetic log generator for testing and benchmarking.",
-        snippet: "input:\n  type: generator\n  generator:\n    events_per_sec: 1000\n    complexity: simple\n",
-        fields: &[
-            FieldDef {
-                key: "events_per_sec",
-                label: "Events / sec",
-                default_val: "1000",
-                placeholder: "1000",
-                options: &[],
-            },
-            FieldDef {
-                key: "complexity",
-                label: "Complexity",
-                default_val: "simple",
-                placeholder: "simple",
-                options: &["simple", "complex"],
-            },
-        ],
-    },
-];
-
-const OUTPUT_TEMPLATES: &[OutputTemplate] = &[
-    OutputTemplate {
-        id: "otlp",
-        label: "OTLP collector",
-        description: "Send logs to an OpenTelemetry collector via OTLP/HTTP.",
-        snippet: "output:\n  type: otlp\n  endpoint: http://localhost:4318/v1/logs\n  compression: none\n",
-        fields: &[
-            FieldDef {
-                key: "endpoint",
-                label: "Endpoint",
-                default_val: "http://localhost:4318/v1/logs",
-                placeholder: "http://otel-collector:4318/v1/logs",
-                options: &[],
-            },
-            FieldDef {
-                key: "compression",
-                label: "Compression",
-                default_val: "none",
-                placeholder: "none",
-                options: &["none", "gzip", "zstd"],
-            },
-        ],
-    },
-    OutputTemplate {
-        id: "elasticsearch",
-        label: "Elasticsearch",
-        description: "Index logs in Elasticsearch.",
-        snippet: "output:\n  type: elasticsearch\n  endpoint: http://localhost:9200\n  index: logs\n  compression: none\n",
-        fields: &[
-            FieldDef {
-                key: "endpoint",
-                label: "Endpoint",
-                default_val: "http://localhost:9200",
-                placeholder: "http://es:9200",
-                options: &[],
-            },
-            FieldDef {
-                key: "index",
-                label: "Index",
-                default_val: "logs",
-                placeholder: "logs",
-                options: &[],
-            },
-            FieldDef {
-                key: "compression",
-                label: "Compression",
-                default_val: "none",
-                placeholder: "none",
-                options: &["none", "gzip"],
-            },
-        ],
-    },
-    OutputTemplate {
-        id: "loki",
-        label: "Grafana Loki",
-        description: "Push logs to Grafana Loki.",
-        snippet: "output:\n  type: loki\n  endpoint: http://localhost:3100\n  static_labels:\n    service: myapp\n  label_columns:\n    - level\n",
-        fields: &[
-            FieldDef {
-                key: "endpoint",
-                label: "Endpoint",
-                default_val: "http://localhost:3100",
-                placeholder: "http://loki:3100",
-                options: &[],
-            },
-            FieldDef {
-                key: "service",
-                label: "Service label",
-                default_val: "myapp",
-                placeholder: "myapp",
-                options: &[],
-            },
-        ],
-    },
-    OutputTemplate {
-        id: "file",
-        label: "NDJSON file",
-        description: "Write logs as newline-delimited JSON to a file.",
-        snippet: "output:\n  type: file\n  path: /var/log/out.ndjson\n",
-        fields: &[FieldDef {
-            key: "path",
-            label: "Path",
-            default_val: "/var/log/out.ndjson",
-            placeholder: "/var/log/out.ndjson",
-            options: &[],
-        }],
-    },
-    OutputTemplate {
-        id: "stdout",
-        label: "stdout",
-        description: "Print logs to the terminal. Great for testing.",
-        snippet: "output:\n  type: stdout\n",
-        fields: &[],
-    },
-    OutputTemplate {
-        id: "null",
-        label: "null sink",
-        description: "Discard all logs. Useful for benchmarking.",
-        snippet: "output:\n  type: \"null\"\n",
-        fields: &[],
-    },
-];
 
 const USE_CASE_TEMPLATES: &[UseCaseTemplate] = &[
     UseCaseTemplate {
@@ -357,13 +62,13 @@ const USE_CASE_TEMPLATES: &[UseCaseTemplate] = &[
 /// Returns the list of available input templates as a JSON array.
 #[wasm_bindgen]
 pub fn get_input_templates() -> JsValue {
-    serde_wasm_bindgen_or_json(INPUT_TEMPLATES)
+    serde_wasm_bindgen_or_json(docspec::INPUT_TEMPLATES)
 }
 
 /// Returns the list of available output templates as a JSON array.
 #[wasm_bindgen]
 pub fn get_output_templates() -> JsValue {
-    serde_wasm_bindgen_or_json(OUTPUT_TEMPLATES)
+    serde_wasm_bindgen_or_json(docspec::OUTPUT_TEMPLATES)
 }
 
 /// Returns the list of use-case starter presets as a JSON array.
@@ -381,14 +86,10 @@ pub fn render_config(
     output_id: &str,
     transform_sql: &str,
 ) -> Result<String, JsValue> {
-    let input = INPUT_TEMPLATES
-        .iter()
-        .find(|t| t.id == input_id)
+    let input = docspec::input_template(input_id)
         .ok_or_else(|| JsValue::from_str(&format!("unknown input template: {input_id}")))?;
 
-    let output = OUTPUT_TEMPLATES
-        .iter()
-        .find(|t| t.id == output_id)
+    let output = docspec::output_template(output_id)
         .ok_or_else(|| JsValue::from_str(&format!("unknown output template: {output_id}")))?;
 
     let mut out = String::from("# Generated by logfwd config builder\n");
@@ -423,19 +124,13 @@ pub fn validate_config(yaml: &str) -> Result<(), JsValue> {
 /// Returns the snippet for a single input template by ID.
 #[wasm_bindgen]
 pub fn get_input_snippet(id: &str) -> Option<String> {
-    INPUT_TEMPLATES
-        .iter()
-        .find(|t| t.id == id)
-        .map(|t| t.snippet.to_string())
+    docspec::input_template(id).map(|template| template.snippet.to_string())
 }
 
 /// Returns the snippet for a single output template by ID.
 #[wasm_bindgen]
 pub fn get_output_snippet(id: &str) -> Option<String> {
-    OUTPUT_TEMPLATES
-        .iter()
-        .find(|t| t.id == id)
-        .map(|t| t.snippet.to_string())
+    docspec::output_template(id).map(|template| template.snippet.to_string())
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/crates/logfwd-config/src/docspec/mod.rs
+++ b/crates/logfwd-config/src/docspec/mod.rs
@@ -3,8 +3,18 @@ use std::fmt::Write as _;
 use serde::Serialize;
 
 /// Public support level for a documented config surface.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::SupportLevel;
+///
+/// let level = SupportLevel::Stable;
+/// assert!(matches!(level, SupportLevel::Stable));
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum SupportLevel {
     /// Supported and intended for production use.
     Stable,
@@ -19,6 +29,21 @@ pub enum SupportLevel {
 }
 
 /// A single editable field in a starter template.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::BuilderFieldDoc;
+///
+/// let field = BuilderFieldDoc {
+///     key: "path",
+///     label: "Path",
+///     default_value: "/var/log/app.log",
+///     placeholder: "/var/log/app.log",
+///     options: &[],
+/// };
+/// assert_eq!(field.key, "path");
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct BuilderFieldDoc {
     /// Stable field identifier used by builder clients.
@@ -35,6 +60,31 @@ pub struct BuilderFieldDoc {
 }
 
 /// A documented starter template for an input or output.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::{BuilderFieldDoc, SupportLevel, TemplateDoc};
+///
+/// let fields = [BuilderFieldDoc {
+///     key: "listen",
+///     label: "Listen",
+///     default_value: "0.0.0.0:9000",
+///     placeholder: "0.0.0.0:9000",
+///     options: &[],
+/// }];
+/// let template = TemplateDoc {
+///     id: "tcp_json",
+///     type_tag: "tcp",
+///     aliases: &[],
+///     label: "TCP listener (JSON)",
+///     description: "Accept newline-delimited JSON logs over TCP.",
+///     support: SupportLevel::Stable,
+///     snippet: "input:\\n  type: tcp\\n  listen: 0.0.0.0:9000\\n",
+///     fields: &fields,
+/// };
+/// assert_eq!(template.type_tag, "tcp");
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct TemplateDoc {
     /// Stable template identifier used by the docs builder and CLI wizard.
@@ -56,6 +106,19 @@ pub struct TemplateDoc {
 }
 
 /// A documented config component type for support/inventory tables.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::{ComponentTypeDoc, SupportLevel};
+///
+/// let component = ComponentTypeDoc {
+///     type_tag: "stdout",
+///     support: SupportLevel::Stable,
+///     description: "Print to stdout.",
+/// };
+/// assert_eq!(component.type_tag, "stdout");
+/// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ComponentTypeDoc {
     /// The config `type:` value used in YAML.
@@ -67,6 +130,14 @@ pub struct ComponentTypeDoc {
 }
 
 /// Starter templates exposed for documented input configurations.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::INPUT_TEMPLATES;
+///
+/// assert!(INPUT_TEMPLATES.iter().any(|template| template.id == "file_json"));
+/// ```
 pub const INPUT_TEMPLATES: &[TemplateDoc] = &[
     TemplateDoc {
         id: "file_json",
@@ -254,6 +325,14 @@ pub const INPUT_TEMPLATES: &[TemplateDoc] = &[
 ];
 
 /// Starter templates exposed for documented output configurations.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::OUTPUT_TEMPLATES;
+///
+/// assert!(OUTPUT_TEMPLATES.iter().any(|template| template.id == "stdout"));
+/// ```
 pub const OUTPUT_TEMPLATES: &[TemplateDoc] = &[
     TemplateDoc {
         id: "otlp",
@@ -376,6 +455,14 @@ pub const OUTPUT_TEMPLATES: &[TemplateDoc] = &[
 ];
 
 /// Input component inventory used for generated support tables.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::INPUT_TYPE_DOCS;
+///
+/// assert!(INPUT_TYPE_DOCS.iter().any(|entry| entry.type_tag == "file"));
+/// ```
 pub const INPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
     ComponentTypeDoc {
         type_tag: "file",
@@ -450,6 +537,14 @@ pub const INPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
 ];
 
 /// Output component inventory used for generated support tables.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::OUTPUT_TYPE_DOCS;
+///
+/// assert!(OUTPUT_TYPE_DOCS.iter().any(|entry| entry.type_tag == "stdout"));
+/// ```
 pub const OUTPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
     ComponentTypeDoc {
         type_tag: "otlp",
@@ -511,6 +606,15 @@ pub const OUTPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
 /// Look up an input starter template by its stable template identifier.
 ///
 /// Returns `None` when `id` is not registered in [`INPUT_TEMPLATES`].
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::input_template;
+///
+/// assert_eq!(input_template("file_json").map(|template| template.type_tag), Some("file"));
+/// assert!(input_template("missing").is_none());
+/// ```
 pub fn input_template(id: &str) -> Option<&'static TemplateDoc> {
     INPUT_TEMPLATES.iter().find(|template| template.id == id)
 }
@@ -518,6 +622,15 @@ pub fn input_template(id: &str) -> Option<&'static TemplateDoc> {
 /// Look up an output starter template by its stable template identifier.
 ///
 /// Returns `None` when `id` is not registered in [`OUTPUT_TEMPLATES`].
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::output_template;
+///
+/// assert_eq!(output_template("stdout").map(|template| template.type_tag), Some("stdout"));
+/// assert!(output_template("missing").is_none());
+/// ```
 pub fn output_template(id: &str) -> Option<&'static TemplateDoc> {
     OUTPUT_TEMPLATES.iter().find(|template| template.id == id)
 }
@@ -526,6 +639,20 @@ pub fn output_template(id: &str) -> Option<&'static TemplateDoc> {
 ///
 /// Hidden entries are omitted. Public support levels are rendered as
 /// human-facing status labels such as `Implemented` and `Not yet supported`.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::{render_component_type_table, ComponentTypeDoc, SupportLevel};
+///
+/// let docs = [ComponentTypeDoc {
+///     type_tag: "stdout",
+///     support: SupportLevel::Stable,
+///     description: "Print to stdout.",
+/// }];
+/// let table = render_component_type_table(&docs);
+/// assert!(table.contains("| `stdout` | Implemented | Print to stdout. |"));
+/// ```
 pub fn render_component_type_table(entries: &[ComponentTypeDoc]) -> String {
     let mut out =
         String::from("| Value | Status | Description |\n|-------|--------|-------------|\n");

--- a/crates/logfwd-config/src/docspec/mod.rs
+++ b/crates/logfwd-config/src/docspec/mod.rs
@@ -507,16 +507,23 @@ pub const OUTPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
 ];
 
 /// Look up an input starter template by its stable template identifier.
+///
+/// Returns `None` when `id` is not registered in [`INPUT_TEMPLATES`].
 pub fn input_template(id: &str) -> Option<&'static TemplateDoc> {
     INPUT_TEMPLATES.iter().find(|template| template.id == id)
 }
 
 /// Look up an output starter template by its stable template identifier.
+///
+/// Returns `None` when `id` is not registered in [`OUTPUT_TEMPLATES`].
 pub fn output_template(id: &str) -> Option<&'static TemplateDoc> {
     OUTPUT_TEMPLATES.iter().find(|template| template.id == id)
 }
 
 /// Render a Markdown support table for public component types.
+///
+/// Hidden entries are omitted. Public support levels are rendered as
+/// human-facing status labels such as `Implemented` and `Not yet supported`.
 pub fn render_component_type_table(entries: &[ComponentTypeDoc]) -> String {
     let mut out =
         String::from("| Value | Status | Description |\n|-------|--------|-------------|\n");

--- a/crates/logfwd-config/src/docspec/mod.rs
+++ b/crates/logfwd-config/src/docspec/mod.rs
@@ -4,21 +4,31 @@ use serde::Serialize;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SupportLevel {
+    /// Supported and intended for production use.
     Stable,
+    /// Available for evaluation, but still changing quickly.
     Experimental,
+    /// Implemented and usable, but still settling.
     Beta,
+    /// Mentioned in the schema surface, but not implemented yet.
     NotYetSupported,
+    /// Internal-only surface that should not appear in public docs.
     Hidden,
 }
 
 /// A single editable field in a starter template.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct BuilderFieldDoc {
+    /// Stable field identifier used by builder clients.
     pub key: &'static str,
+    /// Human-facing field label.
     pub label: &'static str,
+    /// Default value presented to the user.
     #[serde(rename = "default")]
     pub default_value: &'static str,
+    /// Example value shown before editing.
     pub placeholder: &'static str,
+    /// Fixed choices, when the field is an enum-like selector.
     pub options: &'static [&'static str],
 }
 
@@ -46,11 +56,15 @@ pub struct TemplateDoc {
 /// A documented config component type for support/inventory tables.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ComponentTypeDoc {
+    /// The config `type:` value used in YAML.
     pub type_tag: &'static str,
+    /// Public support level shown in generated tables.
     pub support: SupportLevel,
+    /// Short description used in generated docs.
     pub description: &'static str,
 }
 
+/// Starter templates exposed for documented input configurations.
 pub const INPUT_TEMPLATES: &[TemplateDoc] = &[
     TemplateDoc {
         id: "file_json",
@@ -237,6 +251,7 @@ pub const INPUT_TEMPLATES: &[TemplateDoc] = &[
     },
 ];
 
+/// Starter templates exposed for documented output configurations.
 pub const OUTPUT_TEMPLATES: &[TemplateDoc] = &[
     TemplateDoc {
         id: "otlp",
@@ -327,12 +342,12 @@ pub const OUTPUT_TEMPLATES: &[TemplateDoc] = &[
         label: "NDJSON file",
         description: "Write logs as newline-delimited JSON to a file.",
         support: SupportLevel::Stable,
-        snippet: "output:\n  type: file\n  path: /var/log/out.ndjson\n",
+        snippet: "output:\n  type: file\n  path: ./out.ndjson\n",
         fields: &[BuilderFieldDoc {
             key: "path",
             label: "Path",
-            default_value: "/var/log/out.ndjson",
-            placeholder: "/var/log/out.ndjson",
+            default_value: "./out.ndjson",
+            placeholder: "./out.ndjson",
             options: &[],
         }],
     },
@@ -358,6 +373,7 @@ pub const OUTPUT_TEMPLATES: &[TemplateDoc] = &[
     },
 ];
 
+/// Input component inventory used for generated support tables.
 pub const INPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
     ComponentTypeDoc {
         type_tag: "file",
@@ -431,6 +447,7 @@ pub const INPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
     },
 ];
 
+/// Output component inventory used for generated support tables.
 pub const OUTPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
     ComponentTypeDoc {
         type_tag: "otlp",
@@ -489,18 +506,24 @@ pub const OUTPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
     },
 ];
 
+/// Look up an input starter template by its stable template identifier.
 pub fn input_template(id: &str) -> Option<&'static TemplateDoc> {
     INPUT_TEMPLATES.iter().find(|template| template.id == id)
 }
 
+/// Look up an output starter template by its stable template identifier.
 pub fn output_template(id: &str) -> Option<&'static TemplateDoc> {
     OUTPUT_TEMPLATES.iter().find(|template| template.id == id)
 }
 
+/// Render a Markdown support table for public component types.
 pub fn render_component_type_table(entries: &[ComponentTypeDoc]) -> String {
     let mut out =
         String::from("| Value | Status | Description |\n|-------|--------|-------------|\n");
     for entry in entries {
+        if entry.support == SupportLevel::Hidden {
+            continue;
+        }
         let status = match entry.support {
             SupportLevel::Stable => "Implemented",
             SupportLevel::Experimental => "Experimental",

--- a/crates/logfwd-config/src/docspec/mod.rs
+++ b/crates/logfwd-config/src/docspec/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use serde::Serialize;
 
 /// Public support level for a documented config surface.
@@ -538,10 +540,11 @@ pub fn render_component_type_table(entries: &[ComponentTypeDoc]) -> String {
             SupportLevel::NotYetSupported => "Not yet supported",
             SupportLevel::Hidden => "Hidden",
         };
-        out.push_str(&format!(
-            "| `{}` | {} | {} |\n",
+        let _ = writeln!(
+            out,
+            "| `{}` | {} | {} |",
             entry.type_tag, status, entry.description
-        ));
+        );
     }
     out
 }
@@ -589,20 +592,34 @@ mod tests {
     #[test]
     fn every_template_type_is_present_in_component_inventory() {
         for template in INPUT_TEMPLATES {
-            assert!(
-                INPUT_TYPE_DOCS
-                    .iter()
-                    .any(|entry| entry.type_tag == template.type_tag),
-                "missing input type doc for template type {}",
+            let entry = INPUT_TYPE_DOCS
+                .iter()
+                .find(|entry| entry.type_tag == template.type_tag)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "missing input type doc for template type {}",
+                        template.type_tag
+                    )
+                });
+            assert_eq!(
+                entry.support, template.support,
+                "input support mismatch for template type {}",
                 template.type_tag
             );
         }
         for template in OUTPUT_TEMPLATES {
-            assert!(
-                OUTPUT_TYPE_DOCS
-                    .iter()
-                    .any(|entry| entry.type_tag == template.type_tag),
-                "missing output type doc for template type {}",
+            let entry = OUTPUT_TYPE_DOCS
+                .iter()
+                .find(|entry| entry.type_tag == template.type_tag)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "missing output type doc for template type {}",
+                        template.type_tag
+                    )
+                });
+            assert_eq!(
+                entry.support, template.support,
+                "output support mismatch for template type {}",
                 template.type_tag
             );
         }

--- a/crates/logfwd-config/src/docspec/mod.rs
+++ b/crates/logfwd-config/src/docspec/mod.rs
@@ -1,0 +1,628 @@
+use serde::Serialize;
+
+/// Public support level for a documented config surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SupportLevel {
+    Stable,
+    Experimental,
+    Beta,
+    NotYetSupported,
+    Hidden,
+}
+
+/// A single editable field in a starter template.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct BuilderFieldDoc {
+    pub key: &'static str,
+    pub label: &'static str,
+    #[serde(rename = "default")]
+    pub default_value: &'static str,
+    pub placeholder: &'static str,
+    pub options: &'static [&'static str],
+}
+
+/// A documented starter template for an input or output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct TemplateDoc {
+    /// Stable template identifier used by the docs builder and CLI wizard.
+    pub id: &'static str,
+    /// The config `type:` tag emitted by this template.
+    pub type_tag: &'static str,
+    /// Legacy aliases still accepted by the parser, if any.
+    pub aliases: &'static [&'static str],
+    /// Human-facing label shown in pickers.
+    pub label: &'static str,
+    /// One-line description shown in pickers and docs.
+    pub description: &'static str,
+    /// Public support level for the underlying config surface.
+    pub support: SupportLevel,
+    /// YAML starter snippet.
+    pub snippet: &'static str,
+    /// Small editable subset exposed by the docs builder UI.
+    pub fields: &'static [BuilderFieldDoc],
+}
+
+/// A documented config component type for support/inventory tables.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ComponentTypeDoc {
+    pub type_tag: &'static str,
+    pub support: SupportLevel,
+    pub description: &'static str,
+}
+
+pub const INPUT_TEMPLATES: &[TemplateDoc] = &[
+    TemplateDoc {
+        id: "file_json",
+        type_tag: "file",
+        aliases: &[],
+        label: "File (JSON logs)",
+        description: "Tail JSON log files on disk.",
+        support: SupportLevel::Stable,
+        snippet: "input:\n  type: file\n  path: /var/log/app/*.json\n  format: json\n",
+        fields: &[
+            BuilderFieldDoc {
+                key: "path",
+                label: "Path",
+                default_value: "/var/log/app/*.json",
+                placeholder: "/var/log/app/*.json",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "format",
+                label: "Format",
+                default_value: "json",
+                placeholder: "json",
+                options: &["json", "raw", "auto"],
+            },
+        ],
+    },
+    TemplateDoc {
+        id: "file_cri",
+        type_tag: "file",
+        aliases: &[],
+        label: "File (Kubernetes CRI)",
+        description: "Tail Kubernetes container logs from node filesystems.",
+        support: SupportLevel::Stable,
+        snippet: "input:\n  type: file\n  path: /var/log/containers/*.log\n  format: cri\n",
+        fields: &[BuilderFieldDoc {
+            key: "path",
+            label: "Path",
+            default_value: "/var/log/containers/*.log",
+            placeholder: "/var/log/containers/*.log",
+            options: &[],
+        }],
+    },
+    TemplateDoc {
+        id: "file_raw",
+        type_tag: "file",
+        aliases: &[],
+        label: "File (raw lines)",
+        description: "Tail plain-text log files, one event per line.",
+        support: SupportLevel::Stable,
+        snippet: "input:\n  type: file\n  path: /var/log/app/*.log\n  format: raw\n",
+        fields: &[
+            BuilderFieldDoc {
+                key: "path",
+                label: "Path",
+                default_value: "/var/log/app/*.log",
+                placeholder: "/var/log/app/*.log",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "format",
+                label: "Format",
+                default_value: "raw",
+                placeholder: "raw",
+                options: &["raw", "json", "auto"],
+            },
+        ],
+    },
+    TemplateDoc {
+        id: "udp_raw",
+        type_tag: "udp",
+        aliases: &[],
+        label: "UDP listener",
+        description: "Receive raw log lines over UDP (e.g. syslog).",
+        support: SupportLevel::Stable,
+        snippet: "input:\n  type: udp\n  listen: 0.0.0.0:5514\n  format: raw\n",
+        fields: &[
+            BuilderFieldDoc {
+                key: "listen",
+                label: "Listen",
+                default_value: "0.0.0.0:5514",
+                placeholder: "0.0.0.0:5514",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "format",
+                label: "Format",
+                default_value: "raw",
+                placeholder: "raw",
+                options: &["raw", "json"],
+            },
+        ],
+    },
+    TemplateDoc {
+        id: "tcp_json",
+        type_tag: "tcp",
+        aliases: &[],
+        label: "TCP listener (JSON)",
+        description: "Accept newline-delimited JSON logs over TCP.",
+        support: SupportLevel::Stable,
+        snippet: "input:\n  type: tcp\n  listen: 0.0.0.0:9000\n  format: json\n",
+        fields: &[
+            BuilderFieldDoc {
+                key: "listen",
+                label: "Listen",
+                default_value: "0.0.0.0:9000",
+                placeholder: "0.0.0.0:9000",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "format",
+                label: "Format",
+                default_value: "json",
+                placeholder: "json",
+                options: &["json", "raw"],
+            },
+        ],
+    },
+    TemplateDoc {
+        id: "otlp_receiver",
+        type_tag: "otlp",
+        aliases: &[],
+        label: "OTLP receiver",
+        description: "Receive logs via OpenTelemetry Protocol (OTLP/HTTP).",
+        support: SupportLevel::Stable,
+        snippet: "input:\n  type: otlp\n  listen: 0.0.0.0:4318\n",
+        fields: &[BuilderFieldDoc {
+            key: "listen",
+            label: "Listen",
+            default_value: "0.0.0.0:4318",
+            placeholder: "0.0.0.0:4318",
+            options: &[],
+        }],
+    },
+    TemplateDoc {
+        id: "http_json",
+        type_tag: "http",
+        aliases: &[],
+        label: "HTTP endpoint (JSON)",
+        description: "Accept JSON log batches over HTTP POST.",
+        support: SupportLevel::Stable,
+        snippet: "input:\n  type: http\n  listen: 0.0.0.0:8080\n",
+        fields: &[BuilderFieldDoc {
+            key: "listen",
+            label: "Listen",
+            default_value: "0.0.0.0:8080",
+            placeholder: "0.0.0.0:8080",
+            options: &[],
+        }],
+    },
+    TemplateDoc {
+        id: "journald",
+        type_tag: "journald",
+        aliases: &[],
+        label: "systemd journald",
+        description: "Read logs from the systemd journal.",
+        support: SupportLevel::Beta,
+        snippet: "input:\n  type: journald\n",
+        fields: &[],
+    },
+    TemplateDoc {
+        id: "generator",
+        type_tag: "generator",
+        aliases: &[],
+        label: "Generator",
+        description: "Synthetic log generator for testing and benchmarking.",
+        support: SupportLevel::Stable,
+        snippet: "input:\n  type: generator\n  generator:\n    events_per_sec: 1000\n    complexity: simple\n",
+        fields: &[
+            BuilderFieldDoc {
+                key: "events_per_sec",
+                label: "Events / sec",
+                default_value: "1000",
+                placeholder: "1000",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "complexity",
+                label: "Complexity",
+                default_value: "simple",
+                placeholder: "simple",
+                options: &["simple", "complex"],
+            },
+        ],
+    },
+];
+
+pub const OUTPUT_TEMPLATES: &[TemplateDoc] = &[
+    TemplateDoc {
+        id: "otlp",
+        type_tag: "otlp",
+        aliases: &[],
+        label: "OTLP collector",
+        description: "Send logs to an OpenTelemetry collector via OTLP/HTTP.",
+        support: SupportLevel::Stable,
+        snippet: "output:\n  type: otlp\n  endpoint: http://localhost:4318/v1/logs\n  compression: none\n",
+        fields: &[
+            BuilderFieldDoc {
+                key: "endpoint",
+                label: "Endpoint",
+                default_value: "http://localhost:4318/v1/logs",
+                placeholder: "http://otel-collector:4318/v1/logs",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "compression",
+                label: "Compression",
+                default_value: "none",
+                placeholder: "none",
+                options: &["none", "gzip", "zstd"],
+            },
+        ],
+    },
+    TemplateDoc {
+        id: "elasticsearch",
+        type_tag: "elasticsearch",
+        aliases: &[],
+        label: "Elasticsearch",
+        description: "Index logs in Elasticsearch.",
+        support: SupportLevel::Stable,
+        snippet: "output:\n  type: elasticsearch\n  endpoint: http://localhost:9200\n  index: logs\n  compression: none\n",
+        fields: &[
+            BuilderFieldDoc {
+                key: "endpoint",
+                label: "Endpoint",
+                default_value: "http://localhost:9200",
+                placeholder: "http://es:9200",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "index",
+                label: "Index",
+                default_value: "logs",
+                placeholder: "logs",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "compression",
+                label: "Compression",
+                default_value: "none",
+                placeholder: "none",
+                options: &["none", "gzip"],
+            },
+        ],
+    },
+    TemplateDoc {
+        id: "loki",
+        type_tag: "loki",
+        aliases: &[],
+        label: "Grafana Loki",
+        description: "Push logs to Grafana Loki.",
+        support: SupportLevel::Stable,
+        snippet: "output:\n  type: loki\n  endpoint: http://localhost:3100\n  static_labels:\n    service: myapp\n  label_columns:\n    - level\n",
+        fields: &[
+            BuilderFieldDoc {
+                key: "endpoint",
+                label: "Endpoint",
+                default_value: "http://localhost:3100",
+                placeholder: "http://loki:3100",
+                options: &[],
+            },
+            BuilderFieldDoc {
+                key: "service",
+                label: "Service label",
+                default_value: "myapp",
+                placeholder: "myapp",
+                options: &[],
+            },
+        ],
+    },
+    TemplateDoc {
+        id: "file",
+        type_tag: "file",
+        aliases: &[],
+        label: "NDJSON file",
+        description: "Write logs as newline-delimited JSON to a file.",
+        support: SupportLevel::Stable,
+        snippet: "output:\n  type: file\n  path: /var/log/out.ndjson\n",
+        fields: &[BuilderFieldDoc {
+            key: "path",
+            label: "Path",
+            default_value: "/var/log/out.ndjson",
+            placeholder: "/var/log/out.ndjson",
+            options: &[],
+        }],
+    },
+    TemplateDoc {
+        id: "stdout",
+        type_tag: "stdout",
+        aliases: &[],
+        label: "stdout",
+        description: "Print logs to the terminal. Great for testing.",
+        support: SupportLevel::Stable,
+        snippet: "output:\n  type: stdout\n",
+        fields: &[],
+    },
+    TemplateDoc {
+        id: "null",
+        type_tag: "null",
+        aliases: &[],
+        label: "null sink",
+        description: "Discard all logs. Useful for benchmarking.",
+        support: SupportLevel::Stable,
+        snippet: "output:\n  type: \"null\"\n",
+        fields: &[],
+    },
+];
+
+pub const INPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
+    ComponentTypeDoc {
+        type_tag: "file",
+        support: SupportLevel::Stable,
+        description: "Tail files matching a glob pattern.",
+    },
+    ComponentTypeDoc {
+        type_tag: "s3",
+        support: SupportLevel::Stable,
+        description: "Read objects from AWS S3 or an S3-compatible endpoint.",
+    },
+    ComponentTypeDoc {
+        type_tag: "stdin",
+        support: SupportLevel::Stable,
+        description: "Read piped stdin until EOF, then drain outputs and exit.",
+    },
+    ComponentTypeDoc {
+        type_tag: "generator",
+        support: SupportLevel::Stable,
+        description: "Emit synthetic JSON-like records from an in-process source.",
+    },
+    ComponentTypeDoc {
+        type_tag: "udp",
+        support: SupportLevel::Stable,
+        description: "Receive log lines over UDP.",
+    },
+    ComponentTypeDoc {
+        type_tag: "tcp",
+        support: SupportLevel::Stable,
+        description: "Accept log lines over TCP.",
+    },
+    ComponentTypeDoc {
+        type_tag: "otlp",
+        support: SupportLevel::Stable,
+        description: "Receive OTLP logs over a bound listen address.",
+    },
+    ComponentTypeDoc {
+        type_tag: "http",
+        support: SupportLevel::Stable,
+        description: "Receive newline-delimited payloads via HTTP `POST`.",
+    },
+    ComponentTypeDoc {
+        type_tag: "linux_ebpf_sensor",
+        support: SupportLevel::Stable,
+        description: "Linux eBPF sensor input (Arrow-native control + signal rows).",
+    },
+    ComponentTypeDoc {
+        type_tag: "macos_es_sensor",
+        support: SupportLevel::Stable,
+        description: "macOS EndpointSecurity sensor input (Arrow-native control + signal rows).",
+    },
+    ComponentTypeDoc {
+        type_tag: "windows_ebpf_sensor",
+        support: SupportLevel::Stable,
+        description: "Windows eBPF sensor input (Arrow-native control + signal rows).",
+    },
+    ComponentTypeDoc {
+        type_tag: "journald",
+        support: SupportLevel::Beta,
+        description: "Read structured journal entries from systemd journald.",
+    },
+    ComponentTypeDoc {
+        type_tag: "host_metrics",
+        support: SupportLevel::Stable,
+        description: "Host metrics input — process snapshots, CPU, memory, network stats via sysinfo (Arrow-native).",
+    },
+    ComponentTypeDoc {
+        type_tag: "arrow_ipc",
+        support: SupportLevel::Stable,
+        description: "Receive Arrow IPC stream batches via HTTP `POST /v1/arrow`.",
+    },
+];
+
+pub const OUTPUT_TYPE_DOCS: &[ComponentTypeDoc] = &[
+    ComponentTypeDoc {
+        type_tag: "otlp",
+        support: SupportLevel::Stable,
+        description: "OTLP protobuf over HTTP or gRPC.",
+    },
+    ComponentTypeDoc {
+        type_tag: "http",
+        support: SupportLevel::NotYetSupported,
+        description: "Reserved for newline-delimited JSON over HTTP POST.",
+    },
+    ComponentTypeDoc {
+        type_tag: "stdout",
+        support: SupportLevel::Stable,
+        description: "Print to stdout (JSON, console, or text).",
+    },
+    ComponentTypeDoc {
+        type_tag: "elasticsearch",
+        support: SupportLevel::Stable,
+        description: "Elasticsearch Bulk API with index/compression/request-mode controls.",
+    },
+    ComponentTypeDoc {
+        type_tag: "loki",
+        support: SupportLevel::Stable,
+        description: "Grafana Loki push API with label grouping.",
+    },
+    ComponentTypeDoc {
+        type_tag: "file",
+        support: SupportLevel::Stable,
+        description: "Write NDJSON or text to a local file.",
+    },
+    ComponentTypeDoc {
+        type_tag: "null",
+        support: SupportLevel::Stable,
+        description: "Drop records intentionally for tests and benchmark baselines.",
+    },
+    ComponentTypeDoc {
+        type_tag: "tcp",
+        support: SupportLevel::Stable,
+        description: "Send records to a TCP endpoint.",
+    },
+    ComponentTypeDoc {
+        type_tag: "udp",
+        support: SupportLevel::Stable,
+        description: "Send records to a UDP endpoint.",
+    },
+    ComponentTypeDoc {
+        type_tag: "arrow_ipc",
+        support: SupportLevel::Stable,
+        description: "Send Arrow IPC payloads to an HTTP endpoint.",
+    },
+    ComponentTypeDoc {
+        type_tag: "parquet",
+        support: SupportLevel::NotYetSupported,
+        description: "Reserved for Parquet file output.",
+    },
+];
+
+pub fn input_template(id: &str) -> Option<&'static TemplateDoc> {
+    INPUT_TEMPLATES.iter().find(|template| template.id == id)
+}
+
+pub fn output_template(id: &str) -> Option<&'static TemplateDoc> {
+    OUTPUT_TEMPLATES.iter().find(|template| template.id == id)
+}
+
+pub fn render_component_type_table(entries: &[ComponentTypeDoc]) -> String {
+    let mut out =
+        String::from("| Value | Status | Description |\n|-------|--------|-------------|\n");
+    for entry in entries {
+        let status = match entry.support {
+            SupportLevel::Stable => "Implemented",
+            SupportLevel::Experimental => "Experimental",
+            SupportLevel::Beta => "Beta",
+            SupportLevel::NotYetSupported => "Not yet supported",
+            SupportLevel::Hidden => "Hidden",
+        };
+        out.push_str(&format!(
+            "| `{}` | {} | {} |\n",
+            entry.type_tag, status, entry.description
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{
+        INPUT_TEMPLATES, INPUT_TYPE_DOCS, OUTPUT_TEMPLATES, OUTPUT_TYPE_DOCS, input_template,
+        output_template, render_component_type_table,
+    };
+
+    #[test]
+    fn otlp_output_template_uses_http_logs_path() {
+        let otlp = output_template("otlp").expect("otlp template");
+        assert!(otlp.snippet.contains("/v1/logs"));
+    }
+
+    #[test]
+    fn input_templates_have_unique_ids() {
+        let mut ids: Vec<&str> = INPUT_TEMPLATES.iter().map(|template| template.id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), INPUT_TEMPLATES.len());
+    }
+
+    #[test]
+    fn output_templates_have_unique_ids() {
+        let mut ids: Vec<&str> = OUTPUT_TEMPLATES
+            .iter()
+            .map(|template| template.id)
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), OUTPUT_TEMPLATES.len());
+    }
+
+    #[test]
+    fn template_lookup_finds_known_templates() {
+        assert!(input_template("file_json").is_some());
+        assert!(output_template("stdout").is_some());
+    }
+
+    #[test]
+    fn every_template_type_is_present_in_component_inventory() {
+        for template in INPUT_TEMPLATES {
+            assert!(
+                INPUT_TYPE_DOCS
+                    .iter()
+                    .any(|entry| entry.type_tag == template.type_tag),
+                "missing input type doc for template type {}",
+                template.type_tag
+            );
+        }
+        for template in OUTPUT_TEMPLATES {
+            assert!(
+                OUTPUT_TYPE_DOCS
+                    .iter()
+                    .any(|entry| entry.type_tag == template.type_tag),
+                "missing output type doc for template type {}",
+                template.type_tag
+            );
+        }
+    }
+
+    #[test]
+    fn reference_doc_generated_support_tables_are_current() {
+        let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace crates dir")
+            .parent()
+            .expect("workspace root")
+            .to_path_buf();
+        let reference_path = root.join("book/src/content/docs/configuration/reference.mdx");
+        let reference = std::fs::read_to_string(&reference_path).expect("read reference.mdx");
+
+        let input_expected = render_component_type_table(INPUT_TYPE_DOCS);
+        let output_expected = render_component_type_table(OUTPUT_TYPE_DOCS);
+
+        assert_block_matches(
+            &reference,
+            "input-types",
+            &input_expected,
+            reference_path.to_string_lossy().as_ref(),
+        );
+        assert_block_matches(
+            &reference,
+            "output-types",
+            &output_expected,
+            reference_path.to_string_lossy().as_ref(),
+        );
+    }
+
+    fn assert_block_matches(document: &str, name: &str, expected: &str, path: &str) {
+        let begin = format!("{{/* BEGIN GENERATED: {name} */}}");
+        let end = format!("{{/* END GENERATED: {name} */}}");
+        let start = document
+            .find(&begin)
+            .unwrap_or_else(|| panic!("missing {begin} marker in {path}"));
+        let end_index = document[start..]
+            .find(&end)
+            .map(|offset| start + offset)
+            .unwrap_or_else(|| panic!("missing {end} marker in {path}"));
+        let actual = document[start + begin.len()..end_index]
+            .trim_matches('\n')
+            .trim();
+        let expected = expected.trim_matches('\n').trim();
+        assert_eq!(
+            actual, expected,
+            "{path}: generated block '{name}' is stale; update it to match the docspec registry"
+        );
+    }
+}

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -8,6 +8,7 @@
 //! Environment variables in values are expanded using `${VAR}` syntax.
 
 mod compat;
+pub mod docspec;
 mod env;
 mod load;
 mod serde_helpers;

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -8,6 +8,7 @@
 //! Environment variables in values are expanded using `${VAR}` syntax.
 
 mod compat;
+/// Shared metadata for config starter templates and generated reference tables.
 pub mod docspec;
 mod env;
 mod load;

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -9,6 +9,15 @@
 
 mod compat;
 /// Shared metadata for config starter templates and generated reference tables.
+///
+/// # Examples
+///
+/// ```
+/// use logfwd_config::docspec::{input_template, INPUT_TYPE_DOCS};
+///
+/// assert!(input_template("file_json").is_some());
+/// assert!(!INPUT_TYPE_DOCS.is_empty());
+/// ```
 pub mod docspec;
 mod env;
 mod load;

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
@@ -1049,10 +1049,7 @@ fn public_source_path_attached_before_sql_is_queryable() {
 
 #[test]
 fn select_star_includes_public_source_metadata_style_columns() {
-    let mut transform = SqlTransform::new(
-        r#"SELECT * FROM logs WHERE "file.path" = '/var/log/pods/ns_pod_uid/c/0.log'"#,
-    )
-    .expect("sql");
+    let mut transform = SqlTransform::new(r#"SELECT * FROM logs"#).expect("sql");
     let mut scanner = Scanner::new(transform.scan_config());
     let scanned = scanner
         .scan(Bytes::from_static(b"{\"msg\":\"hello\"}\n"))
@@ -1081,7 +1078,7 @@ fn select_star_includes_public_source_metadata_style_columns() {
         .expect("runtime");
     let result = rt
         .block_on(transform.execute(attached))
-        .expect("transform should filter on source metadata");
+        .expect("transform should preserve source metadata columns");
 
     assert_eq!(result.num_rows(), 1);
     assert!(result.column_by_name(field_names::ECS_FILE_PATH).is_some());

--- a/crates/logfwd/src/config_templates.rs
+++ b/crates/logfwd/src/config_templates.rs
@@ -1,30 +1,7 @@
 use std::fmt::Write as _;
 
-/// A reusable input snippet presented by the interactive wizard.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct InputTemplate {
-    /// Stable template identifier.
-    pub(crate) id: &'static str,
-    /// Human-friendly label shown in prompts.
-    pub(crate) label: &'static str,
-    /// One-line description shown below the label in prompts.
-    pub(crate) description: &'static str,
-    /// YAML fragment injected into the generated config.
-    pub(crate) snippet: &'static str,
-}
-
-/// A reusable output snippet presented by the interactive wizard.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct OutputTemplate {
-    /// Stable template identifier.
-    pub(crate) id: &'static str,
-    /// Human-friendly label shown in prompts.
-    pub(crate) label: &'static str,
-    /// One-line description shown below the label in prompts.
-    pub(crate) description: &'static str,
-    /// YAML fragment injected into the generated config.
-    pub(crate) snippet: &'static str,
-}
+pub(crate) type InputTemplate = logfwd_config::docspec::TemplateDoc;
+pub(crate) type OutputTemplate = logfwd_config::docspec::TemplateDoc;
 
 /// A full end-to-end starter scenario (input, transform, output).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,78 +21,10 @@ pub(crate) struct UseCaseTemplate {
 }
 
 /// Input presets currently surfaced by `ff wizard`.
-pub(crate) const INPUT_TEMPLATES: &[InputTemplate] = &[
-    InputTemplate {
-        id: "file_json",
-        label: "File tailing (JSON logs)",
-        description: "Watch JSON log files on disk and stream new lines as they appear.",
-        snippet: "input:\n  type: file\n  path: /var/log/app/*.json\n  format: json\n",
-    },
-    InputTemplate {
-        id: "file_cri",
-        label: "File tailing (Kubernetes CRI)",
-        description: "Tail Kubernetes container logs in CRI format from node filesystems.",
-        snippet: "input:\n  type: file\n  path: /var/log/containers/*.log\n  format: cri\n",
-    },
-    InputTemplate {
-        id: "udp_raw",
-        label: "UDP listener (newline-delimited raw logs)",
-        description: "Receive raw log lines over UDP, e.g. syslog or custom agents.",
-        snippet: "input:\n  type: udp\n  listen: 0.0.0.0:5514\n  format: raw\n",
-    },
-    InputTemplate {
-        id: "tcp_json",
-        label: "TCP listener (newline JSON)",
-        description: "Accept newline-delimited JSON logs over a TCP socket.",
-        snippet: "input:\n  type: tcp\n  listen: 0.0.0.0:9000\n  format: json\n",
-    },
-    InputTemplate {
-        id: "otlp_receiver",
-        label: "OTLP log receiver",
-        description: "Receive logs via the OpenTelemetry Protocol (OTLP/HTTP).",
-        snippet: "input:\n  type: otlp\n  listen: 0.0.0.0:4318\n",
-    },
-];
+pub(crate) const INPUT_TEMPLATES: &[InputTemplate] = logfwd_config::docspec::INPUT_TEMPLATES;
 
 /// Output presets currently surfaced by `ff wizard`.
-pub(crate) const OUTPUT_TEMPLATES: &[OutputTemplate] = &[
-    OutputTemplate {
-        id: "otlp",
-        label: "OTLP collector",
-        description: "Send logs to an OpenTelemetry collector via OTLP/HTTP.",
-        snippet: "output:\n  type: otlp\n  endpoint: http://localhost:4318/v1/logs\n",
-    },
-    OutputTemplate {
-        id: "loki",
-        label: "Grafana Loki",
-        description: "Push logs to Grafana Loki for querying with LogQL.",
-        snippet: "output:\n  type: loki\n  endpoint: http://localhost:3100\n  static_labels:\n    service: logfwd\n  label_columns:\n    - level\n    - app\n",
-    },
-    OutputTemplate {
-        id: "elasticsearch",
-        label: "Elasticsearch",
-        description: "Index logs in Elasticsearch for full-text search.",
-        snippet: "output:\n  type: elasticsearch\n  endpoint: http://localhost:9200\n  index: logs\n",
-    },
-    OutputTemplate {
-        id: "stdout",
-        label: "stdout (for testing)",
-        description: "Print logs to the terminal. Great for trying things out.",
-        snippet: "output:\n  type: stdout\n",
-    },
-    OutputTemplate {
-        id: "file",
-        label: "NDJSON file",
-        description: "Write logs as newline-delimited JSON to a local file.",
-        snippet: "output:\n  type: file\n  path: ./out.ndjson\n",
-    },
-    OutputTemplate {
-        id: "null",
-        label: "null sink (drop data)",
-        description: "Discard all logs. Useful for benchmarking or dry runs.",
-        snippet: "output:\n  type: \"null\"\n",
-    },
-];
+pub(crate) const OUTPUT_TEMPLATES: &[OutputTemplate] = logfwd_config::docspec::OUTPUT_TEMPLATES;
 
 /// Opinionated end-to-end presets for `ff wizard`.
 pub(crate) const USE_CASE_TEMPLATES: &[UseCaseTemplate] = &[

--- a/dev-docs/research/README.md
+++ b/dev-docs/research/README.md
@@ -26,6 +26,7 @@ artifact, or generated file under `dev-docs/research/`.
 ## Active Research
 
 - [checkpoint-snapshot-design.md](checkpoint-snapshot-design.md)
+- [config-doc-generation-design.md](config-doc-generation-design.md)
 - [config-library-poc.md](config-library-poc.md)
 - [crate-restructure-plan.md](crate-restructure-plan.md)
 - [elasticsearch-retry-contract.md](elasticsearch-retry-contract.md)

--- a/dev-docs/research/config-doc-generation-design.md
+++ b/dev-docs/research/config-doc-generation-design.md
@@ -1,0 +1,390 @@
+# Config Doc Generation Design
+
+> **Status:** Active
+> **Date:** 2026-04-22
+> **Context:** Unifying config models, the config builder, and generated input/output reference docs.
+
+## Goal
+
+Generate the repetitive parts of input/output documentation from a single
+structured source without turning the public docs into raw schema dumps.
+
+The target outcome is:
+
+- one canonical source for input/output component inventory;
+- one canonical source for curated per-field docs metadata;
+- generated support tables, field tables, and starter snippets;
+- no drift between:
+  - `crates/logfwd-config/src/types.rs`
+  - `crates/logfwd-config-wasm/src/lib.rs`
+  - `book/src/content/docs/configuration/reference.mdx`
+  - `book/src/content/docs/configuration/inputs.md`
+  - `book/src/content/docs/configuration/outputs.mdx`
+
+## Non-Goals
+
+- Do not fully generate the public config guide from raw Rust types.
+- Do not generate conceptual pages such as quick start, deployment, or SQL docs.
+- Do not require JSON Schema to become the user-facing authoring format.
+- Do not duplicate the entire typed schema in a second manual DSL.
+
+## Current Problem
+
+FastForward currently has three overlapping sources of truth:
+
+1. Typed config models and validation:
+   - `crates/logfwd-config/src/types.rs`
+   - `crates/logfwd-config/src/validate.rs`
+2. Curated builder/template metadata:
+   - `crates/logfwd-config-wasm/src/lib.rs`
+3. Hand-authored public docs:
+   - `book/src/content/docs/configuration/reference.mdx`
+   - `book/src/content/docs/configuration/inputs.md`
+   - `book/src/content/docs/configuration/outputs.mdx`
+
+The experiments in `tmp/config-doc-experiments/` showed:
+
+- model-driven extraction has good coverage but weak user quality;
+- template-driven extraction has good user tone but weak coverage;
+- neither source is sufficient on its own.
+
+## Design Principles
+
+### 1. Keep types as the semantic base
+
+Rust config types remain the source of truth for:
+
+- field names;
+- enum tags and aliases;
+- required vs optional shape;
+- nested object structure;
+- deserialization behavior.
+
+### 2. Add docs metadata, not a parallel schema
+
+The missing layer is user-facing metadata:
+
+- short labels;
+- summaries;
+- defaults worth showing;
+- examples;
+- support status;
+- field-level descriptions;
+- which fields belong in starter templates.
+
+This metadata should be small and curated. It should not try to re-describe the
+full Rust type system.
+
+### 3. Generate references, not narratives
+
+Generated artifacts should be limited to repetitive reference material:
+
+- component inventory tables;
+- per-input/per-output field tables;
+- starter snippets;
+- builder template payloads.
+
+Narrative pages stay hand-authored.
+
+### 4. Prefer CI-enforced coverage over clever parsing
+
+The first production version should be boring:
+
+- explicit metadata registry;
+- explicit coverage checks;
+- generated outputs committed to the repo;
+- CI fails when generated files or registry coverage drift.
+
+Do not start with a fragile parser that tries to infer all docs from arbitrary
+Rust syntax.
+
+## Proposed Source Layout
+
+Add a docs metadata module under `logfwd-config`, for example:
+
+```text
+crates/logfwd-config/src/docspec/
+├── mod.rs
+├── inputs.rs
+├── outputs.rs
+└── model.rs
+```
+
+This module should be usable from:
+
+- a docs generator (`xtask` or `scripts/docs/...`);
+- `logfwd-config-wasm`;
+- tests that enforce coverage against config enums.
+
+## Proposed Data Model
+
+### ComponentDoc
+
+One entry per input or output type.
+
+```rust
+pub struct ComponentDoc {
+    pub kind: ComponentKind,        // input | output
+    pub type_tag: &'static str,     // "file", "otlp", "stdout"
+    pub aliases: &'static [&'static str],
+    pub label: &'static str,        // "File", "OTLP collector"
+    pub summary: &'static str,
+    pub support: SupportLevel,      // stable | experimental | beta | hidden
+    pub docs_slug: &'static str,    // for generated anchors / linking
+    pub starter_snippet: &'static str,
+    pub builder_fields: &'static [BuilderFieldDoc],
+    pub field_docs: &'static [FieldDoc],
+}
+```
+
+### FieldDoc
+
+Curated docs metadata for a config field path within a component.
+
+```rust
+pub struct FieldDoc {
+    pub path: &'static str,         // "path", "format", "http.path", "s3.bucket"
+    pub label: &'static str,        // optional user-facing label
+    pub description: &'static str,
+    pub default: Option<&'static str>,
+    pub examples: &'static [&'static str],
+    pub allowed_values: &'static [&'static str],
+    pub required_override: Option<bool>,
+    pub visibility: FieldVisibility, // reference | builder | advanced | hidden
+}
+```
+
+### BuilderFieldDoc
+
+Only the small subset of fields that the builder UI exposes directly.
+
+```rust
+pub struct BuilderFieldDoc {
+    pub path: &'static str,
+    pub label: &'static str,
+    pub default: &'static str,
+    pub placeholder: &'static str,
+    pub options: &'static [&'static str],
+}
+```
+
+## Why This Shape
+
+This keeps the split clean:
+
+- typed model says what is valid;
+- docs metadata says how to explain it;
+- builder metadata says what to expose in the simple UI.
+
+The builder should reuse the docs metadata entries for labels/defaults/options,
+not define them independently.
+
+## Generation Flow
+
+### Inputs
+
+1. Read typed component inventory from `InputTypeConfig`.
+2. Read docs metadata registry from `docspec::inputs`.
+3. Validate that every public input variant has a matching `ComponentDoc`.
+4. Render:
+   - support/inventory table for `reference.mdx`;
+   - per-input field tables for `inputs.md`;
+   - builder template JSON/JS payload.
+
+### Outputs
+
+1. Read typed component inventory from `OutputConfigV2`.
+2. Read docs metadata registry from `docspec::outputs`.
+3. Validate coverage.
+4. Render:
+   - support/inventory table for `reference.mdx`;
+   - per-output field tables for `outputs.mdx`;
+   - builder template JSON/JS payload.
+
+### Public Docs
+
+Generated content should land in partials or generated include files rather than
+fully replacing hand-authored pages.
+
+Examples:
+
+```text
+book/src/content/docs/configuration/generated/
+├── input-support-table.mdx
+├── output-support-table.mdx
+├── input-field-reference.mdx
+└── output-field-reference.mdx
+```
+
+Then the hand-authored pages include or import those generated sections.
+
+## Where The Typed Inventory Comes From
+
+The coverage validator needs a robust inventory of known component tags.
+
+There are two reasonable approaches:
+
+### Option A: Explicit inventory functions in Rust
+
+Add small helper functions in `logfwd-config` that return:
+
+- input type tags + aliases
+- output type tags
+
+This avoids AST parsing entirely.
+
+Example:
+
+```rust
+pub fn input_type_inventory() -> &'static [ComponentInventory] { ... }
+pub fn output_type_inventory() -> &'static [ComponentInventory] { ... }
+```
+
+This is the simplest and most robust first version.
+
+### Option B: Source parsing in generator code
+
+Parse `types.rs` with `syn` or a source parser to infer the inventory.
+
+This reduces one tiny bit of duplication, but it makes the generator more
+complex and more brittle.
+
+Recommendation: start with Option A.
+
+## What To Generate First
+
+### Phase 1: Component inventory and builder unification
+
+Ship first:
+
+- `ComponentDoc` for all inputs and outputs
+- support level
+- label
+- summary
+- starter snippet
+- builder field subset
+
+Generate:
+
+- support tables for `reference.mdx`
+- builder templates for `logfwd-config-wasm`
+
+Do not generate field tables yet.
+
+Why first:
+
+- immediately removes one of the biggest drift points;
+- low implementation risk;
+- gives us a clean source for component labels/snippets/support status.
+
+### Phase 2: Per-field reference tables
+
+Add curated `FieldDoc` entries for the fields we actually document publicly.
+
+Generate:
+
+- input field tables
+- output field tables
+
+This should initially focus on top-level and high-signal nested fields:
+
+- `path`
+- `listen`
+- `format`
+- `endpoint`
+- `compression`
+- `auth`
+- `tls`
+- `http.*`
+- `generator.*`
+- `s3.*`
+
+Do not block on documenting every nested helper type on day one.
+
+### Phase 3: Validation and defaults enrichment
+
+Add optional enrichment from typed/validation logic:
+
+- required/optional detection
+- enum values
+- aliases
+- defaults that are stable and user-visible
+
+This may still be partly manual because many meaningful defaults live in
+runtime/validation rather than in the Rust field declaration itself.
+
+## What Should Stay Hand-Written
+
+Keep hand-authored:
+
+- `inputs.md` usage notes and operational caveats
+- `outputs.mdx` narrative guidance and warnings
+- `reference.mdx` introductory framing
+- all Learn / Experience content
+
+Generated docs should answer:
+
+- what exists
+- what fields are available
+- what the defaults/options are
+- what a valid starter snippet looks like
+
+Hand-authored docs should answer:
+
+- when to choose this
+- what can go wrong
+- what operational tradeoffs matter
+
+## CI / Drift Checks
+
+Add checks that fail if:
+
+- any public input/output type lacks a `ComponentDoc`;
+- any builder template is not derived from the registry;
+- any generated doc partial is stale;
+- any alias/support-status mismatch exists between typed inventory and docs metadata.
+
+This should live in `xtask` or `scripts/docs`, not in ad hoc shell glue.
+
+## Risks
+
+### Risk: metadata becomes a second schema
+
+Mitigation:
+
+- keep metadata intentionally small;
+- never re-describe low-level typing in the registry if it can be inferred;
+- only store curated user-facing facts there.
+
+### Risk: nested fields become too manual
+
+Mitigation:
+
+- phase the rollout;
+- generate top-level coverage first;
+- only add curated field docs for fields we actually expose in public docs.
+
+### Risk: defaults drift from runtime behavior
+
+Mitigation:
+
+- mark defaults as curated user-visible defaults, not full semantic defaults;
+- where possible, derive them from code helpers later;
+- avoid documenting unstable/internal defaults in generated pages.
+
+## Recommendation
+
+Build a hybrid system:
+
+1. add a small Rust docs metadata registry in `logfwd-config`;
+2. use explicit Rust inventory helpers for coverage, not source parsing;
+3. generate builder templates and support tables first;
+4. generate field reference tables second;
+5. keep narrative docs hand-authored.
+
+This matches the successful pattern used by projects like Vector, Benthos, and
+Terraform providers:
+
+- code/schema provides structural truth;
+- curated metadata provides user-facing descriptions;
+- generated references remove repetitive drift-prone docs.

--- a/justfile
+++ b/justfile
@@ -196,6 +196,10 @@ verification-trigger-contract:
 verify:
     cargo xtask verify
 
+# Regenerate config support tables from the shared docspec registry.
+generate-config-docs:
+    cargo xtask generate-config-docs
+
 # Run all lightweight verification guardrails enforced in CI.
 verification-guardrail: kani-boundary tlc-matrix-contract proptest-regressions verification-trigger-contract
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }
-logfwd-config = { path = "../crates/logfwd-config" }
+logfwd-config = { version = "0.1.0", path = "../crates/logfwd-config" }
 quote = "1"
 regex = "1"
 syn = { version = "2", features = ["full", "visit"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }
+logfwd-config = { path = "../crates/logfwd-config" }
 quote = "1"
 regex = "1"
 syn = { version = "2", features = ["full", "visit"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use logfwd_config::docspec::{self, INPUT_TYPE_DOCS, OUTPUT_TYPE_DOCS};
 use quote::ToTokens;
 use regex::Regex;
 use syn::visit::Visit;
@@ -24,6 +25,8 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Commands {
+    /// Regenerate config support tables in user documentation.
+    GenerateConfigDocs,
     /// Run structural verification checks.
     Verify,
 }
@@ -147,15 +150,13 @@ impl<'ast> Visit<'ast> for Collector {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
+        Commands::GenerateConfigDocs => run_generate_config_docs(),
         Commands::Verify => run_verify(),
     }
 }
 
 fn run_verify() -> Result<()> {
-    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .context("xtask must live under repo root")?
-        .to_path_buf();
+    let repo_root = repo_root()?;
 
     let modules = load_modules(&repo_root)?;
     let mut findings = Vec::new();
@@ -192,6 +193,69 @@ fn run_verify() -> Result<()> {
 
     // TODO(#2409): promote to hard failure once known gaps are addressed
     Ok(())
+}
+
+fn run_generate_config_docs() -> Result<()> {
+    let repo_root = repo_root()?;
+    let reference_path = repo_root.join("book/src/content/docs/configuration/reference.mdx");
+    let mut reference = fs::read_to_string(&reference_path).with_context(|| {
+        format!(
+            "failed to read config reference {}",
+            reference_path.display()
+        )
+    })?;
+
+    reference = replace_generated_block(
+        &reference,
+        "input-types",
+        &docspec::render_component_type_table(INPUT_TYPE_DOCS),
+    )?;
+    reference = replace_generated_block(
+        &reference,
+        "output-types",
+        &docspec::render_component_type_table(OUTPUT_TYPE_DOCS),
+    )?;
+
+    fs::write(&reference_path, reference).with_context(|| {
+        format!(
+            "failed to write regenerated config reference {}",
+            reference_path.display()
+        )
+    })?;
+
+    println!(
+        "xtask generate-config-docs: updated {}",
+        reference_path.display()
+    );
+    Ok(())
+}
+
+fn repo_root() -> Result<PathBuf> {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .context("xtask must live under repo root")
+        .map(Path::to_path_buf)
+}
+
+fn replace_generated_block(document: &str, name: &str, content: &str) -> Result<String> {
+    let begin = format!("{{/* BEGIN GENERATED: {name} */}}");
+    let end = format!("{{/* END GENERATED: {name} */}}");
+    let start = document
+        .find(&begin)
+        .with_context(|| format!("missing begin marker for generated block '{name}'"))?;
+    let block_start = start + begin.len();
+    let end_index = document[block_start..]
+        .find(&end)
+        .map(|offset| block_start + offset)
+        .with_context(|| format!("missing end marker for generated block '{name}'"))?;
+
+    let mut updated = String::with_capacity(document.len() + content.len());
+    updated.push_str(&document[..block_start]);
+    updated.push('\n');
+    updated.push_str(content.trim_matches('\n'));
+    updated.push('\n');
+    updated.push_str(&document[end_index..]);
+    Ok(updated)
 }
 
 fn load_modules(repo_root: &Path) -> Result<Vec<ModuleFacts>> {


### PR DESCRIPTION
## Summary

This PR takes the conservative path for config docs automation.

- adds a shared `logfwd-config::docspec` registry for input/output starter templates and support metadata
- makes both `ff wizard` and `logfwd-config-wasm` read input/output templates from that shared registry
- adds `cargo xtask generate-config-docs` and `just generate-config-docs` to regenerate the input/output support tables in the YAML reference
- makes `logfwd-config` tests verify that the generated support-table blocks in `book/src/content/docs/configuration/reference.mdx` are current
- documents the design and keeps the rest of the config docs hand-authored

## Why

We had real drift between:

- the CLI wizard templates
- the WASM config builder templates
- the hand-maintained support tables in the public config reference

This keeps the automation limited to the repetitive parts that are already drift-prone, without trying to generate the full config docs surface from raw Rust models.

## Validation

- `cargo xtask generate-config-docs`
- `cargo test -p logfwd-config docspec::tests::reference_doc_generated_support_tables_are_current`
- `cargo test -p logfwd templates_avoid_unsupported_syslog_and_bare_otlp_http_endpoints`
- `cargo test -p logfwd wizard_template_renders_with_sql`
- `python3 scripts/docs/validate_operational_sections.py`
- `python3 scripts/docs/validate_research_metadata.py`
- `python3 scripts/docs/validate_root_doc_allowlist.py`
- `cargo fmt --all`
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Generate config support tables in docs from a shared `docspec` registry
> - Adds `logfwd_config::docspec`, a shared module containing `TemplateDoc`, `ComponentTypeDoc`, and `SupportLevel` definitions, plus static `INPUT_TEMPLATES`, `OUTPUT_TEMPLATES`, `INPUT_TYPE_DOCS`, and `OUTPUT_TYPE_DOCS` registries (including a new `journald` input marked Beta).
> - Adds a `cargo xtask generate-config-docs` command (also exposed as `just generate-config-docs`) that renders Markdown tables from the registry and writes them into marker-delimited blocks in [reference.mdx](https://github.com/strawgate/fastforward/pull/2519/files#diff-6a69bd5c38c92acca3dd194d75d77551f1b8f6b98890da7e56f2c9cbe564aac4).
> - Replaces local template arrays in the WASM crate ([lib.rs](https://github.com/strawgate/fastforward/pull/2519/files#diff-d536e1c9d5d1c4af63a69261639f4909edf4451fca1a93cb7adc0448ffb0db3a)) and the CLI wizard ([config_templates.rs](https://github.com/strawgate/fastforward/pull/2519/files#diff-9c0e72b36d9b794d256277c36d905b58f7a378bcd0f09f1be721a399752bd3d6)) with references to the shared registry.
> - Tests in `docspec` assert template uniqueness, lookup correctness, and that the generated blocks in `reference.mdx` are up-to-date with the registry, enforcing CI correctness.
> - Behavioral Change: snippets exposed by the WASM exports and CLI wizard now use registry defaults, which differ from the previous local values (e.g. file output path is `./out.ndjson`, OTLP output includes `compression: none`, Loki snippet has different labels).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e457eab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->