### PR TITLE
feat(tcp_input): support configurable and unlimited max_clients

### DIFF
--- a/crates/logfwd-config/src/tests_input.rs
+++ b/crates/logfwd-config/src/tests_input.rs
@@ -642,6 +642,43 @@ pipelines:
     }
 
     #[test]
+    fn tcp_input_accepts_max_clients() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: tcp
+        listen: 0.0.0.0:514
+        max_clients: 2048
+    outputs:
+      - type: "null"
+"#;
+        let config = Config::load_str(yaml).expect("tcp input must accept max_clients");
+        match &config.pipelines["test"].inputs[0].type_config {
+            InputTypeConfig::Tcp(tcp) => {
+                assert_eq!(tcp.max_clients, Some(2048));
+            }
+            _ => panic!("Expected TCP input config"),
+        }
+    }
+
+    #[test]
+    fn tcp_input_rejects_max_clients_zero() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: tcp
+        listen: 0.0.0.0:514
+        max_clients: 0
+    outputs:
+      - type: "null"
+"#;
+        let err = Config::load_str(yaml).expect_err("tcp input must reject max_clients: 0");
+        assert!(err.to_string().contains("max_clients must be greater than 0"));
+    }
+
+    #[test]
     fn tcp_input_rejects_adaptive_fast_polls_max() {
         let yaml = r#"
 pipelines:

--- a/crates/logfwd-config/src/tests_input.rs
+++ b/crates/logfwd-config/src/tests_input.rs
@@ -675,7 +675,10 @@ pipelines:
       - type: "null"
 "#;
         let err = Config::load_str(yaml).expect_err("tcp input must reject max_clients: 0");
-        assert!(err.to_string().contains("max_clients must be greater than 0"));
+        assert!(
+            err.to_string()
+                .contains("max_clients must be greater than 0")
+        );
     }
 
     #[test]

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -480,6 +480,11 @@ impl Config {
                                     validation_message(err)
                                 )));
                             }
+                            if t.max_clients == Some(0) {
+                                return Err(ConfigError::Validation(format!(
+                                    "pipeline '{name}' input '{label}': tcp max_clients must be greater than 0"
+                                )));
+                            }
                             if let Some(tls) = &t.tls {
                                 let cert_file = tls
                                     .cert_file

--- a/crates/logfwd-io/src/tcp_input/input_source.rs
+++ b/crates/logfwd-io/src/tcp_input/input_source.rs
@@ -4,40 +4,42 @@ impl InputSource for TcpInput {
 
         // Accept new connections up to the limit.
         loop {
-            if self.max_clients.is_some_and(|max| self.clients.len() >= max) {
-                // Drain (and drop) any pending connections beyond the limit so
-                // the kernel accept queue does not fill up and stall.
-                match self.listener.accept() {
-                    Ok((_stream, _addr)) => {
-                        self.connections_accepted += 1;
-                        self.stats.tcp_accepted.store(
-                            self.connections_accepted,
-                            std::sync::atomic::Ordering::Relaxed,
-                        );
-                        if self
-                            .last_max_clients_warning
-                            .is_none_or(|t| t.elapsed() > Duration::from_secs(60))
-                        {
-                            tracing::warn!(
-                                "TCP input '{}' reached max_clients limit ({}), dropping incoming connections",
-                                self.name,
-                                self.max_clients.unwrap()
+            if let Some(max_clients) = self.max_clients
+                && self.clients.len() >= max_clients
+            {
+                    // Drain (and drop) any pending connections beyond the limit so
+                    // the kernel accept queue does not fill up and stall.
+                    match self.listener.accept() {
+                        Ok((_stream, _addr)) => {
+                            self.connections_accepted += 1;
+                            self.stats.tcp_accepted.store(
+                                self.connections_accepted,
+                                std::sync::atomic::Ordering::Relaxed,
                             );
-                            self.last_max_clients_warning = Some(Instant::now());
-                        }
-                        under_pressure = true;
-                        continue; // dropped immediately
-                    }
-                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
-                    Err(e) => {
-                        if let Some(raw) = e.raw_os_error()
-                            && (raw == libc::EMFILE || raw == libc::ENFILE)
-                        {
+                            if self
+                                .last_max_clients_warning
+                                .is_none_or(|t| t.elapsed() > Duration::from_secs(60))
+                            {
+                                tracing::warn!(
+                                    "TCP input '{}' reached max_clients limit ({}), dropping incoming connections",
+                                    self.name,
+                                    max_clients
+                                );
+                                self.last_max_clients_warning = Some(Instant::now());
+                            }
                             under_pressure = true;
+                            continue; // dropped immediately
                         }
-                        break; // transient accept error, not fatal
+                        Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
+                        Err(e) => {
+                            if let Some(raw) = e.raw_os_error()
+                                && (raw == libc::EMFILE || raw == libc::ENFILE)
+                            {
+                                under_pressure = true;
+                            }
+                            break; // transient accept error, not fatal
+                        }
                     }
-                }
             }
             match self.listener.accept() {
                 Ok((stream, _addr)) => {

--- a/crates/logfwd-io/src/tcp_input/input_source.rs
+++ b/crates/logfwd-io/src/tcp_input/input_source.rs
@@ -4,7 +4,7 @@ impl InputSource for TcpInput {
 
         // Accept new connections up to the limit.
         loop {
-            if self.clients.len() >= self.max_clients {
+            if self.max_clients.is_some_and(|max| self.clients.len() >= max) {
                 // Drain (and drop) any pending connections beyond the limit so
                 // the kernel accept queue does not fill up and stall.
                 match self.listener.accept() {
@@ -21,7 +21,7 @@ impl InputSource for TcpInput {
                             tracing::warn!(
                                 "TCP input '{}' reached max_clients limit ({}), dropping incoming connections",
                                 self.name,
-                                self.max_clients
+                                self.max_clients.unwrap()
                             );
                             self.last_max_clients_warning = Some(Instant::now());
                         }

--- a/crates/logfwd-io/src/tcp_input/listener.rs
+++ b/crates/logfwd-io/src/tcp_input/listener.rs
@@ -10,7 +10,7 @@ pub struct TcpInput {
     buf: Vec<u8>,
     idle_timeout: Duration,
     read_timeout: Option<Duration>,
-    max_clients: usize,
+    max_clients: Option<usize>,
     /// Total connections accepted since creation (never decreases).
     connections_accepted: u64,
     /// Rate-limit state for max_clients warnings.

--- a/crates/logfwd-io/src/tcp_input/options.rs
+++ b/crates/logfwd-io/src/tcp_input/options.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, Clone)]
 pub struct TcpInputOptions {
-    /// Maximum number of concurrent connections. Defaults to 1024.
-    pub max_clients: usize,
+    /// Maximum number of concurrent connections. Defaults to unlimited.
+    pub max_clients: Option<usize>,
     /// Connection idle timeout in milliseconds. Defaults to 60000 (60s).
     pub connection_timeout_ms: u64,
     /// Connection read timeout in milliseconds (disconnects if a read yields incomplete data and the next read takes too long). Defaults to no timeout.
@@ -13,7 +13,7 @@ pub struct TcpInputOptions {
 impl Default for TcpInputOptions {
     fn default() -> Self {
         Self {
-            max_clients: 1024,
+            max_clients: None,
             connection_timeout_ms: DEFAULT_IDLE_TIMEOUT.as_millis() as u64,
             read_timeout_ms: None,
             tls: None,

--- a/crates/logfwd-io/src/tcp_input/tests/basic.rs
+++ b/crates/logfwd-io/src/tcp_input/tests/basic.rs
@@ -392,7 +392,7 @@
     #[test]
     fn test_tcp_custom_options() {
         let mut options = TcpInputOptions::default();
-        options.max_clients = 2;
+        options.max_clients = Some(2);
         options.connection_timeout_ms = 1000;
         options.read_timeout_ms = Some(500);
 
@@ -404,7 +404,7 @@
         )
         .unwrap();
 
-        assert_eq!(input.max_clients, 2);
+        assert_eq!(input.max_clients, Some(2));
         assert_eq!(input.idle_timeout.as_millis(), 1000);
         assert_eq!(input.read_timeout.unwrap().as_millis(), 500);
     }

--- a/crates/logfwd-io/src/tcp_input/tests/bounds.rs
+++ b/crates/logfwd-io/src/tcp_input/tests/bounds.rs
@@ -1,4 +1,44 @@
     #[test]
+    fn test_tcp_max_clients_unlimited() {
+        let mut options = TcpInputOptions::default();
+        options.max_clients = None;
+
+        let mut input = TcpInput::with_options(
+            "test_max_conns_unlimited",
+            "127.0.0.1:0",
+            options,
+            std::sync::Arc::new(logfwd_types::diagnostics::ComponentStats::new()),
+        )
+        .unwrap();
+
+        let addr = input.local_addr().unwrap();
+
+        let _client1 = StdTcpStream::connect(addr).unwrap();
+        let _client2 = StdTcpStream::connect(addr).unwrap();
+        let _client3 = StdTcpStream::connect(addr).unwrap();
+        let _client4 = StdTcpStream::connect(addr).unwrap();
+
+        // Wait a bit to ensure connections hit the kernel accept queue
+        std::thread::sleep(Duration::from_millis(50));
+
+        let _events = input.poll().unwrap();
+
+        assert_eq!(
+            input.clients.len(),
+            4,
+            "Should accept all connections when max_clients is None"
+        );
+        assert!(
+            input.last_max_clients_warning.is_none(),
+            "Should not log a warning when max_clients is None"
+        );
+        assert_eq!(
+            input.connections_accepted, 4,
+            "Should have accepted all connections"
+        );
+    }
+
+    #[test]
     fn test_tcp_max_clients_drops_and_warns() {
         let mut options = TcpInputOptions::default();
         options.max_clients = Some(2);

--- a/crates/logfwd-io/src/tcp_input/tests/bounds.rs
+++ b/crates/logfwd-io/src/tcp_input/tests/bounds.rs
@@ -1,7 +1,7 @@
     #[test]
     fn test_tcp_max_clients_drops_and_warns() {
         let mut options = TcpInputOptions::default();
-        options.max_clients = 2;
+        options.max_clients = Some(2);
 
         let mut input = TcpInput::with_options(
             "test_max_conns",

--- a/crates/logfwd-runtime/src/pipeline/input_build.rs
+++ b/crates/logfwd-runtime/src/pipeline/input_build.rs
@@ -417,7 +417,7 @@ pub(super) fn build_input_state(
             }
             let mut options = logfwd_io::tcp_input::TcpInputOptions::default();
             if let Some(v) = t.max_clients {
-                options.max_clients = v;
+                options.max_clients = Some(v);
             }
             if let Some(v) = t.connection_timeout_ms {
                 options.connection_timeout_ms = v.get();


### PR DESCRIPTION
This pull request makes `max_clients` fully configurable and enables an unbounded default to match the backward-compatibility spec in `#2034` and `#2467`.

**Changes included:**
- `crates/logfwd-io/src/tcp_input/options.rs`: Converted `max_clients` to `Option<usize>` with a `None` default to signal unlimited connections.
- `crates/logfwd-io/src/tcp_input/input_source.rs`: Updated the polling acceptance loop to honor bounded settings, gracefully drop new connections when over capacity, and emit a warning once per minute.
- `crates/logfwd-config/src/validate.rs`: Added validation to enforce `max_clients > 0`, explicitly forbidding values that could inadvertently swallow all traffic. Fixed prior clippy lints (`clippy::collapsible_if`).
- `crates/logfwd-runtime/src/pipeline/input_build.rs`: Config mappings pass `Option<usize>` verbatim into the components layer.
- Test suites (`tests_input.rs`, `bounds.rs`) are fully synchronized to capture boundary condition expectations.

Tested locally via `RUSTC_WRAPPER="" cargo clippy` and `cargo test`. All bounding guarantees remain intact.

---
*PR created automatically by Jules for task [12276384846174350218](https://jules.google.com/task/12276384846174350218) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support configurable and unlimited `max_clients` for TCP input
> - Changes `TcpInputOptions::max_clients` from `usize` to `Option<usize>`, with `None` meaning no connection limit.
> - Updates the default from 1024 to `None` (unlimited), so existing deployments without an explicit `max_clients` will no longer have a cap.
> - Adds validation rejecting `max_clients: 0` with a descriptive error.
> - Behavioral Change: the default TCP input no longer limits concurrent clients to 1024; a limit must now be explicitly configured.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4c1e18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->