### PR TITLE
test: cover pipeline topology compile invariants + runtime cleanups

### DIFF
--- a/crates/logfwd-runtime/src/bootstrap.rs
+++ b/crates/logfwd-runtime/src/bootstrap.rs
@@ -124,10 +124,10 @@ pub async fn run_pipelines(
     let use_color = options.use_color;
     tokio::spawn(async move {
         #[cfg(feature = "dhat-heap")]
-        let _profiler_to_drop = profiler;
+        let profiler_to_drop = profiler;
 
         #[cfg(feature = "cpu-profiling")]
-        let _pprof_to_drop = pprof_guard;
+        let pprof_to_drop = pprof_guard;
 
         #[cfg(unix)]
         {
@@ -153,7 +153,7 @@ pub async fn run_pipelines(
 
         #[cfg(feature = "cpu-profiling")]
         {
-            if let Ok(report) = _pprof_to_drop.report().build()
+            if let Ok(report) = pprof_to_drop.report().build()
                 && let Ok(file) = std::fs::File::create("flamegraph.svg")
             {
                 let _ = report.flamegraph(file);
@@ -161,7 +161,7 @@ pub async fn run_pipelines(
         }
 
         #[cfg(feature = "dhat-heap")]
-        drop(_profiler_to_drop);
+        drop(profiler_to_drop);
 
         shutdown_for_signal.cancel();
     });

--- a/crates/logfwd-runtime/src/pipeline/input_poll.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_poll.rs
@@ -283,16 +283,15 @@ pub(super) async fn async_input_poll_loop(
         }
 
         if input.source.is_finished() {
-            if !input.buf.is_empty() {
-                if let Some(msg) =
+            if !input.buf.is_empty()
+                && let Some(msg) =
                     scan_and_transform_for_send(&mut input, &mut transform, &metrics, input_index)
                         .await
-                {
-                    if tx.send(msg).await.is_err() {
-                        break;
-                    }
-                    metrics.inc_channel_depth();
+            {
+                if tx.send(msg).await.is_err() {
+                    break;
                 }
+                metrics.inc_channel_depth();
             }
             break;
         }
@@ -313,19 +312,18 @@ pub(super) async fn async_input_poll_loop(
     }
 
     // Drain remaining buffered data.
-    if !input.buf.is_empty() {
-        if let Some(msg) =
+    if !input.buf.is_empty()
+        && let Some(msg) =
             scan_and_transform_for_send(&mut input, &mut transform, &metrics, input_index).await
-        {
-            if let Err(e) = tx.send(msg).await {
-                tracing::warn!(
-                    input = input.source.name(),
-                    error = %e,
-                    "input.channel_closed_on_shutdown_drain"
-                );
-            } else {
-                metrics.inc_channel_depth();
-            }
+    {
+        if let Err(e) = tx.send(msg).await {
+            tracing::warn!(
+                input = input.source.name(),
+                error = %e,
+                "input.channel_closed_on_shutdown_drain"
+            );
+        } else {
+            metrics.inc_channel_depth();
         }
     }
     input.stats.set_health(reduce_component_health(

--- a/crates/logfwd-runtime/src/pipeline/run.rs
+++ b/crates/logfwd-runtime/src/pipeline/run.rs
@@ -353,11 +353,13 @@ impl Pipeline {
             }
             self.metrics.output_error(&ack.output_name);
         }
-        let (has_held, _checkpoint_advances) =
+        let (has_held, checkpoint_advances) =
             self.ack_all_tickets(ack.tickets, default_ticket_disposition(&ack.outcome));
+        #[cfg(not(feature = "turmoil"))]
+        let _ = &checkpoint_advances;
         #[cfg(feature = "turmoil")]
-        let _checkpoint_advances = {
-            let mut advances = _checkpoint_advances;
+        let checkpoint_advances = {
+            let mut advances = checkpoint_advances;
             advances.sort_unstable();
             advances
         };
@@ -366,7 +368,7 @@ impl Pipeline {
             crate::turmoil_barriers::RuntimeBarrierEvent::AckApplied {
                 batch_id,
                 outcome: outcome_for_event.clone(),
-                checkpoint_advances: _checkpoint_advances,
+                checkpoint_advances,
             },
         )
         .await;

--- a/crates/logfwd-runtime/src/pipeline/submit.rs
+++ b/crates/logfwd-runtime/src/pipeline/submit.rs
@@ -245,6 +245,7 @@ pub(super) async fn scan_and_transform_for_send(
     })
 }
 
+#[allow(clippy::needless_pass_by_ref_mut)]
 #[cfg(feature = "turmoil")]
 pub(super) async fn transform_direct_batch_for_send(
     input: &mut InputState,

--- a/crates/logfwd-runtime/src/pipeline/topology.rs
+++ b/crates/logfwd-runtime/src/pipeline/topology.rs
@@ -165,4 +165,23 @@ mod tests {
         assert_eq!(compiled.transform_count, 1);
         assert_eq!(compiled.output_count, 2);
     }
+
+    #[test]
+    fn compile_topology_counts_zero_transforms_when_transform_is_absent() {
+        let config = build_pipeline_config(
+            vec![build_generator_input(), build_generator_input()],
+            vec![build_stdout_output(), build_stdout_output()],
+            None,
+        );
+        let spec = PipelineSpec {
+            name: "main",
+            config: &config,
+        };
+
+        let compiled = compile_topology(&spec).expect("valid topology compiles");
+        assert_eq!(compiled.name, "main");
+        assert_eq!(compiled.input_count, 2);
+        assert_eq!(compiled.transform_count, 0);
+        assert_eq!(compiled.output_count, 2);
+    }
 }

--- a/crates/logfwd-runtime/src/pipeline/topology.rs
+++ b/crates/logfwd-runtime/src/pipeline/topology.rs
@@ -72,7 +72,7 @@ mod tests {
         StdoutOutputConfig,
     };
 
-    fn pipeline_config(
+    fn build_pipeline_config(
         inputs: Vec<InputConfig>,
         outputs: Vec<OutputConfigV2>,
         transform: Option<String>,
@@ -90,7 +90,7 @@ mod tests {
         }
     }
 
-    fn stdin_input() -> InputConfig {
+    fn build_generator_input() -> InputConfig {
         InputConfig {
             name: Some("in".to_string()),
             format: None,
@@ -100,7 +100,7 @@ mod tests {
         }
     }
 
-    fn stdout_output() -> OutputConfigV2 {
+    fn build_stdout_output() -> OutputConfigV2 {
         OutputConfigV2::Stdout(StdoutOutputConfig {
             name: Some("out".to_string()),
             format: None,
@@ -109,7 +109,11 @@ mod tests {
 
     #[test]
     fn compile_topology_rejects_empty_pipeline_name() {
-        let config = pipeline_config(vec![stdin_input()], vec![stdout_output()], None);
+        let config = build_pipeline_config(
+            vec![build_generator_input()],
+            vec![build_stdout_output()],
+            None,
+        );
         let spec = PipelineSpec {
             name: "",
             config: &config,
@@ -121,7 +125,7 @@ mod tests {
 
     #[test]
     fn compile_topology_rejects_missing_inputs() {
-        let config = pipeline_config(Vec::new(), vec![stdout_output()], None);
+        let config = build_pipeline_config(Vec::new(), vec![build_stdout_output()], None);
         let spec = PipelineSpec {
             name: "main",
             config: &config,
@@ -133,7 +137,7 @@ mod tests {
 
     #[test]
     fn compile_topology_rejects_missing_outputs() {
-        let config = pipeline_config(vec![stdin_input()], Vec::new(), None);
+        let config = build_pipeline_config(vec![build_generator_input()], Vec::new(), None);
         let spec = PipelineSpec {
             name: "main",
             config: &config,
@@ -145,9 +149,9 @@ mod tests {
 
     #[test]
     fn compile_topology_counts_nodes_with_optional_transform() {
-        let config = pipeline_config(
-            vec![stdin_input(), stdin_input()],
-            vec![stdout_output(), stdout_output()],
+        let config = build_pipeline_config(
+            vec![build_generator_input(), build_generator_input()],
+            vec![build_stdout_output(), build_stdout_output()],
             Some("SELECT * FROM logs".to_string()),
         );
         let spec = PipelineSpec {

--- a/crates/logfwd-runtime/src/pipeline/topology.rs
+++ b/crates/logfwd-runtime/src/pipeline/topology.rs
@@ -63,3 +63,102 @@ pub fn compile_topology(spec: &PipelineSpec<'_>) -> Result<CompiledTopology, Str
         output_count,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{PipelineSpec, compile_topology};
+    use logfwd_config::{
+        GeneratorTypeConfig, InputConfig, InputTypeConfig, OutputConfigV2, PipelineConfig,
+        StdoutOutputConfig,
+    };
+
+    fn pipeline_config(
+        inputs: Vec<InputConfig>,
+        outputs: Vec<OutputConfigV2>,
+        transform: Option<String>,
+    ) -> PipelineConfig {
+        PipelineConfig {
+            inputs,
+            outputs,
+            transform,
+            workers: None,
+            enrichment: Vec::new(),
+            resource_attrs: std::collections::HashMap::new(),
+            batch_target_bytes: None,
+            batch_timeout_ms: None,
+            poll_interval_ms: None,
+        }
+    }
+
+    fn stdin_input() -> InputConfig {
+        InputConfig {
+            name: Some("in".to_string()),
+            format: None,
+            sql: None,
+            source_metadata: Default::default(),
+            type_config: InputTypeConfig::Generator(GeneratorTypeConfig::default()),
+        }
+    }
+
+    fn stdout_output() -> OutputConfigV2 {
+        OutputConfigV2::Stdout(StdoutOutputConfig {
+            name: Some("out".to_string()),
+            format: None,
+        })
+    }
+
+    #[test]
+    fn compile_topology_rejects_empty_pipeline_name() {
+        let config = pipeline_config(vec![stdin_input()], vec![stdout_output()], None);
+        let spec = PipelineSpec {
+            name: "",
+            config: &config,
+        };
+
+        let err = compile_topology(&spec).expect_err("empty name should be rejected");
+        assert_eq!(err, "pipeline name must not be empty");
+    }
+
+    #[test]
+    fn compile_topology_rejects_missing_inputs() {
+        let config = pipeline_config(Vec::new(), vec![stdout_output()], None);
+        let spec = PipelineSpec {
+            name: "main",
+            config: &config,
+        };
+
+        let err = compile_topology(&spec).expect_err("missing inputs should be rejected");
+        assert_eq!(err, "pipeline 'main': at least one input is required");
+    }
+
+    #[test]
+    fn compile_topology_rejects_missing_outputs() {
+        let config = pipeline_config(vec![stdin_input()], Vec::new(), None);
+        let spec = PipelineSpec {
+            name: "main",
+            config: &config,
+        };
+
+        let err = compile_topology(&spec).expect_err("missing outputs should be rejected");
+        assert_eq!(err, "pipeline 'main': at least one output is required");
+    }
+
+    #[test]
+    fn compile_topology_counts_nodes_with_optional_transform() {
+        let config = pipeline_config(
+            vec![stdin_input(), stdin_input()],
+            vec![stdout_output(), stdout_output()],
+            Some("SELECT * FROM logs".to_string()),
+        );
+        let spec = PipelineSpec {
+            name: "main",
+            config: &config,
+        };
+
+        let compiled = compile_topology(&spec).expect("valid topology compiles");
+        assert_eq!(compiled.name, "main");
+        assert_eq!(compiled.input_count, 2);
+        assert_eq!(compiled.transform_count, 1);
+        assert_eq!(compiled.output_count, 2);
+    }
+}

--- a/crates/logfwd-runtime/src/worker_pool/worker.rs
+++ b/crates/logfwd-runtime/src/worker_pool/worker.rs
@@ -246,6 +246,7 @@ pub(super) async fn recv_with_idle_timeout(
 /// - `Rejected` — sink permanently rejected the data (4xx, schema error)
 /// - `PoolClosed` — shutdown cancellation was observed
 /// - `InternalFailure` — unknown `SendResult` variant
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn process_item(
     context: ProcessItemContext<'_>,
     batch: RecordBatch,

--- a/crates/logfwd/tests/it/integration.rs
+++ b/crates/logfwd/tests/it/integration.rs
@@ -119,7 +119,7 @@ output:
     let pipe_cfg = &config.pipelines["default"];
     let pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter(), None).unwrap();
 
-    let pipeline = run_until_output_lines(pipeline, 5);
+    let pipeline = run_until_output_lines(pipeline, 10);
 
     let lines_in = pipeline
         .metrics()


### PR DESCRIPTION
## Summary

Adds 5 unit tests for `compile_topology()` in `logfwd-runtime` covering: empty name, missing inputs, missing outputs, with/without transform. Also includes minor production cleanups: flattening nested `if let` chains in `input_poll.rs`, renaming underscore-prefixed bindings in `bootstrap.rs`/`run.rs`, and adding clippy lint suppressions.

**Note:** The predicate pushdown fix for metadata columns (`file.path`, `__source_id`, `_stream`, `_timestamp`) that was originally part of this PR has already been merged into main.

## Changes

- `topology.rs`: +122 lines of new test module with 5 tests
- `input_poll.rs`: Flatten nested `if`/`if let` chains (semantically equivalent)
- `bootstrap.rs`, `run.rs`: Remove unnecessary underscore-prefixed variable names
- `submit.rs`, `worker.rs`: Add clippy lint suppressions
- `integration.rs`: Align wait target (5 → match assertion)

## Test Plan

- All 5 new topology tests pass locally
- All 61 query_analyzer tests pass locally  
- `cargo check -p logfwd-runtime -p logfwd-transform` clean

Relates to #2518

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add unit tests for pipeline topology compile invariants and clean up unused variable warnings
> - Adds a `#[cfg(test)]` module to [topology.rs](https://github.com/strawgate/fastforward/pull/2520/files#diff-6f6fcc3ea7d63a0c8bcaa962f915f4221437d0d51772de3e29b3551564467afd) with four unit tests covering `compile_topology` invariants: empty pipeline name, missing inputs, missing outputs, and correct node counts with/without an optional transform.
> - Renames underscore-prefixed bindings (`_profiler_to_drop`, `_pprof_to_drop`, `_checkpoint_advances`) to non-prefixed names in [bootstrap.rs](https://github.com/strawgate/fastforward/pull/2520/files#diff-851a18d1d09b862e055016804787b7d10ede93b9fda47be883bab270fb223c68) and [run.rs](https://github.com/strawgate/fastforward/pull/2520/files#diff-a7e68976fe8fc62748304781b50e2c43bb33186112618c7217524fa598e5a9d2) so they are used explicitly rather than suppressed.
> - Adds `#[allow(clippy::needless_pass_by_ref_mut)]` and `#[allow(clippy::too_many_arguments)]` to silence clippy lints in [submit.rs](https://github.com/strawgate/fastforward/pull/2520/files#diff-3560543aaafed01d5ba1bcb0337848a45ccbaf03249c8dae7a9bf6701b183c2b) and [worker.rs](https://github.com/strawgate/fastforward/pull/2520/files#diff-5c15f5bfaac602f49cae801d69a266493a44601112a1dac378304ede61bf45cb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc43b89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->