### PR TITLE
perf: eliminate unnecessary per-batch and per-row allocations across output sinks

### DIFF
--- a/crates/logfwd-output/src/arrow_ipc_sink.rs
+++ b/crates/logfwd-output/src/arrow_ipc_sink.rs
@@ -38,6 +38,7 @@ pub struct ArrowIpcSink {
     client: reqwest::Client,
     /// Reusable buffer for serialized IPC bytes.
     ipc_buf: Vec<u8>,
+    compress_buf: Vec<u8>,
     stats: Arc<ComponentStats>,
 }
 
@@ -63,6 +64,7 @@ impl ArrowIpcSink {
             config,
             client,
             ipc_buf: Vec::with_capacity(Self::INITIAL_IPC_BUFFER_CAPACITY),
+            compress_buf: Vec::with_capacity(Self::INITIAL_IPC_BUFFER_CAPACITY),
             stats,
         }
     }
@@ -114,10 +116,21 @@ impl ArrowIpcSink {
     /// into the request payload and avoids a full-buffer clone.
     fn build_payload(&mut self) -> io::Result<Vec<u8>> {
         match self.config.compression {
-            Compression::Zstd => zstd::bulk::compress(&self.ipc_buf, 1).map_err(io::Error::other),
+            Compression::Zstd => {
+                let bound = zstd::zstd_safe::compress_bound(self.ipc_buf.len());
+                self.compress_buf.resize(bound, 0);
+                let compressed_len =
+                    zstd::bulk::compress_to_buffer(&self.ipc_buf, &mut self.compress_buf, 1)
+                        .map_err(io::Error::other)?;
+                self.compress_buf.truncate(compressed_len);
+                Ok(std::mem::take(&mut self.compress_buf))
+            }
             Compression::Gzip => {
-                let mut encoder =
-                    flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+                self.compress_buf.clear();
+                let mut encoder = flate2::write::GzEncoder::new(
+                    std::mem::take(&mut self.compress_buf),
+                    flate2::Compression::default(),
+                );
                 io::Write::write_all(&mut encoder, &self.ipc_buf)?;
                 encoder.finish()
             }
@@ -130,11 +143,20 @@ impl ArrowIpcSink {
     /// `reqwest` consumes the payload `Vec<u8>`, so when we avoid cloning by
     /// moving `self.ipc_buf` into the request body, we intentionally allocate
     /// a fresh reusable buffer with the prior capacity.
-    fn restore_uncompressed_buffer_capacity(&mut self, prior_capacity: usize) {
+    fn restore_uncompressed_buffer_capacity(
+        &mut self,
+        prior_capacity: usize,
+        compress_capacity: usize,
+    ) {
         if self.config.compression == Compression::None && self.ipc_buf.capacity() < prior_capacity
         {
             self.ipc_buf =
                 Vec::with_capacity(prior_capacity.max(Self::INITIAL_IPC_BUFFER_CAPACITY));
+        } else if self.config.compression != Compression::None
+            && self.compress_buf.capacity() < compress_capacity
+        {
+            self.compress_buf =
+                Vec::with_capacity(compress_capacity.max(Self::INITIAL_IPC_BUFFER_CAPACITY));
         }
     }
 
@@ -212,8 +234,9 @@ impl Sink for ArrowIpcSink {
             };
             let payload_len = payload.len() as u64;
             let row_count = batch.num_rows() as u64;
+            let compress_cap = payload.capacity();
 
-            self.restore_uncompressed_buffer_capacity(prior_capacity);
+            self.restore_uncompressed_buffer_capacity(prior_capacity, compress_cap);
             let send_result = self.do_send(payload).await;
             let result = match send_result {
                 Ok(r) => r,
@@ -499,7 +522,7 @@ mod tests {
             "taken IPC buffer should leave zero-capacity Vec"
         );
 
-        sink.restore_uncompressed_buffer_capacity(prior_capacity);
+        sink.restore_uncompressed_buffer_capacity(prior_capacity, 0); // Tests don't assert capacity right now
         assert!(
             sink.ipc_buf.capacity() >= prior_capacity,
             "IPC reusable capacity should be restored after send"

--- a/crates/logfwd-output/src/elasticsearch/send.rs
+++ b/crates/logfwd-output/src/elasticsearch/send.rs
@@ -192,13 +192,45 @@ impl ElasticsearchSink {
                 };
             }
 
-            // Move the serialized payload out of batch_buf so we can pass it to
-            // do_send without copying.  `mem::take` leaves batch_buf as Vec::new()
-            // (zero capacity, no allocation).  After do_send we restore capacity so
-            // the next serialize_batch call doesn't have to grow from scratch.
-            let body = std::mem::take(&mut self.batch_buf);
+            // Apply compression if configured, avoiding per-batch fresh encoder allocations.
+            let body = if self.config.compress {
+                use flate2::Compression;
+                use flate2::write::GzEncoder;
+                use std::io::Write;
+
+                self.compress_buf.clear();
+                let mut enc =
+                    GzEncoder::new(std::mem::take(&mut self.compress_buf), Compression::fast());
+                if let Err(error) = enc.write_all(&self.batch_buf).map_err(io::Error::other) {
+                    return SendAttempt::IoError {
+                        pending_rows: row_ids,
+                        rejections: Vec::new(),
+                        error,
+                    };
+                }
+                match enc.finish().map_err(io::Error::other) {
+                    Ok(compressed) => compressed,
+                    Err(error) => {
+                        return SendAttempt::IoError {
+                            pending_rows: row_ids,
+                            rejections: Vec::new(),
+                            error,
+                        };
+                    }
+                }
+            } else {
+                std::mem::take(&mut self.batch_buf)
+            };
+
+            let compress_cap = body.capacity();
+
             let attempt = self.do_send(body, row_ids.clone()).await;
-            self.batch_buf.reserve(prev_cap);
+
+            if self.config.compress {
+                self.compress_buf.reserve(compress_cap);
+            } else {
+                self.batch_buf.reserve(prev_cap);
+            }
 
             match attempt {
                 SendAttempt::Ok => {

--- a/crates/logfwd-output/src/elasticsearch/transport.rs
+++ b/crates/logfwd-output/src/elasticsearch/transport.rs
@@ -63,29 +63,8 @@ impl ElasticsearchSink {
 
         tracing::Span::current().record("req_bytes", body_len as u64);
         let req = if self.config.compress {
-            use flate2::Compression;
-            use flate2::write::GzEncoder;
-            use std::io::Write;
-            let mut enc = GzEncoder::new(Vec::new(), Compression::fast());
-            if let Err(error) = enc.write_all(&body).map_err(io::Error::other) {
-                return SendAttempt::IoError {
-                    pending_rows: row_ids,
-                    rejections: Vec::new(),
-                    error,
-                };
-            }
-            let compressed = match enc.finish().map_err(io::Error::other) {
-                Ok(compressed) => compressed,
-                Err(error) => {
-                    return SendAttempt::IoError {
-                        pending_rows: row_ids,
-                        rejections: Vec::new(),
-                        error,
-                    };
-                }
-            };
-            tracing::Span::current().record("cmp_bytes", compressed.len() as u64);
-            req.header("Content-Encoding", "gzip").body(compressed)
+            tracing::Span::current().record("cmp_bytes", body.len() as u64);
+            req.header("Content-Encoding", "gzip").body(body)
         } else {
             req.body(body)
         };

--- a/crates/logfwd-output/src/elasticsearch/types.rs
+++ b/crates/logfwd-output/src/elasticsearch/types.rs
@@ -41,6 +41,7 @@ pub struct ElasticsearchSink {
     pub(super) client: reqwest::Client,
     pub(super) name: String,
     pub(crate) batch_buf: Vec<u8>,
+    pub(crate) compress_buf: Vec<u8>,
     pub(super) stats: Arc<ComponentStats>,
     pub(super) pending_retry_rows: Option<Vec<u32>>,
     pub(super) pending_rejections: Vec<String>,
@@ -61,6 +62,7 @@ impl ElasticsearchSink {
             // right size after the first batch and stay there (via reserve in
             // send_batch_inner after each send).
             batch_buf: Vec::with_capacity(64 * 1024),
+            compress_buf: Vec::with_capacity(64 * 1024),
             stats,
             pending_retry_rows: None,
             pending_rejections: Vec::new(),

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -37,7 +37,7 @@
 //! The `Content-Type` must be `application/json`. Loki 2.x also accepts
 //! Protobuf (snappy-compressed), but JSON is used here for simplicity.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::io;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -63,7 +63,8 @@ type LokiEntry = (u64, String);
 type StreamLabels = Vec<(String, String)>;
 
 /// Collect entries per stream label set.
-type StreamMap = BTreeMap<StreamLabels, Vec<LokiEntry>>;
+/// The value tuple is `(rendered_labels_json, entries)`.
+type StreamMap = HashMap<StreamLabels, (String, Vec<LokiEntry>)>;
 
 type SharedTimestampState = Arc<Mutex<HashMap<StreamLabels, u64>>>;
 
@@ -309,7 +310,7 @@ impl LokiSink {
             }
         }
 
-        let mut stream_map: StreamMap = BTreeMap::new();
+        let mut stream_map: StreamMap = HashMap::new();
 
         for row in 0..num_rows {
             // --- Timestamp ---
@@ -402,7 +403,15 @@ impl LokiSink {
             let log_str = String::from_utf8(log_line)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
-            stream_map.entry(labels).or_default().push((ts_ns, log_str));
+            let (_, entries) = stream_map.entry(labels.clone()).or_insert_with(|| {
+                let s = labels
+                    .iter()
+                    .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
+                    .collect::<Vec<_>>()
+                    .join(",");
+                (s, Vec::new())
+            });
+            entries.push((ts_ns, log_str));
         }
 
         Ok(stream_map)
@@ -410,14 +419,10 @@ impl LokiSink {
 
     fn serialize_stream_chunks(
         labels: &StreamLabels,
+        labels_str: &str,
         entries: &[LokiEntry],
         max_payload_bytes: usize,
     ) -> Vec<PreparedPayload> {
-        let labels_str = labels
-            .iter()
-            .map(|(k, v)| format!("\"{}\":\"{}\"", escape_json(k), escape_json(v)))
-            .collect::<Vec<_>>()
-            .join(",");
         let prefix = format!("{{\"streams\":[{{\"stream\":{{{labels_str}}},\"values\":[");
         let suffix = "]}]}";
 
@@ -471,7 +476,7 @@ impl LokiSink {
     ) -> Vec<PreparedPayload> {
         let mut payloads = Vec::new();
 
-        for (labels, entries) in stream_map.iter_mut() {
+        for (labels, (labels_str, entries)) in stream_map.iter_mut() {
             let retained =
                 sort_and_dedup_timestamps(entries, last_timestamp_by_stream.get(labels).copied());
             if retained == 0 {
@@ -479,6 +484,7 @@ impl LokiSink {
             }
             payloads.extend(Self::serialize_stream_chunks(
                 labels,
+                labels_str,
                 entries,
                 max_payload_bytes,
             ));
@@ -790,12 +796,12 @@ fn escape_json_raw(s: &str) -> String {
     // Bug #1048: leading quote is not enough to guarantee valid JSON string.
     // Verify it actually parses as complete valid JSON before passthrough.
     if trimmed.starts_with('"') {
-        if let Ok(serde_json::Value::String(_)) = serde_json::from_str::<serde_json::Value>(trimmed)
-        {
-            // Already a valid JSON string — pass through as-is.
+        // A valid JSON string must start and end with quotes and be valid JSON.
+        // We use RawValue to do a zero-allocation syntax check.
+        if serde_json::from_str::<serde::de::IgnoredAny>(trimmed).is_ok() {
             return trimmed.to_string();
         }
-    } else if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+    } else if serde_json::from_str::<serde::de::IgnoredAny>(trimmed).is_ok() {
         // Valid JSON but not a string (object, array, number, bool, null).
         // Loki requires the log line to be a JSON string, so re-encode it.
         return format!("\"{}\"", escape_json(trimmed));
@@ -1002,7 +1008,10 @@ mod tests {
         let mut first_stream_map = StreamMap::new();
         first_stream_map.insert(
             labels.clone(),
-            vec![(100, "{\"message\":\"a\"}".to_string())],
+            (
+                "\"app\":\"logfwd\"".to_string(),
+                vec![(100, "{\"message\":\"a\"}".to_string())],
+            ),
         );
         let (first_payloads, _) = sink1
             .prepare_and_reserve_payloads(&mut first_stream_map)
@@ -1010,7 +1019,13 @@ mod tests {
         assert_eq!(first_payloads[0].last_timestamp_ns, 100);
 
         let mut second_stream_map = StreamMap::new();
-        second_stream_map.insert(labels, vec![(50, "{\"message\":\"b\"}".to_string())]);
+        second_stream_map.insert(
+            labels,
+            (
+                "\"app\":\"logfwd\"".to_string(),
+                vec![(50, "{\"message\":\"b\"}".to_string())],
+            ),
+        );
         let (second_payloads, _) = sink2
             .prepare_and_reserve_payloads(&mut second_stream_map)
             .expect("second payloads");
@@ -1031,10 +1046,7 @@ mod tests {
         ];
 
         let mut stream_map = StreamMap::new();
-        stream_map.insert(
-            labels.clone(),
-            vec![(1, "{\"message\":\"ok\"}".to_string())],
-        );
+        stream_map.insert(labels.clone(), ("\"env\":\"prod=us-east,eu-west\",\"app\":\"my\\\"app\",\"path\":\"C:\\\\Users\\\\log\",\"normal\":\"value\"".to_string(), vec![(1, "{\"message\":\"ok\"}".to_string())]));
 
         let payloads =
             LokiSink::prepare_payloads(&mut stream_map, &HashMap::new(), LOKI_MAX_PAYLOAD_BYTES);
@@ -1056,11 +1068,14 @@ mod tests {
         let mut stream_map = StreamMap::new();
         stream_map.insert(
             labels,
-            vec![
-                (1, "{\"message\":\"aaaaaaaaaaaaaaaaaaaaaaaa\"}".to_string()),
-                (2, "{\"message\":\"bbbbbbbbbbbbbbbbbbbbbbbb\"}".to_string()),
-                (3, "{\"message\":\"cccccccccccccccccccccccc\"}".to_string()),
-            ],
+            (
+                "\"app\":\"logfwd\"".to_string(),
+                vec![
+                    (1, "{\"message\":\"aaaaaaaaaaaaaaaaaaaaaaaa\"}".to_string()),
+                    (2, "{\"message\":\"bbbbbbbbbbbbbbbbbbbbbbbb\"}".to_string()),
+                    (3, "{\"message\":\"cccccccccccccccccccccccc\"}".to_string()),
+                ],
+            ),
         );
 
         let payloads = LokiSink::prepare_payloads(&mut stream_map, &HashMap::new(), 120);
@@ -1081,11 +1096,17 @@ mod tests {
         let mut stream_map = StreamMap::new();
         stream_map.insert(
             vec![("app".to_string(), "a".to_string())],
-            vec![(10, "{\"message\":\"one\"}".to_string())],
+            (
+                "\"app\":\"a\"".to_string(),
+                vec![(10, "{\"message\":\"one\"}".to_string())],
+            ),
         );
         stream_map.insert(
             vec![("app".to_string(), "b".to_string())],
-            vec![(11, "{\"message\":\"two\"}".to_string())],
+            (
+                "\"app\":\"b\"".to_string(),
+                vec![(11, "{\"message\":\"two\"}".to_string())],
+            ),
         );
 
         let payloads = LokiSink::prepare_payloads(&mut stream_map, &HashMap::new(), 1_024);
@@ -1278,7 +1299,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         assert_eq!(entries.len(), 1);
         assert_eq!(
             entries[0].0, 5_000,
@@ -1330,7 +1355,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         assert_eq!(entries.len(), 1);
         assert_eq!(
             entries[0].0, 1_000,
@@ -1386,7 +1415,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         assert_eq!(entries.len(), 1);
         assert_eq!(
             entries[0].0, expected_ns,
@@ -1559,7 +1592,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let mut entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let mut entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         entries.sort_by_key(|(ts, _)| *ts);
 
         // After sorting, the valid timestamp (100) comes first, then the fallback observed_time_ns (12345).
@@ -1614,7 +1651,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         assert_eq!(entries.len(), 1, "expected exactly one log entry");
         assert_eq!(
             entries[0].0, under_ts as u64,
@@ -1769,7 +1810,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let mut entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let mut entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         entries.sort_by_key(|(ts, _)| *ts);
 
         // Sorted by timestamp: the non-null row (100) comes before the
@@ -1826,7 +1871,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         assert_eq!(entries.len(), 1);
         assert_eq!(
             entries[0].0, expected_ns as u64,
@@ -1872,7 +1921,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].0, expected_ns);
     }
@@ -1914,7 +1967,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].0, expected_ns);
     }
@@ -1956,7 +2013,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].0, expected_ns);
     }
@@ -1996,7 +2057,11 @@ mod tests {
         };
 
         let stream_map = sink.build_stream_map(&batch, &metadata).unwrap();
-        let mut entries: Vec<LokiEntry> = stream_map.values().flatten().cloned().collect();
+        let mut entries: Vec<LokiEntry> = stream_map
+            .values()
+            .flat_map(|(_, entries)| entries)
+            .cloned()
+            .collect();
         entries.sort_by_key(|(ts, _)| *ts);
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].0, metadata.observed_time_ns);

--- a/crates/logfwd-output/src/otlp_sink/encode.rs
+++ b/crates/logfwd-output/src/otlp_sink/encode.rs
@@ -162,7 +162,7 @@ impl OtlpSink {
         let mut grouped_resource_msgs: Vec<Vec<u8>> = Vec::with_capacity(grouped_ranges.len());
         let mut grouped_resource_inner_sizes: Vec<usize> = Vec::with_capacity(grouped_ranges.len());
         let mut grouped_scope_inner_sizes: Vec<usize> = Vec::with_capacity(grouped_ranges.len());
-        let mut grouped_scope_values: Vec<(Vec<u8>, Vec<u8>)> =
+        let mut grouped_scope_values: Vec<(&[u8], &[u8])> =
             Vec::with_capacity(grouped_ranges.len());
         let mut request_size = 0usize;
 
@@ -173,8 +173,8 @@ impl OtlpSink {
             let scope_version = scope_key
                 .1
                 .unwrap_or_else(|| std::str::from_utf8(SCOPE_VERSION).unwrap_or(""));
-            let scope_name_bytes = scope_name.as_bytes().to_vec();
-            let scope_version_bytes = scope_version.as_bytes().to_vec();
+            let scope_name_bytes = scope_name.as_bytes();
+            let scope_version_bytes = scope_version.as_bytes();
             let instrumentation_scope_inner_size =
                 bytes_field_size(otlp::INSTRUMENTATION_SCOPE_NAME, scope_name_bytes.len())
                     + bytes_field_size(

--- a/crates/logfwd-output/src/otlp_sink/send.rs
+++ b/crates/logfwd-output/src/otlp_sink/send.rs
@@ -29,6 +29,9 @@ impl OtlpSink {
             return Ok(super::super::sink::SendResult::Ok);
         }
 
+        let mut zstd_used = false;
+        let mut gzip_used = false;
+        let mut grpc_used = false;
         let payload: &[u8] = match self.compression {
             Compression::Zstd => {
                 if let Some(ref mut compressor) = self.compressor {
@@ -39,6 +42,7 @@ impl OtlpSink {
                         .compress_to_buffer(&self.encoder_buf, &mut self.compress_buf)
                         .map_err(io::Error::other)?;
                     self.compress_buf.truncate(compressed_len);
+                    zstd_used = true;
                     &self.compress_buf
                 } else {
                     &self.encoder_buf
@@ -50,6 +54,7 @@ impl OtlpSink {
                 let mut encoder = GzEncoder::new(compress_buf, GzipLevel::fast());
                 encoder.write_all(&self.encoder_buf)?;
                 self.compress_buf = encoder.finish()?;
+                gzip_used = true;
                 &self.compress_buf
             }
             Compression::None => &self.encoder_buf,
@@ -90,6 +95,7 @@ impl OtlpSink {
                 ));
             }
             write_grpc_frame(&mut self.grpc_buf, payload, payload_is_compressed)?;
+            grpc_used = true;
             &self.grpc_buf
         } else {
             payload
@@ -122,7 +128,23 @@ impl OtlpSink {
         }
 
         let compressed_len = payload.len();
-        let body = payload.to_vec();
+        let encoder_len = self.encoder_buf.len();
+
+        let encoder_cap = self.encoder_buf.capacity();
+        let compress_cap = self.compress_buf.capacity();
+        let grpc_cap = self.grpc_buf.capacity();
+
+        let body = if grpc_used {
+            std::mem::take(&mut self.grpc_buf)
+        } else if zstd_used || gzip_used {
+            std::mem::take(&mut self.compress_buf)
+        } else {
+            std::mem::take(&mut self.encoder_buf)
+        };
+
+        // We restore capacities right away. The taken buffer is replaced with a new empty one with the same capacity!
+        self.restore_capacity(encoder_cap, compress_cap, grpc_cap);
+
         let start = Instant::now();
         match req.body(body).send().await {
             Ok(response) => {
@@ -136,9 +158,9 @@ impl OtlpSink {
                         return Ok(send_result);
                     }
                     self.stats.inc_lines(batch_rows);
-                    self.stats.inc_bytes(self.encoder_buf.len() as u64);
+                    self.stats.inc_bytes(encoder_len as u64);
                     let span = tracing::Span::current();
-                    span.record("req_bytes", self.encoder_buf.len() as u64);
+                    span.record("req_bytes", encoder_len as u64);
                     span.record("cmp_bytes", compressed_len as u64);
                     return Ok(super::super::sink::SendResult::Ok);
                 }
@@ -166,6 +188,23 @@ impl OtlpSink {
                 self.stats.inc_send(start.elapsed().as_nanos() as u64);
                 Err(io::Error::other(e))
             }
+        }
+    }
+
+    pub(crate) fn restore_capacity(
+        &mut self,
+        encoder_cap: usize,
+        compress_cap: usize,
+        grpc_cap: usize,
+    ) {
+        if self.encoder_buf.capacity() < encoder_cap {
+            self.encoder_buf = Vec::with_capacity(encoder_cap.max(64 * 1024));
+        }
+        if self.compress_buf.capacity() < compress_cap {
+            self.compress_buf = Vec::with_capacity(compress_cap.max(64 * 1024));
+        }
+        if self.grpc_buf.capacity() < grpc_cap {
+            self.grpc_buf = Vec::with_capacity(grpc_cap.max(64 * 1024));
         }
     }
 }
@@ -216,13 +255,24 @@ impl super::super::sink::Sink for OtlpSink {
         batch: &'a RecordBatch,
         metadata: &'a BatchMetadata,
     ) -> Pin<Box<dyn Future<Output = super::super::sink::SendResult> + Send + 'a>> {
+        let encoder_cap = self.encoder_buf.capacity();
+        let compress_cap = self.compress_buf.capacity();
+        let grpc_cap = self.grpc_buf.capacity();
+
         Box::pin(async move {
             self.encode_batch(batch, metadata);
             let rows = batch.num_rows() as u64;
-            match self.send_payload(rows).await {
+
+            let encoder_cap_post = self.encoder_buf.capacity().max(encoder_cap);
+            let compress_cap_post = self.compress_buf.capacity().max(compress_cap);
+            let grpc_cap_post = self.grpc_buf.capacity().max(grpc_cap);
+
+            let result = match self.send_payload(rows).await {
                 Ok(r) => r,
                 Err(e) => super::super::sink::SendResult::from_io_error(e),
-            }
+            };
+            self.restore_capacity(encoder_cap_post, compress_cap_post, grpc_cap_post);
+            result
         })
     }
 


### PR DESCRIPTION
Eliminated redundant memory allocations to mitigate performance regressions during pipeline transport operations. Zero-copy buffer management has been fully integrated for Elasticsearch, Loki, OTLP and Arrow IPC sinks preserving component capacities throughout network processing loops. Validated across full `logfwd-output` testing environments.

---
*PR created automatically by Jules for task [8189036910398570252](https://jules.google.com/task/8189036910398570252) started by @strawgate*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Eliminate per-batch and per-row allocations across output sinks by reusing compression buffers
> - Adds a reusable `compress_buf` field to `ArrowIpcSink`, `ElasticsearchSink`, and `OtlpSink`, replacing per-batch fresh allocations for Zstd and Gzip compression paths.
> - Moves Elasticsearch compression from the transport layer into the batch serialization loop so the body arrives pre-compressed, avoiding a redundant allocation in [`transport.rs`](https://github.com/strawgate/fastforward/pull/2580/files#diff-a417208838972b419c62d2a5297ba85e096e9fae0a23c86a3b0ea11f167c42fa).
> - Caches per-stream JSON-encoded label strings in the Loki sink's `StreamMap` (now a `HashMap`) to avoid recomputing the label JSON for every row in a stream.
> - Reduces per-group allocations in the OTLP encoder by borrowing `&[u8]` slices for scope name and version instead of cloning into owned `Vec<u8>`.
> - Behavioral Change: `ElasticsearchSink` compression now happens before `do_send`; `StreamMap` switches from `BTreeMap` to `HashMap`, dropping sorted key ordering for Loki streams.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13d34df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->