### PR TITLE
fix: runtime auto-shutdown when inputs are exhausted

### DIFF
--- a/crates/logfwd-io/src/generator/input.rs
+++ b/crates/logfwd-io/src/generator/input.rs
@@ -242,9 +242,11 @@ impl InputSource for GeneratorInput {
     }
 
     fn health(&self) -> ComponentHealth {
-        // Generator input has no independent bind/startup/shutdown lifecycle.
-        // It is either idle or emitting synthetic events under pipeline control.
-        ComponentHealth::Healthy
+        if self.done {
+            ComponentHealth::Stopped
+        } else {
+            ComponentHealth::Healthy
+        }
     }
 
     fn is_finished(&self) -> bool {

--- a/crates/logfwd/tests/it/finite_pipeline.rs
+++ b/crates/logfwd/tests/it/finite_pipeline.rs
@@ -1,0 +1,41 @@
+use logfwd_config::Config;
+use logfwd_runtime::pipeline::Pipeline;
+use opentelemetry::metrics::MeterProvider;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn finite_pipeline_shuts_down_automatically() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          total_events: 5
+          batch_size: 2
+    outputs:
+      - type: "null"
+"#;
+    let config = Config::load_str(yaml).expect("parse config");
+
+    let meter = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .build()
+        .meter("test");
+    let mut pipeline =
+        Pipeline::from_config_with_data_dir("test", &config.pipelines["test"], &meter, None, None)
+            .unwrap();
+
+    let shutdown = CancellationToken::new();
+
+    // We expect the pipeline to return Ok(()) naturally, without us cancelling the token.
+    // Wrap in timeout to fail if it hangs.
+    let result = tokio::time::timeout(Duration::from_secs(30), pipeline.run_async(&shutdown)).await;
+
+    assert!(
+        result.is_ok(),
+        "Pipeline did not shut down automatically within timeout"
+    );
+    let result = result.unwrap();
+    assert!(result.is_ok(), "Pipeline failed with error: {:?}", result);
+}

--- a/crates/logfwd/tests/it/main.rs
+++ b/crates/logfwd/tests/it/main.rs
@@ -1,3 +1,4 @@
 mod compliance;
 mod compliance_file;
+mod finite_pipeline;
 mod integration;


### PR DESCRIPTION
Fix runtime auto-shutdown when inputs are exhausted (including finite generator)

---
*PR created automatically by Jules for task [18201637941522085061](https://jules.google.com/task/18201637941522085061) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix runtime auto-shutdown when generator inputs are exhausted
> - `GeneratorInput::health()` now returns `Stopped` once the generator has emitted all configured events, previously it always returned `Healthy`.
> - Adds an integration test in [finite_pipeline.rs](https://github.com/strawgate/fastforward/pull/2554/files#diff-db74a3812da09d373e1ad16bfaa2cf118a92f9516fcd1188d75c2ebf88a93d6f) that verifies a pipeline with a finite generator shuts down automatically within 30 seconds without external cancellation.
> - Behavioral Change: pipelines using a finite generator input will now terminate on their own when input is exhausted rather than running indefinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0dc932.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->