### PR TITLE
refactor: harden shared-buffer input batching verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,6 +888,7 @@ jobs:
       - kani-io-output
       - miri-core
       - miri-types
+      - miri-io-buffered
       - simulation-turmoil
       - simulation-loom
       - tlc-safety

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
             miri:
               - 'crates/logfwd-core/**'
               - 'crates/logfwd-types/**'
+              - 'crates/logfwd-io/src/framed.rs'
+              - 'crates/logfwd-io/src/format.rs'
+              - 'crates/logfwd-io/src/input.rs'
+              - 'crates/logfwd-io/tests/it/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/ci.yml'
@@ -585,6 +589,37 @@ jobs:
 
       - name: Run Miri test suite (logfwd-types)
         run: cargo +nightly miri test -p logfwd-types --lib
+        env:
+          MIRIFLAGS: "-Zmiri-strict-provenance"
+          PROPTEST_DISABLE_FAILURE_PERSISTENCE: "1"
+          PROPTEST_CASES: "1"
+
+  miri-io-buffered:
+    name: Miri (io buffered)
+    needs: [changes, lint]
+    if: |
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full') ||
+      (github.event.pull_request.draft == false && needs.changes.outputs.miri == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri, rust-src
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          key: miri-io-buffered-nightly
+
+      - name: Set up Miri
+        run: cargo +nightly miri setup
+
+      - name: Run targeted Miri regression (logfwd-io shared buffer)
+        run: cargo +nightly miri test -p logfwd-io framed::tests::poll_into_miri_shared_buffer_alias_regression --lib
         env:
           MIRIFLAGS: "-Zmiri-strict-provenance"
           PROPTEST_DISABLE_FAILURE_PERSISTENCE: "1"

--- a/crates/logfwd-io/src/format.rs
+++ b/crates/logfwd-io/src/format.rs
@@ -425,6 +425,15 @@ fn normalize_plain_text_fallback(line: &[u8]) -> Option<&[u8]> {
     (!line.is_empty()).then_some(line)
 }
 
+#[inline]
+fn append_json_byte_escape<O: ScannerReadyOutput>(byte: u8, dst: &mut O) {
+    dst.extend_from_slice(b"\\u00");
+    let hi = (byte >> 4) & 0x0F;
+    let lo = byte & 0x0F;
+    dst.push_byte(if hi < 10 { b'0' + hi } else { b'a' + hi - 10 });
+    dst.push_byte(if lo < 10 { b'0' + lo } else { b'a' + lo - 10 });
+}
+
 fn append_json_escaped<O: ScannerReadyOutput>(src: &[u8], dst: &mut O) {
     for &b in src {
         match b {
@@ -435,13 +444,7 @@ fn append_json_escaped<O: ScannerReadyOutput>(src: &[u8], dst: &mut O) {
             b'\n' => dst.extend_from_slice(b"\\n"),
             0x0C => dst.extend_from_slice(b"\\f"),
             b'\r' => dst.extend_from_slice(b"\\r"),
-            0x00..=0x1F | 0x7F => {
-                dst.extend_from_slice(b"\\u00");
-                let hi = (b >> 4) & 0x0F;
-                let lo = b & 0x0F;
-                dst.push_byte(if hi < 10 { b'0' + hi } else { b'a' + hi - 10 });
-                dst.push_byte(if lo < 10 { b'0' + lo } else { b'a' + lo - 10 });
-            }
+            0x00..=0x1F | 0x7F..=0xFF => append_json_byte_escape(b, dst),
             _ => dst.push_byte(b),
         }
     }
@@ -485,6 +488,7 @@ mod tests {
     use crate::input::{FileInput, InputEvent, InputSource};
     use crate::tail::TailConfig;
     use bytes::BytesMut;
+    use proptest::prelude::*;
     use std::time::{Duration, Instant};
 
     fn make_stats() -> Arc<ComponentStats> {
@@ -923,6 +927,34 @@ mod tests {
                 value.get("msg").is_none(),
                 "non-JSON whitespace byte {prefix:#04x} must not be treated as JSON: {trimmed:?}"
             );
+        }
+    }
+
+    #[test]
+    fn plain_text_fallback_escapes_non_utf8_bytes_as_json_hex() {
+        let mut out = Vec::new();
+        write_plain_text_fallback(b"\x80\xff", "body", &mut out);
+        let text = std::str::from_utf8(&out).expect("fallback output must be ASCII JSON");
+        let parsed: serde_json::Value =
+            serde_json::from_str(text.trim_end()).expect("fallback output must parse as JSON");
+        assert_eq!(
+            parsed.get("body").and_then(serde_json::Value::as_str),
+            Some("\u{80}\u{ff}")
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn plain_text_fallback_always_emits_valid_json(
+            field_name in "[ -~]{1,8}",
+            bytes in prop::collection::vec(any::<u8>(), 0..64),
+        ) {
+            let mut out = Vec::new();
+            write_plain_text_fallback(&bytes, &field_name, &mut out);
+            let text = std::str::from_utf8(&out).expect("fallback output must remain ASCII JSON");
+            let parsed: serde_json::Value =
+                serde_json::from_str(text.trim_end()).expect("fallback output must remain valid JSON");
+            prop_assert!(parsed.get(field_name.as_str()).is_some());
         }
     }
 

--- a/crates/logfwd-io/src/format.rs
+++ b/crates/logfwd-io/src/format.rs
@@ -6,7 +6,8 @@
 //! (JSON, CRI, Raw) via composition.
 
 use crate::input::CriMetadata;
-use logfwd_core::cri::{json_escape_bytes, parse_cri_line};
+use bytes::{BufMut, BytesMut};
+use logfwd_core::cri::parse_cri_line;
 use logfwd_core::reassembler::{AggregateResult, CriReassembler};
 use logfwd_types::diagnostics::ComponentStats;
 use std::sync::Arc;
@@ -193,6 +194,26 @@ impl FormatDecoder {
         out: &mut Vec<u8>,
         cri_metadata: Option<&mut CriMetadata>,
     ) {
+        self.process_lines_with_metadata_impl(chunk, out, cri_metadata);
+    }
+
+    /// Process lines and optionally collect CRI metadata sidecar rows,
+    /// appending scanner-ready output directly into a shared `BytesMut`.
+    pub fn process_lines_with_metadata_into(
+        &mut self,
+        chunk: &[u8],
+        out: &mut BytesMut,
+        cri_metadata: Option<&mut CriMetadata>,
+    ) {
+        self.process_lines_with_metadata_impl(chunk, out, cri_metadata);
+    }
+
+    fn process_lines_with_metadata_impl<O: ScannerReadyOutput>(
+        &mut self,
+        chunk: &[u8],
+        out: &mut O,
+        cri_metadata: Option<&mut CriMetadata>,
+    ) {
         match self {
             Self::Passthrough { .. } => {
                 out.extend_from_slice(chunk);
@@ -256,6 +277,31 @@ impl FormatDecoder {
     }
 }
 
+trait ScannerReadyOutput {
+    fn extend_from_slice(&mut self, bytes: &[u8]);
+    fn push_byte(&mut self, byte: u8);
+}
+
+impl ScannerReadyOutput for Vec<u8> {
+    fn extend_from_slice(&mut self, bytes: &[u8]) {
+        Vec::extend_from_slice(self, bytes);
+    }
+
+    fn push_byte(&mut self, byte: u8) {
+        self.push(byte);
+    }
+}
+
+impl ScannerReadyOutput for BytesMut {
+    fn extend_from_slice(&mut self, bytes: &[u8]) {
+        BytesMut::extend_from_slice(self, bytes);
+    }
+
+    fn push_byte(&mut self, byte: u8) {
+        self.put_u8(byte);
+    }
+}
+
 /// Count non-JSON lines in `chunk` and increment the parse-error counter.
 ///
 /// A line is considered a JSON object if, after stripping leading ASCII
@@ -287,9 +333,9 @@ pub(crate) fn count_json_parse_errors(chunk: &[u8], stats: &ComponentStats) {
 /// timestamp and stream are taken from the closing F line, which is correct
 /// because the CRI spec requires all fragments of the same log entry to carry
 /// the same timestamp and stream.
-fn extract_cri_messages(
+fn extract_cri_messages<O: ScannerReadyOutput>(
     input: &[u8],
-    out: &mut Vec<u8>,
+    out: &mut O,
     mut cri_metadata: Option<&mut CriMetadata>,
     aggregators: &mut [CriReassembler; 2],
     plain_text_field_name: &str,
@@ -340,7 +386,7 @@ fn extract_cri_messages(
             if !line.is_empty() && passthrough_on_fail {
                 if starts_with_json_object(line) {
                     out.extend_from_slice(line);
-                    out.push(b'\n');
+                    out.push_byte(b'\n');
                     if let Some(metadata) = &mut cri_metadata {
                         metadata.append_null_rows(1);
                     }
@@ -379,17 +425,43 @@ fn normalize_plain_text_fallback(line: &[u8]) -> Option<&[u8]> {
     (!line.is_empty()).then_some(line)
 }
 
-fn write_plain_text_fallback(line: &[u8], plain_text_field_name: &str, out: &mut Vec<u8>) {
+fn append_json_escaped<O: ScannerReadyOutput>(src: &[u8], dst: &mut O) {
+    for &b in src {
+        match b {
+            b'"' => dst.extend_from_slice(b"\\\""),
+            b'\\' => dst.extend_from_slice(b"\\\\"),
+            0x08 => dst.extend_from_slice(b"\\b"),
+            b'\t' => dst.extend_from_slice(b"\\t"),
+            b'\n' => dst.extend_from_slice(b"\\n"),
+            0x0C => dst.extend_from_slice(b"\\f"),
+            b'\r' => dst.extend_from_slice(b"\\r"),
+            0x00..=0x1F | 0x7F => {
+                dst.extend_from_slice(b"\\u00");
+                let hi = (b >> 4) & 0x0F;
+                let lo = b & 0x0F;
+                dst.push_byte(if hi < 10 { b'0' + hi } else { b'a' + hi - 10 });
+                dst.push_byte(if lo < 10 { b'0' + lo } else { b'a' + lo - 10 });
+            }
+            _ => dst.push_byte(b),
+        }
+    }
+}
+
+fn write_plain_text_fallback<O: ScannerReadyOutput>(
+    line: &[u8],
+    plain_text_field_name: &str,
+    out: &mut O,
+) {
     out.extend_from_slice(b"{\"");
-    json_escape_bytes(plain_text_field_name.as_bytes(), out);
+    append_json_escaped(plain_text_field_name.as_bytes(), out);
     out.extend_from_slice(b"\":\"");
-    json_escape_bytes(line, out);
+    append_json_escaped(line, out);
     out.extend_from_slice(b"\"}\n");
 }
 
 /// Write a CRI message as scanner-ready JSON without CRI metadata injection.
 #[inline]
-fn write_cri_message(msg: &[u8], plain_text_field_name: &str, out: &mut Vec<u8>) {
+fn write_cri_message<O: ScannerReadyOutput>(msg: &[u8], plain_text_field_name: &str, out: &mut O) {
     let json_start = msg.iter().position(|b| !is_json_whitespace(*b));
     if let Some(start) = json_start
         && msg[start] == b'{'
@@ -398,12 +470,12 @@ fn write_cri_message(msg: &[u8], plain_text_field_name: &str, out: &mut Vec<u8>)
     } else {
         // Plain text is still wrapped so the scanner can ingest the record.
         out.extend_from_slice(b"{\"");
-        json_escape_bytes(plain_text_field_name.as_bytes(), out);
+        append_json_escaped(plain_text_field_name.as_bytes(), out);
         out.extend_from_slice(b"\":\"");
-        json_escape_bytes(msg, out);
+        append_json_escaped(msg, out);
         out.extend_from_slice(b"\"}");
     }
-    out.push(b'\n');
+    out.push_byte(b'\n');
 }
 
 #[cfg(test)]
@@ -412,10 +484,34 @@ mod tests {
     use crate::framed::FramedInput;
     use crate::input::{FileInput, InputEvent, InputSource};
     use crate::tail::TailConfig;
+    use bytes::BytesMut;
     use std::time::{Duration, Instant};
 
     fn make_stats() -> Arc<ComponentStats> {
         Arc::new(ComponentStats::new())
+    }
+
+    fn assert_decoder_sinks_match(
+        mut left: FormatDecoder,
+        mut right: FormatDecoder,
+        chunks: &[&[u8]],
+    ) {
+        let mut vec_out = Vec::new();
+        let mut vec_metadata = CriMetadata::default();
+        let mut bytes_out = BytesMut::new();
+        let mut bytes_metadata = CriMetadata::default();
+
+        for chunk in chunks {
+            left.process_lines_with_metadata(chunk, &mut vec_out, Some(&mut vec_metadata));
+            right.process_lines_with_metadata_into(
+                chunk,
+                &mut bytes_out,
+                Some(&mut bytes_metadata),
+            );
+        }
+
+        assert_eq!(vec_out, bytes_out.as_ref());
+        assert_eq!(vec_metadata, bytes_metadata);
     }
 
     fn process_cri_from_tempfile(input: &[u8]) -> Vec<u8> {
@@ -468,6 +564,16 @@ mod tests {
         let mut out = Vec::new();
         proc.process_lines(input, &mut out);
         assert_eq!(out, input);
+    }
+
+    #[test]
+    fn passthrough_json_process_lines_into_matches_vec_sink() {
+        let stats = make_stats();
+        assert_decoder_sinks_match(
+            FormatDecoder::passthrough_json(Arc::clone(&stats)),
+            FormatDecoder::passthrough_json(stats),
+            &[b"{\"msg\":\"ok\"}\nnot json\n"],
+        );
     }
 
     #[test]
@@ -614,6 +720,21 @@ mod tests {
     }
 
     #[test]
+    fn auto_process_lines_into_matches_vec_sink_across_mixed_sequence() {
+        let stats = make_stats();
+        assert_decoder_sinks_match(
+            FormatDecoder::auto(2 * 1024 * 1024, Arc::clone(&stats)),
+            FormatDecoder::auto(2 * 1024 * 1024, stats),
+            &[
+                b"{\"msg\":\"plain\"}\n",
+                b"2024-01-15T10:30:00Z stdout P hello \n",
+                b"2024-01-15T10:30:00Z stdout F world\n",
+                b"not a cri line\n",
+            ],
+        );
+    }
+
+    #[test]
     fn reset_clears_aggregator_state() {
         let stats = make_stats();
         let mut proc = FormatDecoder::cri(2 * 1024 * 1024, stats);
@@ -677,6 +798,20 @@ mod tests {
 
         proc.process_lines(b"2024-01-15T10:30:00Z stdout F \"hello\"}\n", &mut out);
         assert_eq!(out, b"{\"msg\":\"hello\"}\n");
+    }
+
+    #[test]
+    fn cri_process_lines_into_matches_vec_sink_across_partial_sequence() {
+        let stats = make_stats();
+        assert_decoder_sinks_match(
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            FormatDecoder::cri(2 * 1024 * 1024, stats),
+            &[
+                b"2024-01-15T10:30:00Z stdout P {\"msg\":\n",
+                b"2024-01-15T10:30:00Z stdout F \"hello\"}\n",
+                b"2024-01-15T10:30:01Z stderr F plain text\n",
+            ],
+        );
     }
 
     #[test]

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -13,7 +13,7 @@ use bytes::{Bytes, BytesMut};
 
 use crate::filter_hints::FilterHints;
 use crate::format::FormatDecoder;
-use crate::input::{BufferedInputEvent, CriMetadata, InputCadence, InputEvent, InputSource};
+use crate::input::{CriMetadata, FramedReadEvent, InputCadence, InputEvent, InputSource};
 #[cfg(test)]
 use crate::poll_cadence::PollCadenceSignal;
 use crate::tail::ByteOffset;
@@ -119,33 +119,40 @@ impl FramedInput {
         dst: &mut BytesMut,
         data: &[u8],
         source_id: Option<SourceId>,
-        result_events: &mut Vec<BufferedInputEvent>,
+        result_events: &mut Vec<FramedReadEvent>,
     ) {
         if data.is_empty() {
             return;
         }
         let start = dst.len();
         dst.extend_from_slice(data);
-        result_events.push(BufferedInputEvent::Data {
+        result_events.push(FramedReadEvent::Data {
             range: start..dst.len(),
             source_id,
             cri_metadata: None,
         });
     }
 
+    fn unsupported_structured_event_error(event_name: &str) -> io::Error {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("FramedInput only supports raw byte events; inner source emitted {event_name}"),
+        )
+    }
+
     fn process_raw_events_into(
         &mut self,
         raw_events: Vec<InputEvent>,
         dst: &mut BytesMut,
-    ) -> Vec<BufferedInputEvent> {
+    ) -> io::Result<Vec<FramedReadEvent>> {
         self.last_raw_had_payload = raw_events
             .iter()
             .any(|event| matches!(event, InputEvent::Data { .. } | InputEvent::Batch { .. }));
         if raw_events.is_empty() {
-            return vec![];
+            return Ok(vec![]);
         }
 
-        let mut result_events: Vec<BufferedInputEvent> = Vec::new();
+        let mut result_events: Vec<FramedReadEvent> = Vec::new();
 
         for event in raw_events {
             match event {
@@ -337,7 +344,7 @@ impl FramedInput {
                             Some(&mut self.cri_metadata_buf),
                         );
                         if dst.len() > start {
-                            result_events.push(BufferedInputEvent::Data {
+                            result_events.push(FramedReadEvent::Data {
                                 range: start..dst.len(),
                                 source_id,
                                 cri_metadata: self.cri_metadata_for_emitted_data(),
@@ -355,14 +362,10 @@ impl FramedInput {
                         self.sources.remove(&key);
                     }
                 }
-                InputEvent::Batch {
-                    batch,
-                    source_id,
-                    accounted_bytes,
-                } => {
-                    self.stats.inc_lines(batch.num_rows() as u64);
-                    self.stats.inc_bytes(accounted_bytes);
-                    result_events.push(BufferedInputEvent::Batch { batch, source_id });
+                InputEvent::Batch { .. } => {
+                    return Err(Self::unsupported_structured_event_error(
+                        "InputEvent::Batch",
+                    ));
                 }
                 InputEvent::Rotated { source_id } => {
                     match source_id {
@@ -373,7 +376,7 @@ impl FramedInput {
                             self.sources.clear();
                         }
                     }
-                    result_events.push(BufferedInputEvent::Rotated { source_id });
+                    result_events.push(FramedReadEvent::Rotated { source_id });
                 }
                 InputEvent::Truncated { source_id } => {
                     match source_id {
@@ -384,7 +387,7 @@ impl FramedInput {
                             self.sources.clear();
                         }
                     }
-                    result_events.push(BufferedInputEvent::Truncated { source_id });
+                    result_events.push(FramedReadEvent::Truncated { source_id });
                 }
                 InputEvent::EndOfFile { source_id } => {
                     let keys_to_flush: Vec<Option<SourceId>> = match source_id {
@@ -416,7 +419,7 @@ impl FramedInput {
                                     Some(&mut self.cri_metadata_buf),
                                 );
                                 if dst.len() > start {
-                                    result_events.push(BufferedInputEvent::Data {
+                                    result_events.push(FramedReadEvent::Data {
                                         range: start..dst.len(),
                                         source_id: key,
                                         cri_metadata: self.cri_metadata_for_emitted_data(),
@@ -438,15 +441,15 @@ impl FramedInput {
             }
         }
 
-        result_events
+        Ok(result_events)
     }
 
-    fn process_raw_events(&mut self, raw_events: Vec<InputEvent>) -> Vec<InputEvent> {
+    fn process_raw_events(&mut self, raw_events: Vec<InputEvent>) -> io::Result<Vec<InputEvent>> {
         self.last_raw_had_payload = raw_events
             .iter()
             .any(|event| matches!(event, InputEvent::Data { .. } | InputEvent::Batch { .. }));
         if raw_events.is_empty() {
-            return vec![];
+            return Ok(vec![]);
         }
 
         let mut result_events: Vec<InputEvent> = Vec::new();
@@ -712,18 +715,10 @@ impl FramedInput {
                         self.sources.remove(&key);
                     }
                 }
-                InputEvent::Batch {
-                    batch,
-                    source_id,
-                    accounted_bytes,
-                } => {
-                    self.stats.inc_lines(batch.num_rows() as u64);
-                    self.stats.inc_bytes(accounted_bytes);
-                    result_events.push(InputEvent::Batch {
-                        batch,
-                        source_id,
-                        accounted_bytes: 0,
-                    });
+                InputEvent::Batch { .. } => {
+                    return Err(Self::unsupported_structured_event_error(
+                        "InputEvent::Batch",
+                    ));
                 }
                 // Rotation/truncation: clear framing state + forward event.
                 //
@@ -818,32 +813,32 @@ impl FramedInput {
             }
         }
 
-        result_events
+        Ok(result_events)
     }
 }
 
 impl InputSource for FramedInput {
     fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
         let raw_events = self.inner.poll()?;
-        Ok(self.process_raw_events(raw_events))
+        self.process_raw_events(raw_events)
     }
 
-    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<FramedReadEvent>>> {
         let raw_events = self.inner.poll()?;
-        Ok(Some(self.process_raw_events_into(raw_events, dst)))
+        Ok(Some(self.process_raw_events_into(raw_events, dst)?))
     }
 
     fn poll_shutdown(&mut self) -> io::Result<Vec<InputEvent>> {
         let raw_events = self.inner.poll_shutdown()?;
-        Ok(self.process_raw_events(raw_events))
+        self.process_raw_events(raw_events)
     }
 
     fn poll_shutdown_into(
         &mut self,
         dst: &mut BytesMut,
-    ) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+    ) -> io::Result<Option<Vec<FramedReadEvent>>> {
         let raw_events = self.inner.poll_shutdown()?;
-        Ok(Some(self.process_raw_events_into(raw_events, dst)))
+        Ok(Some(self.process_raw_events_into(raw_events, dst)?))
     }
 
     fn name(&self) -> &str {
@@ -1095,7 +1090,7 @@ mod tests {
 
         assert_eq!(dst.as_ref(), b"seed\nline1\nline2\n");
         assert_eq!(events.len(), 1);
-        let BufferedInputEvent::Data {
+        let FramedReadEvent::Data {
             range, source_id, ..
         } = &events[0]
         else {
@@ -1175,7 +1170,7 @@ mod tests {
             .expect("buffered path available");
 
         assert_eq!(second.len(), 1);
-        let BufferedInputEvent::Data {
+        let FramedReadEvent::Data {
             range,
             source_id,
             cri_metadata,
@@ -1231,14 +1226,14 @@ mod tests {
             .expect("second poll_into")
             .expect("buffered path available");
 
-        let BufferedInputEvent::Data {
+        let FramedReadEvent::Data {
             cri_metadata: first_metadata,
             ..
         } = &first[0]
         else {
             panic!("expected first data event");
         };
-        let BufferedInputEvent::Data {
+        let FramedReadEvent::Data {
             cri_metadata: second_metadata,
             ..
         } = &second[0]
@@ -1296,7 +1291,7 @@ mod tests {
             .expect("buffered path available");
 
         assert_eq!(shutdown.len(), 1);
-        let BufferedInputEvent::Data {
+        let FramedReadEvent::Data {
             range,
             cri_metadata,
             ..
@@ -1344,7 +1339,7 @@ mod tests {
             .expect("shared-buffer path available");
         assert_eq!(first.len(), 1);
         let first_range = match &first[0] {
-            BufferedInputEvent::Data {
+            FramedReadEvent::Data {
                 range, source_id, ..
             } => {
                 assert_eq!(*source_id, Some(SourceId(7)));
@@ -1361,7 +1356,7 @@ mod tests {
             .expect("shared-buffer path available");
         assert_eq!(second.len(), 1);
         let second_range = match &second[0] {
-            BufferedInputEvent::Data {
+            FramedReadEvent::Data {
                 range, source_id, ..
             } => {
                 assert_eq!(*source_id, Some(SourceId(7)));
@@ -1531,15 +1526,13 @@ mod tests {
     }
 
     #[test]
-    fn batch_events_increment_stats() {
+    fn batch_events_from_inner_source_are_rejected() {
         let stats = make_stats();
         let batch = make_batch();
-        let expected_rows = batch.num_rows() as u64;
-        let expected_bytes = 1234;
         let source = MockSource::new(vec![vec![InputEvent::Batch {
             batch,
             source_id: None,
-            accounted_bytes: expected_bytes,
+            accounted_bytes: 1234,
         }]]);
         let mut framed = FramedInput::new(
             Box::new(source),
@@ -1547,11 +1540,35 @@ mod tests {
             Arc::clone(&stats),
         );
 
-        let events = framed.poll().unwrap();
-        assert_eq!(events.len(), 1);
-        assert!(matches!(events[0], InputEvent::Batch { .. }));
-        assert_eq!(stats.lines(), expected_rows);
-        assert_eq!(stats.bytes(), expected_bytes);
+        let err = match framed.poll() {
+            Ok(_) => panic!("structured event should be rejected"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("InputEvent::Batch"));
+    }
+
+    #[test]
+    fn poll_into_rejects_batch_events_from_inner_source() {
+        let stats = make_stats();
+        let batch = make_batch();
+        let source = MockSource::new(vec![vec![InputEvent::Batch {
+            batch,
+            source_id: None,
+            accounted_bytes: 1234,
+        }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        let mut dst = BytesMut::new();
+        let err = match framed.poll_into(&mut dst) {
+            Ok(_) => panic!("shared-buffer path should reject structured event"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("InputEvent::Batch"));
+        assert!(dst.is_empty());
     }
 
     #[test]

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -330,6 +330,7 @@ impl FramedInput {
                         let line_count = memchr::memchr_iter(b'\n', chunk).count();
                         self.stats.inc_lines(line_count as u64);
                         let start = dst.len();
+                        self.cri_metadata_buf.clear();
                         state.format.process_lines_with_metadata_into(
                             chunk,
                             dst,
@@ -1195,6 +1196,74 @@ mod tests {
             .expect("non-null span values");
         assert_eq!(metadata.timestamp(values), b"2024-01-15T10:30:00Z");
         assert_eq!(values.stream.as_str(), "stdout");
+    }
+
+    #[test]
+    fn cri_poll_into_clears_metadata_between_complete_messages() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"2024-01-15T10:30:00Z stdout F first\n"),
+                source_id: None,
+                accounted_bytes: 37,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"2024-01-15T10:30:01Z stderr F second\n"),
+                source_id: None,
+                accounted_bytes: 38,
+                cri_metadata: None,
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            stats,
+        );
+        let mut dst = BytesMut::new();
+
+        let first = framed
+            .poll_into(&mut dst)
+            .expect("first poll_into")
+            .expect("buffered path available");
+        let second = framed
+            .poll_into(&mut dst)
+            .expect("second poll_into")
+            .expect("buffered path available");
+
+        let BufferedInputEvent::Data {
+            cri_metadata: first_metadata,
+            ..
+        } = &first[0]
+        else {
+            panic!("expected first data event");
+        };
+        let BufferedInputEvent::Data {
+            cri_metadata: second_metadata,
+            ..
+        } = &second[0]
+        else {
+            panic!("expected second data event");
+        };
+
+        let first_metadata = first_metadata.as_ref().expect("first CRI metadata");
+        let second_metadata = second_metadata.as_ref().expect("second CRI metadata");
+        assert_eq!(first_metadata.rows, 1);
+        assert_eq!(second_metadata.rows, 1);
+        let first_values = first_metadata.spans[0]
+            .values
+            .as_ref()
+            .expect("first non-null metadata");
+        let second_values = second_metadata.spans[0]
+            .values
+            .as_ref()
+            .expect("second non-null metadata");
+        assert_eq!(first_values.stream.as_str(), "stdout");
+        assert_eq!(second_values.stream.as_str(), "stderr");
+        assert_eq!(
+            second_metadata.timestamp(second_values),
+            b"2024-01-15T10:30:01Z"
+        );
     }
 
     #[test]

--- a/crates/logfwd-io/src/framed.rs
+++ b/crates/logfwd-io/src/framed.rs
@@ -9,14 +9,2653 @@
 //! interleaved data from multiple files (or TCP connections) never
 //! cross-contaminates partial lines or CRI P/F aggregation state.
 
-include!("framed/state.rs");
-include!("framed/input.rs");
-include!("framed/processing.rs");
-include!("framed/source.rs");
+use bytes::{Bytes, BytesMut};
+
+use crate::filter_hints::FilterHints;
+use crate::format::FormatDecoder;
+use crate::input::{BufferedInputEvent, CriMetadata, InputCadence, InputEvent, InputSource};
+#[cfg(test)]
+use crate::poll_cadence::PollCadenceSignal;
+use crate::tail::ByteOffset;
+use logfwd_core::checkpoint_tracker::CheckpointTracker;
+use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
+use logfwd_types::pipeline::SourceId;
+use std::collections::HashMap;
+use std::io;
+use std::sync::Arc;
+
+/// Maximum remainder buffer size before discarding (prevents OOM on
+/// input without newlines). Applied per source.
+const MAX_REMAINDER_BYTES: usize = 2 * 1024 * 1024;
+
+const INITIAL_CRI_METADATA_SPANS: usize = 16;
+const INITIAL_CRI_TIMESTAMP_BYTES: usize = 1024;
+
+/// Per-source state for framing and checkpoint tracking.
+///
+/// Each logical source (identified by `Option<SourceId>`) gets its own
+/// remainder buffer, format processor, and checkpoint tracker. This
+/// prevents cross-contamination between sources for both newline framing
+/// and stateful format processing (e.g., CRI P/F aggregation).
+struct SourceState {
+    /// Partial-line bytes after the last newline.
+    remainder: Vec<u8>,
+    /// Per-source format processor (CRI aggregator state is source-scoped).
+    format: FormatDecoder,
+    /// Kani-proven checkpoint offset tracker. Tracks the relationship
+    /// between file read position and the last complete newline boundary.
+    tracker: CheckpointTracker,
+    /// True when remainder bytes are known to start mid-line due to overflow
+    /// truncation. The first completed line formed from this remainder must be
+    /// discarded to avoid emitting a garbled fragment (#1030).
+    overflow_tainted: bool,
+}
+
+impl SourceState {
+    fn is_reclaimable(&self) -> bool {
+        self.remainder.is_empty() && !self.overflow_tainted && !self.format.has_pending_state()
+    }
+}
+
+/// Wraps a raw [`InputSource`] with newline framing and format processing.
+///
+/// The inner source provides raw bytes (from file, TCP, UDP, etc.). This
+/// wrapper splits on newlines, manages partial-line remainders across polls,
+/// and runs format-specific processing (CRI extraction, passthrough, etc.).
+/// The output is scanner-ready bytes.
+///
+/// All per-source state (remainder, format, checkpoint tracker) is keyed by
+/// `Option<SourceId>` so that interleaved data from multiple sources never
+/// mixes partial lines or CRI aggregation state. Sources without identity
+/// (`None`) share a single state entry.
+pub struct FramedInput {
+    inner: Box<dyn InputSource>,
+    /// Template format processor — cloned per-source on first data arrival.
+    format_template: FormatDecoder,
+    /// Per-source state: remainder, format processor, checkpoint tracker.
+    sources: HashMap<Option<SourceId>, SourceState>,
+    out_buf: Vec<u8>,
+    cri_metadata_buf: CriMetadata,
+    /// Spare buffer swapped in when out_buf is emitted, preserving capacity
+    /// across polls without allocating.
+    spare_buf: Vec<u8>,
+    stats: Arc<ComponentStats>,
+    last_raw_had_payload: bool,
+}
+
+impl FramedInput {
+    pub fn new(
+        inner: Box<dyn InputSource>,
+        format: FormatDecoder,
+        stats: Arc<ComponentStats>,
+    ) -> Self {
+        let cri_metadata_buf = if format.emits_cri_metadata() {
+            CriMetadata::with_capacity(INITIAL_CRI_METADATA_SPANS, INITIAL_CRI_TIMESTAMP_BYTES)
+        } else {
+            CriMetadata::default()
+        };
+        Self {
+            inner,
+            format_template: format,
+            sources: HashMap::new(),
+            out_buf: Vec::with_capacity(64 * 1024),
+            cri_metadata_buf,
+            spare_buf: Vec::with_capacity(64 * 1024),
+            stats,
+            last_raw_had_payload: false,
+        }
+    }
+
+    fn cri_metadata_for_emitted_data(&mut self) -> Option<CriMetadata> {
+        if self.cri_metadata_buf.is_empty() {
+            return None;
+        }
+        let replacement = self.cri_metadata_buf.empty_with_preserved_capacity();
+        let metadata = std::mem::replace(&mut self.cri_metadata_buf, replacement);
+        Some(metadata)
+    }
+
+    fn append_buffered_data(
+        dst: &mut BytesMut,
+        data: &[u8],
+        source_id: Option<SourceId>,
+        result_events: &mut Vec<BufferedInputEvent>,
+    ) {
+        if data.is_empty() {
+            return;
+        }
+        let start = dst.len();
+        dst.extend_from_slice(data);
+        result_events.push(BufferedInputEvent::Data {
+            range: start..dst.len(),
+            source_id,
+            cri_metadata: None,
+        });
+    }
+
+    fn process_raw_events_into(
+        &mut self,
+        raw_events: Vec<InputEvent>,
+        dst: &mut BytesMut,
+    ) -> Vec<BufferedInputEvent> {
+        self.last_raw_had_payload = raw_events
+            .iter()
+            .any(|event| matches!(event, InputEvent::Data { .. } | InputEvent::Batch { .. }));
+        if raw_events.is_empty() {
+            return vec![];
+        }
+
+        let mut result_events: Vec<BufferedInputEvent> = Vec::new();
+
+        for event in raw_events {
+            match event {
+                InputEvent::Data {
+                    bytes,
+                    source_id,
+                    accounted_bytes,
+                    ..
+                } => {
+                    self.stats.inc_bytes(accounted_bytes);
+
+                    let key = source_id;
+                    let n_bytes = bytes.len() as u64;
+                    let state = {
+                        let template = &self.format_template;
+                        self.sources.entry(key).or_insert_with(|| SourceState {
+                            remainder: Vec::new(),
+                            format: template.new_instance(),
+                            tracker: CheckpointTracker::new(0),
+                            overflow_tainted: false,
+                        })
+                    };
+                    let tainted_on_entry = state.overflow_tainted;
+
+                    if state.format.is_passthrough()
+                        && state.remainder.is_empty()
+                        && !tainted_on_entry
+                    {
+                        let last_nl = memchr::memrchr(b'\n', &bytes);
+                        match last_nl {
+                            Some(pos) if pos + 1 == bytes.len() => {
+                                state.tracker.apply_read(n_bytes, Some(pos as u64));
+                                let line_count = memchr::memchr_iter(b'\n', &bytes).count();
+                                self.stats.inc_lines(line_count as u64);
+                                if let FormatDecoder::PassthroughJson { stats, .. } = &state.format
+                                {
+                                    crate::format::count_json_parse_errors(&bytes, stats);
+                                }
+                                Self::append_buffered_data(
+                                    dst,
+                                    &bytes,
+                                    source_id,
+                                    &mut result_events,
+                                );
+                                if key.is_some()
+                                    && self.inner.should_reclaim_completed_source_state()
+                                    && self
+                                        .sources
+                                        .get(&key)
+                                        .is_some_and(SourceState::is_reclaimable)
+                                {
+                                    self.sources.remove(&key);
+                                }
+                                continue;
+                            }
+                            Some(pos) => {
+                                let complete = bytes.slice(0..=pos);
+                                state.tracker.apply_read(n_bytes, Some(pos as u64));
+                                let tail = &bytes[pos + 1..];
+                                if tail.len() > MAX_REMAINDER_BYTES {
+                                    tracing::warn!(
+                                        source_key = ?key,
+                                        tail_bytes = tail.len(),
+                                        max_remainder_bytes = MAX_REMAINDER_BYTES,
+                                        "framed.remainder_overflow — tail after newline \
+                                         exceeds MAX_REMAINDER_BYTES; keeping last \
+                                         MAX_REMAINDER_BYTES bytes"
+                                    );
+                                    self.stats.inc_parse_errors(1);
+                                    let start = tail.len() - MAX_REMAINDER_BYTES;
+                                    state.remainder = tail[start..].to_vec();
+                                    state.format.reset();
+                                    state.overflow_tainted = true;
+                                } else {
+                                    state.remainder = tail.to_vec();
+                                }
+                                let line_count = memchr::memchr_iter(b'\n', &complete).count();
+                                self.stats.inc_lines(line_count as u64);
+                                if let FormatDecoder::PassthroughJson { stats, .. } = &state.format
+                                {
+                                    crate::format::count_json_parse_errors(&complete, stats);
+                                }
+                                Self::append_buffered_data(
+                                    dst,
+                                    &complete,
+                                    source_id,
+                                    &mut result_events,
+                                );
+                                continue;
+                            }
+                            None => {
+                                state.tracker.apply_read(n_bytes, None);
+                                if bytes.len() > MAX_REMAINDER_BYTES {
+                                    tracing::warn!(
+                                        source_key = ?key,
+                                        chunk_bytes = bytes.len(),
+                                        max_remainder_bytes = MAX_REMAINDER_BYTES,
+                                        "framed.remainder_overflow — partial line exceeds \
+                                         MAX_REMAINDER_BYTES; keeping last MAX_REMAINDER_BYTES \
+                                         bytes and resetting format state"
+                                    );
+                                    self.stats.inc_parse_errors(1);
+                                    let start = bytes.len() - MAX_REMAINDER_BYTES;
+                                    state.remainder = bytes[start..].to_vec();
+                                    state.format.reset();
+                                    state.overflow_tainted = true;
+                                } else {
+                                    state.remainder = bytes.to_vec();
+                                }
+                                continue;
+                            }
+                        }
+                    }
+
+                    let mut chunk = std::mem::take(&mut state.remainder);
+                    chunk.extend_from_slice(&bytes);
+                    let last_newline_pos = memchr::memrchr(b'\n', &chunk);
+                    let remainder_prefix_len = chunk.len() - bytes.len();
+                    let last_newline_in_new_bytes = last_newline_pos.and_then(|pos| {
+                        (pos >= remainder_prefix_len).then(|| (pos - remainder_prefix_len) as u64)
+                    });
+                    state.tracker.apply_read(n_bytes, last_newline_in_new_bytes);
+
+                    match last_newline_pos {
+                        Some(pos) => {
+                            if pos + 1 < chunk.len() {
+                                let mut tail = chunk.split_off(pos + 1);
+                                if tail.len() > MAX_REMAINDER_BYTES {
+                                    tracing::warn!(
+                                        source_key = ?key,
+                                        tail_bytes = tail.len(),
+                                        max_remainder_bytes = MAX_REMAINDER_BYTES,
+                                        "framed.remainder_overflow — partial line exceeds \
+                                         MAX_REMAINDER_BYTES; keeping last MAX_REMAINDER_BYTES \
+                                         bytes and resetting format state"
+                                    );
+                                    self.stats.inc_parse_errors(1);
+                                    let state = self.sources.get_mut(&key).expect("just inserted");
+                                    state.format.reset();
+                                    let start = tail.len() - MAX_REMAINDER_BYTES;
+                                    state.remainder = tail.split_off(start);
+                                    state.overflow_tainted = true;
+                                } else {
+                                    let state = self.sources.get_mut(&key).expect("just inserted");
+                                    state.remainder = tail;
+                                }
+                                chunk.truncate(pos + 1);
+                            }
+                        }
+                        None => {
+                            if chunk.len() > MAX_REMAINDER_BYTES {
+                                tracing::warn!(
+                                    source_key = ?key,
+                                    chunk_bytes = chunk.len(),
+                                    max_remainder_bytes = MAX_REMAINDER_BYTES,
+                                    "framed.remainder_overflow — partial line exceeds \
+                                     MAX_REMAINDER_BYTES; keeping last MAX_REMAINDER_BYTES \
+                                     bytes and resetting format state"
+                                );
+                                self.stats.inc_parse_errors(1);
+                                let state = self.sources.get_mut(&key).expect("just inserted");
+                                state.format.reset();
+                                let start = chunk.len() - MAX_REMAINDER_BYTES;
+                                state.remainder = chunk.split_off(start);
+                                state.overflow_tainted = true;
+                            } else {
+                                let state = self.sources.get_mut(&key).expect("just inserted");
+                                state.remainder = chunk;
+                            }
+                            continue;
+                        }
+                    }
+
+                    let state = self.sources.get_mut(&key).expect("just inserted");
+                    let mut process_start = 0usize;
+                    if tainted_on_entry && let Some(first_newline) = memchr::memchr(b'\n', &chunk) {
+                        process_start = first_newline + 1;
+                        state.overflow_tainted = false;
+                    }
+                    if process_start < chunk.len() {
+                        let chunk = &chunk[process_start..];
+                        let line_count = memchr::memchr_iter(b'\n', chunk).count();
+                        self.stats.inc_lines(line_count as u64);
+                        let start = dst.len();
+                        state.format.process_lines_with_metadata_into(
+                            chunk,
+                            dst,
+                            Some(&mut self.cri_metadata_buf),
+                        );
+                        if dst.len() > start {
+                            result_events.push(BufferedInputEvent::Data {
+                                range: start..dst.len(),
+                                source_id,
+                                cri_metadata: self.cri_metadata_for_emitted_data(),
+                            });
+                        }
+                    }
+
+                    if key.is_some()
+                        && self.inner.should_reclaim_completed_source_state()
+                        && self
+                            .sources
+                            .get(&key)
+                            .is_some_and(SourceState::is_reclaimable)
+                    {
+                        self.sources.remove(&key);
+                    }
+                }
+                InputEvent::Batch {
+                    batch,
+                    source_id,
+                    accounted_bytes,
+                } => {
+                    self.stats.inc_lines(batch.num_rows() as u64);
+                    self.stats.inc_bytes(accounted_bytes);
+                    result_events.push(BufferedInputEvent::Batch { batch, source_id });
+                }
+                InputEvent::Rotated { source_id } => {
+                    match source_id {
+                        Some(_) => {
+                            self.sources.remove(&source_id);
+                        }
+                        None => {
+                            self.sources.clear();
+                        }
+                    }
+                    result_events.push(BufferedInputEvent::Rotated { source_id });
+                }
+                InputEvent::Truncated { source_id } => {
+                    match source_id {
+                        Some(_) => {
+                            self.sources.remove(&source_id);
+                        }
+                        None => {
+                            self.sources.clear();
+                        }
+                    }
+                    result_events.push(BufferedInputEvent::Truncated { source_id });
+                }
+                InputEvent::EndOfFile { source_id } => {
+                    let keys_to_flush: Vec<Option<SourceId>> = match source_id {
+                        Some(_) => vec![source_id],
+                        None => self.sources.keys().copied().collect(),
+                    };
+                    for key in keys_to_flush {
+                        if let Some(state) = self.sources.get_mut(&key)
+                            && !state.remainder.is_empty()
+                        {
+                            let mut remainder = std::mem::take(&mut state.remainder);
+                            remainder.push(b'\n');
+                            let mut process_start = 0usize;
+                            if state.overflow_tainted {
+                                process_start =
+                                    memchr::memchr(b'\n', &remainder).map_or(0, |i| i + 1);
+                                state.overflow_tainted = false;
+                            }
+                            self.cri_metadata_buf.clear();
+                            let state = self.sources.get_mut(&key).expect("just checked existence");
+                            if process_start < remainder.len() {
+                                let emitted = &remainder[process_start..];
+                                let line_count = memchr::memchr_iter(b'\n', emitted).count();
+                                self.stats.inc_lines(line_count as u64);
+                                let start = dst.len();
+                                state.format.process_lines_with_metadata_into(
+                                    emitted,
+                                    dst,
+                                    Some(&mut self.cri_metadata_buf),
+                                );
+                                if dst.len() > start {
+                                    result_events.push(BufferedInputEvent::Data {
+                                        range: start..dst.len(),
+                                        source_id: key,
+                                        cri_metadata: self.cri_metadata_for_emitted_data(),
+                                    });
+                                }
+                            }
+                            let state = self.sources.get_mut(&key).expect("just checked existence");
+                            state.tracker.apply_remainder_consumed();
+                        }
+                        if self
+                            .sources
+                            .get(&key)
+                            .is_some_and(SourceState::is_reclaimable)
+                        {
+                            self.sources.remove(&key);
+                        }
+                    }
+                }
+            }
+        }
+
+        result_events
+    }
+
+    fn process_raw_events(&mut self, raw_events: Vec<InputEvent>) -> Vec<InputEvent> {
+        self.last_raw_had_payload = raw_events
+            .iter()
+            .any(|event| matches!(event, InputEvent::Data { .. } | InputEvent::Batch { .. }));
+        if raw_events.is_empty() {
+            return vec![];
+        }
+
+        let mut result_events: Vec<InputEvent> = Vec::new();
+
+        for event in raw_events {
+            match event {
+                InputEvent::Data {
+                    bytes,
+                    source_id,
+                    accounted_bytes,
+                    ..
+                } => {
+                    self.stats.inc_bytes(accounted_bytes);
+
+                    let key = source_id;
+                    let n_bytes = bytes.len() as u64;
+
+                    // Get or create per-source state.
+                    let state = {
+                        let template = &self.format_template;
+                        self.sources.entry(key).or_insert_with(|| SourceState {
+                            remainder: Vec::new(),
+                            format: template.new_instance(),
+                            tracker: CheckpointTracker::new(0),
+                            overflow_tainted: false,
+                        })
+                    };
+                    let tainted_on_entry = state.overflow_tainted;
+
+                    // --- ZERO-COPY FAST PATH ---
+                    // For passthrough formats with no remainder and no tainted
+                    // state, forward the Bytes directly without copying.
+                    if state.format.is_passthrough()
+                        && state.remainder.is_empty()
+                        && !tainted_on_entry
+                    {
+                        let last_nl = memchr::memrchr(b'\n', &bytes);
+                        match last_nl {
+                            Some(pos) if pos + 1 == bytes.len() => {
+                                // Entire chunk is complete lines — zero-copy pass.
+                                state.tracker.apply_read(n_bytes, Some(pos as u64));
+                                let line_count = memchr::memchr_iter(b'\n', &bytes).count();
+                                self.stats.inc_lines(line_count as u64);
+                                if let FormatDecoder::PassthroughJson { stats, .. } = &state.format
+                                {
+                                    crate::format::count_json_parse_errors(&bytes, stats);
+                                }
+                                result_events.push(InputEvent::Data {
+                                    bytes,
+                                    source_id,
+                                    accounted_bytes: 0,
+                                    cri_metadata: None,
+                                });
+                                if key.is_some()
+                                    && self.inner.should_reclaim_completed_source_state()
+                                    && self
+                                        .sources
+                                        .get(&key)
+                                        .is_some_and(SourceState::is_reclaimable)
+                                {
+                                    self.sources.remove(&key);
+                                }
+                                continue;
+                            }
+                            Some(pos) => {
+                                // Complete lines + remainder tail.
+                                let complete = bytes.slice(0..=pos);
+                                state.tracker.apply_read(n_bytes, Some(pos as u64));
+                                let tail = &bytes[pos + 1..];
+                                if tail.len() > MAX_REMAINDER_BYTES {
+                                    tracing::warn!(
+                                        source_key = ?key,
+                                        tail_bytes = tail.len(),
+                                        max_remainder_bytes = MAX_REMAINDER_BYTES,
+                                        "framed.remainder_overflow — tail after newline \
+                                         exceeds MAX_REMAINDER_BYTES; keeping last \
+                                         MAX_REMAINDER_BYTES bytes"
+                                    );
+                                    self.stats.inc_parse_errors(1);
+                                    let start = tail.len() - MAX_REMAINDER_BYTES;
+                                    state.remainder = tail[start..].to_vec();
+                                    state.format.reset();
+                                    state.overflow_tainted = true;
+                                } else {
+                                    state.remainder = tail.to_vec();
+                                }
+                                let line_count = memchr::memchr_iter(b'\n', &complete).count();
+                                self.stats.inc_lines(line_count as u64);
+                                if let FormatDecoder::PassthroughJson { stats, .. } = &state.format
+                                {
+                                    crate::format::count_json_parse_errors(&complete, stats);
+                                }
+                                result_events.push(InputEvent::Data {
+                                    bytes: complete,
+                                    source_id,
+                                    accounted_bytes: 0,
+                                    cri_metadata: None,
+                                });
+                                continue;
+                            }
+                            None => {
+                                // No newline — entire chunk is remainder.
+                                state.tracker.apply_read(n_bytes, None);
+                                if bytes.len() > MAX_REMAINDER_BYTES {
+                                    tracing::warn!(
+                                        source_key = ?key,
+                                        chunk_bytes = bytes.len(),
+                                        max_remainder_bytes = MAX_REMAINDER_BYTES,
+                                        "framed.remainder_overflow — partial line exceeds \
+                                         MAX_REMAINDER_BYTES; keeping last MAX_REMAINDER_BYTES \
+                                         bytes and resetting format state"
+                                    );
+                                    self.stats.inc_parse_errors(1);
+                                    let start = bytes.len() - MAX_REMAINDER_BYTES;
+                                    state.remainder = bytes[start..].to_vec();
+                                    state.format.reset();
+                                    state.overflow_tainted = true;
+                                } else {
+                                    state.remainder = bytes.to_vec();
+                                }
+                                continue;
+                            }
+                        }
+                    }
+                    // --- END ZERO-COPY FAST PATH ---
+
+                    // General path: prepend remainder from last poll,
+                    // reusing the Vec's capacity.
+                    let mut chunk = std::mem::take(&mut state.remainder);
+                    chunk.extend_from_slice(&bytes);
+
+                    // Find last newline — everything before is complete lines,
+                    // everything after is the new remainder.
+                    let last_newline_pos = memchr::memrchr(b'\n', &chunk);
+
+                    // Compute the last newline position relative to the NEW
+                    // bytes only (for the checkpoint tracker). The tracker
+                    // only sees bytes read from the file, not the remainder
+                    // prefix.
+                    let remainder_prefix_len = chunk.len() - bytes.len();
+                    // If the last newline is inside the old remainder (not
+                    // the new bytes), the tracker sees no newline in the read.
+                    let last_newline_in_new_bytes = last_newline_pos.and_then(|pos| {
+                        (pos >= remainder_prefix_len).then(|| (pos - remainder_prefix_len) as u64)
+                    });
+
+                    // Update checkpoint tracker with the new read.
+                    state.tracker.apply_read(n_bytes, last_newline_in_new_bytes);
+
+                    match last_newline_pos {
+                        Some(pos) => {
+                            if pos + 1 < chunk.len() {
+                                // Move tail to remainder without allocating.
+                                let mut tail = chunk.split_off(pos + 1);
+                                if tail.len() > MAX_REMAINDER_BYTES {
+                                    // Tail exceeds the per-source cap. Discard the
+                                    // oldest bytes and keep the most recent
+                                    // MAX_REMAINDER_BYTES so the source can
+                                    // eventually emit a complete line. Emit a warning
+                                    // so the data loss is not silent.
+                                    tracing::warn!(
+                                        source_key = ?key,
+                                        tail_bytes = tail.len(),
+                                        max_remainder_bytes = MAX_REMAINDER_BYTES,
+                                        "framed.remainder_overflow — partial line exceeds \
+                                         MAX_REMAINDER_BYTES; keeping last MAX_REMAINDER_BYTES \
+                                         bytes and resetting format state"
+                                    );
+                                    self.stats.inc_parse_errors(1);
+                                    let state = self.sources.get_mut(&key).expect("just inserted");
+                                    // Reset format so the next line starts from a clean
+                                    // state (the discarded prefix may have broken CRI P/F
+                                    // sequence alignment).
+                                    state.format.reset();
+                                    // Keep the tail of the overflow data in the remainder
+                                    // buffer so the next newline can complete it. Do NOT
+                                    // call apply_remainder_consumed() — the data is still
+                                    // pending and the checkpoint must not advance past it.
+                                    let start = tail.len() - MAX_REMAINDER_BYTES;
+                                    state.remainder = tail.split_off(start);
+                                    state.overflow_tainted = true;
+                                } else {
+                                    let state = self.sources.get_mut(&key).expect("just inserted");
+                                    state.remainder = tail;
+                                }
+                                chunk.truncate(pos + 1);
+                            }
+                        }
+                        None => {
+                            // No newline at all — entire chunk is remainder.
+                            if chunk.len() > MAX_REMAINDER_BYTES {
+                                // Same overflow policy as the tail case: warn, reset
+                                // format state, and keep the most recent bytes.
+                                tracing::warn!(
+                                    source_key = ?key,
+                                    chunk_bytes = chunk.len(),
+                                    max_remainder_bytes = MAX_REMAINDER_BYTES,
+                                    "framed.remainder_overflow — partial line exceeds \
+                                     MAX_REMAINDER_BYTES; keeping last MAX_REMAINDER_BYTES \
+                                     bytes and resetting format state"
+                                );
+                                self.stats.inc_parse_errors(1);
+                                let state = self.sources.get_mut(&key).expect("just inserted");
+                                state.format.reset();
+                                let start = chunk.len() - MAX_REMAINDER_BYTES;
+                                state.remainder = chunk.split_off(start);
+                                state.overflow_tainted = true;
+                                // Do NOT call apply_remainder_consumed() — data is preserved.
+                            } else {
+                                let state = self.sources.get_mut(&key).expect("just inserted");
+                                state.remainder = chunk;
+                            }
+                            continue;
+                        }
+                    }
+
+                    // Process complete lines through per-source format handler.
+                    self.out_buf.clear();
+                    self.cri_metadata_buf.clear();
+                    let state = self.sources.get_mut(&key).expect("just inserted");
+                    let mut process_start = 0usize;
+                    if tainted_on_entry {
+                        // Overflow truncation preserves a suffix of a long line.
+                        // Once a newline arrives, that first "line" is a
+                        // synthetic mid-line fragment and must be dropped.
+                        if let Some(first_newline) = memchr::memchr(b'\n', &chunk) {
+                            process_start = first_newline + 1;
+                            state.overflow_tainted = false;
+                        }
+                    }
+                    if process_start < chunk.len() {
+                        state.format.process_lines_with_metadata(
+                            &chunk[process_start..],
+                            &mut self.out_buf,
+                            Some(&mut self.cri_metadata_buf),
+                        );
+                    }
+                    let line_count = memchr::memchr_iter(b'\n', &chunk[process_start..]).count();
+                    self.stats.inc_lines(line_count as u64);
+
+                    if !self.out_buf.is_empty() {
+                        // Take out_buf's content, swap in spare_buf's capacity
+                        // for next iteration. No allocation — the 64KB bounces
+                        // between the two buffers.
+                        let data = std::mem::take(&mut self.out_buf);
+                        let cri_metadata = self.cri_metadata_for_emitted_data();
+                        std::mem::swap(&mut self.out_buf, &mut self.spare_buf);
+                        result_events.push(InputEvent::Data {
+                            bytes: Bytes::from(data),
+                            source_id,
+                            accounted_bytes: 0,
+                            cri_metadata,
+                        });
+                    }
+
+                    if key.is_some()
+                        && self.inner.should_reclaim_completed_source_state()
+                        && self
+                            .sources
+                            .get(&key)
+                            .is_some_and(SourceState::is_reclaimable)
+                    {
+                        self.sources.remove(&key);
+                    }
+                }
+                InputEvent::Batch {
+                    batch,
+                    source_id,
+                    accounted_bytes,
+                } => {
+                    self.stats.inc_lines(batch.num_rows() as u64);
+                    self.stats.inc_bytes(accounted_bytes);
+                    result_events.push(InputEvent::Batch {
+                        batch,
+                        source_id,
+                        accounted_bytes: 0,
+                    });
+                }
+                // Rotation/truncation: clear framing state + forward event.
+                //
+                // When source_id is known, clear only the affected source's
+                // state. When unknown (None), clear all sources as a
+                // conservative fallback.
+                event @ (InputEvent::Rotated { source_id }
+                | InputEvent::Truncated { source_id }) => {
+                    match source_id {
+                        Some(_) => {
+                            self.sources.remove(&source_id);
+                        }
+                        None => {
+                            self.sources.clear();
+                        }
+                    }
+                    result_events.push(event);
+                }
+                // End of file: flush any partial-line remainder.
+                //
+                // When a file ends without a trailing newline the last record
+                // sits in the remainder indefinitely.  Appending a synthetic
+                // `\n` lets the format processor treat it as a complete line so
+                // it reaches the scanner instead of being silently dropped.
+                //
+                // When source_id is known, flush only the affected source's
+                // remainder. When unknown (None), flush all remainders as a
+                // conservative fallback.
+                InputEvent::EndOfFile { source_id } => {
+                    let keys_to_flush: Vec<Option<SourceId>> = match source_id {
+                        Some(_) => vec![source_id],
+                        None => self.sources.keys().copied().collect(),
+                    };
+                    for key in keys_to_flush {
+                        if let Some(state) = self.sources.get_mut(&key)
+                            && !state.remainder.is_empty()
+                        {
+                            let mut remainder = std::mem::take(&mut state.remainder);
+                            remainder.push(b'\n');
+                            let mut process_start = 0usize;
+                            if state.overflow_tainted {
+                                process_start =
+                                    memchr::memchr(b'\n', &remainder).map_or(0, |i| i + 1);
+                                state.overflow_tainted = false;
+                            }
+
+                            self.out_buf.clear();
+                            self.cri_metadata_buf.clear();
+                            let state = self.sources.get_mut(&key).expect("just checked existence");
+                            if process_start < remainder.len() {
+                                state.format.process_lines_with_metadata(
+                                    &remainder[process_start..],
+                                    &mut self.out_buf,
+                                    Some(&mut self.cri_metadata_buf),
+                                );
+                            }
+                            let emitted_line_count =
+                                memchr::memchr_iter(b'\n', &remainder[process_start..]).count();
+                            self.stats.inc_lines(emitted_line_count as u64);
+
+                            // Remainder was flushed — update tracker so
+                            // checkpointable_offset advances past the
+                            // flushed bytes.
+                            let state = self.sources.get_mut(&key).expect("just checked existence");
+                            state.tracker.apply_remainder_consumed();
+
+                            if !self.out_buf.is_empty() {
+                                let data = std::mem::take(&mut self.out_buf);
+                                let cri_metadata = self.cri_metadata_for_emitted_data();
+                                std::mem::swap(&mut self.out_buf, &mut self.spare_buf);
+                                result_events.push(InputEvent::Data {
+                                    bytes: Bytes::from(data),
+                                    source_id: key,
+                                    accounted_bytes: 0,
+                                    cri_metadata,
+                                });
+                            }
+                        }
+                        // Reclaim only completed EOF state. CRI P/F assembly
+                        // can hold pending data even when the line remainder
+                        // is empty, and file-tail EOF can be an idle signal
+                        // rather than a terminal source event.
+                        if self
+                            .sources
+                            .get(&key)
+                            .is_some_and(SourceState::is_reclaimable)
+                        {
+                            self.sources.remove(&key);
+                        }
+                    }
+                }
+            }
+        }
+
+        result_events
+    }
+}
+
+impl InputSource for FramedInput {
+    fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+        let raw_events = self.inner.poll()?;
+        Ok(self.process_raw_events(raw_events))
+    }
+
+    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+        let raw_events = self.inner.poll()?;
+        Ok(Some(self.process_raw_events_into(raw_events, dst)))
+    }
+
+    fn poll_shutdown(&mut self) -> io::Result<Vec<InputEvent>> {
+        let raw_events = self.inner.poll_shutdown()?;
+        Ok(self.process_raw_events(raw_events))
+    }
+
+    fn poll_shutdown_into(
+        &mut self,
+        dst: &mut BytesMut,
+    ) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+        let raw_events = self.inner.poll_shutdown()?;
+        Ok(Some(self.process_raw_events_into(raw_events, dst)))
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn health(&self) -> ComponentHealth {
+        self.inner.health()
+    }
+
+    fn is_finished(&self) -> bool {
+        self.inner.is_finished()
+    }
+
+    fn apply_hints(&mut self, hints: &FilterHints) {
+        self.inner.apply_hints(hints);
+    }
+
+    fn get_cadence(&self) -> InputCadence {
+        let mut cadence = self.inner.get_cadence();
+        cadence.signal.had_data |= self.last_raw_had_payload;
+        cadence
+    }
+
+    /// Return checkpoint offsets from the Kani-proven CheckpointTracker.
+    ///
+    /// Each per-source tracker maintains the relationship between the file
+    /// read offset and the last complete newline boundary. The
+    /// `checkpointable_offset()` is always at a newline boundary, so a
+    /// crash + restart from that offset will not skip any unprocessed data.
+    ///
+    /// This replaces ad-hoc `offset.saturating_sub(remainder_len)` with
+    /// the same proven arithmetic from `CheckpointTracker`.
+    fn checkpoint_data(&self) -> Vec<(SourceId, ByteOffset)> {
+        self.inner
+            .checkpoint_data()
+            .into_iter()
+            .map(|(sid, offset)| {
+                let checkpointable = self.sources.get(&Some(sid)).map_or(offset.0, |state| {
+                    // The tracker's checkpointable_offset is relative to
+                    // the tracker's cumulative read_offset. We need to
+                    // translate: the inner source reports absolute file
+                    // offset, and the tracker reports how much remainder
+                    // to subtract.
+                    let remainder_len = state.tracker.remainder_len();
+                    offset.0.saturating_sub(remainder_len)
+                });
+                (sid, ByteOffset(checkpointable))
+            })
+            .collect()
+    }
+
+    fn source_paths(&self) -> Vec<(SourceId, std::path::PathBuf)> {
+        self.inner.source_paths()
+    }
+
+    fn should_reclaim_completed_source_state(&self) -> bool {
+        self.inner.should_reclaim_completed_source_state()
+    }
+
+    fn set_offset_by_source(&mut self, source_id: SourceId, offset: u64) {
+        self.inner.set_offset_by_source(source_id, offset);
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    include!("framed/tests/basic.rs");
-    include!("framed/tests/framing.rs");
-    include!("framed/tests/source_state.rs");
+    use super::*;
+    use arrow::array::{Int64Array, StringArray};
+    use arrow::datatypes::{DataType, Field, Schema};
+    use arrow::record_batch::RecordBatch;
+    use std::collections::VecDeque;
+
+    /// Mock input source for testing.
+    struct MockSource {
+        name: String,
+        events: VecDeque<Vec<InputEvent>>,
+        shutdown_events: VecDeque<Vec<InputEvent>>,
+        offsets: Vec<(SourceId, ByteOffset)>,
+        source_paths: Vec<(SourceId, std::path::PathBuf)>,
+        health: ComponentHealth,
+        cadence_signal: PollCadenceSignal,
+        cadence_max: u8,
+    }
+
+    impl MockSource {
+        fn new(batches: Vec<Vec<InputEvent>>) -> Self {
+            Self {
+                name: "mock".to_string(),
+                events: batches.into(),
+                shutdown_events: VecDeque::new(),
+                offsets: vec![],
+                source_paths: vec![],
+                health: ComponentHealth::Healthy,
+                cadence_signal: PollCadenceSignal::default(),
+                cadence_max: 0,
+            }
+        }
+
+        fn from_chunks(chunks: Vec<&[u8]>) -> Self {
+            Self::new(
+                chunks
+                    .into_iter()
+                    .map(|c| {
+                        vec![InputEvent::Data {
+                            bytes: Bytes::from(c.to_vec()),
+                            source_id: None,
+                            accounted_bytes: c.len() as u64,
+                            cri_metadata: None,
+                        }]
+                    })
+                    .collect(),
+            )
+        }
+
+        /// Like `from_chunks`, but tags every event with `Some(sid)` so that
+        /// `FramedInput::checkpoint_data()` can actually find the per-source
+        /// state under `Some(SourceId)` instead of falling back to the raw
+        /// offset.  Use this whenever a test needs to assert `checkpoint_data`.
+        fn from_chunks_with_source(chunks: Vec<&[u8]>, sid: SourceId) -> Self {
+            Self::new(
+                chunks
+                    .into_iter()
+                    .map(|c| {
+                        vec![InputEvent::Data {
+                            bytes: Bytes::from(c.to_vec()),
+                            source_id: Some(sid),
+                            accounted_bytes: c.len() as u64,
+                            cri_metadata: None,
+                        }]
+                    })
+                    .collect(),
+            )
+        }
+
+        fn with_offsets(mut self, offsets: Vec<(SourceId, ByteOffset)>) -> Self {
+            self.offsets = offsets;
+            self
+        }
+
+        fn with_shutdown_events(mut self, events: Vec<Vec<InputEvent>>) -> Self {
+            self.shutdown_events = events.into();
+            self
+        }
+
+        fn with_source_paths(mut self, source_paths: Vec<(SourceId, std::path::PathBuf)>) -> Self {
+            self.source_paths = source_paths;
+            self
+        }
+
+        fn with_health(mut self, health: ComponentHealth) -> Self {
+            self.health = health;
+            self
+        }
+
+        fn with_cadence(mut self, signal: PollCadenceSignal, max: u8) -> Self {
+            self.cadence_signal = signal;
+            self.cadence_max = max;
+            self
+        }
+    }
+
+    impl InputSource for MockSource {
+        fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+            Ok(self.events.pop_front().unwrap_or_default())
+        }
+
+        fn poll_shutdown(&mut self) -> io::Result<Vec<InputEvent>> {
+            Ok(self.shutdown_events.pop_front().unwrap_or_default())
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn health(&self) -> ComponentHealth {
+            self.health
+        }
+
+        fn checkpoint_data(&self) -> Vec<(SourceId, ByteOffset)> {
+            self.offsets.clone()
+        }
+
+        fn source_paths(&self) -> Vec<(SourceId, std::path::PathBuf)> {
+            self.source_paths.clone()
+        }
+
+        fn get_cadence(&self) -> InputCadence {
+            InputCadence {
+                signal: self.cadence_signal,
+                adaptive_fast_polls_max: self.cadence_max,
+            }
+        }
+    }
+
+    fn make_stats() -> Arc<ComponentStats> {
+        Arc::new(ComponentStats::new())
+    }
+
+    fn make_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("msg", DataType::Utf8, true),
+            Field::new("seq", DataType::Int64, true),
+        ]));
+        let msg = StringArray::from(vec![Some("alpha"), Some("beta")]);
+        let seq = Int64Array::from(vec![Some(1), Some(2)]);
+        RecordBatch::try_new(schema, vec![Arc::new(msg), Arc::new(seq)]).expect("batch")
+    }
+
+    fn collect_data(events: Vec<InputEvent>) -> Vec<u8> {
+        let mut out = Vec::new();
+        for e in events {
+            if let InputEvent::Data { bytes, .. } = e {
+                out.extend_from_slice(&bytes);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn passthrough_complete_lines() {
+        let stats = make_stats();
+        let source = MockSource::from_chunks(vec![b"line1\nline2\n"]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        let events = framed.poll().unwrap();
+        assert_eq!(collect_data(events), b"line1\nline2\n");
+    }
+
+    #[test]
+    fn passthrough_poll_into_appends_complete_lines() {
+        let stats = make_stats();
+        let source = MockSource::from_chunks(vec![b"line1\nline2\n"]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+        let mut dst = BytesMut::from(&b"seed\n"[..]);
+
+        let events = framed
+            .poll_into(&mut dst)
+            .expect("poll_into")
+            .expect("passthrough path available");
+
+        assert_eq!(dst.as_ref(), b"seed\nline1\nline2\n");
+        assert_eq!(events.len(), 1);
+        let BufferedInputEvent::Data {
+            range, source_id, ..
+        } = &events[0]
+        else {
+            panic!("expected appended data event");
+        };
+        assert_eq!(source_id, &None);
+        assert_eq!(&dst[range.clone()], b"line1\nline2\n");
+    }
+
+    #[test]
+    fn passthrough_poll_shutdown_into_flushes_remainder() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"partial"),
+            source_id: None,
+            accounted_bytes: 7,
+            cri_metadata: None,
+        }]])
+        .with_shutdown_events(vec![vec![InputEvent::EndOfFile { source_id: None }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+        let mut dst = BytesMut::new();
+
+        let first = framed
+            .poll_into(&mut dst)
+            .expect("poll_into")
+            .expect("passthrough path available");
+        assert!(first.is_empty());
+        assert!(dst.is_empty());
+
+        let shutdown = framed
+            .poll_shutdown_into(&mut dst)
+            .expect("shutdown poll_into")
+            .expect("passthrough path available");
+
+        assert_eq!(shutdown.len(), 1);
+        assert_eq!(dst.as_ref(), b"partial\n");
+    }
+
+    #[test]
+    fn cri_poll_into_reassembles_and_tracks_metadata() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"2024-01-15T10:30:00Z stdout P {\"msg\":\n"),
+                source_id: None,
+                accounted_bytes: 40,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"2024-01-15T10:30:00Z stdout F \"hello\"}\n"),
+                source_id: None,
+                accounted_bytes: 43,
+                cri_metadata: None,
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            stats,
+        );
+        let mut dst = BytesMut::from(&b"seed\n"[..]);
+
+        let first = framed
+            .poll_into(&mut dst)
+            .expect("first poll_into")
+            .expect("buffered path available");
+        assert!(first.is_empty());
+        assert_eq!(dst.as_ref(), b"seed\n");
+
+        let second = framed
+            .poll_into(&mut dst)
+            .expect("second poll_into")
+            .expect("buffered path available");
+
+        assert_eq!(second.len(), 1);
+        let BufferedInputEvent::Data {
+            range,
+            source_id,
+            cri_metadata,
+        } = &second[0]
+        else {
+            panic!("expected data event");
+        };
+        assert_eq!(*source_id, None);
+        assert_eq!(&dst[range.clone()], b"{\"msg\":\"hello\"}\n");
+
+        let metadata = cri_metadata.as_ref().expect("CRI metadata");
+        assert_eq!(metadata.rows, 1);
+        assert!(metadata.has_values);
+        assert_eq!(metadata.spans.len(), 1);
+        let values = metadata.spans[0]
+            .values
+            .as_ref()
+            .expect("non-null span values");
+        assert_eq!(metadata.timestamp(values), b"2024-01-15T10:30:00Z");
+        assert_eq!(values.stream.as_str(), "stdout");
+    }
+
+    #[test]
+    fn auto_poll_shutdown_into_flushes_rewritten_remainder() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"not a cri line"),
+            source_id: None,
+            accounted_bytes: 14,
+            cri_metadata: None,
+        }]])
+        .with_shutdown_events(vec![vec![InputEvent::EndOfFile { source_id: None }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::auto(2 * 1024 * 1024, Arc::clone(&stats)),
+            stats,
+        );
+        let mut dst = BytesMut::new();
+
+        let first = framed
+            .poll_into(&mut dst)
+            .expect("poll_into")
+            .expect("buffered path available");
+        assert!(first.is_empty());
+        assert!(dst.is_empty());
+
+        let shutdown = framed
+            .poll_shutdown_into(&mut dst)
+            .expect("shutdown poll_into")
+            .expect("buffered path available");
+
+        assert_eq!(shutdown.len(), 1);
+        let BufferedInputEvent::Data {
+            range,
+            cri_metadata,
+            ..
+        } = &shutdown[0]
+        else {
+            panic!("expected data event");
+        };
+        assert_eq!(&dst[range.clone()], b"{\"body\":\"not a cri line\"}\n");
+
+        let metadata = cri_metadata.as_ref().expect("null-row CRI sidecar");
+        assert_eq!(metadata.rows, 1);
+        assert!(!metadata.has_values);
+        assert_eq!(metadata.spans.len(), 1);
+        assert!(metadata.spans[0].values.is_none());
+    }
+
+    #[test]
+    #[cfg_attr(not(miri), ignore = "miri-targeted shared-buffer regression")]
+    fn poll_into_miri_shared_buffer_alias_regression() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"line-1\nline-2\n"),
+                source_id: Some(SourceId(7)),
+                accounted_bytes: 14,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"line-3\n"),
+                source_id: Some(SourceId(7)),
+                accounted_bytes: 7,
+                cri_metadata: None,
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+        let mut dst = BytesMut::with_capacity(64);
+
+        let first = framed
+            .poll_into(&mut dst)
+            .expect("first poll_into")
+            .expect("shared-buffer path available");
+        assert_eq!(first.len(), 1);
+        let first_range = match &first[0] {
+            BufferedInputEvent::Data {
+                range, source_id, ..
+            } => {
+                assert_eq!(*source_id, Some(SourceId(7)));
+                range.clone()
+            }
+            _ => panic!("expected data event"),
+        };
+        let first_snapshot = dst[first_range.clone()].to_vec();
+        assert_eq!(first_snapshot, b"line-1\nline-2\n");
+
+        let second = framed
+            .poll_into(&mut dst)
+            .expect("second poll_into")
+            .expect("shared-buffer path available");
+        assert_eq!(second.len(), 1);
+        let second_range = match &second[0] {
+            BufferedInputEvent::Data {
+                range, source_id, ..
+            } => {
+                assert_eq!(*source_id, Some(SourceId(7)));
+                range.clone()
+            }
+            _ => panic!("expected data event"),
+        };
+
+        assert_eq!(&dst[first_range], b"line-1\nline-2\n");
+        assert_eq!(&dst[second_range], b"line-3\n");
+    }
+
+    #[test]
+    #[ignore = "benchmark (directional)"]
+    fn bench_poll_into_shared_buffer_directional() {
+        use std::time::Instant;
+
+        const LINES: usize = 4_096;
+        const ITERS: usize = 100;
+
+        let payload: Vec<u8> = (0..LINES)
+            .flat_map(|idx| format!("{{\"msg\":\"line-{idx}\"}}\n").into_bytes())
+            .collect();
+
+        let mut poll_elapsed = std::time::Duration::ZERO;
+        let mut poll_into_elapsed = std::time::Duration::ZERO;
+
+        for _ in 0..ITERS {
+            let stats = make_stats();
+            let source = MockSource::from_chunks(vec![payload.as_slice()]);
+            let mut framed = FramedInput::new(
+                Box::new(source),
+                FormatDecoder::passthrough(Arc::clone(&stats)),
+                stats,
+            );
+            let start = Instant::now();
+            let events = framed.poll().expect("poll");
+            poll_elapsed += start.elapsed();
+            assert_eq!(collect_data(events), payload);
+
+            let stats = make_stats();
+            let source = MockSource::from_chunks(vec![payload.as_slice()]);
+            let mut framed = FramedInput::new(
+                Box::new(source),
+                FormatDecoder::passthrough(Arc::clone(&stats)),
+                stats,
+            );
+            let mut dst = BytesMut::new();
+            let start = Instant::now();
+            let events = framed
+                .poll_into(&mut dst)
+                .expect("poll_into")
+                .expect("shared-buffer path available");
+            poll_into_elapsed += start.elapsed();
+            assert_eq!(events.len(), 1);
+            assert_eq!(dst.as_ref(), payload.as_slice());
+        }
+
+        eprintln!(
+            "framed shared-buffer directional bench: poll={:?} poll_into={:?} ratio={:.3}",
+            poll_elapsed,
+            poll_into_elapsed,
+            poll_into_elapsed.as_secs_f64() / poll_elapsed.as_secs_f64()
+        );
+    }
+
+    #[test]
+    fn framed_input_forwards_inner_health() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![]).with_health(ComponentHealth::Degraded);
+        let framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        assert_eq!(framed.health(), ComponentHealth::Degraded);
+    }
+
+    #[test]
+    fn framed_input_forwards_cadence_snapshot() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![]).with_cadence(
+            PollCadenceSignal {
+                had_data: true,
+                hit_read_budget: true,
+            },
+            7,
+        );
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        let _ = framed.poll().expect("framed poll should succeed");
+        assert_eq!(
+            framed.get_cadence(),
+            InputCadence {
+                signal: PollCadenceSignal {
+                    had_data: true,
+                    hit_read_budget: true,
+                },
+                adaptive_fast_polls_max: 7,
+            }
+        );
+    }
+
+    #[test]
+    fn framed_input_reports_raw_shutdown_payload_when_output_is_empty() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![]).with_shutdown_events(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"partial"),
+            source_id: Some(SourceId(1)),
+            accounted_bytes: 7,
+            cri_metadata: None,
+        }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        let events = framed
+            .poll_shutdown()
+            .expect("shutdown poll should succeed");
+        assert!(events.is_empty());
+        assert!(framed.get_cadence().signal.had_data);
+    }
+
+    #[test]
+    fn remainder_across_polls() {
+        let stats = make_stats();
+        let source = MockSource::from_chunks(vec![b"hello\nwor", b"ld\n"]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        // First poll: "hello\n" is complete, "wor" is remainder
+        let events1 = framed.poll().unwrap();
+        assert_eq!(collect_data(events1), b"hello\n");
+
+        // Second poll: remainder "wor" + "ld\n" → "world\n"
+        let events2 = framed.poll().unwrap();
+        assert_eq!(collect_data(events2), b"world\n");
+    }
+
+    #[test]
+    fn no_newline_becomes_remainder() {
+        let stats = make_stats();
+        let source = MockSource::from_chunks(vec![b"partial", b"more\n"]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        // First poll: no newline, everything goes to remainder
+        let events1 = framed.poll().unwrap();
+        assert!(collect_data(events1).is_empty());
+
+        // Second poll: remainder + new data → complete line
+        let events2 = framed.poll().unwrap();
+        assert_eq!(collect_data(events2), b"partialmore\n");
+    }
+
+    #[test]
+    fn batch_events_increment_stats() {
+        let stats = make_stats();
+        let batch = make_batch();
+        let expected_rows = batch.num_rows() as u64;
+        let expected_bytes = 1234;
+        let source = MockSource::new(vec![vec![InputEvent::Batch {
+            batch,
+            source_id: None,
+            accounted_bytes: expected_bytes,
+        }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        let events = framed.poll().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], InputEvent::Batch { .. }));
+        assert_eq!(stats.lines(), expected_rows);
+        assert_eq!(stats.bytes(), expected_bytes);
+    }
+
+    #[test]
+    fn data_events_use_accounted_bytes_for_stats() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"line\n"),
+            source_id: None,
+            accounted_bytes: 99,
+            cri_metadata: None,
+        }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        let events = framed.poll().unwrap();
+        assert_eq!(collect_data(events), b"line\n");
+        assert_eq!(stats.lines(), 1);
+        assert_eq!(stats.bytes(), 99);
+    }
+
+    #[test]
+    fn remainder_capped_at_max_and_tainted_line_is_dropped() {
+        let stats = make_stats();
+        // Send > 2 MiB without a newline.
+        let big = vec![b'x'; MAX_REMAINDER_BYTES + 1];
+        let source = MockSource::from_chunks(vec![&big, b"\n"]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        // First poll: no newline, overflow triggers parse_error.
+        let events = framed.poll().unwrap();
+        assert!(collect_data(events).is_empty());
+        assert_eq!(
+            stats
+                .parse_errors_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        // The overflow remainder is capped but NOT discarded.
+        let state = framed.sources.get(&None).unwrap();
+        assert_eq!(
+            state.remainder.len(),
+            MAX_REMAINDER_BYTES,
+            "overflow remainder must be capped to MAX_REMAINDER_BYTES, not dropped"
+        );
+
+        // Second poll: newline completes only the tainted fragment; it must be dropped.
+        let events2 = framed.poll().unwrap();
+        let data2 = collect_data(events2);
+        assert!(
+            data2.is_empty(),
+            "tainted overflow remainder must be discarded when the first newline arrives"
+        );
+    }
+
+    #[test]
+    fn tail_after_newline_is_capped_at_max_and_tainted_line_is_dropped() {
+        let stats = make_stats();
+        let mut chunk = b"ok\n".to_vec();
+        chunk.extend(vec![b'x'; MAX_REMAINDER_BYTES + 1]);
+        let source = MockSource::from_chunks(vec![&chunk, b"\n"]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        // First poll: "ok\n" emitted; overflow tail triggers parse_error and
+        // is preserved as remainder (last MAX_REMAINDER_BYTES bytes).
+        let events = framed.poll().unwrap();
+        assert_eq!(collect_data(events), b"ok\n");
+        assert_eq!(
+            stats
+                .parse_errors_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
+        // The overflow remainder is preserved (not silently dropped).
+        let state = framed.sources.get(&None).unwrap();
+        assert_eq!(
+            state.remainder.len(),
+            MAX_REMAINDER_BYTES,
+            "overflow tail must be truncated to MAX_REMAINDER_BYTES, not dropped"
+        );
+
+        // Second poll: newline terminates only tainted overflow bytes; that
+        // line must be discarded.
+        let events2 = framed.poll().unwrap();
+        let data2 = collect_data(events2);
+        assert!(
+            data2.is_empty(),
+            "tainted overflow remainder must be discarded when the first newline arrives"
+        );
+    }
+
+    /// Regression for #1030: after remainder overflow, the first completed
+    /// line is a truncated mid-line fragment and must be discarded.
+    #[test]
+    fn overflow_fragment_is_discarded_when_newline_arrives() {
+        let stats = make_stats();
+        let big = vec![b'x'; MAX_REMAINDER_BYTES + 1];
+        let source = MockSource::from_chunks(vec![&big, b"\nreal-line\n"]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        // First poll: overflow, nothing emitted.
+        let events1 = framed.poll().unwrap();
+        assert!(collect_data(events1).is_empty());
+
+        // Second poll: truncated overflow fragment must be dropped, while the
+        // next complete real line is preserved.
+        let events2 = framed.poll().unwrap();
+        assert_eq!(collect_data(events2), b"real-line\n");
+    }
+
+    #[test]
+    fn checkpoint_advances_after_tainted_fragment_is_discarded() {
+        let stats = make_stats();
+        let sid = SourceId(9);
+        let big = vec![b'x'; MAX_REMAINDER_BYTES + 1];
+        let first = big.len() as u64;
+        let second_bytes = b"\nreal-line\n";
+        let total = first + second_bytes.len() as u64;
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from(big),
+                source_id: Some(sid),
+                accounted_bytes: 0,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::Data {
+                bytes: Bytes::from(second_bytes.to_vec()),
+                source_id: Some(sid),
+                accounted_bytes: 0,
+                cri_metadata: None,
+            }],
+        ])
+        .with_offsets(vec![(sid, ByteOffset(total))]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        let _ = framed.poll().unwrap();
+        let cp1 = framed.checkpoint_data();
+        assert!(
+            cp1[0].1.0 < total,
+            "checkpoint must stay behind raw offset while overflow remainder is buffered"
+        );
+
+        let events2 = framed.poll().unwrap();
+        assert_eq!(collect_data(events2), b"real-line\n");
+        let cp2 = framed.checkpoint_data();
+        assert_eq!(cp2[0].1, ByteOffset(total));
+    }
+
+    /// `checkpoint_data()` must account for overflow remainder when the source
+    /// has a real `SourceId`.  With `source_id: None` the lookup in
+    /// `self.sources.get(&Some(sid))` silently falls back to the raw offset,
+    /// making the assertion trivially true regardless of correctness.  This
+    /// test uses `from_chunks_with_source` so the per-source state is actually
+    /// keyed under `Some(SourceId(1))` and the checkpoint path is exercised.
+    #[test]
+    fn checkpoint_data_accounts_for_overflow_remainder() {
+        let stats = make_stats();
+        let sid = SourceId(1);
+        // The inner source claims it has read `big.len()` bytes.  We set the
+        // reported offset to exactly that many bytes so the checkpoint must
+        // subtract the remainder to be correct.
+        let big_len = MAX_REMAINDER_BYTES + 1;
+        let big = vec![b'x'; big_len];
+        // Reported offset equals the number of bytes the inner source has
+        // "read" so far: big_len bytes with no newline.
+        let reported_offset = big_len as u64;
+        let source = MockSource::from_chunks_with_source(vec![&big, b"\n"], sid)
+            .with_offsets(vec![(sid, ByteOffset(reported_offset))]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        // First poll: no newline — overflow triggers parse_error and remainder
+        // is capped to MAX_REMAINDER_BYTES.
+        let _ = framed.poll().unwrap();
+
+        // The per-source state must be reachable under Some(sid).
+        let state = framed.sources.get(&Some(sid)).unwrap();
+        assert_eq!(state.remainder.len(), MAX_REMAINDER_BYTES);
+
+        // checkpoint_data() must subtract the remainder length from the raw
+        // offset, not return the raw offset unchanged.
+        let cp = framed.checkpoint_data();
+        assert_eq!(cp.len(), 1, "expected exactly one checkpoint entry");
+        let (cp_sid, cp_offset) = cp[0];
+        assert_eq!(cp_sid, sid);
+        // The checkpointable offset must be strictly less than the reported
+        // offset because there is an undelivered remainder buffered.
+        assert!(
+            cp_offset.0 < reported_offset,
+            "checkpoint offset ({}) must be less than raw offset ({}) when remainder is buffered",
+            cp_offset.0,
+            reported_offset
+        );
+    }
+
+    /// `checkpoint_data()` must account for the overflow tail remainder when
+    /// a newline precedes the overflow.  Uses `from_chunks_with_source` so the
+    /// assertion exercises the real `self.sources.get(&Some(sid))` path.
+    #[test]
+    fn checkpoint_data_accounts_for_overflow_tail_remainder() {
+        let stats = make_stats();
+        let sid = SourceId(1);
+        let mut chunk = b"ok\n".to_vec();
+        chunk.extend(vec![b'x'; MAX_REMAINDER_BYTES + 1]);
+        let chunk_len = chunk.len() as u64;
+        let source = MockSource::from_chunks_with_source(vec![&chunk, b"\n"], sid)
+            .with_offsets(vec![(sid, ByteOffset(chunk_len))]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        // First poll: "ok\n" is emitted and the overflow tail becomes the
+        // remainder (capped to MAX_REMAINDER_BYTES).
+        let events = framed.poll().unwrap();
+        assert_eq!(collect_data(events), b"ok\n");
+
+        // Per-source state is keyed under Some(sid).
+        let state = framed.sources.get(&Some(sid)).unwrap();
+        assert_eq!(state.remainder.len(), MAX_REMAINDER_BYTES);
+
+        // The checkpoint must be behind the raw offset because the remainder
+        // has not yet been delivered as a complete line.
+        let cp = framed.checkpoint_data();
+        assert_eq!(cp.len(), 1);
+        let (cp_sid, cp_offset) = cp[0];
+        assert_eq!(cp_sid, sid);
+        assert!(
+            cp_offset.0 < chunk_len,
+            "checkpoint offset ({}) must be less than raw offset ({}) when overflow tail is buffered",
+            cp_offset.0,
+            chunk_len
+        );
+    }
+
+    #[test]
+    fn rotated_clears_remainder_and_format() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"partial"),
+                source_id: None,
+                accounted_bytes: 7,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::Rotated { source_id: None }],
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"fresh\n"),
+                source_id: None,
+                accounted_bytes: 6,
+                cri_metadata: None,
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        // Partial goes to remainder
+        let _ = framed.poll().unwrap();
+
+        // Rotation clears remainder
+        let events2 = framed.poll().unwrap();
+        assert!(
+            events2
+                .iter()
+                .any(|e| matches!(e, InputEvent::Rotated { .. }))
+        );
+
+        // Fresh data starts clean (no stale "partial" prefix)
+        let events3 = framed.poll().unwrap();
+        assert_eq!(collect_data(events3), b"fresh\n");
+    }
+
+    #[test]
+    fn cri_format_extracts_messages() {
+        let stats = make_stats();
+        let input = b"2024-01-15T10:30:00Z stdout F {\"msg\":\"hello\"}\n";
+        let source = MockSource::from_chunks(vec![input.as_slice()]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            stats,
+        );
+
+        let events = framed.poll().unwrap();
+        assert_eq!(collect_data(events), b"{\"msg\":\"hello\"}\n");
+    }
+
+    #[test]
+    fn cri_format_emits_metadata_sidecar() {
+        let stats = make_stats();
+        let input = b"2024-01-15T10:30:00Z stdout F {\"msg\":\"hello\"}\n";
+        let source = MockSource::from_chunks(vec![input.as_slice()]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            stats,
+        );
+
+        let events = framed.poll().unwrap();
+        let InputEvent::Data {
+            bytes,
+            cri_metadata: Some(metadata),
+            ..
+        } = &events[0]
+        else {
+            panic!("expected data event with CRI metadata");
+        };
+        assert_eq!(bytes.as_ref(), b"{\"msg\":\"hello\"}\n");
+        assert_eq!(metadata.rows, 1);
+        let values = metadata.spans[0].values.as_ref().expect("metadata values");
+        assert_eq!(metadata.timestamp(values), b"2024-01-15T10:30:00Z");
+        assert_eq!(values.stream.as_str(), "stdout");
+    }
+
+    #[test]
+    fn split_anywhere_produces_same_output() {
+        let stats = make_stats();
+        let full_input = b"{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n";
+
+        // Reference: process entire input at once
+        let source_full = MockSource::from_chunks(vec![full_input.as_slice()]);
+        let mut framed_full = FramedInput::new(
+            Box::new(source_full),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+        let reference = collect_data(framed_full.poll().unwrap());
+
+        // Split at every possible byte position
+        for split_at in 1..full_input.len() {
+            let stats2 = make_stats();
+            let chunk1 = &full_input[..split_at];
+            let chunk2 = &full_input[split_at..];
+            let source = MockSource::from_chunks(vec![chunk1, chunk2]);
+            let mut framed = FramedInput::new(
+                Box::new(source),
+                FormatDecoder::passthrough(Arc::clone(&stats2)),
+                stats2,
+            );
+
+            let mut collected = collect_data(framed.poll().unwrap());
+            collected.extend_from_slice(&collect_data(framed.poll().unwrap()));
+
+            assert_eq!(
+                collected, reference,
+                "split at byte {split_at} produced different output"
+            );
+        }
+    }
+
+    /// A file (or any source) that ends without a trailing newline must not
+    /// silently drop its last record.  The `EndOfFile` event causes
+    /// `FramedInput` to flush the remainder buffer with a synthetic newline.
+    #[test]
+    fn eof_flushes_remainder() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"no-newline"),
+                source_id: None,
+                accounted_bytes: 10,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::EndOfFile { source_id: None }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(stats.clone()),
+            stats,
+        );
+
+        // First poll: data with no newline — goes to remainder, nothing emitted.
+        let events1 = framed.poll().unwrap();
+        assert!(collect_data(events1).is_empty());
+
+        // Second poll: EndOfFile flushes the remainder as a complete line.
+        let events2 = framed.poll().unwrap();
+        assert_eq!(collect_data(events2), b"no-newline\n");
+    }
+
+    /// Runtime shutdown is a terminal lifecycle event: when the wrapped source
+    /// emits EOF from `poll_shutdown`, `FramedInput` must flush bytes that were
+    /// already held in its per-source remainder buffer.
+    #[test]
+    fn poll_shutdown_flushes_existing_remainder() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"no-newline"),
+            source_id: None,
+            accounted_bytes: 10,
+            cri_metadata: None,
+        }]])
+        .with_shutdown_events(vec![vec![InputEvent::EndOfFile { source_id: None }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(stats.clone()),
+            stats,
+        );
+
+        let events1 = framed.poll().unwrap();
+        assert!(collect_data(events1).is_empty());
+
+        let events2 = framed.poll_shutdown().unwrap();
+        assert_eq!(collect_data(events2), b"no-newline\n");
+    }
+
+    /// Multiple records in a file where only the last one lacks a newline:
+    /// all records must be emitted.
+    #[test]
+    fn eof_flushes_only_partial_remainder() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"complete\npartial"),
+                source_id: None,
+                accounted_bytes: 16,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::EndOfFile { source_id: None }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(stats.clone()),
+            stats,
+        );
+
+        // First poll: "complete\n" is emitted; "partial" stays in remainder.
+        let events1 = framed.poll().unwrap();
+        assert_eq!(collect_data(events1), b"complete\n");
+
+        // Second poll: EndOfFile flushes "partial" with a synthetic newline.
+        let events2 = framed.poll().unwrap();
+        assert_eq!(collect_data(events2), b"partial\n");
+    }
+
+    /// A redundant EndOfFile (no bytes in remainder) must produce no output.
+    #[test]
+    fn eof_with_empty_remainder_is_noop() {
+        let stats = make_stats();
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"line\n"),
+                source_id: None,
+                accounted_bytes: 5,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::EndOfFile { source_id: None }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(stats.clone()),
+            stats,
+        );
+
+        let events1 = framed.poll().unwrap();
+        assert_eq!(collect_data(events1), b"line\n");
+
+        let events2 = framed.poll().unwrap();
+        assert!(collect_data(events2).is_empty());
+    }
+
+    #[test]
+    fn eof_flushes_remainder_and_advances_checkpoint() {
+        let stats = make_stats();
+        let sid = SourceId(42);
+        let chunk = b"partial-line";
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from(chunk.to_vec()),
+                source_id: Some(sid),
+                accounted_bytes: chunk.len() as u64,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::EndOfFile {
+                source_id: Some(sid),
+            }],
+        ])
+        .with_offsets(vec![(sid, ByteOffset(chunk.len() as u64))]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        let events1 = framed.poll().expect("first poll");
+        assert!(collect_data(events1).is_empty());
+        let before_flush = framed.checkpoint_data();
+        assert_eq!(before_flush[0].0, sid);
+        assert!(
+            before_flush[0].1.0 < chunk.len() as u64,
+            "checkpoint should remain behind raw offset while remainder is buffered"
+        );
+
+        let events2 = framed.poll().expect("eof poll");
+        assert_eq!(collect_data(events2), b"partial-line\n");
+        let after_flush = framed.checkpoint_data();
+        assert_eq!(after_flush[0], (sid, ByteOffset(chunk.len() as u64)));
+    }
+
+    #[test]
+    fn eof_for_source_only_flushes_matching_remainder() {
+        let stats = make_stats();
+        let sid_a = SourceId(10);
+        let sid_b = SourceId(11);
+        let source = MockSource::new(vec![
+            vec![
+                InputEvent::Data {
+                    bytes: Bytes::from_static(b"alpha"),
+                    source_id: Some(sid_a),
+                    accounted_bytes: 5,
+                    cri_metadata: None,
+                },
+                InputEvent::Data {
+                    bytes: Bytes::from_static(b"beta"),
+                    source_id: Some(sid_b),
+                    accounted_bytes: 4,
+                    cri_metadata: None,
+                },
+            ],
+            vec![InputEvent::EndOfFile {
+                source_id: Some(sid_a),
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            Arc::clone(&stats),
+        );
+
+        let first = framed.poll().expect("first poll");
+        assert!(collect_data(first).is_empty());
+
+        let flushed = framed.poll().expect("second poll");
+        assert_eq!(collect_data(flushed), b"alpha\n");
+
+        let state_b = framed
+            .sources
+            .get(&Some(sid_b))
+            .expect("sid_b state should still exist");
+        assert_eq!(state_b.remainder, b"beta");
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-source remainder tests
+    // -----------------------------------------------------------------------
+
+    /// Two sources interleaving with partial lines -- no cross-contamination.
+    #[test]
+    fn two_sources_interleaved_no_cross_contamination() {
+        let stats = make_stats();
+        let sid_a = SourceId(100);
+        let sid_b = SourceId(200);
+
+        let source = MockSource::new(vec![
+            // Poll 1: partial lines from both sources in one batch
+            vec![
+                InputEvent::Data {
+                    bytes: Bytes::from_static(b"hello-from-A"),
+                    source_id: Some(sid_a),
+                    accounted_bytes: 12,
+                    cri_metadata: None,
+                },
+                InputEvent::Data {
+                    bytes: Bytes::from_static(b"hello-from-B"),
+                    source_id: Some(sid_b),
+                    accounted_bytes: 12,
+                    cri_metadata: None,
+                },
+            ],
+            // Poll 2: complete the lines from each source
+            vec![
+                InputEvent::Data {
+                    bytes: Bytes::from_static(b"-done\n"),
+                    source_id: Some(sid_a),
+                    accounted_bytes: 6,
+                    cri_metadata: None,
+                },
+                InputEvent::Data {
+                    bytes: Bytes::from_static(b"-done\n"),
+                    source_id: Some(sid_b),
+                    accounted_bytes: 6,
+                    cri_metadata: None,
+                },
+            ],
+        ]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        // Poll 1: no complete lines -- everything in remainders.
+        let events1 = framed.poll().unwrap();
+        assert!(collect_data(events1).is_empty());
+
+        // Poll 2: each source gets its own remainder prepended.
+        let events2 = framed.poll().unwrap();
+        let mut output_a = Vec::new();
+        let mut output_b = Vec::new();
+        for e in events2 {
+            if let InputEvent::Data {
+                bytes, source_id, ..
+            } = e
+            {
+                match source_id {
+                    Some(sid) if sid == sid_a => output_a.extend_from_slice(&bytes),
+                    Some(sid) if sid == sid_b => output_b.extend_from_slice(&bytes),
+                    _ => panic!("unexpected source_id"),
+                }
+            }
+        }
+        assert_eq!(output_a, b"hello-from-A-done\n");
+        assert_eq!(output_b, b"hello-from-B-done\n");
+    }
+
+    /// Truncation clears all remainders (current behavior).
+    #[test]
+    fn truncation_clears_all_remainders() {
+        let stats = make_stats();
+        let sid_a = SourceId(100);
+        let sid_b = SourceId(200);
+
+        let source = MockSource::new(vec![
+            // Partial lines from two sources
+            vec![
+                InputEvent::Data {
+                    bytes: Bytes::from_static(b"partial-A"),
+                    source_id: Some(sid_a),
+                    accounted_bytes: 9,
+                    cri_metadata: None,
+                },
+                InputEvent::Data {
+                    bytes: Bytes::from_static(b"partial-B"),
+                    source_id: Some(sid_b),
+                    accounted_bytes: 9,
+                    cri_metadata: None,
+                },
+            ],
+            // Truncation
+            vec![InputEvent::Truncated { source_id: None }],
+            // Fresh data from source A
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"fresh-A\n"),
+                source_id: Some(sid_a),
+                accounted_bytes: 8,
+                cri_metadata: None,
+            }],
+        ]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        // Partials go into remainders
+        let _ = framed.poll().unwrap();
+
+        // Truncation clears all
+        let _ = framed.poll().unwrap();
+
+        // Fresh data from A -- must NOT include "partial-A" prefix
+        let events3 = framed.poll().unwrap();
+        assert_eq!(collect_data(events3), b"fresh-A\n");
+    }
+
+    /// checkpoint_data() subtracts remainder length from inner offsets.
+    #[test]
+    fn checkpoint_data_subtracts_remainder() {
+        let stats = make_stats();
+        let sid = SourceId(42);
+
+        // The inner source reports offset 1000 for our source.
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"hello\nwor"),
+            source_id: Some(sid),
+            accounted_bytes: 9,
+            cri_metadata: None,
+        }]])
+        .with_offsets(vec![(sid, ByteOffset(1000))]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        // After poll, "wor" (3 bytes) is in the remainder for sid.
+        let _ = framed.poll().unwrap();
+
+        let cp = framed.checkpoint_data();
+        assert_eq!(cp.len(), 1);
+        assert_eq!(cp[0].0, sid);
+        // 1000 - 3 = 997
+        assert_eq!(cp[0].1, ByteOffset(997));
+    }
+
+    /// checkpoint_data() returns the raw offset when no remainder is buffered.
+    #[test]
+    fn checkpoint_data_no_remainder() {
+        let stats = make_stats();
+        let sid = SourceId(42);
+
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"complete\n"),
+            source_id: Some(sid),
+            accounted_bytes: 9,
+            cri_metadata: None,
+        }]])
+        .with_offsets(vec![(sid, ByteOffset(500))]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        let _ = framed.poll().unwrap();
+
+        let cp = framed.checkpoint_data();
+        assert_eq!(cp.len(), 1);
+        assert_eq!(cp[0].1, ByteOffset(500));
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-source CRI isolation tests
+    // -----------------------------------------------------------------------
+
+    /// CRI P/F aggregation state is isolated between sources.
+    ///
+    /// Source A sends a P (partial) line, source B sends an F (full) line.
+    /// Without per-source format state, B's F would complete A's P, merging
+    /// data from two different files into one record.
+    #[test]
+    fn cri_pf_state_isolated_between_sources() {
+        let stats = make_stats();
+        let sid_a = SourceId(100);
+        let sid_b = SourceId(200);
+
+        let source = MockSource::new(vec![
+            // Source A: CRI partial line
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"2024-01-15T10:30:00Z stdout P hello \n"),
+                source_id: Some(sid_a),
+                accounted_bytes: 38,
+                cri_metadata: None,
+            }],
+            // Source B: CRI full line (must NOT merge with A's partial)
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"2024-01-15T10:30:01Z stderr F {\"msg\":\"world\"}\n"),
+                source_id: Some(sid_b),
+                accounted_bytes: 50,
+                cri_metadata: None,
+            }],
+            // Source A: CRI full line (completes A's partial)
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"2024-01-15T10:30:02Z stdout F from-A\n"),
+                source_id: Some(sid_a),
+                accounted_bytes: 39,
+                cri_metadata: None,
+            }],
+        ]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            stats,
+        );
+
+        // Poll 1: A's partial — nothing emitted
+        let events1 = framed.poll().unwrap();
+        assert!(collect_data(events1).is_empty());
+
+        // Poll 2: B's full line — emitted as standalone
+        let events2 = framed.poll().unwrap();
+        let data2 = collect_data(events2);
+        assert_eq!(data2, b"{\"msg\":\"world\"}\n");
+        assert!(
+            !data2.windows(5).any(|w| w == b"hello"),
+            "B's output must NOT contain A's partial"
+        );
+
+        // Poll 3: A's full line — completes A's P+F sequence
+        let events3 = framed.poll().unwrap();
+        let data3 = collect_data(events3);
+        assert!(
+            data3.windows(5).any(|w| w == b"hello"),
+            "A's output should contain the merged P+F data"
+        );
+    }
+
+    /// CheckpointTracker is updated correctly through framing operations.
+    #[test]
+    fn checkpoint_tracker_tracks_remainder() {
+        let stats = make_stats();
+        let sid = SourceId(42);
+
+        let source = MockSource::new(vec![
+            // First read: 9 bytes, newline at position 5
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"hello\nwor"),
+                source_id: Some(sid),
+                accounted_bytes: 9,
+                cri_metadata: None,
+            }],
+            // Second read: 3 bytes, newline at position 1 (the 'd\n')
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"ld\n"),
+                source_id: Some(sid),
+                accounted_bytes: 3,
+                cri_metadata: None,
+            }],
+        ])
+        .with_offsets(vec![(sid, ByteOffset(12))]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        // After first poll: remainder is "wor" (3 bytes)
+        let _ = framed.poll().unwrap();
+        let state = framed.sources.get(&Some(sid)).unwrap();
+        assert_eq!(state.tracker.remainder_len(), 3);
+
+        // After second poll: remainder is empty (all consumed)
+        let _ = framed.poll().unwrap();
+        assert!(
+            !framed.sources.contains_key(&Some(sid)),
+            "complete source state should be reclaimed once no remainder is buffered"
+        );
+
+        // Checkpoint should fall back to the raw source offset when no
+        // remainder state remains: 12 - 0 = 12.
+        let cp = framed.checkpoint_data();
+        assert_eq!(cp[0].1, ByteOffset(12));
+    }
+
+    #[test]
+    fn file_json_does_not_inject_source_path_column() {
+        let stats = make_stats();
+        let sid = SourceId(7);
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"{\"msg\":\"hello\"}\n"),
+            source_id: Some(sid),
+            accounted_bytes: 0,
+            cri_metadata: None,
+        }]])
+        .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/main.log".into())]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough_json(Arc::clone(&stats)),
+            stats,
+        );
+
+        let out = collect_data(framed.poll().unwrap());
+        assert_eq!(out, b"{\"msg\":\"hello\"}\n");
+    }
+
+    #[test]
+    fn file_json_preserves_source_id_without_rewriting_payload() {
+        let stats = make_stats();
+        let sid = SourceId(17);
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"{\"msg\":\"hello\"}\n"),
+            source_id: Some(sid),
+            accounted_bytes: 0,
+            cri_metadata: None,
+        }]])
+        .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/main.log".into())]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough_json(Arc::clone(&stats)),
+            stats,
+        );
+
+        let events = framed.poll().unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            InputEvent::Data {
+                bytes,
+                source_id: Some(actual_sid),
+                ..
+            } => {
+                assert_eq!(&bytes[..], b"{\"msg\":\"hello\"}\n");
+                assert_eq!(*actual_sid, sid);
+            }
+            _ => panic!("expected data event with preserved source_id"),
+        }
+    }
+
+    #[test]
+    fn file_cri_does_not_inject_source_path_alongside_cri_metadata() {
+        let stats = make_stats();
+        let sid = SourceId(8);
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"2024-01-15T10:30:00Z stdout F {\"msg\":\"hello\"}\n"),
+            source_id: Some(sid),
+            accounted_bytes: 0,
+            cri_metadata: None,
+        }]])
+        .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/0.log".into())]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(2 * 1024 * 1024, Arc::clone(&stats)),
+            stats,
+        );
+
+        let out = collect_data(framed.poll().unwrap());
+        assert_eq!(out, b"{\"msg\":\"hello\"}\n");
+    }
+
+    #[test]
+    fn file_json_preserves_leading_whitespace_without_source_path_rewrite() {
+        let stats = make_stats();
+        let sid = SourceId(9);
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"  \t{\"msg\":\"hello\"}\n"),
+            source_id: Some(sid),
+            accounted_bytes: 0,
+            cri_metadata: None,
+        }]])
+        .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/1.log".into())]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough_json(Arc::clone(&stats)),
+            stats,
+        );
+
+        let out = collect_data(framed.poll().unwrap());
+        assert_eq!(out, b"  \t{\"msg\":\"hello\"}\n");
+    }
+
+    #[test]
+    fn file_json_empty_object_is_not_rewritten_for_source_path() {
+        let stats = make_stats();
+        let sid = SourceId(11);
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"{}\n"),
+            source_id: Some(sid),
+            accounted_bytes: 0,
+            cri_metadata: None,
+        }]])
+        .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/2.log".into())]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough_json(Arc::clone(&stats)),
+            stats,
+        );
+
+        let out = collect_data(framed.poll().unwrap());
+        assert_eq!(out, b"{}\n");
+    }
+
+    #[test]
+    fn file_raw_passthrough_does_not_inject_source_path() {
+        let stats = make_stats();
+        let sid = SourceId(10);
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"{\"msg\":\"hello\"}\n"),
+            source_id: Some(sid),
+            accounted_bytes: 0,
+            cri_metadata: None,
+        }]])
+        .with_source_paths(vec![(sid, "/var/log/pods/ns_pod_uid/c/raw.log".into())]);
+
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(Arc::clone(&stats)),
+            stats,
+        );
+
+        let out = collect_data(framed.poll().unwrap());
+        assert_eq!(out, b"{\"msg\":\"hello\"}\n");
+    }
+
+    /// EndOfFile must reclaim per-source state so long-running inputs (S3)
+    /// don't accumulate dead entries in the `sources` HashMap.
+    #[test]
+    fn eof_removes_source_state() {
+        let stats = make_stats();
+        let sid = SourceId(42);
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"hello\npartial"),
+                source_id: Some(sid),
+                accounted_bytes: 13,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::EndOfFile {
+                source_id: Some(sid),
+            }],
+            // New data for the same SourceId after EOF — must work.
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"world\n"),
+                source_id: Some(sid),
+                accounted_bytes: 6,
+                cri_metadata: None,
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough(stats.clone()),
+            stats,
+        );
+
+        // Poll 1: "hello\n" emitted, "partial" in remainder.
+        let events1 = framed.poll().unwrap();
+        assert_eq!(collect_data(events1), b"hello\n");
+        assert!(framed.sources.contains_key(&Some(sid)));
+
+        // Poll 2: EOF flushes "partial\n" and removes source state.
+        let events2 = framed.poll().unwrap();
+        assert_eq!(collect_data(events2), b"partial\n");
+        assert!(
+            !framed.sources.contains_key(&Some(sid)),
+            "source state should be removed after EOF"
+        );
+
+        // Poll 3: new data for the same SourceId creates fresh state.
+        let events3 = framed.poll().unwrap();
+        assert_eq!(collect_data(events3), b"world\n");
+    }
+
+    #[test]
+    fn complete_source_state_is_reclaimed_without_eof() {
+        let stats = make_stats();
+        let sid = SourceId(42);
+        let source = MockSource::new(vec![vec![InputEvent::Data {
+            bytes: Bytes::from_static(b"{\"msg\":\"done\"}\n"),
+            source_id: Some(sid),
+            accounted_bytes: 15,
+            cri_metadata: None,
+        }]]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::passthrough_json(stats.clone()),
+            stats,
+        );
+
+        let events = framed.poll().unwrap();
+
+        assert_eq!(collect_data(events), b"{\"msg\":\"done\"}\n");
+        assert!(
+            framed.sources.is_empty(),
+            "complete source state should not accumulate for ephemeral sources"
+        );
+    }
+
+    #[test]
+    fn cri_partial_source_state_survives_until_full_record() {
+        let stats = make_stats();
+        let sid = SourceId(42);
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(
+                    b"2024-01-01T00:00:00.000000000Z stdout P {\"msg\":\"part",
+                ),
+                source_id: Some(sid),
+                accounted_bytes: 57,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"ial\"}\n2024-01-01T00:00:00.000000000Z stdout F \n"),
+                source_id: Some(sid),
+                accounted_bytes: 54,
+                cri_metadata: None,
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(1024, stats.clone()),
+            stats,
+        );
+
+        let first = framed.poll().unwrap();
+        assert!(first.is_empty());
+        assert!(
+            framed.sources.contains_key(&Some(sid)),
+            "CRI partial state must survive across polls"
+        );
+
+        let second = framed.poll().unwrap();
+        let output = collect_data(second);
+        assert!(
+            output.ends_with(b"\"msg\":\"partial\"}\n"),
+            "unexpected CRI output: {}",
+            String::from_utf8_lossy(&output)
+        );
+        assert!(
+            framed.sources.is_empty(),
+            "CRI source state should be reclaimed after the full record completes"
+        );
+    }
+
+    #[test]
+    fn eof_does_not_reclaim_pending_cri_fragment() {
+        let stats = make_stats();
+        let sid = SourceId(43);
+        let source = MockSource::new(vec![
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(
+                    b"2024-01-01T00:00:00.000000000Z stdout P {\"msg\":\"part\n",
+                ),
+                source_id: Some(sid),
+                accounted_bytes: 58,
+                cri_metadata: None,
+            }],
+            vec![InputEvent::EndOfFile {
+                source_id: Some(sid),
+            }],
+            vec![InputEvent::Data {
+                bytes: Bytes::from_static(b"2024-01-01T00:00:00.000000000Z stdout F ial\"}\n"),
+                source_id: Some(sid),
+                accounted_bytes: 53,
+                cri_metadata: None,
+            }],
+        ]);
+        let mut framed = FramedInput::new(
+            Box::new(source),
+            FormatDecoder::cri(1024, stats.clone()),
+            stats,
+        );
+
+        assert!(framed.poll().unwrap().is_empty());
+        assert!(
+            framed.sources.contains_key(&Some(sid)),
+            "CRI P fragment should leave pending format state"
+        );
+
+        assert!(framed.poll().unwrap().is_empty());
+        assert!(
+            framed.sources.contains_key(&Some(sid)),
+            "EOF must not remove pending CRI state"
+        );
+
+        let output = collect_data(framed.poll().unwrap());
+        assert!(
+            output.ends_with(b"\"msg\":\"partial\"}\n"),
+            "unexpected CRI output after EOF: {}",
+            String::from_utf8_lossy(&output)
+        );
+    }
 }

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -1,10 +1,11 @@
 use std::io::{self, Read};
+use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::mpsc;
 use std::thread;
 
 use arrow::record_batch::RecordBatch;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use logfwd_types::diagnostics::ComponentHealth;
 use logfwd_types::pipeline::SourceId;
 
@@ -366,6 +367,31 @@ pub enum InputEvent {
     EndOfFile { source_id: Option<SourceId> },
 }
 
+/// Events produced by the shared-buffer input path.
+///
+/// `Data` references a byte range already appended into the caller-owned
+/// destination buffer supplied to [`InputSource::poll_into`] or
+/// [`InputSource::poll_shutdown_into`]. The range is expressed in that buffer's
+/// post-append coordinate space so the caller can derive row origins and sidecar
+/// alignment without another copy.
+pub enum BufferedInputEvent {
+    Data {
+        range: Range<usize>,
+        source_id: Option<SourceId>,
+        cri_metadata: Option<CriMetadata>,
+    },
+    Batch {
+        batch: RecordBatch,
+        source_id: Option<SourceId>,
+    },
+    Rotated {
+        source_id: Option<SourceId>,
+    },
+    Truncated {
+        source_id: Option<SourceId>,
+    },
+}
+
 /// Trait for input sources that produce raw bytes.
 #[derive(Debug, Clone)]
 pub struct TlsInputConfig {
@@ -378,6 +404,16 @@ pub struct TlsInputConfig {
 pub trait InputSource: Send {
     /// Poll for new events. Returns empty vec if no new data.
     fn poll(&mut self) -> io::Result<Vec<InputEvent>>;
+
+    /// Poll and append scanner-ready bytes directly into `dst` when supported.
+    ///
+    /// The default implementation returns `Ok(None)` so existing sources keep
+    /// using the `poll()` path unchanged. Implementations that support shared
+    /// buffering must append any produced data into `dst` and describe the
+    /// appended ranges with [`BufferedInputEvent::Data`].
+    fn poll_into(&mut self, _dst: &mut BytesMut) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+        Ok(None)
+    }
 
     /// Poll during runtime shutdown before buffered input is drained.
     ///
@@ -394,6 +430,17 @@ pub trait InputSource: Send {
     /// to avoid hanging process shutdown on a misbehaving source.
     fn poll_shutdown(&mut self) -> io::Result<Vec<InputEvent>> {
         Ok(Vec::new())
+    }
+
+    /// Shutdown-drain variant of [`InputSource::poll_into`].
+    ///
+    /// The default implementation returns `Ok(None)` so callers fall back to the
+    /// existing shutdown `poll_shutdown()` path.
+    fn poll_shutdown_into(
+        &mut self,
+        _dst: &mut BytesMut,
+    ) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+        Ok(None)
     }
 
     /// Name of this input (from config).

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -407,6 +407,15 @@ pub trait InputSource: Send {
     /// using the `poll()` path unchanged. Implementations that support shared
     /// buffering must append any produced data into `dst` and describe the
     /// appended ranges with [`FramedReadEvent::Data`].
+    ///
+    /// # Contract
+    ///
+    /// - On `Ok(Some(events))`, all returned ranges must reference bytes
+    ///   appended to `dst` during *this* call.
+    /// - On `Ok(None)`, `dst` must not be modified (caller falls back to
+    ///   `poll()`).
+    /// - On `Err(_)`, `dst` may contain partially appended bytes. The caller
+    ///   must not assume `dst` is unchanged after an error.
     fn poll_into(&mut self, _dst: &mut BytesMut) -> io::Result<Option<Vec<FramedReadEvent>>> {
         Ok(None)
     }

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -367,22 +367,18 @@ pub enum InputEvent {
     EndOfFile { source_id: Option<SourceId> },
 }
 
-/// Events produced by the shared-buffer input path.
+/// Events produced by the shared-buffer framing path.
 ///
 /// `Data` references a byte range already appended into the caller-owned
 /// destination buffer supplied to [`InputSource::poll_into`] or
 /// [`InputSource::poll_shutdown_into`]. The range is expressed in that buffer's
 /// post-append coordinate space so the caller can derive row origins and sidecar
 /// alignment without another copy.
-pub enum BufferedInputEvent {
+pub enum FramedReadEvent {
     Data {
         range: Range<usize>,
         source_id: Option<SourceId>,
         cri_metadata: Option<CriMetadata>,
-    },
-    Batch {
-        batch: RecordBatch,
-        source_id: Option<SourceId>,
     },
     Rotated {
         source_id: Option<SourceId>,
@@ -410,8 +406,8 @@ pub trait InputSource: Send {
     /// The default implementation returns `Ok(None)` so existing sources keep
     /// using the `poll()` path unchanged. Implementations that support shared
     /// buffering must append any produced data into `dst` and describe the
-    /// appended ranges with [`BufferedInputEvent::Data`].
-    fn poll_into(&mut self, _dst: &mut BytesMut) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+    /// appended ranges with [`FramedReadEvent::Data`].
+    fn poll_into(&mut self, _dst: &mut BytesMut) -> io::Result<Option<Vec<FramedReadEvent>>> {
         Ok(None)
     }
 
@@ -439,7 +435,7 @@ pub trait InputSource: Send {
     fn poll_shutdown_into(
         &mut self,
         _dst: &mut BytesMut,
-    ) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+    ) -> io::Result<Option<Vec<FramedReadEvent>>> {
         Ok(None)
     }
 

--- a/crates/logfwd-io/tests/it/framed_buffered_equivalence.rs
+++ b/crates/logfwd-io/tests/it/framed_buffered_equivalence.rs
@@ -1,0 +1,347 @@
+//! Property tests that compare the legacy `poll()` path against the shared-buffer
+//! `poll_into()` path for the same raw event sequences.
+
+use std::collections::{HashMap, VecDeque};
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use bytes::{Bytes, BytesMut};
+use logfwd_io::format::FormatDecoder;
+use logfwd_io::framed::FramedInput;
+use logfwd_io::input::{BufferedInputEvent, CriMetadata, InputEvent, InputSource};
+use logfwd_io::tail::ByteOffset;
+use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
+use logfwd_types::pipeline::SourceId;
+use proptest::prelude::*;
+use proptest::test_runner::Config as ProptestConfig;
+
+const MAX_SOURCES: u64 = 3;
+
+#[derive(Clone, Copy, Debug)]
+enum FormatKind {
+    Passthrough,
+    PassthroughJson,
+    Cri,
+    Auto,
+}
+
+impl FormatKind {
+    fn build(self, stats: Arc<ComponentStats>) -> FormatDecoder {
+        match self {
+            Self::Passthrough => FormatDecoder::passthrough(stats),
+            Self::PassthroughJson => FormatDecoder::passthrough_json(stats),
+            Self::Cri => FormatDecoder::cri(2 * 1024 * 1024, stats),
+            Self::Auto => FormatDecoder::auto(2 * 1024 * 1024, stats),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Transition {
+    Data { source: SourceId, bytes: Vec<u8> },
+    Rotated { source: SourceId },
+    Truncated { source: SourceId },
+    EndOfFile { source: SourceId },
+}
+
+#[derive(Default)]
+struct ReplayState {
+    poll_events: VecDeque<Vec<InputEvent>>,
+    shutdown_events: VecDeque<Vec<InputEvent>>,
+    offsets: HashMap<SourceId, ByteOffset>,
+}
+
+#[derive(Clone)]
+struct ReplaySource {
+    name: &'static str,
+    shared: Arc<Mutex<ReplayState>>,
+}
+
+impl ReplaySource {
+    fn new(name: &'static str, shared: Arc<Mutex<ReplayState>>) -> Self {
+        Self { name, shared }
+    }
+}
+
+impl InputSource for ReplaySource {
+    fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+        Ok(self
+            .shared
+            .lock()
+            .expect("replay source lock")
+            .poll_events
+            .pop_front()
+            .unwrap_or_default())
+    }
+
+    fn poll_shutdown(&mut self) -> io::Result<Vec<InputEvent>> {
+        Ok(self
+            .shared
+            .lock()
+            .expect("replay source lock")
+            .shutdown_events
+            .pop_front()
+            .unwrap_or_default())
+    }
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn health(&self) -> ComponentHealth {
+        ComponentHealth::Healthy
+    }
+
+    fn checkpoint_data(&self) -> Vec<(SourceId, ByteOffset)> {
+        self.shared
+            .lock()
+            .expect("replay source lock")
+            .offsets
+            .iter()
+            .map(|(sid, offset)| (*sid, *offset))
+            .collect()
+    }
+
+    fn should_reclaim_completed_source_state(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum NormalizedEvent {
+    Data {
+        bytes: Vec<u8>,
+        source_id: Option<SourceId>,
+        cri_metadata: Option<CriMetadata>,
+    },
+    Rotated {
+        source_id: Option<SourceId>,
+    },
+    Truncated {
+        source_id: Option<SourceId>,
+    },
+}
+
+fn format_strategy() -> impl Strategy<Value = FormatKind> {
+    prop_oneof![
+        Just(FormatKind::Passthrough),
+        Just(FormatKind::PassthroughJson),
+        Just(FormatKind::Cri),
+        Just(FormatKind::Auto),
+    ]
+}
+
+fn transition_strategy() -> impl Strategy<Value = Transition> {
+    let source = (0..MAX_SOURCES).prop_map(SourceId);
+    prop_oneof![
+        (source.clone(), prop::collection::vec(any::<u8>(), 1..128))
+            .prop_map(|(source, bytes)| Transition::Data { source, bytes }),
+        source
+            .clone()
+            .prop_map(|source| Transition::Rotated { source }),
+        source
+            .clone()
+            .prop_map(|source| Transition::Truncated { source }),
+        source.prop_map(|source| Transition::EndOfFile { source }),
+    ]
+}
+
+fn to_input_event(transition: &Transition) -> InputEvent {
+    match transition {
+        Transition::Data { source, bytes } => InputEvent::Data {
+            bytes: Bytes::from(bytes.clone()),
+            source_id: Some(*source),
+            accounted_bytes: bytes.len() as u64,
+            cri_metadata: None,
+        },
+        Transition::Rotated { source } => InputEvent::Rotated {
+            source_id: Some(*source),
+        },
+        Transition::Truncated { source } => InputEvent::Truncated {
+            source_id: Some(*source),
+        },
+        Transition::EndOfFile { source } => InputEvent::EndOfFile {
+            source_id: Some(*source),
+        },
+    }
+}
+
+fn push_poll_transition(shared: &Arc<Mutex<ReplayState>>, transition: &Transition) {
+    let event = to_input_event(transition);
+    let mut guard = shared.lock().expect("replay source lock");
+    if let Transition::Data { source, bytes } = transition {
+        let offset = guard.offsets.entry(*source).or_insert(ByteOffset(0));
+        offset.0 += bytes.len() as u64;
+    }
+    guard.poll_events.push_back(vec![event]);
+}
+
+fn push_shutdown_transition(shared: &Arc<Mutex<ReplayState>>, transition: &Transition) {
+    let event = to_input_event(transition);
+    let mut guard = shared.lock().expect("replay source lock");
+    if let Transition::Data { source, bytes } = transition {
+        let offset = guard.offsets.entry(*source).or_insert(ByteOffset(0));
+        offset.0 += bytes.len() as u64;
+    }
+    guard.shutdown_events.push_back(vec![event]);
+}
+
+fn normalize_legacy(events: Vec<InputEvent>) -> Vec<NormalizedEvent> {
+    events
+        .into_iter()
+        .filter_map(|event| match event {
+            InputEvent::Data {
+                bytes,
+                source_id,
+                cri_metadata,
+                ..
+            } => Some(NormalizedEvent::Data {
+                bytes: bytes.to_vec(),
+                source_id,
+                cri_metadata,
+            }),
+            InputEvent::Rotated { source_id } => Some(NormalizedEvent::Rotated { source_id }),
+            InputEvent::Truncated { source_id } => Some(NormalizedEvent::Truncated { source_id }),
+            InputEvent::Batch { .. } | InputEvent::EndOfFile { .. } => None,
+        })
+        .collect()
+}
+
+fn normalize_buffered(events: Vec<BufferedInputEvent>, dst: &BytesMut) -> Vec<NormalizedEvent> {
+    events
+        .into_iter()
+        .map(|event| match event {
+            BufferedInputEvent::Data {
+                range,
+                source_id,
+                cri_metadata,
+            } => NormalizedEvent::Data {
+                bytes: dst[range].to_vec(),
+                source_id,
+                cri_metadata,
+            },
+            BufferedInputEvent::Rotated { source_id } => NormalizedEvent::Rotated { source_id },
+            BufferedInputEvent::Truncated { source_id } => NormalizedEvent::Truncated { source_id },
+            BufferedInputEvent::Batch { .. } => {
+                panic!("replay source should not emit batch events")
+            }
+        })
+        .collect()
+}
+
+struct EquivalenceHarness {
+    legacy_shared: Arc<Mutex<ReplayState>>,
+    buffered_shared: Arc<Mutex<ReplayState>>,
+    legacy: FramedInput,
+    buffered: FramedInput,
+    dst: BytesMut,
+}
+
+impl EquivalenceHarness {
+    fn new(format: FormatKind) -> Self {
+        let legacy_shared = Arc::new(Mutex::new(ReplayState::default()));
+        let buffered_shared = Arc::new(Mutex::new(ReplayState::default()));
+        let legacy_stats = Arc::new(ComponentStats::new());
+        let buffered_stats = Arc::new(ComponentStats::new());
+        let legacy = FramedInput::new(
+            Box::new(ReplaySource::new("legacy", Arc::clone(&legacy_shared))),
+            format.build(Arc::clone(&legacy_stats)),
+            legacy_stats,
+        );
+        let buffered = FramedInput::new(
+            Box::new(ReplaySource::new("buffered", Arc::clone(&buffered_shared))),
+            format.build(Arc::clone(&buffered_stats)),
+            buffered_stats,
+        );
+        Self {
+            legacy_shared,
+            buffered_shared,
+            legacy,
+            buffered,
+            dst: BytesMut::new(),
+        }
+    }
+
+    fn apply_poll_transition(&mut self, transition: &Transition) {
+        push_poll_transition(&self.legacy_shared, transition);
+        push_poll_transition(&self.buffered_shared, transition);
+        let legacy = normalize_legacy(self.legacy.poll().expect("legacy poll"));
+        let buffered = normalize_buffered(
+            self.buffered
+                .poll_into(&mut self.dst)
+                .expect("buffered poll_into")
+                .expect("FramedInput shared-buffer path"),
+            &self.dst,
+        );
+        assert_eq!(legacy, buffered);
+        assert_eq!(
+            sorted_checkpoints(self.legacy.checkpoint_data()),
+            sorted_checkpoints(self.buffered.checkpoint_data())
+        );
+    }
+
+    fn apply_shutdown_transition(&mut self, transition: &Transition) {
+        push_shutdown_transition(&self.legacy_shared, transition);
+        push_shutdown_transition(&self.buffered_shared, transition);
+        let legacy = normalize_legacy(self.legacy.poll_shutdown().expect("legacy poll_shutdown"));
+        let buffered = normalize_buffered(
+            self.buffered
+                .poll_shutdown_into(&mut self.dst)
+                .expect("buffered poll_shutdown_into")
+                .expect("FramedInput shared-buffer shutdown path"),
+            &self.dst,
+        );
+        assert_eq!(legacy, buffered);
+        assert_eq!(
+            sorted_checkpoints(self.legacy.checkpoint_data()),
+            sorted_checkpoints(self.buffered.checkpoint_data())
+        );
+    }
+}
+
+fn sorted_checkpoints(mut checkpoints: Vec<(SourceId, ByteOffset)>) -> Vec<(SourceId, ByteOffset)> {
+    checkpoints.sort_by_key(|(source_id, _)| source_id.0);
+    checkpoints
+}
+
+fn build_equivalence_proptest_config() -> ProptestConfig {
+    let mut config = ProptestConfig {
+        cases: logfwd_test_utils::state_machine_proptest_cases(),
+        max_shrink_iters: 5_000,
+        ..ProptestConfig::default()
+    };
+    if cfg!(miri) || std::env::var_os("LOGFWD_DISABLE_PROPTEST_PERSISTENCE").is_some() {
+        config.failure_persistence = None;
+    }
+    config
+}
+
+proptest! {
+    #![proptest_config(build_equivalence_proptest_config())]
+
+    #[test]
+    fn poll_into_matches_poll_for_random_sequences(
+        format in format_strategy(),
+        transitions in prop::collection::vec(transition_strategy(), 1..40),
+    ) {
+        let mut harness = EquivalenceHarness::new(format);
+        for transition in &transitions {
+            harness.apply_poll_transition(transition);
+        }
+    }
+
+    #[test]
+    fn poll_shutdown_into_matches_poll_shutdown_for_random_sequences(
+        format in format_strategy(),
+        poll_transitions in prop::collection::vec(transition_strategy(), 0..20),
+        shutdown_transitions in prop::collection::vec(transition_strategy(), 1..20),
+    ) {
+        let mut harness = EquivalenceHarness::new(format);
+        for transition in &poll_transitions {
+            harness.apply_poll_transition(transition);
+        }
+        for transition in &shutdown_transitions {
+            harness.apply_shutdown_transition(transition);
+        }
+    }
+}

--- a/crates/logfwd-io/tests/it/framed_buffered_equivalence.rs
+++ b/crates/logfwd-io/tests/it/framed_buffered_equivalence.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use bytes::{Bytes, BytesMut};
 use logfwd_io::format::FormatDecoder;
 use logfwd_io::framed::FramedInput;
-use logfwd_io::input::{BufferedInputEvent, CriMetadata, InputEvent, InputSource};
+use logfwd_io::input::{CriMetadata, FramedReadEvent, InputEvent, InputSource};
 use logfwd_io::tail::ByteOffset;
 use logfwd_types::diagnostics::{ComponentHealth, ComponentStats};
 use logfwd_types::pipeline::SourceId;
@@ -207,11 +207,11 @@ fn normalize_legacy(events: Vec<InputEvent>) -> Vec<NormalizedEvent> {
         .collect()
 }
 
-fn normalize_buffered(events: Vec<BufferedInputEvent>, dst: &BytesMut) -> Vec<NormalizedEvent> {
+fn normalize_buffered(events: Vec<FramedReadEvent>, dst: &BytesMut) -> Vec<NormalizedEvent> {
     events
         .into_iter()
         .map(|event| match event {
-            BufferedInputEvent::Data {
+            FramedReadEvent::Data {
                 range,
                 source_id,
                 cri_metadata,
@@ -220,11 +220,8 @@ fn normalize_buffered(events: Vec<BufferedInputEvent>, dst: &BytesMut) -> Vec<No
                 source_id,
                 cri_metadata,
             },
-            BufferedInputEvent::Rotated { source_id } => NormalizedEvent::Rotated { source_id },
-            BufferedInputEvent::Truncated { source_id } => NormalizedEvent::Truncated { source_id },
-            BufferedInputEvent::Batch { .. } => {
-                panic!("replay source should not emit batch events")
-            }
+            FramedReadEvent::Rotated { source_id } => NormalizedEvent::Rotated { source_id },
+            FramedReadEvent::Truncated { source_id } => NormalizedEvent::Truncated { source_id },
         })
         .collect()
 }

--- a/crates/logfwd-io/tests/it/main.rs
+++ b/crates/logfwd-io/tests/it/main.rs
@@ -1,5 +1,6 @@
 mod checkpoint_state_machine;
 mod file_boundary_contract;
+mod framed_buffered_equivalence;
 mod framed_state_machine;
 mod journald_e2e;
 mod otlp_receiver_contract;

--- a/crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs
+++ b/crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs
@@ -3,6 +3,9 @@
 //! This isolates the buffered shutdown/flush decision surface from the async
 //! I/O shell so it can be covered with Kani and proptest.
 
+/// Minimum single-chunk size (bytes) that triggers an immediate flush
+/// without waiting for the batch timeout, avoiding excessive buffering
+/// when a source emits large payloads in one poll.
 pub(super) const LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES: usize = 64 * 1024;
 
 /// Continue shutdown repolling when the shared-buffer path might still emit

--- a/crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs
+++ b/crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs
@@ -11,6 +11,7 @@ pub(super) const LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES: usize = 64 * 1024;
 /// Continue shutdown repolling when the shared-buffer path might still emit
 /// scanner-ready payload on a later poll.
 #[must_use]
+#[allow(clippy::fn_params_excessive_bools)]
 pub(super) const fn should_repoll_buffered_shutdown(
     is_finished: bool,
     had_source_payload: bool,
@@ -32,6 +33,7 @@ pub(super) const fn should_repoll_buffered_shutdown(
 /// Preserve the old "large first chunk flushes immediately" behavior on the
 /// shared-buffer path.
 #[must_use]
+#[allow(clippy::fn_params_excessive_bools)]
 pub(super) const fn should_flush_large_single_shared_buffer_chunk(
     buffer_was_empty_at_poll: bool,
     event_count: usize,

--- a/crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs
+++ b/crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs
@@ -1,0 +1,219 @@
+//! Pure policy helpers for shared-buffer input handling.
+//!
+//! This isolates the buffered shutdown/flush decision surface from the async
+//! I/O shell so it can be covered with Kani and proptest.
+
+/// Continue shutdown repolling when the shared-buffer path might still emit
+/// scanner-ready payload on a later poll.
+#[must_use]
+pub(super) const fn should_repoll_buffered_shutdown(
+    is_finished: bool,
+    had_source_payload: bool,
+    emitted_any_events: bool,
+    emitted_payload: bool,
+) -> bool {
+    if is_finished {
+        return false;
+    }
+    if !emitted_any_events {
+        return had_source_payload;
+    }
+    if had_source_payload && !emitted_payload {
+        return true;
+    }
+    emitted_payload
+}
+
+/// Preserve the old "large first chunk flushes immediately" behavior on the
+/// shared-buffer path.
+#[must_use]
+pub(super) const fn should_flush_large_single_shared_buffer_chunk(
+    buffer_was_empty_at_poll: bool,
+    event_count: usize,
+    first_event_starts_at_zero: bool,
+    first_event_len: usize,
+) -> bool {
+    const MIN_DIRECT_FLUSH_BYTES: usize = 64 * 1024;
+    buffer_was_empty_at_poll
+        && event_count == 1
+        && first_event_starts_at_zero
+        && first_event_len >= MIN_DIRECT_FLUSH_BYTES
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{should_flush_large_single_shared_buffer_chunk, should_repoll_buffered_shutdown};
+    use proptest::prelude::*;
+
+    #[test]
+    fn shutdown_repoll_stops_once_source_is_finished() {
+        assert!(!should_repoll_buffered_shutdown(true, true, true, true));
+        assert!(!should_repoll_buffered_shutdown(true, false, false, false));
+    }
+
+    #[test]
+    fn shutdown_repoll_continues_after_source_payload_even_with_empty_output() {
+        assert!(should_repoll_buffered_shutdown(false, true, false, false));
+    }
+
+    #[test]
+    fn large_single_chunk_flush_requires_empty_start_and_threshold() {
+        assert!(should_flush_large_single_shared_buffer_chunk(
+            true,
+            1,
+            true,
+            64 * 1024
+        ));
+        assert!(!should_flush_large_single_shared_buffer_chunk(
+            false,
+            1,
+            true,
+            64 * 1024
+        ));
+        assert!(!should_flush_large_single_shared_buffer_chunk(
+            true,
+            2,
+            true,
+            64 * 1024
+        ));
+        assert!(!should_flush_large_single_shared_buffer_chunk(
+            true,
+            1,
+            false,
+            64 * 1024
+        ));
+        assert!(!should_flush_large_single_shared_buffer_chunk(
+            true,
+            1,
+            true,
+            (64 * 1024) - 1
+        ));
+    }
+
+    proptest! {
+        #[test]
+        fn shutdown_repoll_matches_reference_formula(
+            is_finished in any::<bool>(),
+            had_source_payload in any::<bool>(),
+            emitted_any_events in any::<bool>(),
+            emitted_payload in any::<bool>(),
+        ) {
+            let expected = if is_finished {
+                false
+            } else if !emitted_any_events {
+                had_source_payload
+            } else if had_source_payload && !emitted_payload {
+                true
+            } else {
+                emitted_payload
+            };
+
+            prop_assert_eq!(
+                should_repoll_buffered_shutdown(
+                    is_finished,
+                    had_source_payload,
+                    emitted_any_events,
+                    emitted_payload,
+                ),
+                expected
+            );
+        }
+
+        #[test]
+        fn large_single_chunk_flush_matches_reference_formula(
+            buffer_was_empty_at_poll in any::<bool>(),
+            event_count in 0usize..4,
+            first_event_starts_at_zero in any::<bool>(),
+            first_event_len in 0usize..(128 * 1024),
+        ) {
+            let expected = buffer_was_empty_at_poll
+                && event_count == 1
+                && first_event_starts_at_zero
+                && first_event_len >= 64 * 1024;
+
+            prop_assert_eq!(
+                should_flush_large_single_shared_buffer_chunk(
+                    buffer_was_empty_at_poll,
+                    event_count,
+                    first_event_starts_at_zero,
+                    first_event_len,
+                ),
+                expected
+            );
+        }
+    }
+}
+
+#[cfg(kani)]
+mod verification {
+    use super::{should_flush_large_single_shared_buffer_chunk, should_repoll_buffered_shutdown};
+
+    #[kani::proof]
+    fn verify_buffered_shutdown_repoll_matches_reference_formula() {
+        let is_finished = kani::any::<bool>();
+        let had_source_payload = kani::any::<bool>();
+        let emitted_any_events = kani::any::<bool>();
+        let emitted_payload = kani::any::<bool>();
+
+        let expected = if is_finished {
+            false
+        } else if !emitted_any_events {
+            had_source_payload
+        } else if had_source_payload && !emitted_payload {
+            true
+        } else {
+            emitted_payload
+        };
+
+        assert_eq!(
+            should_repoll_buffered_shutdown(
+                is_finished,
+                had_source_payload,
+                emitted_any_events,
+                emitted_payload,
+            ),
+            expected
+        );
+
+        kani::cover!(
+            should_repoll_buffered_shutdown(false, true, false, false),
+            "empty buffered output after source payload is reachable"
+        );
+        kani::cover!(
+            !should_repoll_buffered_shutdown(true, true, true, true),
+            "finished buffered shutdown stops repolling"
+        );
+    }
+
+    #[kani::proof]
+    fn verify_large_single_chunk_flush_matches_reference_formula() {
+        let buffer_was_empty_at_poll = kani::any::<bool>();
+        let event_count = kani::any_where(|count: &usize| *count <= 2);
+        let first_event_starts_at_zero = kani::any::<bool>();
+        let first_event_len = kani::any_where(|len: &usize| *len <= 128 * 1024);
+
+        let expected = buffer_was_empty_at_poll
+            && event_count == 1
+            && first_event_starts_at_zero
+            && first_event_len >= 64 * 1024;
+
+        assert_eq!(
+            should_flush_large_single_shared_buffer_chunk(
+                buffer_was_empty_at_poll,
+                event_count,
+                first_event_starts_at_zero,
+                first_event_len,
+            ),
+            expected
+        );
+
+        kani::cover!(
+            should_flush_large_single_shared_buffer_chunk(true, 1, true, 64 * 1024),
+            "direct flush threshold path reachable"
+        );
+        kani::cover!(
+            !should_flush_large_single_shared_buffer_chunk(true, 1, true, 1024),
+            "below-threshold shared buffer stays buffered"
+        );
+    }
+}

--- a/crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs
+++ b/crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs
@@ -3,6 +3,8 @@
 //! This isolates the buffered shutdown/flush decision surface from the async
 //! I/O shell so it can be covered with Kani and proptest.
 
+pub(super) const LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES: usize = 64 * 1024;
+
 /// Continue shutdown repolling when the shared-buffer path might still emit
 /// scanner-ready payload on a later poll.
 #[must_use]
@@ -33,16 +35,18 @@ pub(super) const fn should_flush_large_single_shared_buffer_chunk(
     first_event_starts_at_zero: bool,
     first_event_len: usize,
 ) -> bool {
-    const MIN_DIRECT_FLUSH_BYTES: usize = 64 * 1024;
     buffer_was_empty_at_poll
         && event_count == 1
         && first_event_starts_at_zero
-        && first_event_len >= MIN_DIRECT_FLUSH_BYTES
+        && first_event_len >= LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{should_flush_large_single_shared_buffer_chunk, should_repoll_buffered_shutdown};
+    use super::{
+        LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES, should_flush_large_single_shared_buffer_chunk,
+        should_repoll_buffered_shutdown,
+    };
     use proptest::prelude::*;
 
     #[test]
@@ -62,31 +66,31 @@ mod tests {
             true,
             1,
             true,
-            64 * 1024
+            LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES
         ));
         assert!(!should_flush_large_single_shared_buffer_chunk(
             false,
             1,
             true,
-            64 * 1024
+            LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES
         ));
         assert!(!should_flush_large_single_shared_buffer_chunk(
             true,
             2,
             true,
-            64 * 1024
+            LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES
         ));
         assert!(!should_flush_large_single_shared_buffer_chunk(
             true,
             1,
             false,
-            64 * 1024
+            LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES
         ));
         assert!(!should_flush_large_single_shared_buffer_chunk(
             true,
             1,
             true,
-            (64 * 1024) - 1
+            LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES - 1
         ));
     }
 
@@ -129,7 +133,7 @@ mod tests {
             let expected = buffer_was_empty_at_poll
                 && event_count == 1
                 && first_event_starts_at_zero
-                && first_event_len >= 64 * 1024;
+                && first_event_len >= LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES;
 
             prop_assert_eq!(
                 should_flush_large_single_shared_buffer_chunk(
@@ -146,7 +150,10 @@ mod tests {
 
 #[cfg(kani)]
 mod verification {
-    use super::{should_flush_large_single_shared_buffer_chunk, should_repoll_buffered_shutdown};
+    use super::{
+        LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES, should_flush_large_single_shared_buffer_chunk,
+        should_repoll_buffered_shutdown,
+    };
 
     #[kani::proof]
     fn verify_buffered_shutdown_repoll_matches_reference_formula() {
@@ -195,7 +202,7 @@ mod verification {
         let expected = buffer_was_empty_at_poll
             && event_count == 1
             && first_event_starts_at_zero
-            && first_event_len >= 64 * 1024;
+            && first_event_len >= LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES;
 
         assert_eq!(
             should_flush_large_single_shared_buffer_chunk(
@@ -208,7 +215,12 @@ mod verification {
         );
 
         kani::cover!(
-            should_flush_large_single_shared_buffer_chunk(true, 1, true, 64 * 1024),
+            should_flush_large_single_shared_buffer_chunk(
+                true,
+                1,
+                true,
+                LARGE_SINGLE_CHUNK_DIRECT_FLUSH_BYTES,
+            ),
             "direct flush threshold path reachable"
         );
         kani::cover!(

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
@@ -6,9 +6,9 @@ use super::super::source_metadata::*;
 use super::super::*;
 use arrow::array::{Array, StringArray, StringViewArray, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use logfwd_arrow::Scanner;
-use logfwd_io::input::{CriMetadata, InputEvent};
+use logfwd_io::input::{BufferedInputEvent, CriMetadata, InputEvent};
 use logfwd_types::source_metadata::{SourceMetadataPlan, SourcePathColumn};
 use proptest::prelude::*;
 use std::collections::HashMap;
@@ -88,6 +88,17 @@ fn shutdown_repoll_continues_for_eof_only_output_after_source_payload() {
     }];
 
     assert!(should_repoll_shutdown(&events, false, true));
+}
+
+#[test]
+fn buffered_shutdown_repoll_continues_for_payload_without_finish() {
+    let events = vec![BufferedInputEvent::Data {
+        range: 0..2,
+        source_id: Some(SourceId(1)),
+        cri_metadata: None,
+    }];
+
+    assert!(should_repoll_shutdown_buffered(&events, false, false));
 }
 
 #[test]
@@ -533,6 +544,83 @@ impl InputSource for SplitLineSource {
     }
 }
 
+struct SharedBufferSource {
+    emitted: bool,
+    finished: bool,
+}
+
+impl InputSource for SharedBufferSource {
+    fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+        panic!("poll() should not be used when poll_into() is available");
+    }
+
+    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+        if self.emitted {
+            self.finished = true;
+            return Ok(Some(Vec::new()));
+        }
+        let start = dst.len();
+        dst.extend_from_slice(b"{\"msg\":\"shared\"}\n");
+        self.emitted = true;
+        self.finished = true;
+        Ok(Some(vec![BufferedInputEvent::Data {
+            range: start..dst.len(),
+            source_id: None,
+            cri_metadata: None,
+        }]))
+    }
+
+    fn name(&self) -> &str {
+        "shared-buffer"
+    }
+
+    fn health(&self) -> ComponentHealth {
+        ComponentHealth::Healthy
+    }
+
+    fn is_finished(&self) -> bool {
+        self.finished
+    }
+}
+
+struct LargeSharedBufferSource {
+    emitted: bool,
+    finished: bool,
+}
+
+impl InputSource for LargeSharedBufferSource {
+    fn poll(&mut self) -> io::Result<Vec<InputEvent>> {
+        panic!("poll() should not be used when poll_into() is available");
+    }
+
+    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+        if self.emitted {
+            return Ok(Some(Vec::new()));
+        }
+        let start = dst.len();
+        let chunk = vec![b'x'; 80 * 1024];
+        dst.extend_from_slice(&chunk);
+        self.emitted = true;
+        Ok(Some(vec![BufferedInputEvent::Data {
+            range: start..dst.len(),
+            source_id: None,
+            cri_metadata: None,
+        }]))
+    }
+
+    fn name(&self) -> &str {
+        "large-shared-buffer"
+    }
+
+    fn health(&self) -> ComponentHealth {
+        ComponentHealth::Healthy
+    }
+
+    fn is_finished(&self) -> bool {
+        self.finished
+    }
+}
+
 struct BatchSource {
     emitted: bool,
 }
@@ -940,6 +1028,144 @@ fn io_worker_shutdown_repolls_until_source_finishes() {
         chunk.source_paths.get(&SourceId(14)).map(String::as_str),
         Some("/var/log/shutdown.log")
     );
+}
+
+#[test]
+fn io_worker_extends_existing_buffer_via_poll_into_path() {
+    let (tx, mut rx) = mpsc::channel(IO_CPU_CHANNEL_CAPACITY);
+    let shutdown = CancellationToken::new();
+    let stats = Arc::new(ComponentStats::new_with_health(ComponentHealth::Starting));
+    let input = InputState {
+        source: Box::new(SharedBufferSource {
+            emitted: false,
+            finished: false,
+        }),
+        buf: BytesMut::from(&b"{\"msg\":\"seed\"}\n"[..]),
+        row_origins: Vec::new(),
+        source_paths: HashMap::new(),
+        cri_metadata: CriMetadata::default(),
+        stats,
+    };
+    let meter = opentelemetry::global::meter("io_worker_shared_buffer_path");
+    let metrics = Arc::new(PipelineMetrics::new("test", "SELECT * FROM logs", &meter));
+
+    let handle = std::thread::spawn(move || {
+        io_worker_loop(
+            input,
+            Arc::from("configured-input"),
+            tx,
+            metrics,
+            shutdown,
+            usize::MAX,
+            Duration::from_secs(60),
+            Duration::from_millis(1),
+            0,
+            SourceMetadataPlan::default(),
+        );
+    });
+
+    let item = rx.blocking_recv().expect("io worker item");
+    drop(rx);
+    handle.join().expect("io worker exits");
+
+    let IoWorkItem::Bytes(chunk) = item else {
+        panic!("expected byte chunk");
+    };
+    assert_eq!(
+        chunk.bytes.as_ref(),
+        b"{\"msg\":\"seed\"}\n{\"msg\":\"shared\"}\n"
+    );
+}
+
+#[test]
+fn io_worker_uses_poll_into_path_with_empty_buffer() {
+    let (tx, mut rx) = mpsc::channel(IO_CPU_CHANNEL_CAPACITY);
+    let shutdown = CancellationToken::new();
+    let stats = Arc::new(ComponentStats::new_with_health(ComponentHealth::Starting));
+    let input = InputState {
+        source: Box::new(SharedBufferSource {
+            emitted: false,
+            finished: false,
+        }),
+        buf: BytesMut::new(),
+        row_origins: Vec::new(),
+        source_paths: HashMap::new(),
+        cri_metadata: CriMetadata::default(),
+        stats,
+    };
+    let meter = opentelemetry::global::meter("io_worker_shared_buffer_empty_start");
+    let metrics = Arc::new(PipelineMetrics::new("test", "SELECT * FROM logs", &meter));
+
+    let handle = std::thread::spawn(move || {
+        io_worker_loop(
+            input,
+            Arc::from("configured-input"),
+            tx,
+            metrics,
+            shutdown,
+            usize::MAX,
+            Duration::from_secs(60),
+            Duration::from_millis(1),
+            0,
+            SourceMetadataPlan::default(),
+        );
+    });
+
+    let item = rx.blocking_recv().expect("io worker item");
+    drop(rx);
+    handle.join().expect("io worker exits");
+
+    let IoWorkItem::Bytes(chunk) = item else {
+        panic!("expected byte chunk");
+    };
+    assert_eq!(chunk.bytes.as_ref(), b"{\"msg\":\"shared\"}\n");
+}
+
+#[test]
+fn io_worker_flushes_large_shared_buffer_chunk_without_waiting_for_timeout() {
+    let (tx, mut rx) = mpsc::channel(IO_CPU_CHANNEL_CAPACITY);
+    let shutdown = CancellationToken::new();
+    let stats = Arc::new(ComponentStats::new_with_health(ComponentHealth::Starting));
+    let input = InputState {
+        source: Box::new(LargeSharedBufferSource {
+            emitted: false,
+            finished: false,
+        }),
+        buf: BytesMut::new(),
+        row_origins: Vec::new(),
+        source_paths: HashMap::new(),
+        cri_metadata: CriMetadata::default(),
+        stats,
+    };
+    let meter = opentelemetry::global::meter("io_worker_large_shared_buffer");
+    let metrics = Arc::new(PipelineMetrics::new("test", "SELECT * FROM logs", &meter));
+    let worker_shutdown = shutdown.clone();
+
+    let handle = std::thread::spawn(move || {
+        io_worker_loop(
+            input,
+            Arc::from("configured-input"),
+            tx,
+            metrics,
+            worker_shutdown,
+            usize::MAX,
+            Duration::from_secs(60),
+            Duration::from_millis(1),
+            0,
+            SourceMetadataPlan::default(),
+        );
+    });
+
+    let item = rx.blocking_recv().expect("io worker item");
+    shutdown.cancel();
+    drop(rx);
+    handle.join().expect("io worker exits");
+
+    let IoWorkItem::Bytes(chunk) = item else {
+        panic!("expected byte chunk");
+    };
+    assert_eq!(chunk.bytes.len(), 80 * 1024);
+    assert!(chunk.bytes.iter().all(|byte| *byte == b'x'));
 }
 
 #[test]

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
@@ -8,7 +8,7 @@ use arrow::array::{Array, StringArray, StringViewArray, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema};
 use bytes::{Bytes, BytesMut};
 use logfwd_arrow::Scanner;
-use logfwd_io::input::{BufferedInputEvent, CriMetadata, InputEvent};
+use logfwd_io::input::{CriMetadata, FramedReadEvent, InputEvent};
 use logfwd_types::source_metadata::{SourceMetadataPlan, SourcePathColumn};
 use proptest::prelude::*;
 use std::collections::HashMap;
@@ -92,7 +92,7 @@ fn shutdown_repoll_continues_for_eof_only_output_after_source_payload() {
 
 #[test]
 fn buffered_shutdown_repoll_continues_for_payload_without_finish() {
-    let events = vec![BufferedInputEvent::Data {
+    let events = vec![FramedReadEvent::Data {
         range: 0..2,
         source_id: Some(SourceId(1)),
         cri_metadata: None,
@@ -554,7 +554,7 @@ impl InputSource for SharedBufferSource {
         panic!("poll() should not be used when poll_into() is available");
     }
 
-    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<FramedReadEvent>>> {
         if self.emitted {
             self.finished = true;
             return Ok(Some(Vec::new()));
@@ -563,7 +563,7 @@ impl InputSource for SharedBufferSource {
         dst.extend_from_slice(b"{\"msg\":\"shared\"}\n");
         self.emitted = true;
         self.finished = true;
-        Ok(Some(vec![BufferedInputEvent::Data {
+        Ok(Some(vec![FramedReadEvent::Data {
             range: start..dst.len(),
             source_id: None,
             cri_metadata: None,
@@ -593,7 +593,7 @@ impl InputSource for LargeSharedBufferSource {
         panic!("poll() should not be used when poll_into() is available");
     }
 
-    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<BufferedInputEvent>>> {
+    fn poll_into(&mut self, dst: &mut BytesMut) -> io::Result<Option<Vec<FramedReadEvent>>> {
         if self.emitted {
             return Ok(Some(Vec::new()));
         }
@@ -601,7 +601,7 @@ impl InputSource for LargeSharedBufferSource {
         let chunk = vec![b'x'; 80 * 1024];
         dst.extend_from_slice(&chunk);
         self.emitted = true;
-        Ok(Some(vec![BufferedInputEvent::Data {
+        Ok(Some(vec![FramedReadEvent::Data {
             range: start..dst.len(),
             source_id: None,
             cri_metadata: None,
@@ -743,70 +743,8 @@ const IO_CPU_CHANNEL_CAPACITY: usize = 4;
 /// Constant for shutdown drain log interval (mirrors the production constant).
 const SHUTDOWN_DRAIN_PROGRESS_LOG_INTERVAL_ROUNDS: usize = 64;
 
-#[derive(Clone, Debug)]
-enum BufferedSequenceOp {
-    Data(u8),
-    Batch(u8),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum BufferedSequenceOutput {
-    Bytes(Vec<u8>),
-    Batch(usize),
-}
-
-fn make_test_batch(rows: usize, tag: &str) -> RecordBatch {
-    let schema = Arc::new(Schema::new(vec![Field::new("msg", DataType::Utf8, true)]));
-    let values = (0..rows)
-        .map(|row| format!("{tag}-{row}"))
-        .collect::<Vec<_>>();
-    RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values))]).expect("batch")
-}
-
-fn buffered_data_payload(id: u8) -> Vec<u8> {
+fn framed_data_payload(id: u8) -> Vec<u8> {
     format!("{{\"msg\":\"data-{id}\"}}\n").into_bytes()
-}
-
-fn expected_buffered_outputs(ops: &[BufferedSequenceOp]) -> Vec<BufferedSequenceOutput> {
-    let mut outputs = Vec::new();
-    let mut pending_bytes = Vec::new();
-
-    for op in ops {
-        match *op {
-            BufferedSequenceOp::Data(id) => {
-                pending_bytes.extend_from_slice(&buffered_data_payload(id))
-            }
-            BufferedSequenceOp::Batch(rows) => {
-                if !pending_bytes.is_empty() {
-                    outputs.push(BufferedSequenceOutput::Bytes(std::mem::take(
-                        &mut pending_bytes,
-                    )));
-                }
-                outputs.push(BufferedSequenceOutput::Batch((rows as usize % 3) + 1));
-            }
-        }
-    }
-
-    if !pending_bytes.is_empty() {
-        outputs.push(BufferedSequenceOutput::Bytes(pending_bytes));
-    }
-
-    outputs
-}
-
-fn drain_io_work_items(rx: &mut mpsc::Receiver<IoWorkItem>) -> Vec<BufferedSequenceOutput> {
-    let mut outputs = Vec::new();
-    while let Ok(item) = rx.try_recv() {
-        match item {
-            IoWorkItem::Bytes(chunk) => {
-                outputs.push(BufferedSequenceOutput::Bytes(chunk.bytes.to_vec()))
-            }
-            IoWorkItem::Batch { batch, .. } => {
-                outputs.push(BufferedSequenceOutput::Batch(batch.num_rows()))
-            }
-        }
-    }
-    outputs
 }
 
 #[test]
@@ -1234,84 +1172,10 @@ fn io_worker_flushes_large_shared_buffer_chunk_without_waiting_for_timeout() {
     assert!(chunk.bytes.iter().all(|byte| *byte == b'x'));
 }
 
-#[test]
-fn process_buffered_events_preserves_later_data_after_interleaved_batch() {
-    let (tx, mut rx) = mpsc::channel(IO_CPU_CHANNEL_CAPACITY);
-    let stats = Arc::new(ComponentStats::new_with_health(ComponentHealth::Starting));
-    let mut input = InputState {
-        source: Box::new(SingleDataSource { emitted: false }),
-        buf: BytesMut::from(
-            &[
-                buffered_data_payload(1).as_slice(),
-                buffered_data_payload(2).as_slice(),
-            ]
-            .concat()[..],
-        ),
-        row_origins: Vec::new(),
-        source_paths: HashMap::new(),
-        cri_metadata: CriMetadata::default(),
-        stats,
-    };
-    let meter = opentelemetry::global::meter("process_buffered_events_interleaved_batch");
-    let metrics = PipelineMetrics::new("test", "SELECT * FROM logs", &meter);
-    let mut last_bp_warn = None;
-    let mut buffered_since = None;
-    let mut pending_row_origin = None;
-    let first_len = buffered_data_payload(1).len();
-    let second_len = buffered_data_payload(2).len();
-
-    let ok = process_buffered_events(
-        &mut input,
-        &Arc::from("configured-input"),
-        vec![
-            BufferedInputEvent::Data {
-                range: 0..first_len,
-                source_id: None,
-                cri_metadata: None,
-            },
-            BufferedInputEvent::Batch {
-                batch: make_test_batch(2, "batch"),
-                source_id: None,
-            },
-            BufferedInputEvent::Data {
-                range: first_len..(first_len + second_len),
-                source_id: None,
-                cri_metadata: None,
-            },
-        ],
-        &tx,
-        &metrics,
-        &mut last_bp_warn,
-        0,
-        1,
-        &mut buffered_since,
-        &mut pending_row_origin,
-        true,
-        SourceMetadataPlan::default(),
-    );
-
-    assert!(ok);
-    assert!(input.buf.is_empty());
-    assert_eq!(
-        drain_io_work_items(&mut rx),
-        vec![
-            BufferedSequenceOutput::Bytes(buffered_data_payload(1)),
-            BufferedSequenceOutput::Batch(2),
-            BufferedSequenceOutput::Bytes(buffered_data_payload(2)),
-        ]
-    );
-}
-
 proptest! {
     #[test]
-    fn process_buffered_events_matches_reference_order_for_generated_sequences(
-        ops in prop::collection::vec(
-            prop_oneof![
-                any::<u8>().prop_map(BufferedSequenceOp::Data),
-                any::<u8>().prop_map(BufferedSequenceOp::Batch),
-            ],
-            1..16,
-        )
+    fn process_buffered_events_preserves_generated_data_sequences(
+        ids in prop::collection::vec(any::<u8>(), 1..16),
     ) {
         let (tx, mut rx) = mpsc::channel(64);
         let stats = Arc::new(ComponentStats::new_with_health(ComponentHealth::Starting));
@@ -1330,24 +1194,18 @@ proptest! {
         let mut buffered_since = None;
         let mut pending_row_origin = None;
         let mut events = Vec::new();
+        let mut expected = Vec::new();
 
-        for op in &ops {
-            match *op {
-                BufferedSequenceOp::Data(id) => {
-                    let payload = buffered_data_payload(id);
-                    let start = input.buf.len();
-                    input.buf.extend_from_slice(&payload);
-                    events.push(BufferedInputEvent::Data {
-                        range: start..input.buf.len(),
-                        source_id: None,
-                        cri_metadata: None,
-                    });
-                }
-                BufferedSequenceOp::Batch(rows) => events.push(BufferedInputEvent::Batch {
-                    batch: make_test_batch((rows as usize % 3) + 1, "batch"),
-                    source_id: None,
-                }),
-            }
+        for id in &ids {
+            let payload = framed_data_payload(*id);
+            let start = input.buf.len();
+            input.buf.extend_from_slice(&payload);
+            expected.extend_from_slice(&payload);
+            events.push(FramedReadEvent::Data {
+                range: start..input.buf.len(),
+                source_id: None,
+                cri_metadata: None,
+            });
         }
 
         let ok = process_buffered_events(
@@ -1367,7 +1225,12 @@ proptest! {
 
         prop_assert!(ok);
         prop_assert!(input.buf.is_empty());
-        prop_assert_eq!(drain_io_work_items(&mut rx), expected_buffered_outputs(&ops));
+        let item = rx.try_recv().expect("one emitted bytes chunk");
+        let IoWorkItem::Bytes(chunk) = item else {
+            panic!("expected bytes chunk");
+        };
+        prop_assert_eq!(chunk.bytes.as_ref(), expected.as_slice());
+        prop_assert!(rx.try_recv().is_err());
     }
 }
 

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
@@ -743,6 +743,72 @@ const IO_CPU_CHANNEL_CAPACITY: usize = 4;
 /// Constant for shutdown drain log interval (mirrors the production constant).
 const SHUTDOWN_DRAIN_PROGRESS_LOG_INTERVAL_ROUNDS: usize = 64;
 
+#[derive(Clone, Debug)]
+enum BufferedSequenceOp {
+    Data(u8),
+    Batch(u8),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum BufferedSequenceOutput {
+    Bytes(Vec<u8>),
+    Batch(usize),
+}
+
+fn make_test_batch(rows: usize, tag: &str) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![Field::new("msg", DataType::Utf8, true)]));
+    let values = (0..rows)
+        .map(|row| format!("{tag}-{row}"))
+        .collect::<Vec<_>>();
+    RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values))]).expect("batch")
+}
+
+fn buffered_data_payload(id: u8) -> Vec<u8> {
+    format!("{{\"msg\":\"data-{id}\"}}\n").into_bytes()
+}
+
+fn expected_buffered_outputs(ops: &[BufferedSequenceOp]) -> Vec<BufferedSequenceOutput> {
+    let mut outputs = Vec::new();
+    let mut pending_bytes = Vec::new();
+
+    for op in ops {
+        match *op {
+            BufferedSequenceOp::Data(id) => {
+                pending_bytes.extend_from_slice(&buffered_data_payload(id))
+            }
+            BufferedSequenceOp::Batch(rows) => {
+                if !pending_bytes.is_empty() {
+                    outputs.push(BufferedSequenceOutput::Bytes(std::mem::take(
+                        &mut pending_bytes,
+                    )));
+                }
+                outputs.push(BufferedSequenceOutput::Batch((rows as usize % 3) + 1));
+            }
+        }
+    }
+
+    if !pending_bytes.is_empty() {
+        outputs.push(BufferedSequenceOutput::Bytes(pending_bytes));
+    }
+
+    outputs
+}
+
+fn drain_io_work_items(rx: &mut mpsc::Receiver<IoWorkItem>) -> Vec<BufferedSequenceOutput> {
+    let mut outputs = Vec::new();
+    while let Ok(item) = rx.try_recv() {
+        match item {
+            IoWorkItem::Bytes(chunk) => {
+                outputs.push(BufferedSequenceOutput::Bytes(chunk.bytes.to_vec()))
+            }
+            IoWorkItem::Batch { batch, .. } => {
+                outputs.push(BufferedSequenceOutput::Batch(batch.num_rows()))
+            }
+        }
+    }
+    outputs
+}
+
 #[test]
 fn io_worker_uses_configured_input_name_for_source_metadata() {
     let (tx, mut rx) = mpsc::channel(IO_CPU_CHANNEL_CAPACITY);
@@ -1166,6 +1232,143 @@ fn io_worker_flushes_large_shared_buffer_chunk_without_waiting_for_timeout() {
     };
     assert_eq!(chunk.bytes.len(), 80 * 1024);
     assert!(chunk.bytes.iter().all(|byte| *byte == b'x'));
+}
+
+#[test]
+fn process_buffered_events_preserves_later_data_after_interleaved_batch() {
+    let (tx, mut rx) = mpsc::channel(IO_CPU_CHANNEL_CAPACITY);
+    let stats = Arc::new(ComponentStats::new_with_health(ComponentHealth::Starting));
+    let mut input = InputState {
+        source: Box::new(SingleDataSource { emitted: false }),
+        buf: BytesMut::from(
+            &[
+                buffered_data_payload(1).as_slice(),
+                buffered_data_payload(2).as_slice(),
+            ]
+            .concat()[..],
+        ),
+        row_origins: Vec::new(),
+        source_paths: HashMap::new(),
+        cri_metadata: CriMetadata::default(),
+        stats,
+    };
+    let meter = opentelemetry::global::meter("process_buffered_events_interleaved_batch");
+    let metrics = PipelineMetrics::new("test", "SELECT * FROM logs", &meter);
+    let mut last_bp_warn = None;
+    let mut buffered_since = None;
+    let mut pending_row_origin = None;
+    let first_len = buffered_data_payload(1).len();
+    let second_len = buffered_data_payload(2).len();
+
+    let ok = process_buffered_events(
+        &mut input,
+        &Arc::from("configured-input"),
+        vec![
+            BufferedInputEvent::Data {
+                range: 0..first_len,
+                source_id: None,
+                cri_metadata: None,
+            },
+            BufferedInputEvent::Batch {
+                batch: make_test_batch(2, "batch"),
+                source_id: None,
+            },
+            BufferedInputEvent::Data {
+                range: first_len..(first_len + second_len),
+                source_id: None,
+                cri_metadata: None,
+            },
+        ],
+        &tx,
+        &metrics,
+        &mut last_bp_warn,
+        0,
+        1,
+        &mut buffered_since,
+        &mut pending_row_origin,
+        true,
+        SourceMetadataPlan::default(),
+    );
+
+    assert!(ok);
+    assert!(input.buf.is_empty());
+    assert_eq!(
+        drain_io_work_items(&mut rx),
+        vec![
+            BufferedSequenceOutput::Bytes(buffered_data_payload(1)),
+            BufferedSequenceOutput::Batch(2),
+            BufferedSequenceOutput::Bytes(buffered_data_payload(2)),
+        ]
+    );
+}
+
+proptest! {
+    #[test]
+    fn process_buffered_events_matches_reference_order_for_generated_sequences(
+        ops in prop::collection::vec(
+            prop_oneof![
+                any::<u8>().prop_map(BufferedSequenceOp::Data),
+                any::<u8>().prop_map(BufferedSequenceOp::Batch),
+            ],
+            1..16,
+        )
+    ) {
+        let (tx, mut rx) = mpsc::channel(64);
+        let stats = Arc::new(ComponentStats::new_with_health(ComponentHealth::Starting));
+        let mut input = InputState {
+            source: Box::new(SingleDataSource { emitted: false }),
+            buf: BytesMut::new(),
+            row_origins: Vec::new(),
+            source_paths: HashMap::new(),
+            cri_metadata: CriMetadata::default(),
+            stats,
+        };
+        let input_name: Arc<str> = Arc::from("configured-input");
+        let meter = opentelemetry::global::meter("process_buffered_events_proptest");
+        let metrics = PipelineMetrics::new("test", "SELECT * FROM logs", &meter);
+        let mut last_bp_warn = None;
+        let mut buffered_since = None;
+        let mut pending_row_origin = None;
+        let mut events = Vec::new();
+
+        for op in &ops {
+            match *op {
+                BufferedSequenceOp::Data(id) => {
+                    let payload = buffered_data_payload(id);
+                    let start = input.buf.len();
+                    input.buf.extend_from_slice(&payload);
+                    events.push(BufferedInputEvent::Data {
+                        range: start..input.buf.len(),
+                        source_id: None,
+                        cri_metadata: None,
+                    });
+                }
+                BufferedSequenceOp::Batch(rows) => events.push(BufferedInputEvent::Batch {
+                    batch: make_test_batch((rows as usize % 3) + 1, "batch"),
+                    source_id: None,
+                }),
+            }
+        }
+
+        let ok = process_buffered_events(
+            &mut input,
+            &input_name,
+            events,
+            &tx,
+            &metrics,
+            &mut last_bp_warn,
+            0,
+            1,
+            &mut buffered_since,
+            &mut pending_row_origin,
+            true,
+            SourceMetadataPlan::default(),
+        );
+
+        prop_assert!(ok);
+        prop_assert!(input.buf.is_empty());
+        prop_assert_eq!(drain_io_work_items(&mut rx), expected_buffered_outputs(&ops));
+    }
 }
 
 #[test]

--- a/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_pipeline_tests.rs
@@ -601,6 +601,7 @@ impl InputSource for LargeSharedBufferSource {
         let chunk = vec![b'x'; 80 * 1024];
         dst.extend_from_slice(&chunk);
         self.emitted = true;
+        self.finished = true;
         Ok(Some(vec![FramedReadEvent::Data {
             range: start..dst.len(),
             source_id: None,

--- a/crates/logfwd-runtime/src/pipeline/io_worker.rs
+++ b/crates/logfwd-runtime/src/pipeline/io_worker.rs
@@ -122,6 +122,35 @@ fn is_large_single_buffered_data_event(
 }
 
 #[cfg(not(feature = "turmoil"))]
+fn next_buffered_data_start(events: &[BufferedInputEvent], from_index: usize) -> Option<usize> {
+    events
+        .iter()
+        .skip(from_index + 1)
+        .filter_map(|event| match event {
+            BufferedInputEvent::Data { range, .. } => Some(range.start),
+            BufferedInputEvent::Batch { .. }
+            | BufferedInputEvent::Rotated { .. }
+            | BufferedInputEvent::Truncated { .. } => None,
+        })
+        .min()
+}
+
+#[cfg(not(feature = "turmoil"))]
+fn rebase_future_buffered_data_ranges(
+    events: &mut [BufferedInputEvent],
+    from_index: usize,
+    offset: usize,
+) {
+    for event in events.iter_mut().skip(from_index) {
+        if let BufferedInputEvent::Data { range, .. } = event {
+            debug_assert!(range.start >= offset);
+            debug_assert!(range.end >= offset);
+            *range = (range.start - offset)..(range.end - offset);
+        }
+    }
+}
+
+#[cfg(not(feature = "turmoil"))]
 pub(crate) fn should_repoll_shutdown_buffered(
     events: &[BufferedInputEvent],
     is_finished: bool,
@@ -691,7 +720,7 @@ pub(super) fn process_io_events(
 
 #[cfg(not(feature = "turmoil"))]
 #[allow(clippy::too_many_arguments)]
-fn process_buffered_events(
+pub(super) fn process_buffered_events(
     input: &mut InputState,
     input_name: &Arc<str>,
     events: Vec<BufferedInputEvent>,
@@ -705,6 +734,7 @@ fn process_buffered_events(
     buffer_was_empty_at_poll: bool,
     source_metadata_plan: SourceMetadataPlan,
 ) -> bool {
+    let mut events = events;
     let source_path_snapshot = if source_metadata_plan.has_source_path() {
         input.source.source_paths()
     } else {
@@ -713,7 +743,12 @@ fn process_buffered_events(
     let should_flush_large_single_chunk =
         is_large_single_buffered_data_event(&events, buffer_was_empty_at_poll);
 
-    for event in events {
+    let mut index = 0usize;
+    while index < events.len() {
+        let event = std::mem::replace(
+            &mut events[index],
+            BufferedInputEvent::Rotated { source_id: None },
+        );
         match event {
             BufferedInputEvent::Data {
                 range,
@@ -744,6 +779,11 @@ fn process_buffered_events(
                 );
             }
             BufferedInputEvent::Batch { batch, source_id } => {
+                let future_data_start = next_buffered_data_start(&events, index);
+                let future_bytes = future_data_start.map(|start| input.buf.split_off(start));
+                if let Some(start) = future_data_start {
+                    rebase_future_buffered_data_ranges(&mut events, index + 1, start);
+                }
                 if !flush_buf(
                     &mut input.buf,
                     &mut input.row_origins,
@@ -797,6 +837,9 @@ fn process_buffered_events(
                     }
                     Err(mpsc::error::TrySendError::Closed(_)) => return false,
                 }
+                if let Some(future_bytes) = future_bytes {
+                    input.buf = future_bytes;
+                }
             }
             BufferedInputEvent::Rotated { .. } => {
                 input.stats.inc_rotations();
@@ -807,6 +850,7 @@ fn process_buffered_events(
                 tracing::info!(input = input.source.name(), "input.file_truncated");
             }
         }
+        index += 1;
     }
     let flush_by_size = input.buf.len() >= safe_batch_target_bytes;
     if flush_by_size || should_flush_large_single_chunk {

--- a/crates/logfwd-runtime/src/pipeline/io_worker.rs
+++ b/crates/logfwd-runtime/src/pipeline/io_worker.rs
@@ -21,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 #[cfg(not(feature = "turmoil"))]
 use logfwd_diagnostics::diagnostics::PipelineMetrics;
 #[cfg(not(feature = "turmoil"))]
-use logfwd_io::input::{BufferedInputEvent, CriMetadata, InputEvent};
+use logfwd_io::input::{CriMetadata, FramedReadEvent, InputEvent};
 #[cfg(not(feature = "turmoil"))]
 use logfwd_io::poll_cadence::AdaptivePollController;
 #[cfg(not(feature = "turmoil"))]
@@ -96,21 +96,18 @@ pub(crate) fn should_repoll_shutdown(
 }
 
 #[cfg(not(feature = "turmoil"))]
-fn buffered_events_have_payload(events: &[BufferedInputEvent]) -> bool {
-    events.iter().any(|event| {
-        matches!(
-            event,
-            BufferedInputEvent::Data { .. } | BufferedInputEvent::Batch { .. }
-        )
-    })
+fn framed_read_events_have_payload(events: &[FramedReadEvent]) -> bool {
+    events
+        .iter()
+        .any(|event| matches!(event, FramedReadEvent::Data { .. }))
 }
 
 #[cfg(not(feature = "turmoil"))]
 fn is_large_single_buffered_data_event(
-    events: &[BufferedInputEvent],
+    events: &[FramedReadEvent],
     buffer_was_empty_at_poll: bool,
 ) -> bool {
-    let Some(BufferedInputEvent::Data { range, .. }) = events.first() else {
+    let Some(FramedReadEvent::Data { range, .. }) = events.first() else {
         return false;
     };
     should_flush_large_single_shared_buffer_chunk(
@@ -122,37 +119,8 @@ fn is_large_single_buffered_data_event(
 }
 
 #[cfg(not(feature = "turmoil"))]
-fn next_buffered_data_start(events: &[BufferedInputEvent], from_index: usize) -> Option<usize> {
-    events
-        .iter()
-        .skip(from_index + 1)
-        .filter_map(|event| match event {
-            BufferedInputEvent::Data { range, .. } => Some(range.start),
-            BufferedInputEvent::Batch { .. }
-            | BufferedInputEvent::Rotated { .. }
-            | BufferedInputEvent::Truncated { .. } => None,
-        })
-        .min()
-}
-
-#[cfg(not(feature = "turmoil"))]
-fn rebase_future_buffered_data_ranges(
-    events: &mut [BufferedInputEvent],
-    from_index: usize,
-    offset: usize,
-) {
-    for event in events.iter_mut().skip(from_index) {
-        if let BufferedInputEvent::Data { range, .. } = event {
-            debug_assert!(range.start >= offset);
-            debug_assert!(range.end >= offset);
-            *range = (range.start - offset)..(range.end - offset);
-        }
-    }
-}
-
-#[cfg(not(feature = "turmoil"))]
 pub(crate) fn should_repoll_shutdown_buffered(
-    events: &[BufferedInputEvent],
+    events: &[FramedReadEvent],
     is_finished: bool,
     had_source_payload: bool,
 ) -> bool {
@@ -160,7 +128,7 @@ pub(crate) fn should_repoll_shutdown_buffered(
         is_finished,
         had_source_payload,
         !events.is_empty(),
-        buffered_events_have_payload(events),
+        framed_read_events_have_payload(events),
     )
 }
 
@@ -723,7 +691,7 @@ pub(super) fn process_io_events(
 pub(super) fn process_buffered_events(
     input: &mut InputState,
     input_name: &Arc<str>,
-    events: Vec<BufferedInputEvent>,
+    events: Vec<FramedReadEvent>,
     tx: &mpsc::Sender<IoWorkItem>,
     metrics: &PipelineMetrics,
     last_bp_warn: &mut Option<Instant>,
@@ -734,7 +702,6 @@ pub(super) fn process_buffered_events(
     buffer_was_empty_at_poll: bool,
     source_metadata_plan: SourceMetadataPlan,
 ) -> bool {
-    let mut events = events;
     let source_path_snapshot = if source_metadata_plan.has_source_path() {
         input.source.source_paths()
     } else {
@@ -743,14 +710,9 @@ pub(super) fn process_buffered_events(
     let should_flush_large_single_chunk =
         is_large_single_buffered_data_event(&events, buffer_was_empty_at_poll);
 
-    let mut index = 0usize;
-    while index < events.len() {
-        let event = std::mem::replace(
-            &mut events[index],
-            BufferedInputEvent::Rotated { source_id: None },
-        );
+    for event in events {
         match event {
-            BufferedInputEvent::Data {
+            FramedReadEvent::Data {
                 range,
                 source_id,
                 cri_metadata,
@@ -778,79 +740,15 @@ pub(super) fn process_buffered_events(
                     &input.buf[range],
                 );
             }
-            BufferedInputEvent::Batch { batch, source_id } => {
-                let future_data_start = next_buffered_data_start(&events, index);
-                let future_bytes = future_data_start.map(|start| input.buf.split_off(start));
-                if let Some(start) = future_data_start {
-                    rebase_future_buffered_data_ranges(&mut events, index + 1, start);
-                }
-                if !flush_buf(
-                    &mut input.buf,
-                    &mut input.row_origins,
-                    pending_row_origin,
-                    &mut input.source_paths,
-                    &mut input.cri_metadata,
-                    &*input.source,
-                    tx,
-                    metrics,
-                    last_bp_warn,
-                    input_index,
-                    source_metadata_plan,
-                ) {
-                    return false;
-                }
-                *buffered_since = None;
-
-                let row_origins = if source_metadata_plan.has_any() {
-                    vec![RowOriginSpan {
-                        source_id,
-                        input_name: Arc::clone(input_name),
-                        rows: batch.num_rows(),
-                    }]
-                } else {
-                    Vec::new()
-                };
-                let source_paths = if source_metadata_plan.has_source_path() {
-                    source_paths_by_id(&source_path_snapshot, &row_origins)
-                } else {
-                    HashMap::new()
-                };
-                let item = IoWorkItem::Batch {
-                    batch,
-                    checkpoints: input.source.checkpoint_data(),
-                    row_origins,
-                    source_paths,
-                    queued_at: tokio::time::Instant::now(),
-                    input_index,
-                };
-                match tx.try_send(item) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full(item)) => {
-                        if last_bp_warn.is_none_or(|t| t.elapsed() >= Duration::from_secs(5)) {
-                            tracing::warn!(input = input.source.name(), "input.backpressure");
-                            *last_bp_warn = Some(Instant::now());
-                        }
-                        metrics.inc_backpressure_stall();
-                        if tx.blocking_send(item).is_err() {
-                            return false;
-                        }
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => return false,
-                }
-                if let Some(future_bytes) = future_bytes {
-                    input.buf = future_bytes;
-                }
-            }
-            BufferedInputEvent::Rotated { .. } => {
+            FramedReadEvent::Rotated { .. } => {
                 input.stats.inc_rotations();
                 tracing::info!(input = input.source.name(), "input.file_rotated");
             }
-            BufferedInputEvent::Truncated { .. } => {
+            FramedReadEvent::Truncated { .. } => {
                 input.stats.inc_rotations();
                 tracing::info!(input = input.source.name(), "input.file_truncated");
             }
         }
-        index += 1;
     }
     let flush_by_size = input.buf.len() >= safe_batch_target_bytes;
     if flush_by_size || should_flush_large_single_chunk {

--- a/crates/logfwd-runtime/src/pipeline/io_worker.rs
+++ b/crates/logfwd-runtime/src/pipeline/io_worker.rs
@@ -21,7 +21,7 @@ use tokio_util::sync::CancellationToken;
 #[cfg(not(feature = "turmoil"))]
 use logfwd_diagnostics::diagnostics::PipelineMetrics;
 #[cfg(not(feature = "turmoil"))]
-use logfwd_io::input::{CriMetadata, InputEvent};
+use logfwd_io::input::{BufferedInputEvent, CriMetadata, InputEvent};
 #[cfg(not(feature = "turmoil"))]
 use logfwd_io::poll_cadence::AdaptivePollController;
 #[cfg(not(feature = "turmoil"))]
@@ -35,6 +35,10 @@ use logfwd_io::tail::ByteOffset;
 #[cfg(not(feature = "turmoil"))]
 use std::collections::HashSet;
 
+#[cfg(not(feature = "turmoil"))]
+use super::buffered_input_policy::{
+    should_flush_large_single_shared_buffer_chunk, should_repoll_buffered_shutdown,
+};
 #[cfg(not(feature = "turmoil"))]
 use super::health::{
     HealthTransitionEvent, reduce_component_health, reduce_component_health_after_poll_failure,
@@ -89,6 +93,46 @@ pub(crate) fn should_repoll_shutdown(
             )
         })
     })
+}
+
+#[cfg(not(feature = "turmoil"))]
+fn buffered_events_have_payload(events: &[BufferedInputEvent]) -> bool {
+    events.iter().any(|event| {
+        matches!(
+            event,
+            BufferedInputEvent::Data { .. } | BufferedInputEvent::Batch { .. }
+        )
+    })
+}
+
+#[cfg(not(feature = "turmoil"))]
+fn is_large_single_buffered_data_event(
+    events: &[BufferedInputEvent],
+    buffer_was_empty_at_poll: bool,
+) -> bool {
+    let Some(BufferedInputEvent::Data { range, .. }) = events.first() else {
+        return false;
+    };
+    should_flush_large_single_shared_buffer_chunk(
+        buffer_was_empty_at_poll,
+        events.len(),
+        range.start == 0,
+        range.len(),
+    )
+}
+
+#[cfg(not(feature = "turmoil"))]
+pub(crate) fn should_repoll_shutdown_buffered(
+    events: &[BufferedInputEvent],
+    is_finished: bool,
+    had_source_payload: bool,
+) -> bool {
+    should_repoll_buffered_shutdown(
+        is_finished,
+        had_source_payload,
+        !events.is_empty(),
+        buffered_events_have_payload(events),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -645,6 +689,152 @@ pub(super) fn process_io_events(
     true
 }
 
+#[cfg(not(feature = "turmoil"))]
+#[allow(clippy::too_many_arguments)]
+fn process_buffered_events(
+    input: &mut InputState,
+    input_name: &Arc<str>,
+    events: Vec<BufferedInputEvent>,
+    tx: &mpsc::Sender<IoWorkItem>,
+    metrics: &PipelineMetrics,
+    last_bp_warn: &mut Option<Instant>,
+    input_index: usize,
+    safe_batch_target_bytes: usize,
+    buffered_since: &mut Option<Instant>,
+    pending_row_origin: &mut Option<PendingRowOrigin>,
+    buffer_was_empty_at_poll: bool,
+    source_metadata_plan: SourceMetadataPlan,
+) -> bool {
+    let source_path_snapshot = if source_metadata_plan.has_source_path() {
+        input.source.source_paths()
+    } else {
+        Vec::new()
+    };
+    let should_flush_large_single_chunk =
+        is_large_single_buffered_data_event(&events, buffer_was_empty_at_poll);
+
+    for event in events {
+        match event {
+            BufferedInputEvent::Data {
+                range,
+                source_id,
+                cri_metadata,
+            } => {
+                if source_metadata_plan.has_any() {
+                    if source_metadata_plan.has_source_path() {
+                        capture_source_path(
+                            &mut input.source_paths,
+                            &source_path_snapshot,
+                            source_id,
+                        );
+                    }
+                    append_data_row_origins(
+                        &mut input.row_origins,
+                        pending_row_origin,
+                        source_id,
+                        input_name,
+                        &input.buf[range.clone()],
+                    );
+                }
+                append_cri_metadata_for_data(
+                    &mut input.cri_metadata,
+                    cri_metadata,
+                    &input.buf[..range.start],
+                    &input.buf[range],
+                );
+            }
+            BufferedInputEvent::Batch { batch, source_id } => {
+                if !flush_buf(
+                    &mut input.buf,
+                    &mut input.row_origins,
+                    pending_row_origin,
+                    &mut input.source_paths,
+                    &mut input.cri_metadata,
+                    &*input.source,
+                    tx,
+                    metrics,
+                    last_bp_warn,
+                    input_index,
+                    source_metadata_plan,
+                ) {
+                    return false;
+                }
+                *buffered_since = None;
+
+                let row_origins = if source_metadata_plan.has_any() {
+                    vec![RowOriginSpan {
+                        source_id,
+                        input_name: Arc::clone(input_name),
+                        rows: batch.num_rows(),
+                    }]
+                } else {
+                    Vec::new()
+                };
+                let source_paths = if source_metadata_plan.has_source_path() {
+                    source_paths_by_id(&source_path_snapshot, &row_origins)
+                } else {
+                    HashMap::new()
+                };
+                let item = IoWorkItem::Batch {
+                    batch,
+                    checkpoints: input.source.checkpoint_data(),
+                    row_origins,
+                    source_paths,
+                    queued_at: tokio::time::Instant::now(),
+                    input_index,
+                };
+                match tx.try_send(item) {
+                    Ok(()) => {}
+                    Err(mpsc::error::TrySendError::Full(item)) => {
+                        if last_bp_warn.is_none_or(|t| t.elapsed() >= Duration::from_secs(5)) {
+                            tracing::warn!(input = input.source.name(), "input.backpressure");
+                            *last_bp_warn = Some(Instant::now());
+                        }
+                        metrics.inc_backpressure_stall();
+                        if tx.blocking_send(item).is_err() {
+                            return false;
+                        }
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => return false,
+                }
+            }
+            BufferedInputEvent::Rotated { .. } => {
+                input.stats.inc_rotations();
+                tracing::info!(input = input.source.name(), "input.file_rotated");
+            }
+            BufferedInputEvent::Truncated { .. } => {
+                input.stats.inc_rotations();
+                tracing::info!(input = input.source.name(), "input.file_truncated");
+            }
+        }
+    }
+    let flush_by_size = input.buf.len() >= safe_batch_target_bytes;
+    if flush_by_size || should_flush_large_single_chunk {
+        metrics.inc_flush_by_size();
+        if !flush_buf(
+            &mut input.buf,
+            &mut input.row_origins,
+            pending_row_origin,
+            &mut input.source_paths,
+            &mut input.cri_metadata,
+            &*input.source,
+            tx,
+            metrics,
+            last_bp_warn,
+            input_index,
+            source_metadata_plan,
+        ) {
+            return false;
+        }
+        *buffered_since = None;
+        return true;
+    }
+    if buffered_since.is_none() && !input.buf.is_empty() {
+        *buffered_since = Some(Instant::now());
+    }
+    true
+}
+
 // ---------------------------------------------------------------------------
 // I/O worker loop
 // ---------------------------------------------------------------------------
@@ -683,15 +873,28 @@ pub(super) fn io_worker_loop(
             ));
             let mut shutdown_poll_rounds = 0usize;
             loop {
-                match input.source.poll_shutdown() {
-                    Ok(events) => {
+                let buffer_was_empty_at_poll = input.buf.is_empty();
+                let buffered_events = match input.source.poll_shutdown_into(&mut input.buf) {
+                    Ok(events) => events,
+                    Err(e) => {
+                        tracing::warn!(
+                            input = input.source.name(),
+                            error = %e,
+                            "input.shutdown_poll_error"
+                        );
+                        break;
+                    }
+                };
+
+                match buffered_events {
+                    Some(events) => {
                         let cadence = input.source.get_cadence();
-                        let should_repoll = should_repoll_shutdown(
+                        let should_repoll = should_repoll_shutdown_buffered(
                             &events,
                             input.source.is_finished(),
                             cadence.signal.had_data,
                         );
-                        if !process_io_events(
+                        if !process_buffered_events(
                             &mut input,
                             &input_name,
                             events,
@@ -702,6 +905,7 @@ pub(super) fn io_worker_loop(
                             safe_batch_target_bytes,
                             &mut buffered_since,
                             &mut pending_row_origin,
+                            buffer_was_empty_at_poll,
                             source_metadata_plan,
                         ) {
                             break 'io_loop;
@@ -728,21 +932,68 @@ pub(super) fn io_worker_loop(
                             break;
                         }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            input = input.source.name(),
-                            error = %e,
-                            "input.shutdown_poll_error"
-                        );
-                        break;
-                    }
+                    None => match input.source.poll_shutdown() {
+                        Ok(events) => {
+                            let cadence = input.source.get_cadence();
+                            let should_repoll = should_repoll_shutdown(
+                                &events,
+                                input.source.is_finished(),
+                                cadence.signal.had_data,
+                            );
+                            if !process_io_events(
+                                &mut input,
+                                &input_name,
+                                events,
+                                &tx,
+                                &metrics,
+                                &mut last_bp_warn,
+                                input_index,
+                                safe_batch_target_bytes,
+                                &mut buffered_since,
+                                &mut pending_row_origin,
+                                source_metadata_plan,
+                            ) {
+                                break 'io_loop;
+                            }
+                            if !should_repoll {
+                                break;
+                            }
+                            shutdown_poll_rounds = shutdown_poll_rounds.saturating_add(1);
+                            if shutdown_poll_rounds
+                                .is_multiple_of(SHUTDOWN_DRAIN_PROGRESS_LOG_INTERVAL_ROUNDS)
+                            {
+                                tracing::warn!(
+                                    input = input.source.name(),
+                                    rounds = shutdown_poll_rounds,
+                                    "input.shutdown_drain_still_active"
+                                );
+                            }
+                            if shutdown_poll_rounds >= MAX_SHUTDOWN_POLL_ROUNDS {
+                                tracing::error!(
+                                    input = input.source.name(),
+                                    rounds = shutdown_poll_rounds,
+                                    "input.shutdown_drain_aborted_hard_limit"
+                                );
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                input = input.source.name(),
+                                error = %e,
+                                "input.shutdown_poll_error"
+                            );
+                            break;
+                        }
+                    },
                 }
             }
             break;
         }
 
-        let events = match input.source.poll() {
-            Ok(e) => e,
+        let buffer_was_empty_at_poll = input.buf.is_empty();
+        let buffered_events = match input.source.poll_into(&mut input.buf) {
+            Ok(events) => events,
             Err(e) => {
                 adaptive_poll.reset_fast_polls();
                 input.stats.inc_errors();
@@ -767,27 +1018,74 @@ pub(super) fn io_worker_loop(
         let cadence = input.source.get_cadence();
         adaptive_poll.observe_signal(cadence.signal);
 
-        if events.is_empty() {
-            if adaptive_poll.should_fast_poll() {
-                metrics.inc_cadence_fast_repoll();
-            } else {
-                metrics.inc_cadence_idle_sleep();
-                std::thread::sleep(poll_interval);
+        match buffered_events {
+            Some(events) => {
+                if events.is_empty() {
+                    if adaptive_poll.should_fast_poll() {
+                        metrics.inc_cadence_fast_repoll();
+                    } else {
+                        metrics.inc_cadence_idle_sleep();
+                        std::thread::sleep(poll_interval);
+                    }
+                } else if !process_buffered_events(
+                    &mut input,
+                    &input_name,
+                    events,
+                    &tx,
+                    &metrics,
+                    &mut last_bp_warn,
+                    input_index,
+                    safe_batch_target_bytes,
+                    &mut buffered_since,
+                    &mut pending_row_origin,
+                    buffer_was_empty_at_poll,
+                    source_metadata_plan,
+                ) {
+                    break 'io_loop;
+                }
             }
-        } else if !process_io_events(
-            &mut input,
-            &input_name,
-            events,
-            &tx,
-            &metrics,
-            &mut last_bp_warn,
-            input_index,
-            safe_batch_target_bytes,
-            &mut buffered_since,
-            &mut pending_row_origin,
-            source_metadata_plan,
-        ) {
-            break 'io_loop;
+            None => {
+                let events = match input.source.poll() {
+                    Ok(e) => e,
+                    Err(e) => {
+                        adaptive_poll.reset_fast_polls();
+                        input.stats.inc_errors();
+                        consecutive_poll_failures = consecutive_poll_failures.saturating_add(1);
+                        input
+                            .stats
+                            .set_health(reduce_component_health_after_poll_failure(
+                                input.stats.health(),
+                                consecutive_poll_failures,
+                            ));
+                        tracing::warn!(input = input.source.name(), error = %e, "input.poll_error");
+                        std::thread::sleep(Duration::from_millis(100));
+                        continue;
+                    }
+                };
+
+                if events.is_empty() {
+                    if adaptive_poll.should_fast_poll() {
+                        metrics.inc_cadence_fast_repoll();
+                    } else {
+                        metrics.inc_cadence_idle_sleep();
+                        std::thread::sleep(poll_interval);
+                    }
+                } else if !process_io_events(
+                    &mut input,
+                    &input_name,
+                    events,
+                    &tx,
+                    &metrics,
+                    &mut last_bp_warn,
+                    input_index,
+                    safe_batch_target_bytes,
+                    &mut buffered_since,
+                    &mut pending_row_origin,
+                    source_metadata_plan,
+                ) {
+                    break 'io_loop;
+                }
+            }
         }
 
         if input.source.is_finished() {

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -4,6 +4,7 @@
 //! accumulates bytes) and a CPU worker (scans to RecordBatch, runs SQL).
 //! See `input_pipeline` for the I/O/compute separation architecture.
 
+mod buffered_input_policy;
 mod build;
 mod checkpoint_io;
 mod checkpoint_policy;

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -2,28 +2,9 @@
 
 How data flows through logfwd, from bytes on disk to serialized output.
 
-## Ingest Glossary
+## Layers
 
-This document uses one architectural vocabulary for the pre-Arrow path:
-
-- **Source**: where data enters the system (`FileInput`, TCP, UDP, OTLP HTTP, Arrow IPC)
-- **Framing**: line boundaries and per-source remainder management
-- **Normalization**: CRI / auto / passthrough processing that produces scanner-ready NDJSON
-- **Batching**: when to flush scanner-ready bytes to the scanner
-- **Parsing**: NDJSON field extraction driven by structural classification
-- **Materialization**: Arrow `RecordBatch` assembly
-- **Enrichment**: source metadata and CRI sidecar attachment
-- **Transform**: SQL / DataFusion processing
-- **Sink**: OTLP, Elasticsearch, Loki, stdout, JSON lines, file
-
-The code still uses implementation-specific names such as `InputEvent`,
-`InputSource`, `FramedInput`, `io_worker`, and `cpu_worker`. Those names are
-about to be cleaned up, but the architectural model above is the stable way to
-talk about the ingest path.
-
-## Crate Layers
-
-```text
+```
 ┌─────────────────────────────────────────────────────────┐
 │  logfwd (binary)                                        │
 │  CLI entrypoints, config loading, signal handling       │
@@ -32,26 +13,31 @@ talk about the ingest path.
                           ▼
 ┌─────────────────────────────────────────────────────────┐
 │  logfwd-runtime                                          │
-│  Async orchestration, worker pool, batching, SQL, sink   │
+│  Async orchestration, worker pool, processor chain       │
+│                                                         │
+│  ┌──────────┐   ┌───────────┐   ┌───────────────────┐  │
+│  │  Input   │──▶│ Transform │──▶│     Output        │  │
+│  │ threads  │   │  (SQL)    │   │  (HTTP/stdout)    │  │
+│  └──────────┘   └───────────┘   └───────────────────┘  │
 └─────────────────────────────────────────────────────────┘
-                          │
-                          ▼
+       │              │                    │
+       ▼              ▼                    ▼
 ┌──────────────────────────────────────────────────┐
 │  logfwd-arrow                                    │
-│  Scanner wrapper, Arrow builders, RecordBatch    │
+│  ScanBuilder impls, SIMD backends, RecordBatch   │
 └──────────────────────────────────────────────────┘
-                          │
-                          ▼
+       │
+       ▼
 ┌──────────────────────────────────────────────────┐
 │  logfwd-core                                     │
 │  Pure logic, proven, no_std, forbid(unsafe)      │
 └──────────────────────────────────────────────────┘
 ```
 
-Dependencies flow downward. `logfwd-core` knows nothing about Arrow, I/O, or
-async. `logfwd-arrow` bridges core parsing to Arrow types. `logfwd-runtime`
-owns the long-lived runtime shell, and the binary crate stays focused on
-startup/CLI/bootstrap concerns.
+Dependencies flow downward. logfwd-core knows nothing about Arrow,
+IO, or async. logfwd-arrow bridges core's parsing to Arrow types.
+`logfwd-runtime` owns the long-lived async runtime, and the binary crate
+now stays focused on startup/CLI/bootstrap concerns.
 
 `logfwd-diagnostics` owns the diagnostics control-plane surface (diagnostics
 HTTP endpoints, readiness/status shaping, stderr/span buffering, and the
@@ -61,61 +47,58 @@ generated `dashboard.html` asset served by diagnostics).
 and profiling binaries used to measure scanner, pipeline, output, and source
 metadata behavior under representative cardinality and allocation pressure.
 
-## Data Flow
+## Ingest vocabulary
 
-There are two equally important ways to think about ingest:
+Use these terms consistently when discussing the raw-byte path:
 
-- **Semantic layers**: Source -> Framing -> Normalization -> Batching -> Parsing -> Materialization
-- **Ownership / control layers**: who owns mutable bytes, when batches flush, and which worker drives polling
+- **Source**: input-specific byte production and lifecycle (`FileInput`, TCP, UDP, OTLP receiver).
+- **Framing**: newline and per-source remainder handling in `FramedInput`.
+- **Normalization**: format-aware shaping that preserves scanner semantics (for example CRI sidecar metadata).
+- **Batching**: accumulation of scanner-ready bytes before scan in the runtime input path.
+- **Parsing**: `Scanner::scan(Bytes)` turning contiguous bytes into Arrow arrays.
+- **Materialization**: Arrow `RecordBatch` construction plus sidecar column attachment.
+- **Transform**: DataFusion SQL execution over the scanned batch.
+- **Sink**: output encoding and transport.
 
-Most prior confusion came from mixing those two views. `InputSource::poll()` is
-mostly a control-plane interface; `FramedInput` is a semantic layer; runtime
-batch accumulation is an ownership / flush-policy layer.
+Ownership boundaries cut across those semantic layers:
 
-### 1. Source: bytes enter the system
+- The source side owns mutable read buffers (`BytesMut`) while bytes are still being filled.
+- `InputEvent::Data` carries immutable `Bytes` once ownership crosses a component boundary.
+- The scanner contract remains a contiguous `Bytes` buffer even when bytes arrived in fragments upstream.
 
-```text
-Disk/TCP/UDP/HTTP → InputSource::poll() → InputEvent
+## Data flow
+
+### 1. Reading: bytes enter the system
+
+```
+Disk → FileReader (`BytesMut`) → InputEvent::Data { bytes: Bytes }
 ```
 
 **FileTailer** (`logfwd-io/src/tail.rs`) is composed of two internal layers:
 - **FileDiscovery**: path watching via notify (kqueue/inotify), glob evaluation,
   rotation detection, deleted-file cleanup, LRU eviction.
-- **FileReader**: open file descriptors, persistent read buffer, byte reading.
+- **FileReader**: open file descriptors, per-file `BytesMut` read buffers, byte reading.
 
 File-discovery reliability notes: `dev-docs/references/file-discovery.md`.
 
-Today the source boundary is already `bytes::Bytes`, not `Vec<u8>`.
-`InputEvent::Data` carries:
+> **Note:** the `Bytes` boundary is now inside `logfwd-io`, not only in
+> `logfwd-runtime`. The tailer owns mutable per-source `BytesMut` read buffers,
+> `InputEvent::Data` carries immutable `Bytes`, and `FramedInput` keeps only
+> small per-source `Vec<u8>` remainders where a line is incomplete or tainted.
 
-- `bytes: Bytes`
-- `source_id: Option<SourceId>`
-- `accounted_bytes: u64`
-- optional CRI sidecar metadata
+Each input source is polled on its own input-side worker thread. That thread
+owns the mutable accumulation buffer used before scan and sends immutable
+`Bytes` chunks to a per-input CPU worker over a bounded `tokio::sync::mpsc`
+channel.
 
-Structured receivers can skip the raw-byte path entirely and emit
-`InputEvent::Batch { batch: RecordBatch, ... }`.
+### 2. Framing: input bytes → complete lines
 
-Each input source runs on its own OS thread. Reads feed a bounded
-`tokio::sync::mpsc` channel to the async pipeline loop. The channel
-carries immutable ownership (`Bytes` or `RecordBatch`) cleanly across the
-thread boundary.
-
-### 2. Framing and Normalization: source bytes -> scanner-ready NDJSON
-
-```text
-InputEvent::Data { bytes: Bytes, ... } -> FramedInput::poll() -> scanner-ready bytes
+```
+Bytes → FramedInput::poll() → scanner-ready `InputEvent::Data { bytes: Bytes }`
 ```
 
 **FramedInput** (`logfwd-io/src/framed.rs`) combines format detection
-with per-source remainder tracking. Architecturally it owns:
-
-- newline framing
-- partial-line remainder state
-- CRI partial-record aggregation state
-- checkpoint frontier bookkeeping relative to complete newline boundaries
-
-It handles three formats:
+with per-source remainder tracking. It handles three formats:
 
 - **Json**: Lines are already JSON. Splits on `\n`, carries
   partial lines across reads via per-source remainder buffers.
@@ -126,8 +109,14 @@ It handles three formats:
 - **Text/Raw**: Passes lines through verbatim. Line capture into `body` is
   controlled by scanner `line_field_name`.
 
-`FramedInput` is the semantic owner for raw-byte inputs. The runtime should not
-grow a second framing path beside it.
+For passthrough formats, `FramedInput` already has a zero-copy fast path: if a
+chunk arrives with no carried remainder and no overflow-tainted state, complete
+lines can be forwarded directly as `Bytes` without an intermediate output copy.
+For the shared-buffer batching path, `FramedInput::poll_into()` can now also
+append scanner-ready output directly into the runtime-owned `BytesMut` batch
+buffer, including CRI/Auto normalization and CRI sidecar metadata collection.
+The remaining complexity in this area is about when the runtime chooses that
+path, not about changing the scanner contract away from contiguous `Bytes`.
 
 **NewlineFramer** (`logfwd-core/src/framer.rs`): fixed-size
 output (4096 lines, 64KB stack), no heap, Kani-proven. It returns byte
@@ -137,43 +126,18 @@ ranges into the input buffer — zero-copy.
 zero-copy for F-only lines (99% of traffic), copies only for P+F
 reassembly. Kani-proven.
 
-### 3. Batching: scanner-ready bytes -> contiguous scan input
+**Current scanner boundary:** the scanner still consumes one contiguous `Bytes`
+buffer per scan. Upstream work may reduce or relocate copies, but default scan
+entry remains `Scanner::scan(Bytes)`.
 
-The runtime batches scanner-ready bytes before scan. Today this is already a
-deferred-copy design:
+**Current transition state:** the shared-buffer `FramedInput` path exists, but
+`logfwd-runtime` still keeps the legacy `InputEvent::Data { bytes: Bytes }`
+route for fresh-buffer scans. The runtime currently switches to
+`FramedInput::poll_into()` once a batch already has buffered bytes, preserving
+the old single-chunk direct-flush behavior while removing the extra append on
+continuation polls (#2539).
 
-- one buffered scanner-ready `Bytes` chunk is kept without copying
-- if more chunks arrive, they are held as separate `Bytes`
-- concatenation happens once at flush time if the scanner needs a contiguous buffer
-
-This means pre-scan ownership can be conceptually fragmented even though the
-default scanner contract is contiguous.
-
-The current hot boundary is:
-
-```text
-FramedInput output -> pending_chunk | pending_chunks -> Scanner::scan(Bytes)
-```
-
-That distinction matters for future work:
-
-- fragmented accumulation before scan is acceptable
-- the default scan call still takes one contiguous `Bytes`
-- removing copies should happen by filling that contiguous buffer earlier, not
-  by making every layer pretend fragments are free
-
-**Target:** Replace the remaining copy-heavy raw-byte path with a layered
-shared-buffer model (#2424, #2426, #2539):
-
-```text
-Source bytes
-  → FramedInput shared-buffer append
-  → contiguous scanner batch
-  → streaming structural classifier
-  → Scanner
-```
-
-### 4. Parsing: structural classification + field extraction
+### 3. Structural classification: SIMD pre-pass
 
 ```text
 &[u8] → find_structural_chars(block) → StreamingClassifier → processed bitmasks
@@ -196,11 +160,11 @@ Platform-specific SIMD:
 - **x86_64**: AVX2 preferred (2 × 32-byte loads), SSE2 fallback
 - **other**: scalar loop (LLVM auto-vectorizes)
 
-The classifier detects `\n`, space, `"`, `\`, `,`, `:`, `{`, `}`, `[`, and
-`]` in one pass. This eliminates separate newline scanning and enables
-bitmask-based JSON field extraction.
+The classifier detects `\n`, space, `"`, `\`, `,`, `:`, `{`, `}`, `[`,
+and `]` in one pass. This eliminates separate newline scanning and
+enables bitmask-based JSON field extraction.
 
-### 5. Materialization: parsed fields -> Arrow RecordBatch
+### 4. Scanning: JSON → typed fields
 
 ```text
 &[u8] + streaming structural bitmasks → ScanBuilder callbacks → typed column values
@@ -235,6 +199,12 @@ field has a single type across all rows it gets a bare column name
 (`status` as `Int64`). When a field has mixed types, the builder emits
 a `StructArray` conflict column (`status: Struct { int, str }`).
 
+### 5. Building: typed fields → Arrow RecordBatch
+
+```
+ScanBuilder callbacks → StreamingBuilder → RecordBatch
+```
+
 **StreamingBuilder** (`logfwd-arrow/src/streaming_builder.rs`):
 Implements `ScanBuilder`. Stores `(offset, len)` views into the input
 `bytes::Bytes` buffer. Produces `StringViewArray` (zero-copy) via
@@ -247,14 +217,9 @@ Implements `ScanBuilder`. Stores `(offset, len)` views into the input
 - `Scanner::scan_detached(Bytes) → RecordBatch` — self-contained
   `StringArray`, buffer can be freed. For persistence/compression.
 
-The scanner boundary is intentionally contiguous. `Scanner::scan` takes a
-single `Bytes` because the current scanner + `StreamingBuilder` pair stores
-views into one backing buffer. Pre-scan accumulation may use one chunk or many
-chunks, but the default scanner contract is still one contiguous `Bytes`.
+### 6. Metadata attach and transform: RecordBatch → RecordBatch
 
-### 6. Enrichment and Transform: RecordBatch -> RecordBatch
-
-```text
+```
 RecordBatch → sidecar attach/replace → SqlTransform::execute_blocking() → RecordBatch
 ```
 
@@ -282,9 +247,9 @@ duplicate-header, and row-alignment semantics remain local to the transform
 crate; `logfwd-arrow` only owns the shared columnar builder and Arrow
 finalization mechanics.
 
-### 7. Sink: RecordBatch -> wire format
+### 7. Output: RecordBatch → wire format
 
-```text
+```
 RecordBatch → OutputSink::send_batch() → HTTP/stdout/file
 ```
 
@@ -304,7 +269,7 @@ RecordBatch → OutputSink::send_batch() → HTTP/stdout/file
 Each boundary is a trait that logfwd-core defines and other crates
 implement:
 
-```text
+```
 logfwd-core defines          logfwd-arrow implements
 ──────────────────────────    ──────────────────────────
 ScanBuilder                   StreamingBuilder
@@ -326,69 +291,66 @@ OutputSink / Sink traits       OtlpSink, ElasticsearchSink,
 `logfwd-diagnostics` provides the diagnostics server and telemetry-facing
 snapshot types consumed by runtime/bootstrap wiring.
 
-## Pipeline Loop
+## Pipeline loop
 
-The async runtime shell in
-`run_async()` (`crates/logfwd-runtime/src/pipeline/run.rs`) orchestrates the
-per-input workers, owns downstream delivery, and applies output acknowledgements
-to the checkpoint lifecycle machine.
+The runtime path is split into three stages:
 
-Production topology:
+```
+1. Input-side worker thread (`io_worker.rs`)
+   - polls `InputSource`
+   - receives `InputEvent`s from `FramedInput`
+   - accumulates scanner-ready bytes in `InputState.buf: BytesMut`
+   - direct-flushes large solitary chunks when possible
+   - emits `IoWorkItem::Bytes { bytes: Bytes, ... }`
 
-```text
-Per input:
-  InputSource / FramedInput
-    -> I/O worker OS thread
-    -> bounded(4) I/O -> CPU channel
-    -> CPU worker OS thread
-    -> ChannelMsg
-    -> async pipeline loop in run_async()
-    -> processor chain / output pool / ack handling
+2. Per-input CPU worker (`cpu_worker.rs`)
+   - calls `Scanner::scan(Bytes)`
+   - attaches source metadata and CRI sidecars
+   - runs the per-input SQL transform
+   - emits `ChannelMsg { batch, checkpoints, ... }`
+
+3. Async pipeline (`run_async()`)
+   - receives already scanned + transformed batches
+   - runs processor stages
+   - submits to the async output worker pool
+   - advances checkpoint lifecycle from output ACK/reject results
 ```
 
-In production, polling and pre-scan batching happen in the I/O worker, scan +
-SQL happen in the CPU worker, and `run_async()` receives already transformed
-`ChannelMsg` values from those CPU workers.
+This separation matters for batching work:
 
-`turmoil` is intentionally different: it uses `async_input_poll_loop` and keeps
-scan + transform inline in the async test path. The docs below describe the
-production worker topology unless explicitly noted otherwise.
+- **Current pre-scan batching seam** is in the input-side worker (`InputState.buf`).
+- **Scanner boundary** is in the CPU worker and remains contiguous `Bytes`.
+- **Pipeline async loop** no longer owns raw-byte accumulation.
 
-## Buffer Lifecycle
+## Buffer lifecycle
 
 Understanding who owns what and when copies happen:
 
-```text
-Current runtime shape (production, non-`turmoil`):
-  source reads / receives bytes                           [kernel/network -> userspace]
-  InputEvent::Data carries Bytes                          (ownership transfer)
-  FramedInput may copy for remainder prepend or format rewrite
-  runtime batches one Bytes or many Bytes                 (no eager copy on arrival)
-  flush: concatenate once if needed for scan boundary     [contiguous scan input]
-  Scanner receives one Bytes                              (zero-copy into builder views)
-  StreamingBuilder stores views -> RecordBatch            (zero-copy)
-  Enrichment attaches source / CRI sidecars as columns
-
-Current ownership boundaries:
-  source boundary: InputEvent::{Data(Bytes), Batch(RecordBatch), ...}
-  batching boundary: pending_chunk | pending_chunks in I/O worker state
-  scan boundary: one contiguous Bytes for Scanner::scan()
-
-Shared-buffer target:
-  source reads / receives bytes
-  FramedInput appends scanner-ready bytes into shared BytesMut
-  runtime flushes contiguous buffer directly
-  Scanner receives one Bytes
-  StreamingBuilder stores views -> RecordBatch
 ```
+Current on `main`:
+  tailer reads → per-file BytesMut                       [kernel → userspace]
+  tailer emits InputEvent::Data { bytes: Bytes }         (ownership transfer)
+  FramedInput passthrough fast path                      (zero-copy when no remainder/taint)
+  FramedInput shared-buffer path via poll_into()         (direct append for buffered continuation polls)
+  FramedInput legacy event path                          (still used for fresh-buffer scans)
+  io_worker: input.buf.extend_from_slice(&bytes)         [remaining pre-scan copy on legacy path]
+  io_worker flush: split().freeze() → Bytes              (zero-copy — refcount only)
+  cpu_worker: Scanner::scan(Bytes)                       (no re-copy before scan)
+  StreamingBuilder stores views → RecordBatch            (zero-copy)
+  sidecar attach/replace appends Arrow columns before SQL
+  Bytes dropped when RecordBatch is consumed
 
-The important architectural point is not "everything is always contiguous."
-It is:
+Current ownership boundary:
+  source/framing side: per-source BytesMut + small Vec remainders
+  runtime batching boundary: InputState.buf as contiguous BytesMut
+  scanner boundary: contiguous Bytes
 
-- mutable raw-byte ownership should be explicit
-- production pre-scan accumulation may be fragmented
-- the default scanner boundary is still contiguous
-- `FramedInput` remains the one framing contract for raw-byte sources
+Next target in this seam:
+  use the shared-buffer path for more of the runtime batching lifecycle, not only buffered continuation polls
+  remove more legacy `InputEvent::Data` reassembly from the pre-scan hot path
+  keep the scanner contract as `Scanner::scan(Bytes)`
+  benchmark the wider enablement before deleting the fallback route
+```
 
 ## Data-Oriented Design
 

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -70,7 +70,7 @@ Ownership boundaries cut across those semantic layers:
 
 ### 1. Reading: bytes enter the system
 
-```
+```text
 Disk → FileReader (`BytesMut`) → InputEvent::Data { bytes: Bytes }
 ```
 
@@ -93,7 +93,7 @@ channel.
 
 ### 2. Framing: input bytes → complete lines
 
-```
+```text
 Bytes → FramedInput::poll() → scanner-ready `InputEvent::Data { bytes: Bytes }`
 ```
 
@@ -295,7 +295,7 @@ snapshot types consumed by runtime/bootstrap wiring.
 
 The runtime path is split into three stages:
 
-```
+```text
 1. Input-side worker thread (`io_worker.rs`)
    - polls `InputSource`
    - receives `InputEvent`s from `FramedInput`
@@ -326,7 +326,7 @@ This separation matters for batching work:
 
 Understanding who owns what and when copies happen:
 
-```
+```text
 Current on `main`:
   tailer reads → per-file BytesMut                       [kernel → userspace]
   tailer emits InputEvent::Data { bytes: Bytes }         (ownership transfer)

--- a/dev-docs/DESIGN.md
+++ b/dev-docs/DESIGN.md
@@ -239,9 +239,8 @@ Current implication: the remaining hot-path copy on `main` is not “tailer to
 event” anymore. It is the runtime reassembly step that appends scanner-ready
 `Bytes` into `InputState.buf` before scan on the legacy event route. The next
 architecture slice should widen the shared-buffer path so more polls append
-directly into that final batch buffer before scan.
-therefore target that seam directly rather than reintroducing divergent
-source-side batching paths.
+directly into that final batch buffer before scan, targeting that seam
+directly rather than reintroducing divergent source-side batching paths.
 
 ### Verification strategy
 

--- a/dev-docs/DESIGN.md
+++ b/dev-docs/DESIGN.md
@@ -6,11 +6,6 @@ receivers, processors, and exporters. OTel semantics are optional adapters at th
 **RecordBatch in, RecordBatch out.** The pipeline doesn't care whether the data is logs,
 metrics, traces, or CSV files.
 
-For ingest discussions, this document uses the canonical layer names defined in
-the [Ingest Glossary](ARCHITECTURE.md#ingest-glossary). Those names describe
-responsibilities. They intentionally do not mirror every current type or
-module name in the codebase.
-
 ## Target architecture
 
 ```
@@ -211,35 +206,42 @@ zero schema knowledge.
 OTAP's star schema (4+ tables with foreign keys) is optimized for wire efficiency, not
 queryability. Convert at the boundary when needed.
 
-### bytes::Bytes for ingest buffer ownership
+### bytes::Bytes for pipeline buffer ownership
 
-The ingest path uses `Bytes` / `BytesMut` because the scanner boundary is still
-contiguous even when pre-scan accumulation is conceptually fragmented.
+The ingest path uses `BytesMut` while a component still owns mutable fill state,
+then hands off immutable `Bytes` once ownership crosses a boundary. This is the
+standard Rust pattern for I/O pipelines where buffers cross thread/async
+boundaries and may need to outlive the original producer.
 
-Current ownership model:
+Why `Bytes` instead of `Vec<u8>`: The Arrow `StreamingBuilder` needs the input
+buffer to outlive the scan phase — `StringViewArray` stores `(offset, len)` views
+into the buffer, and the `RecordBatch` carries these through SQL transform and
+output serialization. `Bytes` provides this lifetime extension via refcounting.
+`Vec<u8>` cannot be shared without cloning.
 
-- sources and `FramedInput` exchange raw-byte data as `Bytes`
-- in production (`not(feature = "turmoil")`), the I/O worker holds either one
-  `Bytes` chunk or many `Bytes` chunks before scan
-- if multiple chunks are buffered, the I/O worker concatenates once at flush
-  time before handing contiguous bytes to the scanner
-- `turmoil` keeps a simpler `BytesMut` accumulation path for the async test
-  harness
-- `Scanner::scan(Bytes)` still receives one contiguous backing buffer
+Why not `Arc<Vec<u8>>`: `Bytes` supports zero-copy `slice()` and `split()` that
+`Arc<Vec<u8>>` does not. That matters both for the zero-copy passthrough framing
+path already on `main` and for the shared-buffer framing path now landing in
+`FramedInput`, which still needs to preserve one contiguous scanner input.
 
-Why `Bytes` instead of `Vec<u8>`: the Arrow `StreamingBuilder` needs the input
-buffer to outlive scan because `StringViewArray` stores `(offset, len)` views
-into the buffer, and the `RecordBatch` carries those views through transform
-and output serialization. `Bytes` provides that lifetime extension via
-refcounting. `Vec<u8>` cannot be shared without cloning.
+Current boundary:
 
-Why not `Arc<Vec<u8>>`: `Bytes` supports zero-copy `slice()` and cheap ownership
-transfers in a way `Arc<Vec<u8>>` does not.
+- `logfwd-io` tailing uses per-source `BytesMut` read buffers.
+- `InputEvent::Data` already carries `Bytes`.
+- `FramedInput` may still keep small `Vec<u8>` remainders where a line is
+  incomplete or overflow-tainted.
+- `logfwd-runtime` currently performs the remaining pre-scan accumulation into
+  `InputState.buf: BytesMut`.
+- `logfwd-core` is untouched by this ownership shift; the scanner still takes
+  contiguous `Bytes` via `Bytes::Deref`.
 
-Important boundary rule: pre-scan batching may be represented as one chunk or
-many chunks, but the default scanner contract is still contiguous `Bytes`.
-Future shared-buffer work should optimize around that contract rather than
-assuming fragmented scan is free.
+Current implication: the remaining hot-path copy on `main` is not “tailer to
+event” anymore. It is the runtime reassembly step that appends scanner-ready
+`Bytes` into `InputState.buf` before scan on the legacy event route. The next
+architecture slice should widen the shared-buffer path so more polls append
+directly into that final batch buffer before scan.
+therefore target that seam directly rather than reintroducing divergent
+source-side batching paths.
 
 ### Verification strategy
 

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -161,6 +161,13 @@ do not stop at patching the shell. Extract the transition policy into a local pu
 reducer or state module when feasible, then add Kani proofs for single-step invariants
 and proptest sequence coverage for multi-step behavior.
 
+For shared-buffer input work specifically, treat the runtime consumer of
+`BufferedInputEvent` as a separate state machine from `FramedInput` itself.
+`poll()` vs `poll_into()` equivalence tests are necessary but not sufficient:
+add a reducer-level sequence test that mixes `Data`, `Batch`, and control
+events and checks emitted `IoWorkItem` ordering against a reference model.
+That is the seam where shared byte ranges meet flush boundaries.
+
 ### Running proofs
 
 ```bash

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -21,6 +21,8 @@ If the property is temporal ("eventually," "always," "never after X") → TLA+.
 If the function is pure, bounded, and critical → Kani.  
 If it's stateful, heap-heavy, or async → proptest.  
 For unsafe code, use Kani and proptest both.
+For allocator-backed shared-buffer paths that are too integration-heavy for
+Kani, add a narrow targeted Miri regression instead of a broad unsound proof.
 
 ---
 
@@ -169,6 +171,7 @@ cargo build -p logfwd-core \
   --target thumbv6m-none-eabi          # Verify no_std compliance
 MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-core --lib
 MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-types --lib
+MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-io framed::tests::poll_into_miri_shared_buffer_alias_regression --lib
 ```
 
 ### Non-core pure seam boundary contract

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -162,7 +162,7 @@ reducer or state module when feasible, then add Kani proofs for single-step inva
 and proptest sequence coverage for multi-step behavior.
 
 For shared-buffer input work specifically, treat the runtime consumer of
-`BufferedInputEvent` as a separate state machine from `FramedInput` itself.
+`FramedReadEvent` as a separate state machine from `FramedInput` itself.
 `poll()` vs `poll_into()` equivalence tests are necessary but not sufficient:
 add a reducer-level sequence test that mixes `Data`, `Batch`, and control
 events and checks emitted `IoWorkItem` ordering against a reference model.

--- a/dev-docs/verification/kani-boundary-contract.toml
+++ b/dev-docs/verification/kani-boundary-contract.toml
@@ -181,6 +181,12 @@ reason = "The typed delivery outcome -> checkpoint disposition compatibility map
 issue = 1314
 
 [[seams]]
+path = "crates/logfwd-runtime/src/pipeline/buffered_input_policy.rs"
+status = "required"
+reason = "Shared-buffer shutdown repoll and large-first-chunk flush policy is a local pure seam extracted from the async io worker."
+issue = 2539
+
+[[seams]]
 path = "crates/logfwd-runtime/src/pipeline/checkpoint_io.rs"
 status = "recommended"
 reason = "Final checkpoint flush retry-window policy is an isolated local seam and should remain explicitly verified."

--- a/justfile
+++ b/justfile
@@ -157,12 +157,16 @@ miri:
     RUSTC_WRAPPER="" cargo +nightly miri setup
     just miri-core
     just miri-types
+    just miri-io-buffered
 
 miri-core:
     RUSTC_WRAPPER="" MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-core --lib
 
 miri-types:
     RUSTC_WRAPPER="" MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-types --lib
+
+miri-io-buffered:
+    RUSTC_WRAPPER="" MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-io framed::tests::poll_into_miri_shared_buffer_alias_regression --lib
 
 # Run the required Kani crate set enforced by CI guardrails.
 kani-required:

--- a/scripts/verify_proptest_regressions.py
+++ b/scripts/verify_proptest_regressions.py
@@ -20,6 +20,7 @@ NO_PERSISTENCE_ALLOWLIST = {
     "crates/logfwd-types/src/pipeline/lifecycle.rs",
     "crates/logfwd-io/tests/it/checkpoint_state_machine.rs",
     "crates/logfwd-io/tests/it/framed_state_machine.rs",
+    "crates/logfwd-io/tests/it/framed_buffered_equivalence.rs",
 }
 
 


### PR DESCRIPTION
## Summary
- continue the `#2539` shared-buffer batching refactor in the input path
- add stateful equivalence coverage for legacy `poll()` versus shared-buffer `poll_into()` and shutdown variants across passthrough, passthrough_json, CRI, and auto formats
- extract shared-buffer shutdown repoll and large-first-chunk flush policy into a pure runtime seam and mark it as a required Kani boundary
- add a targeted Miri regression and directional benchmark for the shared-buffer `FramedInput` path, plus CI/local wiring for that check
- update architecture, design, and verification docs to reflect the new shared-buffer direction and verification split

## Details
- `logfwd-io` now supports appending scanner-ready output directly into a shared `BytesMut` sink via `FormatDecoder` and `FramedInput`
- `logfwd-runtime` now carries buffered-input policy in `buffered_input_policy.rs`, keeping the async `io_worker` shell smaller and proofable
- the new IO equivalence tests compare emitted bytes, metadata, and checkpoint state between the legacy and buffered paths under randomized event sequences
- the new Miri test specifically checks that later `poll_into()` appends do not corrupt or invalidate earlier appended ranges

## Verification
- `python3 scripts/verify_kani_boundary_contract.py`
- `cargo test -p logfwd-io framed_buffered_equivalence -- --nocapture`
- `cargo test -p logfwd-runtime buffered_input_policy -- --nocapture`
- `cargo test -p logfwd-runtime buffered_shutdown_repoll_continues_for_payload_without_finish -- --nocapture`
- `cargo kani -p logfwd-runtime --harness verify_buffered_shutdown_repoll_matches_reference_formula`
- `cargo kani -p logfwd-runtime --harness verify_large_single_chunk_flush_matches_reference_formula`
- `cargo test -p logfwd-io framed::tests::poll_into_miri_shared_buffer_alias_regression --lib -- --ignored --nocapture`
- `cargo test -p logfwd-io framed::tests::bench_poll_into_shared_buffer_directional --lib -- --ignored --nocapture`
- `cargo +nightly miri setup`
- `RUSTC_WRAPPER="" MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test -p logfwd-io framed::tests::poll_into_miri_shared_buffer_alias_regression --lib`

## Notes
- no new TLA+ spec was added for this slice because the active TLA models intentionally abstract away byte-level framing/shared-buffer assembly; the new proof target here is the extracted local runtime policy seam, not a new temporal protocol
- there are still pre-existing `unused-qualifications` warnings in `crates/logfwd-io/src/host_metrics.rs`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden shared-buffer input batching with policy functions, equivalence tests, and Miri CI
> - Adds `poll_into`/`poll_shutdown_into` to `InputSource` (defaulting to `Ok(None)`) so sources can write directly into a shared `BytesMut`, and updates `io_worker_loop` to prefer this path over legacy `poll()`.
> - Introduces `buffered_input_policy` with two pure policy functions (`should_repoll_buffered_shutdown`, `should_flush_large_single_shared_buffer_chunk`) plus Kani proofs and proptests verifying their correctness.
> - Generalizes `FormatDecoder` output via a `ScannerReadyOutput` trait so scanner-ready bytes can be written into either `Vec<u8>` or `BytesMut`, and replaces the `json_escape_bytes` dependency with a local escaper.
> - Adds a proptest equivalence harness in [`framed_buffered_equivalence.rs`](https://github.com/strawgate/fastforward/pull/2545/files#diff-eee3f21c9710e271963831aa2863d61d0cb9ce83af2e11ceed4cda6e0abe3e0a) asserting that `poll_into`/`poll_shutdown_into` produce identical normalized events and checkpoints to the legacy `poll()`/`poll_shutdown()` path across random input sequences.
> - Adds a `miri-io-buffered` CI job running a targeted aliasing regression test for the shared-buffer path under strict Miri provenance flags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3b3f1a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->