### PR TITLE
fix: restore main ci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,9 +4680,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
@@ -1237,8 +1237,9 @@ output:
     std::thread::spawn(move || {
         let deadline = Instant::now() + Duration::from_secs(5);
         loop {
-            // Wait until transform_in shows all rows were scanned.
-            if metrics.transform_in.lines_total.load(Ordering::Relaxed) >= 20 {
+            // Simple SQL predicates can be pushed into the scanner, so
+            // transform_in reflects only rows that survive the filter.
+            if metrics.transform_in.lines_total.load(Ordering::Relaxed) >= 10 {
                 std::thread::sleep(Duration::from_millis(50));
                 sd.cancel();
                 return;
@@ -1257,15 +1258,19 @@ output:
         "split pipeline with SQL should work: {result:?}"
     );
 
-    // CPU worker scans 20 lines.
+    // Scanner-level predicate pushdown filters the 20 source rows to 10
+    // rows before they reach the transform stage.
     let lines_in = pipeline
         .metrics
         .transform_in
         .lines_total
         .load(Ordering::Relaxed);
-    assert_eq!(lines_in, 20, "expected 20 lines scanned, got {lines_in}");
+    assert_eq!(
+        lines_in, 10,
+        "expected 10 filtered rows into transform, got {lines_in}"
+    );
 
-    // SQL WHERE filters half -> 10 rows reach output.
+    // Those same 10 rows reach output.
     let lines_out = pipeline
         .metrics
         .transform_out

--- a/crates/logfwd-runtime/src/worker_pool/worker.rs
+++ b/crates/logfwd-runtime/src/worker_pool/worker.rs
@@ -84,14 +84,17 @@ pub(super) async fn worker_task(
                         let output_name = sink.name().to_string();
                         let process_result = AssertUnwindSafe(
                             process_item(
-                                id,
-                                &mut *sink,
-                                &output_health,
+                                ProcessItemContext {
+                                    worker_id: id,
+                                    sink: &mut *sink,
+                                    output_health: &output_health,
+                                    metadata: &metadata,
+                                    max_retry_delay,
+                                    cancel: &cancel,
+                                    #[cfg(feature = "turmoil")]
+                                    batch_id,
+                                },
                                 batch,
-                                &metadata,
-                                max_retry_delay,
-                                &cancel,
-                                batch_id,
                             )
                             .instrument(output_span.clone()),
                         )
@@ -187,6 +190,25 @@ pub(super) async fn worker_task(
     }
 }
 
+/// Shared immutable inputs for processing a single work item.
+pub(super) struct ProcessItemContext<'a> {
+    /// Worker slot id used for metrics, tracing, and health events.
+    pub(super) worker_id: usize,
+    /// Mutable borrowed sink reference that receives the batch.
+    pub(super) sink: &'a mut dyn Sink,
+    /// Shared output health tracker for readiness and failure transitions.
+    pub(super) output_health: &'a OutputHealthTracker,
+    /// Batch metadata propagated to the sink call.
+    pub(super) metadata: &'a BatchMetadata,
+    /// Maximum retry backoff applied to transient sink failures.
+    pub(super) max_retry_delay: Duration,
+    /// Shutdown signal checked between retries and before sleeps.
+    pub(super) cancel: &'a tokio_util::sync::CancellationToken,
+    #[cfg(feature = "turmoil")]
+    /// Turmoil-only batch id used for deterministic barrier injection.
+    pub(super) batch_id: u64,
+}
+
 fn panic_payload_message(payload: &(dyn Any + Send)) -> &str {
     if let Some(msg) = payload.downcast_ref::<&'static str>() {
         msg
@@ -225,15 +247,18 @@ pub(super) async fn recv_with_idle_timeout(
 /// - `PoolClosed` — shutdown cancellation was observed
 /// - `InternalFailure` — unknown `SendResult` variant
 pub(super) async fn process_item(
-    worker_id: usize,
-    sink: &mut dyn Sink,
-    output_health: &OutputHealthTracker,
+    context: ProcessItemContext<'_>,
     batch: RecordBatch,
-    metadata: &BatchMetadata,
-    max_retry_delay: Duration,
-    cancel: &tokio_util::sync::CancellationToken,
-    #[cfg_attr(not(feature = "turmoil"), allow(unused_variables))] batch_id: u64,
 ) -> (DeliveryOutcome, u64, usize) {
+    let worker_id = context.worker_id;
+    let sink = &mut *context.sink;
+    let output_health = context.output_health;
+    let metadata = context.metadata;
+    let max_retry_delay = context.max_retry_delay;
+    let cancel = context.cancel;
+    #[cfg(feature = "turmoil")]
+    let batch_id = context.batch_id;
+
     sink.begin_batch();
 
     const BATCH_TIMEOUT_SECS: u64 = 60;
@@ -454,7 +479,7 @@ mod tests {
 
     use super::super::pool::WorkerConfig;
     use super::super::types::{DeliveryOutcome, WorkItem, WorkerMsg};
-    use super::{process_item, worker_task};
+    use super::{ProcessItemContext, process_item, worker_task};
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     enum TerminalizationAction {
@@ -603,14 +628,17 @@ mod tests {
         };
 
         let (outcome, _send_latency_ns, retries) = process_item(
-            0,
-            &mut sink,
-            &output_health,
+            ProcessItemContext {
+                worker_id: 0,
+                sink: &mut sink,
+                output_health: &output_health,
+                metadata: &metadata,
+                max_retry_delay: Duration::from_millis(10),
+                cancel: &cancel,
+                #[cfg(feature = "turmoil")]
+                batch_id: 0, // test only
+            },
             make_batch(),
-            &metadata,
-            Duration::from_millis(10),
-            &cancel,
-            0, // batch_id (test only)
         )
         .await;
 


### PR DESCRIPTION
## Summary
- refactor worker batch processing to use a small context object so  no longer trips clippy's argument-count lint
- update the split pipeline SQL filter test to match scanner-side predicate pushdown behavior
- bump  in  to 0.103.13 so lint can proceed past the advisory check

## Verification
- 
- 
running 1 test
test pipeline::input_pipeline::tests::split_pipeline_processes_file_with_sql_filter ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 224 filtered out; finished in 0.43s
- 
- 


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI by updating test expectations and refactoring `process_item` to use `ProcessItemContext`
> - Updates [input_pipeline_tests.rs](https://github.com/strawgate/fastforward/pull/2544/files#diff-f9a907492cf69cf080e69bac49e3a40a35cb8dc3c685d9c09647e65f80b9f91d) to expect 10 rows at `transform_in` instead of 20, reflecting that scanner-level predicate pushdown filters rows before they reach the transform stage.
> - Introduces a `ProcessItemContext` struct in [worker.rs](https://github.com/strawgate/fastforward/pull/2544/files#diff-5c15f5bfaac602f49cae801d69a266493a44601112a1dac378304ede61bf45cb) to bundle the previously discrete parameters passed to `process_item`, reducing argument count without changing logic.
> - Behavioral Change: `transform_in` metrics now count only rows surviving the filter, not total scanned rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 665e9aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->