### PR TITLE
refactor: remove duplicate code across 9 crates (-279 lines)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ logfwd-core               Pure logic, proven, no_std, forbid(unsafe)
 
 | Crate | Key constraints |
 |-------|----------------|
-| `logfwd-core` | `no_std` + `forbid(unsafe_code)`. Only deps: memchr + wide. Every public fn needs a Kani proof. No panics, no unwrap, no indexing. |
+| `logfwd-core` | `no_std` + `forbid(unsafe_code)`. Only deps: memchr + wide + logfwd-kani + logfwd-lint-attrs. Every public fn needs a Kani proof. No panics, no unwrap, no indexing. |
 | `logfwd-arrow` | Implements core's ScanBuilder. unsafe allowed for SIMD only. proptest: SIMD ≡ scalar. |
 | `logfwd-io` | IO lives here. Tests use tempfiles. No raw payload injection (see #1615). |
 | `logfwd-transform` | DataFusion is the SQL engine. Enrichment tables implement Arrow RecordBatchReader. |

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -74,13 +74,21 @@ crates/
   logfwd-core/         Proven kernel. Scanner, parsers, pipeline state machine, OTLP encoding. no_std.
   logfwd-arrow/        Arrow integration. ScanBuilder impls, SIMD backends, RecordBatch builders.
   logfwd-config/       YAML config parsing and validation.
+  logfwd-config-wasm/  WASM bindings for the config validator (browser/Node.js).
   logfwd-io/           I/O layer. File tailing, TCP/UDP/OTLP inputs, checkpointing, diagnostics.
   logfwd-transform/    DataFusion SQL transforms, UDFs (grok, regexp_extract, geo_lookup).
   logfwd-output/       Output sinks (OTLP, Elasticsearch, Loki, JSON lines, stdout).
+  logfwd-types/        Shared value types, state-machine semantics, diagnostics.
+  logfwd-diagnostics/  Diagnostics control plane: HTTP endpoints, dashboard, readiness.
   logfwd-bench/        Criterion benchmarks for the scanner pipeline.
   logfwd-competitive-bench/  Comparative benchmarks vs other log agents.
   logfwd-test-utils/   Shared test utilities.
+  logfwd-kani/         Verification oracles and Kani proof helpers.
+  logfwd-lint-attrs/   Custom proc-macro lint attributes (no_panic, pure).
+  logfwd-lints/        Custom Clippy-style lint passes.
   logfwd-ebpf-proto/   eBPF log capture protocol definitions (experimental).
+  logfwd-otap-proto/   OTAP protocol definitions.
+  logfwd-proto-build/  Protobuf build scripts.
 ```
 
 ## Build, test, lint, bench, fuzz

--- a/crates/logfwd-arrow/src/conflict_schema.rs
+++ b/crates/logfwd-arrow/src/conflict_schema.rs
@@ -380,6 +380,22 @@ mod tests {
             .expect("make_conflict_struct_batch: failed to build RecordBatch")
     }
 
+    /// Build a RecordBatch with a single struct column from arbitrary children.
+    fn make_struct_batch(field_name: &str, children: Vec<(&str, Arc<dyn Array>)>) -> RecordBatch {
+        let struct_fields: Fields = children
+            .iter()
+            .map(|(name, arr)| Field::new(*name, arr.data_type().clone(), true))
+            .collect();
+        let arrays: Vec<Arc<dyn Array>> = children.into_iter().map(|(_, arr)| arr).collect();
+        let struct_arr = StructArray::new(struct_fields.clone(), arrays, None);
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            field_name,
+            DataType::Struct(struct_fields),
+            true,
+        )]));
+        RecordBatch::try_new(schema, vec![Arc::new(struct_arr) as Arc<dyn Array>]).unwrap()
+    }
+
     // -----------------------------------------------------------------------
     // Tests
     // -----------------------------------------------------------------------
@@ -463,24 +479,19 @@ mod tests {
     fn bool_conflict_normalizes_to_utf8() {
         use arrow::array::BooleanArray;
 
-        let int_arr: Arc<dyn Array> = Arc::new(Int64Array::from(vec![None, None]));
-        let bool_arr: Arc<dyn Array> = Arc::new(BooleanArray::from(vec![Some(true), Some(false)]));
-
-        let struct_fields = Fields::from(vec![
-            Field::new("int", DataType::Int64, true),
-            Field::new("bool", DataType::Boolean, true),
-        ]);
-
-        let struct_arr = StructArray::new(struct_fields.clone(), vec![int_arr, bool_arr], None);
-
-        let schema = Arc::new(Schema::new(vec![Field::new(
+        let batch = make_struct_batch(
             "status",
-            DataType::Struct(struct_fields),
-            true,
-        )]));
-
-        let batch =
-            RecordBatch::try_new(schema, vec![Arc::new(struct_arr) as Arc<dyn Array>]).unwrap();
+            vec![
+                (
+                    "int",
+                    Arc::new(Int64Array::from(vec![None, None])) as Arc<dyn Array>,
+                ),
+                (
+                    "bool",
+                    Arc::new(BooleanArray::from(vec![Some(true), Some(false)])) as Arc<dyn Array>,
+                ),
+            ],
+        );
 
         let normalized = normalize_conflict_columns(batch);
         let status = normalized.column_by_name("status").unwrap();
@@ -545,31 +556,24 @@ mod tests {
     fn bool_child_preserved_as_string() {
         use arrow::array::BooleanArray;
 
-        let bool_arr: Arc<dyn Array> =
-            Arc::new(BooleanArray::from(vec![Some(true), Some(false), None]));
-        let str_arr: Arc<dyn Array> = Arc::new(StringArray::from(vec![
-            None::<&str>,
-            None,
-            Some("fallback"),
-        ]));
-
-        let struct_fields = Fields::from(vec![
-            Field::new("bool", DataType::Boolean, true),
-            Field::new("str", DataType::Utf8, true),
-        ]);
-        let struct_arr = StructArray::new(
-            struct_fields.clone(),
-            vec![Arc::clone(&bool_arr), Arc::clone(&str_arr)],
-            None,
-        );
-
-        let schema = Arc::new(Schema::new(vec![Field::new(
+        let batch = make_struct_batch(
             "active",
-            DataType::Struct(struct_fields),
-            true,
-        )]));
-        let batch =
-            RecordBatch::try_new(schema, vec![Arc::new(struct_arr) as Arc<dyn Array>]).unwrap();
+            vec![
+                (
+                    "bool",
+                    Arc::new(BooleanArray::from(vec![Some(true), Some(false), None]))
+                        as Arc<dyn Array>,
+                ),
+                (
+                    "str",
+                    Arc::new(StringArray::from(vec![
+                        None::<&str>,
+                        None,
+                        Some("fallback"),
+                    ])) as Arc<dyn Array>,
+                ),
+            ],
+        );
 
         let normalized = normalize_conflict_columns(batch);
         let active = normalized.column_by_name("active").unwrap();
@@ -590,26 +594,19 @@ mod tests {
     fn int_priority_over_bool() {
         use arrow::array::BooleanArray;
 
-        let int_arr: Arc<dyn Array> = Arc::new(Int64Array::from(vec![Some(42i64), None]));
-        let bool_arr: Arc<dyn Array> = Arc::new(BooleanArray::from(vec![Some(true), Some(false)]));
-
-        let struct_fields = Fields::from(vec![
-            Field::new("int", DataType::Int64, true),
-            Field::new("bool", DataType::Boolean, true),
-        ]);
-        let struct_arr = StructArray::new(
-            struct_fields.clone(),
-            vec![Arc::clone(&int_arr), Arc::clone(&bool_arr)],
-            None,
-        );
-
-        let schema = Arc::new(Schema::new(vec![Field::new(
+        let batch = make_struct_batch(
             "x",
-            DataType::Struct(struct_fields),
-            true,
-        )]));
-        let batch =
-            RecordBatch::try_new(schema, vec![Arc::new(struct_arr) as Arc<dyn Array>]).unwrap();
+            vec![
+                (
+                    "int",
+                    Arc::new(Int64Array::from(vec![Some(42i64), None])) as Arc<dyn Array>,
+                ),
+                (
+                    "bool",
+                    Arc::new(BooleanArray::from(vec![Some(true), Some(false)])) as Arc<dyn Array>,
+                ),
+            ],
+        );
 
         let normalized = normalize_conflict_columns(batch);
         let x = normalized.column_by_name("x").unwrap();
@@ -627,28 +624,24 @@ mod tests {
     fn schema_metadata_preserved() {
         use std::collections::HashMap;
 
-        let int_arr: Arc<dyn Array> = Arc::new(Int64Array::from(vec![Some(200i64), None]));
-        let str_arr: Arc<dyn Array> = Arc::new(StringArray::from(vec![None, Some("OK")]));
-
-        let struct_fields = Fields::from(vec![
-            Field::new("int", DataType::Int64, true),
-            Field::new("str", DataType::Utf8, true),
-        ]);
-        let struct_arr = StructArray::new(
-            struct_fields.clone(),
-            vec![Arc::clone(&int_arr), Arc::clone(&str_arr)],
-            None,
+        let batch = make_struct_batch(
+            "status",
+            vec![
+                (
+                    "int",
+                    Arc::new(Int64Array::from(vec![Some(200i64), None])) as Arc<dyn Array>,
+                ),
+                (
+                    "str",
+                    Arc::new(StringArray::from(vec![None, Some("OK")])) as Arc<dyn Array>,
+                ),
+            ],
         );
 
         let mut meta = HashMap::new();
         meta.insert("custom.key".to_string(), "custom.value".to_string());
-
-        let schema = Arc::new(Schema::new_with_metadata(
-            vec![Field::new("status", DataType::Struct(struct_fields), true)],
-            meta,
-        ));
-        let batch =
-            RecordBatch::try_new(schema, vec![Arc::new(struct_arr) as Arc<dyn Array>]).unwrap();
+        let schema_with_meta = Arc::new(batch.schema().as_ref().clone().with_metadata(meta));
+        let batch = RecordBatch::try_new(schema_with_meta, batch.columns().to_vec()).unwrap();
 
         let normalized = normalize_conflict_columns(batch);
         assert_eq!(

--- a/crates/logfwd-arrow/src/conflict_schema.rs
+++ b/crates/logfwd-arrow/src/conflict_schema.rs
@@ -126,11 +126,7 @@ pub fn normalize_conflict_columns(batch: RecordBatch) -> RecordBatch {
     let schema = batch.schema();
 
     // Fast path: no struct columns at all.
-    let has_conflict_struct = schema
-        .fields()
-        .iter()
-        .any(|f| matches!(f.data_type(), DataType::Struct(cf) if is_conflict_struct(cf)));
-    if !has_conflict_struct {
+    if !has_conflict_struct_columns(&schema) {
         return batch;
     }
 
@@ -352,7 +348,6 @@ mod tests {
             str_vals.len(),
             "int_vals and str_vals must have the same length"
         );
-        let _num_rows = int_vals.len();
 
         let int_arr: Arc<dyn Array> = Arc::new(Int64Array::from(int_vals));
 

--- a/crates/logfwd-arrow/src/conflict_schema.rs
+++ b/crates/logfwd-arrow/src/conflict_schema.rs
@@ -125,7 +125,7 @@ pub fn has_conflict_struct_columns(schema: &Schema) -> bool {
 pub fn normalize_conflict_columns(batch: RecordBatch) -> RecordBatch {
     let schema = batch.schema();
 
-    // Fast path: no struct columns at all.
+    // Fast path: no conflict-struct columns.
     if !has_conflict_struct_columns(&schema) {
         return batch;
     }

--- a/crates/logfwd-arrow/src/streaming_builder/finish.rs
+++ b/crates/logfwd-arrow/src/streaming_builder/finish.rs
@@ -22,6 +22,7 @@ fn scatter_int64(entries: &[(u32, i64)], num_rows: usize) -> Int64Array {
     let mut valid = vec![false; num_rows];
     for &(row, v) in entries {
         let r = row as usize;
+        debug_assert!(r < num_rows, "row index out of bounds: {r} >= {num_rows}");
         if r < num_rows {
             values[r] = v;
             valid[r] = true;
@@ -37,6 +38,7 @@ fn scatter_float64(entries: &[(u32, f64)], num_rows: usize) -> Float64Array {
     let mut valid = vec![false; num_rows];
     for &(row, v) in entries {
         let r = row as usize;
+        debug_assert!(r < num_rows, "row index out of bounds: {r} >= {num_rows}");
         if r < num_rows {
             values[r] = v;
             valid[r] = true;
@@ -52,6 +54,7 @@ fn scatter_bool(entries: &[(u32, bool)], num_rows: usize) -> BooleanArray {
     let mut valid = vec![false; num_rows];
     for &(row, v) in entries {
         let r = row as usize;
+        debug_assert!(r < num_rows, "row index out of bounds: {r} >= {num_rows}");
         if r < num_rows {
             values[r] = v;
             valid[r] = true;

--- a/crates/logfwd-arrow/src/streaming_builder/finish.rs
+++ b/crates/logfwd-arrow/src/streaming_builder/finish.rs
@@ -15,6 +15,51 @@ use logfwd_core::scanner::BuilderState;
 
 use super::{StreamingBuilder, append_string_view, new_emitted_name_set};
 
+/// Scatter `(row, value)` pairs into a nullable [`Int64Array`].
+#[inline]
+fn scatter_int64(entries: &[(u32, i64)], num_rows: usize) -> Int64Array {
+    let mut values = vec![0i64; num_rows];
+    let mut valid = vec![false; num_rows];
+    for &(row, v) in entries {
+        let r = row as usize;
+        if r < num_rows {
+            values[r] = v;
+            valid[r] = true;
+        }
+    }
+    Int64Array::new(values.into(), Some(NullBuffer::from(valid)))
+}
+
+/// Scatter `(row, value)` pairs into a nullable [`Float64Array`].
+#[inline]
+fn scatter_float64(entries: &[(u32, f64)], num_rows: usize) -> Float64Array {
+    let mut values = vec![0.0f64; num_rows];
+    let mut valid = vec![false; num_rows];
+    for &(row, v) in entries {
+        let r = row as usize;
+        if r < num_rows {
+            values[r] = v;
+            valid[r] = true;
+        }
+    }
+    Float64Array::new(values.into(), Some(NullBuffer::from(valid)))
+}
+
+/// Scatter `(row, value)` pairs into a nullable [`BooleanArray`].
+#[inline]
+fn scatter_bool(entries: &[(u32, bool)], num_rows: usize) -> BooleanArray {
+    let mut values = vec![false; num_rows];
+    let mut valid = vec![false; num_rows];
+    for &(row, v) in entries {
+        let r = row as usize;
+        if r < num_rows {
+            values[r] = v;
+            valid[r] = true;
+        }
+    }
+    BooleanArray::new(values.into(), Some(NullBuffer::from(valid)))
+}
+
 impl StreamingBuilder {
     /// Build a RecordBatch with zero-copy StringViewArrays.
     ///
@@ -85,35 +130,13 @@ impl StreamingBuilder {
                 let mut child_arrays: Vec<ArrayRef> = Vec::new();
 
                 if fc.has_int {
-                    let mut values = vec![0i64; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.int_values {
-                        let row = row as usize;
-                        if row >= num_rows {
-                            continue;
-                        }
-                        values[row] = v;
-                        valid[row] = true;
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = Int64Array::new(values.into(), Some(nulls));
+                    let array = scatter_int64(&fc.int_values, num_rows);
                     child_fields.push(Arc::new(Field::new("int", DataType::Int64, true)));
                     child_arrays.push(Arc::new(array) as ArrayRef);
                 }
 
                 if fc.has_float {
-                    let mut values = vec![0.0f64; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.float_values {
-                        let row = row as usize;
-                        if row >= num_rows {
-                            continue;
-                        }
-                        values[row] = v;
-                        valid[row] = true;
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = Float64Array::new(values.into(), Some(nulls));
+                    let array = scatter_float64(&fc.float_values, num_rows);
                     child_fields.push(Arc::new(Field::new("float", DataType::Float64, true)));
                     child_arrays.push(Arc::new(array) as ArrayRef);
                 }
@@ -147,18 +170,7 @@ impl StreamingBuilder {
                 }
 
                 if fc.has_bool {
-                    let mut values = vec![false; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.bool_values {
-                        let row = row as usize;
-                        if row >= num_rows {
-                            continue;
-                        }
-                        values[row] = v;
-                        valid[row] = true;
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = BooleanArray::new(values.into(), Some(nulls));
+                    let array = scatter_bool(&fc.bool_values, num_rows);
                     child_fields.push(Arc::new(Field::new("bool", DataType::Boolean, true)));
                     child_arrays.push(Arc::new(array) as ArrayRef);
                 }
@@ -182,36 +194,14 @@ impl StreamingBuilder {
                 // Single-type field: bare flat column.
                 if fc.has_int {
                     reserve_name(name.as_ref())?;
-                    let mut values = vec![0i64; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.int_values {
-                        let row = row as usize;
-                        if row >= num_rows {
-                            continue;
-                        }
-                        values[row] = v;
-                        valid[row] = true;
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = Int64Array::new(values.into(), Some(nulls));
+                    let array = scatter_int64(&fc.int_values, num_rows);
                     schema_fields.push(Field::new(name.as_ref(), DataType::Int64, true));
                     arrays.push(Arc::new(array) as ArrayRef);
                 }
 
                 if fc.has_float {
                     reserve_name(name.as_ref())?;
-                    let mut values = vec![0.0f64; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.float_values {
-                        let row = row as usize;
-                        if row >= num_rows {
-                            continue;
-                        }
-                        values[row] = v;
-                        valid[row] = true;
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = Float64Array::new(values.into(), Some(nulls));
+                    let array = scatter_float64(&fc.float_values, num_rows);
                     schema_fields.push(Field::new(name.as_ref(), DataType::Float64, true));
                     arrays.push(Arc::new(array) as ArrayRef);
                 }
@@ -249,18 +239,7 @@ impl StreamingBuilder {
 
                 if fc.has_bool {
                     reserve_name(name.as_ref())?;
-                    let mut values = vec![false; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.bool_values {
-                        let row = row as usize;
-                        if row >= num_rows {
-                            continue;
-                        }
-                        values[row] = v;
-                        valid[row] = true;
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = BooleanArray::new(values.into(), Some(nulls));
+                    let array = scatter_bool(&fc.bool_values, num_rows);
                     schema_fields.push(Field::new(name.as_ref(), DataType::Boolean, true));
                     arrays.push(Arc::new(array) as ArrayRef);
                 }
@@ -392,33 +371,13 @@ impl StreamingBuilder {
                 let mut child_arrays: Vec<ArrayRef> = Vec::new();
 
                 if fc.has_int {
-                    let mut values = vec![0i64; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.int_values {
-                        let r = row as usize;
-                        if r < num_rows {
-                            values[r] = v;
-                            valid[r] = true;
-                        }
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = Int64Array::new(values.into(), Some(nulls));
+                    let array = scatter_int64(&fc.int_values, num_rows);
                     child_fields.push(Arc::new(Field::new("int", DataType::Int64, true)));
                     child_arrays.push(Arc::new(array) as ArrayRef);
                 }
 
                 if fc.has_float {
-                    let mut values = vec![0.0f64; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.float_values {
-                        let r = row as usize;
-                        if r < num_rows {
-                            values[r] = v;
-                            valid[r] = true;
-                        }
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = Float64Array::new(values.into(), Some(nulls));
+                    let array = scatter_float64(&fc.float_values, num_rows);
                     child_fields.push(Arc::new(Field::new("float", DataType::Float64, true)));
                     child_arrays.push(Arc::new(array) as ArrayRef);
                 }
@@ -446,17 +405,7 @@ impl StreamingBuilder {
                 }
 
                 if fc.has_bool {
-                    let mut values = vec![false; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.bool_values {
-                        let r = row as usize;
-                        if r < num_rows {
-                            values[r] = v;
-                            valid[r] = true;
-                        }
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = BooleanArray::new(values.into(), Some(nulls));
+                    let array = scatter_bool(&fc.bool_values, num_rows);
                     child_fields.push(Arc::new(Field::new("bool", DataType::Boolean, true)));
                     child_arrays.push(Arc::new(array) as ArrayRef);
                 }
@@ -476,34 +425,14 @@ impl StreamingBuilder {
             } else {
                 if fc.has_int {
                     reserve_name(name.as_ref())?;
-                    let mut values = vec![0i64; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.int_values {
-                        let r = row as usize;
-                        if r < num_rows {
-                            values[r] = v;
-                            valid[r] = true;
-                        }
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = Int64Array::new(values.into(), Some(nulls));
+                    let array = scatter_int64(&fc.int_values, num_rows);
                     schema_fields.push(Field::new(name.as_ref(), DataType::Int64, true));
                     arrays.push(Arc::new(array) as ArrayRef);
                 }
 
                 if fc.has_float {
                     reserve_name(name.as_ref())?;
-                    let mut values = vec![0.0f64; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.float_values {
-                        let r = row as usize;
-                        if r < num_rows {
-                            values[r] = v;
-                            valid[r] = true;
-                        }
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = Float64Array::new(values.into(), Some(nulls));
+                    let array = scatter_float64(&fc.float_values, num_rows);
                     schema_fields.push(Field::new(name.as_ref(), DataType::Float64, true));
                     arrays.push(Arc::new(array) as ArrayRef);
                 }
@@ -533,17 +462,7 @@ impl StreamingBuilder {
 
                 if fc.has_bool {
                     reserve_name(name.as_ref())?;
-                    let mut values = vec![false; num_rows];
-                    let mut valid = vec![false; num_rows];
-                    for &(row, v) in &fc.bool_values {
-                        let r = row as usize;
-                        if r < num_rows {
-                            values[r] = v;
-                            valid[r] = true;
-                        }
-                    }
-                    let nulls = NullBuffer::from(valid);
-                    let array = BooleanArray::new(values.into(), Some(nulls));
+                    let array = scatter_bool(&fc.bool_values, num_rows);
                     schema_fields.push(Field::new(name.as_ref(), DataType::Boolean, true));
                     arrays.push(Arc::new(array) as ArrayRef);
                 }

--- a/crates/logfwd-arrow/src/streaming_builder/tests.rs
+++ b/crates/logfwd-arrow/src/streaming_builder/tests.rs
@@ -678,32 +678,6 @@ mod tests {
         assert!(col.is_null(2), "row 2 should be null");
     }
 
-    /// Three-way conflict: int, float, str all appear -- struct has all three children.
-    #[test]
-    fn three_way_conflict_int_float_str() {
-        let buf = bytes::Bytes::from_static(b"text");
-        let mut b = StreamingBuilder::new(None);
-        b.begin_batch(buf.clone());
-        let si = b.resolve_field(b"mixed");
-        b.begin_row();
-        b.append_int_by_idx(si, b"42");
-        b.end_row();
-        b.begin_row();
-        b.append_float_by_idx(si, b"3.14");
-        b.end_row();
-        b.begin_row();
-        b.append_str_by_idx(si, &buf[0..4]);
-        b.end_row();
-        let batch = b.finish_batch().unwrap();
-        let col = batch.column_by_name("mixed").expect("mixed struct");
-        assert!(matches!(col.data_type(), DataType::Struct(_)));
-        let sa = col.as_any().downcast_ref::<ArrowStructArray>().unwrap();
-        let child_names: Vec<&str> = sa.fields().iter().map(|f| f.name().as_str()).collect();
-        assert!(child_names.contains(&"int"), "missing int child");
-        assert!(child_names.contains(&"float"), "missing float child");
-        assert!(child_names.contains(&"str"), "missing str child");
-    }
-
     /// Single-type int field stays as bare flat Int64 column, not a struct.
     #[test]
     fn single_type_field_stays_flat() {

--- a/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
+++ b/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
@@ -70,7 +70,7 @@ fn print_stats(label: &str, stats: &stats_alloc::Stats, total_rows: u64) {
 // StreamingBuilder workload runners
 // ---------------------------------------------------------------------------
 
-fn run_streaming_detached(warmup: bool) -> stats_alloc::Stats {
+fn run_streaming(warmup: bool, detached: bool) -> stats_alloc::Stats {
     let mut sb = StreamingBuilder::new(None);
 
     if warmup {
@@ -102,7 +102,11 @@ fn run_streaming_detached(warmup: bool) -> stats_alloc::Stats {
             sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
             sb.end_row();
         }
-        let _ = sb.finish_batch_detached().unwrap();
+        if detached {
+            let _ = sb.finish_batch_detached().unwrap();
+        } else {
+            let _ = sb.finish_batch().unwrap();
+        }
     }
 
     let region = Region::new(GLOBAL);
@@ -137,81 +141,11 @@ fn run_streaming_detached(warmup: bool) -> stats_alloc::Stats {
             sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
             sb.end_row();
         }
-        let batch = sb.finish_batch_detached().unwrap();
-        assert_eq!(batch.num_rows(), ROWS_PER_BATCH as usize);
-    }
-
-    region.change()
-}
-
-fn run_streaming_view(warmup: bool) -> stats_alloc::Stats {
-    let mut sb = StreamingBuilder::new(None);
-
-    if warmup {
-        let dummy = bytes::Bytes::from_static(b"");
-        sb.begin_batch(dummy);
-        let indices: Vec<usize> = FIELD_NAMES
-            .iter()
-            .map(|name| sb.resolve_field(name.as_bytes()))
-            .collect();
-        for row in 0..ROWS_PER_BATCH {
-            sb.begin_row();
-            for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
-                sb.append_i64_value_by_idx(idx, row as i64);
-            }
-            for &idx in &[
-                indices[2],
-                indices[3],
-                indices[5],
-                indices[6],
-                indices[7],
-                indices[8],
-                indices[9],
-                indices[10],
-                indices[11],
-                indices[14],
-            ] {
-                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
-            }
-            sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
-            sb.end_row();
-        }
-        let _ = sb.finish_batch().unwrap();
-    }
-
-    let region = Region::new(GLOBAL);
-
-    for _batch in 0..NUM_BATCHES {
-        let dummy = bytes::Bytes::from_static(b"");
-        sb.begin_batch(dummy);
-        let indices: Vec<usize> = FIELD_NAMES
-            .iter()
-            .map(|name| sb.resolve_field(name.as_bytes()))
-            .collect();
-
-        for row in 0..ROWS_PER_BATCH {
-            sb.begin_row();
-            for &idx in &[indices[0], indices[1], indices[4], indices[12]] {
-                sb.append_i64_value_by_idx(idx, row as i64);
-            }
-            for &idx in &[
-                indices[2],
-                indices[3],
-                indices[5],
-                indices[6],
-                indices[7],
-                indices[8],
-                indices[9],
-                indices[10],
-                indices[11],
-                indices[14],
-            ] {
-                sb.append_decoded_str_by_idx(idx, b"example-value-0123456789");
-            }
-            sb.append_f64_value_by_idx(indices[13], row as f64 * 0.001);
-            sb.end_row();
-        }
-        let batch = sb.finish_batch().unwrap();
+        let batch = if detached {
+            sb.finish_batch_detached().unwrap()
+        } else {
+            sb.finish_batch().unwrap()
+        };
         assert_eq!(batch.num_rows(), ROWS_PER_BATCH as usize);
     }
 
@@ -265,54 +199,7 @@ fn make_columnar_plan() -> (
     (plan, int_handles, str_handles, float_handles)
 }
 
-fn run_columnar_detached(warmup: bool) -> stats_alloc::Stats {
-    let (plan, int_handles, str_handles, float_handles) = make_columnar_plan();
-    let mut b = ColumnarBatchBuilder::new(plan);
-
-    if warmup {
-        // Full warmup batch to prime all vec capacities
-        b.begin_batch();
-        for row in 0..ROWS_PER_BATCH {
-            b.begin_row();
-            for &h in &int_handles {
-                b.write_i64(h, row as i64);
-            }
-            for &h in &str_handles {
-                b.write_str(h, "example-value-0123456789").unwrap();
-            }
-            for &h in &float_handles {
-                b.write_f64(h, row as f64 * 0.001);
-            }
-            b.end_row();
-        }
-        let _ = b.finish_batch().unwrap();
-    }
-
-    let region = Region::new(GLOBAL);
-
-    for _batch in 0..NUM_BATCHES {
-        b.begin_batch();
-        for row in 0..ROWS_PER_BATCH {
-            b.begin_row();
-            for &h in &int_handles {
-                b.write_i64(h, row as i64);
-            }
-            for &h in &str_handles {
-                b.write_str(h, "example-value-0123456789").unwrap();
-            }
-            for &h in &float_handles {
-                b.write_f64(h, row as f64 * 0.001);
-            }
-            b.end_row();
-        }
-        let batch = b.finish_batch().unwrap();
-        assert_eq!(batch.num_rows(), ROWS_PER_BATCH as usize);
-    }
-
-    region.change()
-}
-
-fn run_columnar_view(warmup: bool) -> stats_alloc::Stats {
+fn run_columnar(warmup: bool) -> stats_alloc::Stats {
     let (plan, int_handles, str_handles, float_handles) = make_columnar_plan();
     let mut b = ColumnarBatchBuilder::new(plan);
 
@@ -370,23 +257,19 @@ fn allocation_profile() {
 
     eprintln!("\n=== StreamingBuilder ({total_rows} rows, {NUM_BATCHES} batches) ===\n");
     eprintln!("  -- Cold start --");
-    print_stats(
-        "detached (cold)",
-        &run_streaming_detached(false),
-        total_rows,
-    );
-    print_stats("view (cold)", &run_streaming_view(false), total_rows);
+    print_stats("detached (cold)", &run_streaming(false, true), total_rows);
+    print_stats("view (cold)", &run_streaming(false, false), total_rows);
     eprintln!("\n  -- Steady state (warmed) --");
-    print_stats("detached (warm)", &run_streaming_detached(true), total_rows);
-    print_stats("view (warm)", &run_streaming_view(true), total_rows);
+    print_stats("detached (warm)", &run_streaming(true, true), total_rows);
+    print_stats("view (warm)", &run_streaming(true, false), total_rows);
 
     eprintln!("\n=== ColumnarBatchBuilder ({total_rows} rows, {NUM_BATCHES} batches) ===\n");
     eprintln!("  -- Cold start --");
-    print_stats("detached (cold)", &run_columnar_detached(false), total_rows);
-    print_stats("view (cold)", &run_columnar_view(false), total_rows);
+    print_stats("detached (cold)", &run_columnar(false), total_rows);
+    print_stats("view (cold)", &run_columnar(false), total_rows);
     eprintln!("\n  -- Steady state (warmed) --");
-    print_stats("detached (warm)", &run_columnar_detached(true), total_rows);
-    print_stats("view (warm)", &run_columnar_view(true), total_rows);
+    print_stats("detached (warm)", &run_columnar(true), total_rows);
+    print_stats("view (warm)", &run_columnar(true), total_rows);
     eprintln!();
 }
 
@@ -396,10 +279,10 @@ fn allocation_profile() {
 fn allocation_comparison() {
     let total_rows = u64::from(ROWS_PER_BATCH) * NUM_BATCHES;
 
-    let sb_det = run_streaming_detached(true);
-    let sb_view = run_streaming_view(true);
-    let cb_det = run_columnar_detached(true);
-    let cb_view = run_columnar_view(true);
+    let sb_det = run_streaming(true, true);
+    let sb_view = run_streaming(true, false);
+    let cb_det = run_columnar(true);
+    let cb_view = run_columnar(true);
 
     eprintln!("\n=== Allocation Comparison — warm, {total_rows} rows ===\n");
     eprintln!(

--- a/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
+++ b/crates/logfwd-arrow/tests/columnar_alloc_profile.rs
@@ -265,11 +265,9 @@ fn allocation_profile() {
 
     eprintln!("\n=== ColumnarBatchBuilder ({total_rows} rows, {NUM_BATCHES} batches) ===\n");
     eprintln!("  -- Cold start --");
-    print_stats("detached (cold)", &run_columnar(false), total_rows);
-    print_stats("view (cold)", &run_columnar(false), total_rows);
+    print_stats("finish_batch (cold)", &run_columnar(false), total_rows);
     eprintln!("\n  -- Steady state (warmed) --");
-    print_stats("detached (warm)", &run_columnar(true), total_rows);
-    print_stats("view (warm)", &run_columnar(true), total_rows);
+    print_stats("finish_batch (warm)", &run_columnar(true), total_rows);
     eprintln!();
 }
 

--- a/crates/logfwd-bench/src/e2e_profile.rs
+++ b/crates/logfwd-bench/src/e2e_profile.rs
@@ -2,7 +2,6 @@
 //! Profile each stage of the full pipeline: read → scan → transform → encode → "send"
 //! Run with: cargo run -p logfwd-bench --release --features bench-tools --bin e2e_profile
 
-use std::io::Write;
 use std::sync::Arc;
 use std::time::Instant;
 

--- a/crates/logfwd-bench/src/e2e_profile.rs
+++ b/crates/logfwd-bench/src/e2e_profile.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use logfwd_arrow::scanner::Scanner;
+use logfwd_bench::generate_simple;
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_io::compress::ChunkCompressor;
 use logfwd_output::BatchMetadata;
@@ -162,23 +163,4 @@ fn main() {
             "  {n:>7} lines: scan={scan:>5}ms  xform={xform:>4}ms  otlp={encode:>5}ms  zstd={compress:>4}ms  total={total:>5}ms  {lps:>8} lines/sec"
         );
     }
-}
-
-fn generate_simple(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 180);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let paths = [
-        "/api/v1/users",
-        "/api/v1/orders",
-        "/api/v2/products",
-        "/health",
-        "/api/v1/auth",
-    ];
-    for i in 0..n {
-        write!(buf, r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{:016x}","service":"myapp"}}"#,
-            i % 1000, levels[i % 4], paths[i % 5], 10000 + (i * 7) % 90000,
-            1 + (i * 13) % 500, (i as u64).wrapping_mul(0x517cc1b727220a95)).unwrap();
-        buf.push(b'\n');
-    }
-    buf
 }

--- a/crates/logfwd-bench/src/explore.rs
+++ b/crates/logfwd-bench/src/explore.rs
@@ -2,7 +2,6 @@
 //! Exploratory benchmark: scanner + SQL transform across many dimensions.
 //! Run with: cargo run -p logfwd-bench --release --bin explore
 
-use std::io::Write;
 use std::time::Instant;
 
 use logfwd_arrow::scanner::Scanner;

--- a/crates/logfwd-bench/src/explore.rs
+++ b/crates/logfwd-bench/src/explore.rs
@@ -6,6 +6,7 @@ use std::io::Write;
 use std::time::Instant;
 
 use logfwd_arrow::scanner::Scanner;
+use logfwd_bench::{generate_narrow, generate_simple, generate_wide};
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_transform::SqlTransform;
 
@@ -341,73 +342,4 @@ fn bench_scan_only(dataset: &str, lines: usize, fields: usize, data: &[u8]) {
         lps,
         batch.num_rows()
     );
-}
-
-// --- Data generators ---
-
-fn generate_simple(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 180);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let paths = [
-        "/api/v1/users",
-        "/api/v1/orders",
-        "/api/v2/products",
-        "/health",
-        "/api/v1/auth",
-    ];
-    for i in 0..n {
-        write!(
-            buf,
-            r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{:016x}","service":"myapp"}}"#,
-            i % 1000,
-            levels[i % 4],
-            paths[i % 5],
-            10000 + (i * 7) % 90000,
-            1 + (i * 13) % 500,
-            (i as u64).wrapping_mul(0x517cc1b727220a95),
-        ).unwrap();
-        buf.push(b'\n');
-    }
-    buf
-}
-
-fn generate_wide(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 600);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let methods = ["GET", "POST", "PUT", "DELETE", "PATCH"];
-    let regions = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"];
-    let namespaces = ["default", "kube-system", "monitoring", "logging"];
-    for i in 0..n {
-        write!(
-            buf,
-            r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request {}","duration_ms":{},"service":"myapp","host":"node-{}","pod":"app-{:04}","namespace":"{}","method":"{}","status_code":{},"region":"{}","user_id":"user-{}","trace_id":"{:032x}","response_bytes":{},"latency_p99_ms":{},"error_count":{},"cache_hit":{},"db_query_ms":{},"upstream":"svc-{}","version":"v{}.{}"}}"#,
-            i % 1000, levels[i % 4], i, 1 + (i * 13) % 500,
-            i % 10, i % 100, namespaces[i % 4], methods[i % 5],
-            [200, 201, 400, 404, 500][i % 5], regions[i % 4],
-            i % 1000, (i as u64).wrapping_mul(0x517cc1b727220a95),
-            100 + (i * 37) % 10000, 10 + (i * 11) % 1000,
-            i32::from(i % 20 == 0),
-            if i % 3 == 0 { "true" } else { "false" },
-            (i * 7) % 200, i % 4, 1 + i % 5, i % 10,
-        ).unwrap();
-        buf.push(b'\n');
-    }
-    buf
-}
-
-fn generate_narrow(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 60);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    for i in 0..n {
-        write!(
-            buf,
-            r#"{{"ts":"{}","lvl":"{}","msg":"event {}"}}"#,
-            i,
-            levels[i % 4],
-            i
-        )
-        .unwrap();
-        buf.push(b'\n');
-    }
-    buf
 }

--- a/crates/logfwd-bench/src/lib.rs
+++ b/crates/logfwd-bench/src/lib.rs
@@ -1,11 +1,11 @@
 //! Shared deterministic data generators and helpers for logfwd benchmarks.
 //!
-//! All generators accept a `seed` parameter for reproducible output. Given the
-//! same `(count, seed)` pair, every call returns byte-identical results.
+//! Generators are deterministic and index-based (no seed parameter). Given the
+//! same `count`, every call returns byte-identical results.
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 // Bench harnesses print reports to stdout/stderr.
 
-use std::fmt::Write;
+use std::io::Write;
 use std::sync::Arc;
 
 use logfwd_output::{BatchMetadata, Compression, OtlpProtocol, OtlpSink};
@@ -60,7 +60,7 @@ pub fn make_otlp_sink(compression: Compression) -> OtlpSink {
 // Inline JSON-line generators (non-seeded, index-based)
 // ---------------------------------------------------------------------------
 
-/// Generate `n` JSON log lines with 7 fields (timestamp, level, message,
+/// Generate `n` JSON log lines with 6 fields (timestamp, level, message,
 /// duration_ms, request_id, service).
 pub fn generate_simple(n: usize) -> Vec<u8> {
     let mut buf = Vec::with_capacity(n * 180);

--- a/crates/logfwd-bench/src/lib.rs
+++ b/crates/logfwd-bench/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 // Bench harnesses print reports to stdout/stderr.
 
+use std::fmt::Write;
 use std::sync::Arc;
 
 use logfwd_output::{BatchMetadata, Compression, OtlpProtocol, OtlpSink};
@@ -53,4 +54,79 @@ pub fn make_otlp_sink(compression: Compression) -> OtlpSink {
         Arc::new(ComponentStats::default()),
     )
     .expect("valid otlp sink for bench")
+}
+
+// ---------------------------------------------------------------------------
+// Inline JSON-line generators (non-seeded, index-based)
+// ---------------------------------------------------------------------------
+
+/// Generate `n` JSON log lines with 7 fields (timestamp, level, message,
+/// duration_ms, request_id, service).
+pub fn generate_simple(n: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(n * 180);
+    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
+    let paths = [
+        "/api/v1/users",
+        "/api/v1/orders",
+        "/api/v2/products",
+        "/health",
+        "/api/v1/auth",
+    ];
+    for i in 0..n {
+        write!(
+            buf,
+            r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{:016x}","service":"myapp"}}"#,
+            i % 1000,
+            levels[i % 4],
+            paths[i % 5],
+            10000 + (i * 7) % 90000,
+            1 + (i * 13) % 500,
+            (i as u64).wrapping_mul(0x517cc1b727220a95),
+        ).unwrap();
+        buf.push(b'\n');
+    }
+    buf
+}
+
+/// Generate `n` JSON log lines with 20 fields (wide schema).
+pub fn generate_wide(n: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(n * 600);
+    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
+    let methods = ["GET", "POST", "PUT", "DELETE", "PATCH"];
+    let regions = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"];
+    let namespaces = ["default", "kube-system", "monitoring", "logging"];
+    for i in 0..n {
+        write!(
+            buf,
+            r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request {}","duration_ms":{},"service":"myapp","host":"node-{}","pod":"app-{:04}","namespace":"{}","method":"{}","status_code":{},"region":"{}","user_id":"user-{}","trace_id":"{:032x}","response_bytes":{},"latency_p99_ms":{},"error_count":{},"cache_hit":{},"db_query_ms":{},"upstream":"svc-{}","version":"v{}.{}"}}"#,
+            i % 1000, levels[i % 4], i, 1 + (i * 13) % 500,
+            i % 10, i % 100, namespaces[i % 4], methods[i % 5],
+            [200, 201, 400, 404, 500][i % 5], regions[i % 4],
+            i % 1000, (i as u64).wrapping_mul(0x517cc1b727220a95),
+            100 + (i * 37) % 10000, 10 + (i * 11) % 1000,
+            i32::from(i % 20 == 0),
+            if i % 3 == 0 { "true" } else { "false" },
+            (i * 7) % 200, i % 4, 1 + i % 5, i % 10,
+        ).unwrap();
+        buf.push(b'\n');
+    }
+    buf
+}
+
+/// Generate `n` JSON log lines with 3 fields (narrow schema: ts, lvl, msg).
+pub fn generate_narrow(n: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(n * 60);
+    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
+    for i in 0..n {
+        write!(
+            buf,
+            r#"{{"ts":"{}","lvl":"{}","msg":"event {}"}}"#,
+            i,
+            levels[i % 4],
+            i
+        )
+        .unwrap();
+        buf.push(b'\n');
+    }
+    buf
 }

--- a/crates/logfwd-bench/src/lib.rs
+++ b/crates/logfwd-bench/src/lib.rs
@@ -130,3 +130,41 @@ pub fn generate_narrow(n: usize) -> Vec<u8> {
     }
     buf
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{generate_narrow, generate_simple, generate_wide};
+
+    #[test]
+    fn simple_is_deterministic() {
+        assert_eq!(generate_simple(100), generate_simple(100));
+    }
+
+    #[test]
+    fn simple_line_count_matches_n() {
+        let out = generate_simple(50);
+        assert_eq!(out.iter().filter(|&&b| b == b'\n').count(), 50);
+    }
+
+    #[test]
+    fn wide_is_deterministic() {
+        assert_eq!(generate_wide(100), generate_wide(100));
+    }
+
+    #[test]
+    fn wide_line_count_matches_n() {
+        let out = generate_wide(50);
+        assert_eq!(out.iter().filter(|&&b| b == b'\n').count(), 50);
+    }
+
+    #[test]
+    fn narrow_is_deterministic() {
+        assert_eq!(generate_narrow(100), generate_narrow(100));
+    }
+
+    #[test]
+    fn narrow_line_count_matches_n() {
+        let out = generate_narrow(50);
+        assert_eq!(out.iter().filter(|&&b| b == b'\n').count(), 50);
+    }
+}

--- a/crates/logfwd-bench/src/rss.rs
+++ b/crates/logfwd-bench/src/rss.rs
@@ -5,6 +5,7 @@
 use std::io::Write;
 
 use logfwd_arrow::scanner::Scanner;
+use logfwd_bench::{generate_simple, generate_wide};
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_transform::SqlTransform;
 
@@ -212,44 +213,4 @@ fn main() {
 
     drop(data);
     println!("  After cleanup:           {:.1} MB", rss_mb());
-}
-
-fn generate_simple(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 180);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let paths = [
-        "/api/v1/users",
-        "/api/v1/orders",
-        "/api/v2/products",
-        "/health",
-        "/api/v1/auth",
-    ];
-    for i in 0..n {
-        write!(buf, r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{:016x}","service":"myapp"}}"#,
-            i % 1000, levels[i % 4], paths[i % 5], 10000 + (i * 7) % 90000,
-            1 + (i * 13) % 500, (i as u64).wrapping_mul(0x517cc1b727220a95)).unwrap();
-        buf.push(b'\n');
-    }
-    buf
-}
-
-fn generate_wide(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 600);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let methods = ["GET", "POST", "PUT", "DELETE", "PATCH"];
-    let regions = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"];
-    let namespaces = ["default", "kube-system", "monitoring", "logging"];
-    for i in 0..n {
-        write!(buf, r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request {}","duration_ms":{},"service":"myapp","host":"node-{}","pod":"app-{:04}","namespace":"{}","method":"{}","status_code":{},"region":"{}","user_id":"user-{}","trace_id":"{:032x}","response_bytes":{},"latency_p99_ms":{},"error_count":{},"cache_hit":{},"db_query_ms":{},"upstream":"svc-{}","version":"v{}.{}"}}"#,
-            i % 1000, levels[i % 4], i, 1 + (i * 13) % 500,
-            i % 10, i % 100, namespaces[i % 4], methods[i % 5],
-            [200, 201, 400, 404, 500][i % 5], regions[i % 4],
-            i % 1000, (i as u64).wrapping_mul(0x517cc1b727220a95),
-            100 + (i * 37) % 10000, 10 + (i * 11) % 1000,
-            i32::from(i % 20 == 0),
-            if i % 3 == 0 { "true" } else { "false" },
-            (i * 7) % 200, i % 4, 1 + i % 5, i % 10).unwrap();
-        buf.push(b'\n');
-    }
-    buf
 }

--- a/crates/logfwd-bench/src/rss.rs
+++ b/crates/logfwd-bench/src/rss.rs
@@ -2,8 +2,6 @@
 //! Measure actual RSS (resident set size) at each pipeline stage.
 //! Run with: cargo run -p logfwd-bench --release --features bench-tools --bin rss
 
-use std::io::Write;
-
 use logfwd_arrow::scanner::Scanner;
 use logfwd_bench::{generate_simple, generate_wide};
 use logfwd_core::scan_config::ScanConfig;

--- a/crates/logfwd-bench/src/sizes.rs
+++ b/crates/logfwd-bench/src/sizes.rs
@@ -2,8 +2,6 @@
 //! Measure data sizes across the pipeline: raw JSON → Arrow RecordBatch → IPC → Parquet
 //! Run with: cargo run -p logfwd-bench --release --bin sizes
 
-use std::io::Write;
-
 use arrow::ipc::writer::{FileWriter, IpcWriteOptions};
 use arrow::record_batch::RecordBatch;
 use logfwd_arrow::scanner::Scanner;

--- a/crates/logfwd-bench/src/sizes.rs
+++ b/crates/logfwd-bench/src/sizes.rs
@@ -7,6 +7,7 @@ use std::io::Write;
 use arrow::ipc::writer::{FileWriter, IpcWriteOptions};
 use arrow::record_batch::RecordBatch;
 use logfwd_arrow::scanner::Scanner;
+use logfwd_bench::{generate_narrow, generate_simple, generate_wide};
 use logfwd_core::scan_config::ScanConfig;
 use logfwd_transform::SqlTransform;
 
@@ -272,69 +273,6 @@ fn write_parquet(batch: &RecordBatch) -> usize {
 }
 
 // --- Helpers ---
-
-fn generate_simple(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 180);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let paths = [
-        "/api/v1/users",
-        "/api/v1/orders",
-        "/api/v2/products",
-        "/health",
-        "/api/v1/auth",
-    ];
-    for i in 0..n {
-        write!(
-            buf,
-            r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request handled GET {}/{}","duration_ms":{},"request_id":"{:016x}","service":"myapp"}}"#,
-            i % 1000, levels[i % 4], paths[i % 5], 10000 + (i * 7) % 90000,
-            1 + (i * 13) % 500, (i as u64).wrapping_mul(0x517cc1b727220a95),
-        ).unwrap();
-        buf.push(b'\n');
-    }
-    buf
-}
-
-fn generate_wide(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 600);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    let methods = ["GET", "POST", "PUT", "DELETE", "PATCH"];
-    let regions = ["us-east-1", "us-west-2", "eu-west-1", "ap-southeast-1"];
-    let namespaces = ["default", "kube-system", "monitoring", "logging"];
-    for i in 0..n {
-        write!(
-            buf,
-            r#"{{"timestamp":"2024-01-15T10:30:00.{:03}Z","level":"{}","message":"request {}","duration_ms":{},"service":"myapp","host":"node-{}","pod":"app-{:04}","namespace":"{}","method":"{}","status_code":{},"region":"{}","user_id":"user-{}","trace_id":"{:032x}","response_bytes":{},"latency_p99_ms":{},"error_count":{},"cache_hit":{},"db_query_ms":{},"upstream":"svc-{}","version":"v{}.{}"}}"#,
-            i % 1000, levels[i % 4], i, 1 + (i * 13) % 500,
-            i % 10, i % 100, namespaces[i % 4], methods[i % 5],
-            [200, 201, 400, 404, 500][i % 5], regions[i % 4],
-            i % 1000, (i as u64).wrapping_mul(0x517cc1b727220a95),
-            100 + (i * 37) % 10000, 10 + (i * 11) % 1000,
-            i32::from(i % 20 == 0),
-            if i % 3 == 0 { "true" } else { "false" },
-            (i * 7) % 200, i % 4, 1 + i % 5, i % 10,
-        ).unwrap();
-        buf.push(b'\n');
-    }
-    buf
-}
-
-fn generate_narrow(n: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(n * 60);
-    let levels = ["INFO", "DEBUG", "WARN", "ERROR"];
-    for i in 0..n {
-        write!(
-            buf,
-            r#"{{"ts":"{}","lvl":"{}","msg":"event {}"}}"#,
-            i,
-            levels[i % 4],
-            i
-        )
-        .unwrap();
-        buf.push(b'\n');
-    }
-    buf
-}
 
 fn fmt_bytes(n: usize) -> String {
     if n >= 1_073_741_824 {

--- a/crates/logfwd-config/src/lib.rs
+++ b/crates/logfwd-config/src/lib.rs
@@ -55,6 +55,18 @@ pub use validate::validate_host_port;
 // Tests
 // ---------------------------------------------------------------------------
 
+/// Asserts that `Config::load_str(yaml)` fails and the error message contains
+/// every given substring (AND logic). Replaces the repetitive
+/// `unwrap_err → to_string → contains` pattern across test files.
+#[cfg(test)]
+macro_rules! assert_config_err {
+    ($yaml:expr, $($substr:expr),+ $(,)?) => {{
+        let err = $crate::Config::load_str($yaml).unwrap_err();
+        let msg = err.to_string();
+        $(assert!(msg.contains($substr), "expected {:?} in error: {msg}", $substr);)+
+    }};
+}
+
 #[cfg(test)]
 mod tests_config_parsing;
 #[cfg(test)]

--- a/crates/logfwd-config/src/tests_config_parsing.rs
+++ b/crates/logfwd-config/src/tests_config_parsing.rs
@@ -226,16 +226,7 @@ output:
   type: otlp
   endpoint: ${LOGFWD_NONEXISTENT_VAR_12345}
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("LOGFWD_NONEXISTENT_VAR_12345"),
-            "error should mention the variable name: {msg}"
-        );
-        assert!(
-            msg.contains("not set"),
-            "error should say variable is not set: {msg}"
-        );
+        assert_config_err!(yaml, "LOGFWD_NONEXISTENT_VAR_12345", "not set");
     }
 
     #[test]
@@ -263,12 +254,7 @@ pipelines:
     outputs:
       - type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("duplicate entry with key \"app\""),
-            "duplicate pipeline names must be rejected before validation: {msg}"
-        );
+        assert_config_err!(yaml, "duplicate entry with key \"app\"");
     }
 
     #[test]

--- a/crates/logfwd-config/src/tests_enrichment.rs
+++ b/crates/logfwd-config/src/tests_enrichment.rs
@@ -7,78 +7,37 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn enrichment_geo_database_missing_path_rejected() {
-        let yaml = r"
-pipelines:
-  app:
-    inputs:
-      - type: file
-        path: /tmp/x.log
-    outputs:
-      - type: stdout
-    enrichment:
-      - type: geo_database
-        format: mmdb
-        path: /nonexistent/path/to/GeoLite2-City.mmdb
-";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("not found"),
-            "expected 'not found' in error: {msg}"
-        );
-        assert!(
-            msg.contains("geo database"),
-            "expected 'geo database' in error: {msg}"
-        );
-    }
-
-    #[test]
-    fn enrichment_csv_missing_path_rejected() {
-        let yaml = r"
-pipelines:
-  app:
-    inputs:
-      - type: file
-        path: /tmp/x.log
-    outputs:
-      - type: stdout
-    enrichment:
-      - type: csv
-        table_name: assets
-        path: /nonexistent/path/to/assets.csv
-";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("not found"),
-            "expected 'not found' in error: {msg}"
-        );
-        assert!(msg.contains("csv"), "expected 'csv' in error: {msg}");
-    }
-
-    #[test]
-    fn enrichment_jsonl_missing_path_rejected() {
-        let yaml = r"
-pipelines:
-  app:
-    inputs:
-      - type: file
-        path: /tmp/x.log
-    outputs:
-      - type: stdout
-    enrichment:
-      - type: jsonl
-        table_name: ips
-        path: /nonexistent/path/to/data.jsonl
-";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("not found"),
-            "expected 'not found' in error: {msg}"
-        );
-        assert!(msg.contains("jsonl"), "expected 'jsonl' in error: {msg}");
+    fn enrichment_missing_path_rejected() {
+        let cases = [
+            (
+                "geo_database",
+                "format: mmdb\n        path: /nonexistent/path/to/GeoLite2-City.mmdb",
+                &["not found", "geo database"][..],
+            ),
+            (
+                "csv",
+                "table_name: assets\n        path: /nonexistent/path/to/assets.csv",
+                &["not found", "csv"][..],
+            ),
+            (
+                "jsonl",
+                "table_name: ips\n        path: /nonexistent/path/to/data.jsonl",
+                &["not found", "jsonl"][..],
+            ),
+        ];
+        for (etype, extra, expected) in cases {
+            let yaml = format!(
+                "pipelines:\n  app:\n    inputs:\n      - type: file\n        path: /tmp/x.log\n    outputs:\n      - type: stdout\n    enrichment:\n      - type: {etype}\n        {extra}\n"
+            );
+            let err = Config::load_str(&yaml).unwrap_err();
+            let msg = err.to_string();
+            for substr in expected {
+                assert!(
+                    msg.contains(substr),
+                    "expected {substr:?} in error for {etype}: {msg}"
+                );
+            }
+        }
     }
 
     #[test]
@@ -122,12 +81,7 @@ pipelines:
         table_name: env
         labels: {}
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("at least one label"),
-            "expected 'at least one label' in error: {msg}"
-        );
+        assert_config_err!(yaml, "at least one label");
     }
 
     #[test]
@@ -297,88 +251,24 @@ enrichment:
     // -----------------------------------------------------------------------
 
     #[test]
-    fn geo_database_empty_path_rejected() {
-        let yaml = r#"
-pipelines:
-  test:
-    inputs:
-      - type: file
-        path: /tmp/test.log
-    outputs:
-      - type: stdout
-    enrichment:
-      - type: geo_database
-        format: mmdb
-        path: ""
-"#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("path") && err.to_string().contains("empty"),
-            "expected empty-path rejection for geo_database: {err}"
-        );
-    }
-
-    #[test]
-    fn csv_enrichment_empty_path_rejected() {
-        let yaml = r#"
-pipelines:
-  test:
-    inputs:
-      - type: file
-        path: /tmp/test.log
-    outputs:
-      - type: stdout
-    enrichment:
-      - type: csv
-        table_name: assets
-        path: ""
-"#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("path") && err.to_string().contains("empty"),
-            "expected empty-path rejection for csv enrichment: {err}"
-        );
-    }
-
-    #[test]
-    fn jsonl_enrichment_empty_path_rejected() {
-        let yaml = r#"
-pipelines:
-  test:
-    inputs:
-      - type: file
-        path: /tmp/test.log
-    outputs:
-      - type: stdout
-    enrichment:
-      - type: jsonl
-        table_name: owners
-        path: "   "
-"#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("path") && err.to_string().contains("empty"),
-            "expected empty-path rejection for jsonl enrichment: {err}"
-        );
-    }
-
-    #[test]
-    fn geo_database_whitespace_path_rejected() {
-        let yaml = "pipelines:\n  test:\n    inputs:\n      - type: file\n        path: /tmp/test.log\n    outputs:\n      - type: stdout\n    enrichment:\n      - type: geo_database\n        format: mmdb\n        path: \"   \"\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("path") && err.to_string().contains("empty"),
-            "whitespace-only path must be rejected for geo_database: {err}"
-        );
-    }
-
-    #[test]
-    fn csv_enrichment_whitespace_path_rejected() {
-        let yaml = "pipelines:\n  test:\n    inputs:\n      - type: file\n        path: /tmp/test.log\n    outputs:\n      - type: stdout\n    enrichment:\n      - type: csv\n        table_name: assets\n        path: \"   \"\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("path") && err.to_string().contains("empty"),
-            "whitespace-only path must be rejected for csv enrichment: {err}"
-        );
+    fn enrichment_empty_or_whitespace_path_rejected() {
+        let cases = [
+            ("geo_database", "format: mmdb\n        path: \"\""),
+            ("csv", "table_name: assets\n        path: \"\""),
+            ("jsonl", "table_name: owners\n        path: \"   \""),
+            ("geo_database", "format: mmdb\n        path: \"   \""),
+            ("csv", "table_name: assets\n        path: \"   \""),
+        ];
+        for (etype, extra) in cases {
+            let yaml = format!(
+                "pipelines:\n  test:\n    inputs:\n      - type: file\n        path: /tmp/test.log\n    outputs:\n      - type: stdout\n    enrichment:\n      - type: {etype}\n        {extra}\n"
+            );
+            let err = Config::load_str(&yaml).unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("path") && msg.contains("empty"),
+                "expected empty-path rejection for {etype}: {msg}"
+            );
+        }
     }
 }

--- a/crates/logfwd-config/src/tests_generator_config.rs
+++ b/crates/logfwd-config/src/tests_generator_config.rs
@@ -136,11 +136,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("generator.sequence.field"),
-            "expected empty sequence field rejection: {err}"
-        );
+        assert_config_err!(yaml, "generator.sequence.field");
     }
 
     #[test]
@@ -159,12 +155,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("must not duplicate a generator.attributes key"),
-            "expected duplicate generated field rejection: {err}"
-        );
+        assert_config_err!(yaml, "must not duplicate a generator.attributes key");
     }
 
     #[test]
@@ -179,11 +170,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("batch_size must be at least 1"),
-            "expected zero batch size rejection: {err}"
-        );
+        assert_config_err!(yaml, "batch_size must be at least 1");
     }
 
     #[test]
@@ -200,12 +187,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("attributes keys must not be empty"),
-            "expected empty attribute key rejection: {err}"
-        );
+        assert_config_err!(yaml, "attributes keys must not be empty");
     }
 
     #[test]
@@ -222,11 +204,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("float values must be finite"),
-            "expected non-finite attribute rejection: {err}"
-        );
+        assert_config_err!(yaml, "float values must be finite");
     }
 
     #[test]
@@ -242,12 +220,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("event_created_unix_nano_field must not be empty"),
-            "expected empty event_created field rejection: {err}"
-        );
+        assert_config_err!(yaml, "event_created_unix_nano_field must not be empty");
     }
 
     #[test]
@@ -265,12 +238,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("must not duplicate a generator.attributes key"),
-            "expected event_created/attribute duplication rejection: {err}"
-        );
+        assert_config_err!(yaml, "must not duplicate a generator.attributes key");
     }
 
     #[test]
@@ -288,12 +256,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("must not duplicate generator.sequence.field"),
-            "expected event_created/sequence duplication rejection: {err}"
-        );
+        assert_config_err!(yaml, "must not duplicate generator.sequence.field");
     }
 
     #[test]
@@ -309,11 +272,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("require generator.profile=record"),
-            "expected record profile requirement rejection: {err}"
-        );
+        assert_config_err!(yaml, "require generator.profile=record");
     }
 
     // -----------------------------------------------------------------------
@@ -380,11 +339,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("step_ms must not be zero"),
-            "expected zero step rejection: {err}"
-        );
+        assert_config_err!(yaml, "step_ms must not be zero");
     }
 
     #[test]
@@ -400,11 +355,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("YYYY-MM-DDTHH:MM:SSZ"),
-            "expected format rejection: {err}"
-        );
+        assert_config_err!(yaml, "YYYY-MM-DDTHH:MM:SSZ");
     }
 
     #[test]
@@ -421,12 +372,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("only supported for the logs profile"),
-            "expected logs-only rejection: {err}"
-        );
+        assert_config_err!(yaml, "only supported for the logs profile");
     }
 
     #[test]
@@ -442,11 +388,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("day 31 out of range"),
-            "expected invalid date rejection: {err}"
-        );
+        assert_config_err!(yaml, "day 31 out of range");
     }
 
     #[test]
@@ -462,10 +404,6 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("month 13 out of range"),
-            "expected invalid month rejection: {err}"
-        );
+        assert_config_err!(yaml, "month 13 out of range");
     }
 }

--- a/crates/logfwd-config/src/tests_generator_unsupported.rs
+++ b/crates/logfwd-config/src/tests_generator_unsupported.rs
@@ -17,11 +17,6 @@ pipelines:
       - type: loki
         endpoint: http://localhost:3100
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("has an unsupported type"),
-            "{}",
-            err
-        );
+        assert_config_err!(yaml, "has an unsupported type");
     }
 }

--- a/crates/logfwd-config/src/tests_input.rs
+++ b/crates/logfwd-config/src/tests_input.rs
@@ -152,11 +152,9 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).expect_err("stdin should reject unsupported format");
-        assert!(
-            err.to_string()
-                .contains("stdin input only supports format auto, cri, json, or raw"),
-            "unexpected error: {err}"
+        assert_config_err!(
+            yaml,
+            "stdin input only supports format auto, cri, json, or raw"
         );
     }
 
@@ -169,11 +167,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).expect_err("stdin should reject path");
-        assert!(
-            err.to_string().contains("unknown field `path`"),
-            "unexpected error: {err}"
-        );
+        assert_config_err!(yaml, "unknown field `path`");
     }
 
     #[test]
@@ -263,12 +257,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("sensor inputs do not support 'format'"),
-            "unexpected error: {err}"
-        );
+        assert_config_err!(yaml, "sensor inputs do not support 'format'");
     }
 
     #[test]
@@ -341,11 +330,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err().to_string();
-        assert!(
-            err.contains("'format' is not supported for arrow_ipc inputs"),
-            "expected arrow_ipc format rejection, got: {err}"
-        );
+        assert_config_err!(yaml, "'format' is not supported for arrow_ipc inputs");
     }
 
     #[test]
@@ -396,11 +381,7 @@ input:
 output:
   type: stdout
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("sensor.control_path must not be empty")
-        );
+        assert_config_err!(yaml, "sensor.control_path must not be empty");
     }
 
     #[test]
@@ -413,11 +394,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("unknown sensor family 'made_up_family'")
-        );
+        assert_config_err!(yaml, "unknown sensor family 'made_up_family'");
     }
 
     #[test]
@@ -444,12 +421,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("unknown sensor event type 'process_exec'"),
-            "unexpected error: {err}"
-        );
+        assert_config_err!(yaml, "unknown sensor event type 'process_exec'");
     }
 
     #[test]
@@ -462,12 +434,7 @@ input:
 output:
   type: stdout
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("sensor.exclude_event_types entries must not be empty"),
-            "unexpected error: {err}"
-        );
+        assert_config_err!(yaml, "sensor.exclude_event_types entries must not be empty");
     }
 
     #[test]
@@ -512,12 +479,9 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains(
-                "sensor.include_event_types and sensor.exclude_event_types are only supported for linux_ebpf_sensor inputs"
-            ),
-            "unexpected error: {err}"
+        assert_config_err!(
+            yaml,
+            "sensor.include_event_types and sensor.exclude_event_types are only supported for linux_ebpf_sensor inputs"
         );
     }
 
@@ -531,12 +495,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("max_open_files must be at least 1"),
-            "expected 'max_open_files must be at least 1' in error: {msg}"
-        );
+        assert_config_err!(yaml, "max_open_files must be at least 1");
     }
 
     #[test]
@@ -674,11 +633,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).expect_err("tcp input must reject max_clients: 0");
-        assert!(
-            err.to_string()
-                .contains("max_clients must be greater than 0")
-        );
+        assert_config_err!(yaml, "max_clients must be greater than 0");
     }
 
     #[test]
@@ -726,12 +681,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("requires both tls.cert_file and tls.key_file"),
-            "expected TCP cert/key pairing validation: {err}"
-        );
+        assert_config_err!(yaml, "requires both tls.cert_file and tls.key_file");
     }
 
     #[test]
@@ -768,12 +718,7 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("require_client_auth requires tls.client_ca_file"),
-            "expected TCP mTLS client CA validation failure: {err}"
-        );
+        assert_config_err!(yaml, "require_client_auth requires tls.client_ca_file");
     }
 
     #[test]
@@ -791,11 +736,9 @@ pipelines:
     outputs:
       - type: "null"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("client_ca_file requires tls.require_client_auth: true"),
-            "expected TCP client CA without mTLS validation failure: {err}"
+        assert_config_err!(
+            yaml,
+            "client_ca_file requires tls.require_client_auth: true"
         );
     }
 

--- a/crates/logfwd-config/src/tests_otlp_config.rs
+++ b/crates/logfwd-config/src/tests_otlp_config.rs
@@ -45,4 +45,61 @@ pipelines:
             _ => panic!("Expected OTLP input config"),
         }
     }
+
+    // ── OTLP TLS validation (mirrors TCP TLS tests in tests_input.rs) ──
+
+    #[test]
+    fn otlp_tls_requires_cert_and_key_together() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: otlp
+        listen: 0.0.0.0:4318
+        tls:
+          cert_file: /tmp/server.pem
+    outputs:
+      - type: "null"
+"#;
+        assert_config_err!(yaml, "requires both tls.cert_file and tls.key_file");
+    }
+
+    #[test]
+    fn otlp_mtls_requires_client_ca() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: otlp
+        listen: 0.0.0.0:4318
+        tls:
+          cert_file: /tmp/server.pem
+          key_file: /tmp/server.key
+          require_client_auth: true
+    outputs:
+      - type: "null"
+"#;
+        assert_config_err!(yaml, "require_client_auth requires tls.client_ca_file");
+    }
+
+    #[test]
+    fn otlp_client_ca_requires_mtls_enabled() {
+        let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: otlp
+        listen: 0.0.0.0:4318
+        tls:
+          cert_file: /tmp/server.pem
+          key_file: /tmp/server.key
+          client_ca_file: /tmp/ca.pem
+    outputs:
+      - type: "null"
+"#;
+        assert_config_err!(
+            yaml,
+            "client_ca_file requires tls.require_client_auth: true"
+        );
+    }
 }

--- a/crates/logfwd-config/src/tests_output.rs
+++ b/crates/logfwd-config/src/tests_output.rs
@@ -42,12 +42,7 @@ output:
   type: http
   endpoint: http://localhost:9200
 ";
-        let err = Config::load_str(yaml).expect_err("http output should be rejected");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("not yet implemented"),
-            "error should mention 'not yet implemented': {msg}"
-        );
+        assert_config_err!(yaml, "not yet implemented");
     }
 
     #[test]
@@ -59,12 +54,7 @@ input:
 output:
   type: file
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("file output requires 'path'"),
-            "expected missing path validation in error: {msg}"
-        );
+        assert_config_err!(yaml, "file output requires 'path'");
     }
 
     #[test]
@@ -93,9 +83,7 @@ output:
     #[test]
     fn file_output_rejects_console_format() {
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: file\n  path: /tmp/out.ndjson\n  format: console\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("file output only supports format json or text"));
+        assert_config_err!(yaml, "file output only supports format json or text");
     }
 
     #[test]
@@ -255,12 +243,7 @@ output:
   endpoint: http://localhost:9200
   request_mode: fancy
 ";
-        let err = Config::load_str(yaml).expect_err("invalid request_mode should fail");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("fancy") && msg.contains("buffered") && msg.contains("streaming"),
-            "expected request_mode enum rejection: {msg}"
-        );
+        assert_config_err!(yaml, "fancy", "buffered", "streaming");
     }
 
     #[test]
@@ -275,8 +258,7 @@ output:
   compression: gzip
   request_mode: streaming
 ";
-        let err = Config::load_str(yaml).expect_err("streaming+gzip should fail");
-        assert!(err.to_string().contains("does not support gzip"));
+        assert_config_err!(yaml, "does not support gzip");
     }
 
     #[test]
@@ -290,12 +272,7 @@ output:
   endpoint: http://localhost:4318/v1/logs
   request_mode: streaming
 ";
-        let err = Config::load_str(yaml).expect_err("request_mode should be es-only");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("unknown field") && msg.contains("request_mode"),
-            "otlp output should reject request_mode at parse time: {msg}"
-        );
+        assert_config_err!(yaml, "unknown field", "request_mode");
     }
 
     // -----------------------------------------------------------------------
@@ -307,23 +284,13 @@ output:
         // Unquoted `type: null` is YAML null — must be rejected, not silently
         // routed to the Null sink.
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: null\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("invalid type: unit value") && msg.contains("output.type"),
-            "unquoted type: null must be rejected: {msg}"
-        );
+        assert_config_err!(yaml, "invalid type: unit value", "output.type");
     }
 
     #[test]
     fn empty_output_type_with_endpoint_is_rejected() {
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type:\n  endpoint: https://collector:4318\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("invalid type: unit value") && msg.contains("output.type"),
-            "empty output type with endpoint must be rejected before it can become the null sink: {msg}"
-        );
+        assert_config_err!(yaml, "invalid type: unit value", "output.type");
     }
 
     #[test]
@@ -338,12 +305,7 @@ pipelines:
     outputs:
       - type: null
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("invalid type: unit value") && msg.contains("pipelines.app.outputs[0]"),
-            "unquoted type: null in list must be rejected: {msg}"
-        );
+        assert_config_err!(yaml, "invalid type: unit value", "pipelines.app.outputs[0]");
     }
 
     #[test]
@@ -367,13 +329,11 @@ output:
   type: "null"
   endpoint: https://collector:4318
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("unknown field `endpoint`")
-                && msg.contains("expected `name`")
-                && msg.contains("output"),
-            "explicit null output with endpoint must be rejected: {msg}"
+        assert_config_err!(
+            yaml,
+            "unknown field `endpoint`",
+            "expected `name`",
+            "output"
         );
     }
 
@@ -414,34 +374,19 @@ output:
     #[test]
     fn whole_output_null_is_rejected() {
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput: null\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("output is required when input is specified"),
-            "whole output null must not be treated as the null sink: {msg}"
-        );
+        assert_config_err!(yaml, "output is required when input is specified");
     }
 
     #[test]
     fn missing_output_type_is_rejected() {
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput: {}\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("missing configuration field \"output.type\""),
-            "missing output type must fail clearly: {msg}"
-        );
+        assert_config_err!(yaml, "missing configuration field \"output.type\"");
     }
 
     #[test]
     fn empty_string_output_type_is_rejected() {
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: \"\"\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("unknown variant ``") && msg.contains("output.type"),
-            "empty-string output type must fail clearly: {msg}"
-        );
+        assert_config_err!(yaml, "unknown variant ``", "output.type");
     }
 
     #[test]
@@ -449,12 +394,7 @@ output:
         // `type: ~` (YAML null as type value) must not silently become the Null
         // sink — that would cause silent data loss.
         let yaml = "input:\n  type: file\n  path: /tmp/x.log\noutput:\n  type: ~\n";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("invalid type: unit value") && msg.contains("output.type"),
-            "null type field value must be rejected: {msg}"
-        );
+        assert_config_err!(yaml, "invalid type: unit value", "output.type");
     }
 
     // -----------------------------------------------------------------------
@@ -474,11 +414,7 @@ pipelines:
         endpoint: http://localhost:4317
         index: my-index
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("index"),
-            "expected index rejection: {err}"
-        );
+        assert_config_err!(yaml, "index");
     }
 
     #[test]
@@ -494,11 +430,7 @@ pipelines:
         endpoint: http://localhost:9200
         protocol: grpc
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("protocol"),
-            "expected protocol rejection: {err}"
-        );
+        assert_config_err!(yaml, "protocol");
     }
 
     #[test]
@@ -513,11 +445,7 @@ pipelines:
       - type: stdout
         compression: zstd
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("compression"),
-            "expected compression rejection: {err}"
-        );
+        assert_config_err!(yaml, "compression");
     }
 
     #[test]
@@ -533,11 +461,7 @@ pipelines:
         auth:
           bearer_token: "secret"
 "#;
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("auth"),
-            "expected auth rejection: {err}"
-        );
+        assert_config_err!(yaml, "auth");
     }
 
     #[test]
@@ -552,11 +476,7 @@ pipelines:
       - type: stdout
         path: /tmp/out.log
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("path"),
-            "expected path rejection: {err}"
-        );
+        assert_config_err!(yaml, "path");
     }
 
     // -----------------------------------------------------------------------
@@ -575,12 +495,7 @@ pipelines:
       - type: stdout
         tenant_id: my-tenant
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("unknown field") && msg.contains("tenant_id"),
-            "stdout output should reject tenant_id at parse time: {msg}"
-        );
+        assert_config_err!(yaml, "unknown field", "tenant_id");
     }
 
     #[test]
@@ -596,12 +511,7 @@ pipelines:
         static_labels:
           env: prod
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("unknown field") && msg.contains("static_labels"),
-            "stdout output should reject static_labels at parse time: {msg}"
-        );
+        assert_config_err!(yaml, "unknown field", "static_labels");
     }
 
     #[test]
@@ -617,12 +527,7 @@ pipelines:
         label_columns:
           - container_name
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("unknown field") && msg.contains("label_columns"),
-            "stdout output should reject label_columns at parse time: {msg}"
-        );
+        assert_config_err!(yaml, "unknown field", "label_columns");
     }
 
     // -----------------------------------------------------------------------
@@ -645,12 +550,10 @@ pipelines:
         endpoint: http://localhost:4317
         compression: gzip
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("arrow_ipc output only supports 'zstd' or 'none'")
-                && msg.contains("'gzip'"),
-            "expected arrow_ipc-specific gzip rejection, got: {msg}"
+        assert_config_err!(
+            yaml,
+            "arrow_ipc output only supports 'zstd' or 'none'",
+            "'gzip'"
         );
     }
 

--- a/crates/logfwd-config/src/tests_server.rs
+++ b/crates/logfwd-config/src/tests_server.rs
@@ -61,12 +61,7 @@ output:
 server:
   diagnostics: ${LOGFWD_DIAG_ADDR}
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("LOGFWD_DIAG_ADDR"),
-            "error should mention the variable name: {msg}"
-        );
+        assert_config_err!(yaml, "LOGFWD_DIAG_ADDR");
     }
 
     // -----------------------------------------------------------------------
@@ -95,15 +90,6 @@ output:
 server:
   log_level: inof
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("log_level"),
-            "expected 'log_level' in error: {msg}"
-        );
-        assert!(
-            msg.contains("not a recognised log level"),
-            "expected 'not a recognised log level' in error: {msg}"
-        );
+        assert_config_err!(yaml, "log_level", "not a recognised log level");
     }
 }

--- a/crates/logfwd-config/src/tests_static_labels.rs
+++ b/crates/logfwd-config/src/tests_static_labels.rs
@@ -18,13 +18,7 @@ pipelines:
           ok_key: ok_value
           bad_key: \"\"
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("keys and values must not be empty"),
-            "{}",
-            err
-        );
+        assert_config_err!(yaml, "keys and values must not be empty");
 
         let yaml2 = "
 pipelines:
@@ -39,12 +33,6 @@ pipelines:
         static_labels:
           \"\": ok_value
 ";
-        let err2 = Config::load_str(yaml2).unwrap_err();
-        assert!(
-            err2.to_string()
-                .contains("keys and values must not be empty"),
-            "{}",
-            err2
-        );
+        assert_config_err!(yaml2, "keys and values must not be empty");
     }
 }

--- a/crates/logfwd-config/src/tests_validation.rs
+++ b/crates/logfwd-config/src/tests_validation.rs
@@ -14,9 +14,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("path"), "expected 'path' in error: {msg}");
+        assert_config_err!(yaml, "path");
     }
 
     #[test]
@@ -28,12 +26,7 @@ input:
 output:
   type: otlp
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("endpoint"),
-            "expected 'endpoint' in error: {msg}"
-        );
+        assert_config_err!(yaml, "endpoint");
     }
 
     #[test]
@@ -91,9 +84,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("listen"), "expected 'listen' in error: {msg}");
+        assert_config_err!(yaml, "listen");
     }
 
     #[test]
@@ -104,9 +95,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("listen"), "expected 'listen' in error: {msg}");
+        assert_config_err!(yaml, "listen");
     }
 
     #[test]
@@ -117,9 +106,7 @@ input:
 output:
   type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("listen"), "expected 'listen' in error: {msg}");
+        assert_config_err!(yaml, "listen");
     }
 
     #[test]
@@ -138,9 +125,7 @@ pipelines:
     outputs:
       - type: stdout
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("mix"), "expected 'mix' in error: {msg}");
+        assert_config_err!(yaml, "mix");
     }
 
     #[test]
@@ -149,12 +134,7 @@ pipelines:
 server:
   log_level: info
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("must define"),
-            "expected 'must define' in error: {msg}"
-        );
+        assert_config_err!(yaml, "must define");
     }
 
     #[test]
@@ -215,11 +195,9 @@ pipelines:
     outputs:
       - type: stdout
 ";
-        let err = Config::load_str(yaml).expect_err("top-level transform must be rejected");
-        assert!(
-            err.to_string()
-                .contains("top-level `transform` cannot be used with `pipelines:`"),
-            "unexpected validation error: {err}"
+        assert_config_err!(
+            yaml,
+            "top-level `transform` cannot be used with `pipelines:`"
         );
     }
 
@@ -272,12 +250,7 @@ output:
   type: otlp
   endpoint: ${LOGFWD_NONEXISTENT_ENDPOINT_VAR}
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("LOGFWD_NONEXISTENT_ENDPOINT_VAR"),
-            "error should mention the variable name: {msg}"
-        );
+        assert_config_err!(yaml, "LOGFWD_NONEXISTENT_ENDPOINT_VAR");
     }
 
     #[test]
@@ -318,16 +291,7 @@ pipelines:
 resource_attrs:
   service.name: my-service
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("top-level `resource_attrs`"),
-            "error should mention top-level resource_attrs: {msg}"
-        );
-        assert!(
-            msg.contains("pipelines"),
-            "error should mention pipelines: {msg}"
-        );
+        assert_config_err!(yaml, "top-level `resource_attrs`", "pipelines");
     }
 
     #[test]
@@ -345,16 +309,7 @@ enrichment:
     format: mmdb
     path: /tmp/geo.mmdb
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("top-level `enrichment`"),
-            "error should mention top-level enrichment: {msg}"
-        );
-        assert!(
-            msg.contains("pipelines"),
-            "error should mention pipelines form: {msg}"
-        );
+        assert_config_err!(yaml, "top-level `enrichment`", "pipelines");
     }
 
     #[test]
@@ -369,16 +324,7 @@ pipelines:
       - type: stdout
     workers: 0
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("workers"),
-            "expected 'workers' in error: {msg}"
-        );
-        assert!(
-            msg.contains("must be in range 1..=1024"),
-            "expected range-bounded workers message in error: {msg}"
-        );
+        assert_config_err!(yaml, "workers", "must be in range 1..=1024");
     }
 
     #[test]
@@ -393,12 +339,7 @@ pipelines:
       - type: stdout
     batch_target_bytes: 0
 ";
-        let err = Config::load_str(yaml).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("batch_target_bytes"),
-            "expected 'batch_target_bytes' in error: {msg}"
-        );
+        assert_config_err!(yaml, "batch_target_bytes");
     }
 
     #[test]

--- a/crates/logfwd-config/src/validate.rs
+++ b/crates/logfwd-config/src/validate.rs
@@ -514,50 +514,7 @@ impl Config {
                                 )));
                             }
                             if let Some(tls) = &t.tls {
-                                let cert_file = tls
-                                    .cert_file
-                                    .as_deref()
-                                    .map(str::trim)
-                                    .filter(|v| !v.is_empty());
-                                let key_file = tls
-                                    .key_file
-                                    .as_deref()
-                                    .map(str::trim)
-                                    .filter(|v| !v.is_empty());
-                                let client_ca_file = match tls.client_ca_file.as_deref() {
-                                    Some(path) => {
-                                        let path = path.trim();
-                                        if path.is_empty() {
-                                            return Err(ConfigError::Validation(format!(
-                                                "pipeline '{name}' input '{label}': tcp tls client_ca_file must not be empty"
-                                            )));
-                                        }
-                                        Some(path)
-                                    }
-                                    None => None,
-                                };
-
-                                if tls.require_client_auth && client_ca_file.is_none() {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': tcp tls require_client_auth requires tls.client_ca_file"
-                                    )));
-                                }
-                                if client_ca_file.is_some() && !tls.require_client_auth {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': tcp tls client_ca_file requires tls.require_client_auth: true"
-                                    )));
-                                }
-
-                                if cert_file.is_none() || key_file.is_none() {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': tcp tls requires both tls.cert_file and tls.key_file"
-                                    )));
-                                }
-                            }
-                            if t.max_clients == Some(0) {
-                                return Err(ConfigError::Validation(format!(
-                                    "pipeline '{name}' input '{label}': max_clients cannot be 0"
-                                )));
+                                validate_server_tls(name, &label, "tcp", tls)?;
                             }
                             track_listen_addr_uniqueness(
                                 &mut seen_listen_addrs,
@@ -581,45 +538,7 @@ impl Config {
                             }
 
                             if let Some(tls) = &o.tls {
-                                let cert_file = tls
-                                    .cert_file
-                                    .as_deref()
-                                    .map(str::trim)
-                                    .filter(|v| !v.is_empty());
-                                let key_file = tls
-                                    .key_file
-                                    .as_deref()
-                                    .map(str::trim)
-                                    .filter(|v| !v.is_empty());
-                                let client_ca_file = match tls.client_ca_file.as_deref() {
-                                    Some(path) => {
-                                        let path = path.trim();
-                                        if path.is_empty() {
-                                            return Err(ConfigError::Validation(format!(
-                                                "pipeline '{name}' input '{label}': otlp tls client_ca_file must not be empty"
-                                            )));
-                                        }
-                                        Some(path)
-                                    }
-                                    None => None,
-                                };
-
-                                if tls.require_client_auth && client_ca_file.is_none() {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': otlp tls require_client_auth requires tls.client_ca_file"
-                                    )));
-                                }
-                                if client_ca_file.is_some() && !tls.require_client_auth {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': otlp tls client_ca_file requires tls.require_client_auth: true"
-                                    )));
-                                }
-
-                                if cert_file.is_none() || key_file.is_none() {
-                                    return Err(ConfigError::Validation(format!(
-                                        "pipeline '{name}' input '{label}': otlp tls requires both tls.cert_file and tls.key_file"
-                                    )));
-                                }
+                                validate_server_tls(name, &label, "otlp", tls)?;
                             }
 
                             track_listen_addr_uniqueness(
@@ -1658,6 +1577,55 @@ fn validate_sensor_event_type_list(
 /// Validate that a bind address is a parseable `host:port` socket address.
 fn validate_bind_addr(addr: &str) -> Result<(), ConfigError> {
     validate_host_port(addr)
+}
+
+/// Validate server-side TLS configuration (cert/key pairs and mutual auth).
+fn validate_server_tls(
+    pipeline_name: &str,
+    input_label: &str,
+    protocol: &str,
+    tls: &crate::shared::TlsServerConfig,
+) -> Result<(), ConfigError> {
+    let cert_file = tls
+        .cert_file
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty());
+    let key_file = tls
+        .key_file
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty());
+    let client_ca_file = match tls.client_ca_file.as_deref() {
+        Some(path) => {
+            let path = path.trim();
+            if path.is_empty() {
+                return Err(ConfigError::Validation(format!(
+                    "pipeline '{pipeline_name}' input '{input_label}': {protocol} tls client_ca_file must not be empty"
+                )));
+            }
+            Some(path)
+        }
+        None => None,
+    };
+
+    if tls.require_client_auth && client_ca_file.is_none() {
+        return Err(ConfigError::Validation(format!(
+            "pipeline '{pipeline_name}' input '{input_label}': {protocol} tls require_client_auth requires tls.client_ca_file"
+        )));
+    }
+    if client_ca_file.is_some() && !tls.require_client_auth {
+        return Err(ConfigError::Validation(format!(
+            "pipeline '{pipeline_name}' input '{input_label}': {protocol} tls client_ca_file requires tls.require_client_auth: true"
+        )));
+    }
+
+    if cert_file.is_none() || key_file.is_none() {
+        return Err(ConfigError::Validation(format!(
+            "pipeline '{pipeline_name}' input '{input_label}': {protocol} tls requires both tls.cert_file and tls.key_file"
+        )));
+    }
+    Ok(())
 }
 
 /// Validate that a string has a valid `host:port` format where port is a u16.

--- a/crates/logfwd-core/AGENTS.md
+++ b/crates/logfwd-core/AGENTS.md
@@ -4,7 +4,7 @@ Read `README.md` in this directory for crate constraints and module map.
 
 Key rules:
 - `#![no_std]` + `#![forbid(unsafe_code)]` — the compiler enforces these, not lints
-- Only deps: memchr + wide
+- Only deps: memchr + wide + logfwd-kani + logfwd-lint-attrs
 - Every new public function requires a Kani proof (proptest only for async/heap-heavy code Kani can't reach)
 - No `.unwrap()`, no panics, no indexing — use `?` or `.get()`
 - See `../../dev-docs/VERIFICATION.md` for proof requirements and exemptions

--- a/crates/logfwd-core/README.md
+++ b/crates/logfwd-core/README.md
@@ -8,7 +8,7 @@ Proven pure-logic kernel. Scanner, parsers, pipeline state machine, OTLP encodin
 |------|-------------|
 | `#![no_std]` + alloc | Compiler. CI: `cargo build --target thumbv6m-none-eabi` |
 | `#![forbid(unsafe_code)]` | Compiler. Cannot be overridden with `#[allow]`. |
-| Only deps: memchr + wide | CI dependency allowlist check |
+| Only deps: memchr + wide + logfwd-kani + logfwd-lint-attrs | CI dependency allowlist check |
 | No panics | `clippy::unwrap_used`, `clippy::panic`, `clippy::indexing_slicing` = deny |
 | Proof-bearing core modules stay Kani-covered | CI Kani job + `dev-docs/VERIFICATION.md` inventory |
 | No IO, no threads, no async | Structural (`no_std` removes the APIs) |

--- a/crates/logfwd-core/src/cri.rs
+++ b/crates/logfwd-core/src/cri.rs
@@ -328,6 +328,15 @@ mod tests {
     use proptest::prelude::*;
     use proptest::test_runner::Config as ProptestConfig;
 
+    fn process_chunk_collect(chunk: &[u8]) -> (Vec<Vec<u8>>, usize, usize) {
+        let mut reassembler = CriReassembler::new(1024 * 1024);
+        let mut lines = Vec::new();
+        let (count, errors) = process_cri_chunk(chunk, &mut reassembler, |msg| {
+            lines.push(msg.to_vec());
+        });
+        (lines, count, errors)
+    }
+
     #[test]
     fn test_parse_full_line() {
         let line =
@@ -395,11 +404,7 @@ mod tests {
         let chunk = b"2024-01-15T10:30:00Z stdout F line one\n\
                        2024-01-15T10:30:01Z stdout F line two\n\
                        2024-01-15T10:30:02Z stderr F line three\n";
-        let mut reassembler = CriReassembler::new(1024 * 1024);
-        let mut lines = Vec::new();
-        let (count, errors) = process_cri_chunk(chunk, &mut reassembler, |msg| {
-            lines.push(msg.to_vec());
-        });
+        let (lines, count, errors) = process_chunk_collect(chunk);
         assert_eq!(count, 3);
         assert_eq!(errors, 0);
         assert_eq!(lines[0], b"line one");
@@ -460,11 +465,7 @@ mod tests {
         let chunk = b"not-a-cri-line\n\
                        2024-01-15T10:30:00Z stdout F valid line\n\
                        also-invalid\n";
-        let mut reassembler = CriReassembler::new(1024 * 1024);
-        let mut lines = Vec::new();
-        let (count, errors) = process_cri_chunk(chunk, &mut reassembler, |msg| {
-            lines.push(msg.to_vec());
-        });
+        let (lines, count, errors) = process_chunk_collect(chunk);
         assert_eq!(count, 1);
         assert_eq!(errors, 2);
         assert_eq!(lines[0], b"valid line");
@@ -711,11 +712,7 @@ mod tests {
     fn test_invalid_flag_counted_as_parse_error() {
         let chunk = b"2024-01-15T10:30:00Z stdout X bad\n\
                        2024-01-15T10:30:00Z stdout F valid\n";
-        let mut reassembler = CriReassembler::new(1024 * 1024);
-        let mut lines = Vec::new();
-        let (count, errors) = process_cri_chunk(chunk, &mut reassembler, |msg| {
-            lines.push(msg.to_vec());
-        });
+        let (lines, count, errors) = process_chunk_collect(chunk);
         assert_eq!(count, 1);
         assert_eq!(errors, 1);
         assert_eq!(lines[0], b"valid");
@@ -748,11 +745,7 @@ mod tests {
         // not be silently dropped as a parse error (#698).
         let chunk = b"2024-01-15T10:30:00Z stdout F\n\
                        2024-01-15T10:30:01Z stdout F has content\n";
-        let mut reassembler = CriReassembler::new(1024 * 1024);
-        let mut lines = Vec::new();
-        let (count, errors) = process_cri_chunk(chunk, &mut reassembler, |msg| {
-            lines.push(msg.to_vec());
-        });
+        let (lines, count, errors) = process_chunk_collect(chunk);
         assert_eq!(count, 2);
         assert_eq!(errors, 0);
         assert_eq!(lines[0], b"");

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -1133,14 +1133,26 @@ mod tests {
     }
 
     use alloc::string::ToString;
+    use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
+
+    fn scan_default(buf: &[u8]) -> TestBuilder {
+        let config = ScanConfig::default();
+        let mut builder = TestBuilder::new();
+        scan_streaming(buf, &config, &mut builder);
+        builder
+    }
+
+    fn config_with_predicate(pred: ScanPredicate) -> ScanConfig {
+        ScanConfig {
+            row_predicate: Some(pred),
+            ..ScanConfig::default()
+        }
+    }
 
     #[test]
     fn simple_object() {
         let buf = br#"{"name":"alice","age":30}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         let row = &builder.rows[0];
         assert!(row.iter().any(|(k, v)| k == "name" && v == "alice"));
@@ -1205,10 +1217,7 @@ mod tests {
     #[test]
     fn ndjson_two_lines() {
         let buf = b"{\"a\":\"x\"}\n{\"b\":\"y\"}\n";
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 2);
         assert!(builder.rows[0].iter().any(|(k, v)| k == "a" && v == "x"));
         assert!(builder.rows[1].iter().any(|(k, v)| k == "b" && v == "y"));
@@ -1217,10 +1226,7 @@ mod tests {
     #[test]
     fn nested_object_skipped() {
         let buf = br#"{"outer":{"inner":1},"flat":"val"}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         let row = &builder.rows[0];
         assert!(
@@ -1233,10 +1239,7 @@ mod tests {
     #[test]
     fn null_boolean_number() {
         let buf = br#"{"n":null,"t":true,"f":false,"i":42,"x":3.14}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         let row = &builder.rows[0];
         assert!(row.iter().any(|(k, v)| k == "n" && v == "null"));
@@ -1249,10 +1252,7 @@ mod tests {
     #[test]
     fn validates_null_token() {
         let buf = br#"{"x":nul}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         assert!(builder.rows[0].is_empty());
     }
@@ -1260,10 +1260,7 @@ mod tests {
     #[test]
     fn validates_boolean_token() {
         let buf = br#"{"x":turkey}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         assert!(builder.rows[0].is_empty());
     }
@@ -1272,10 +1269,7 @@ mod tests {
     fn escaped_quotes_in_value() {
         // After #410 fix: scanner decodes \" to " in string values.
         let buf = br#"{"msg":"said \"hello\""}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         let row = &builder.rows[0];
         assert!(
@@ -1287,113 +1281,25 @@ mod tests {
     // --- Escape decoding tests (#410) ---
 
     #[test]
-    fn unicode_escape_u0041() {
-        // \u0041 is 'A' — must be decoded, not double-escaped.
-        let buf = br#"{"a":"\u0041"}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
-        assert_eq!(builder.rows.len(), 1);
-        let row = &builder.rows[0];
-        assert!(row.iter().any(|(k, v)| k == "a" && v == "A"));
-    }
-
-    #[test]
-    fn unicode_escape_e_acute() {
-        // \u00e9 is 'é' — must be decoded to UTF-8.
-        let buf = br#"{"msg":"caf\u00e9"}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
-        assert_eq!(builder.rows.len(), 1);
-        let row = &builder.rows[0];
-        assert!(row.iter().any(|(k, v)| k == "msg" && v == "café"));
-    }
-
-    #[test]
-    fn unicode_surrogate_pair() {
-        // \uD83D\uDE00 is U+1F600 (😀) — surrogate pair decoded to UTF-8.
-        let buf = br#"{"e":"\uD83D\uDE00"}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
-        assert_eq!(builder.rows.len(), 1);
-        let row = &builder.rows[0];
-        assert!(row.iter().any(|(k, v)| k == "e" && v == "😀"));
-    }
-
-    #[test]
-    fn escape_newline_tab_cr() {
-        let buf = br#"{"a":"line1\nline2\ttab\rret"}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
-        assert_eq!(builder.rows.len(), 1);
-        let row = &builder.rows[0];
-        assert!(
-            row.iter()
-                .any(|(k, v)| k == "a" && v == "line1\nline2\ttab\rret")
-        );
-    }
-
-    #[test]
-    fn escape_backslash() {
-        // \\\\ in raw bytes is two JSON-escaped backslashes → two literal backslashes
-        let buf = b"{\"a\":\"c:\\\\path\\\\file\"}";
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
-        assert_eq!(builder.rows.len(), 1);
-        let row = &builder.rows[0];
-        assert!(row.iter().any(|(k, v)| k == "a" && v == "c:\\path\\file"));
-    }
-
-    #[test]
-    fn escape_solidus() {
-        let buf = br#"{"url":"http:\/\/example.com"}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
-        assert_eq!(builder.rows.len(), 1);
-        let row = &builder.rows[0];
-        assert!(
-            row.iter()
-                .any(|(k, v)| k == "url" && v == "http://example.com")
-        );
-    }
-
-    #[test]
-    fn no_escape_passthrough() {
-        // Strings without backslashes pass through unchanged (fast path).
-        let buf = br#"{"x":"hello world"}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
-        assert_eq!(builder.rows.len(), 1);
-        let row = &builder.rows[0];
-        assert!(row.iter().any(|(k, v)| k == "x" && v == "hello world"));
-    }
-
-    #[test]
-    fn mixed_escapes_and_plain_text() {
-        let buf = br#"{"m":"start\n\tmiddle \u0041 end"}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
-        assert_eq!(builder.rows.len(), 1);
-        let row = &builder.rows[0];
-        assert!(
-            row.iter()
-                .any(|(k, v)| k == "m" && v == "start\n\tmiddle A end")
-        );
+    fn escape_decoding() {
+        let cases: &[(&[u8], &str, &str)] = &[
+            (br#"{"a":"\u0041"}"#, "a", "A"),
+            (br#"{"msg":"caf\u00e9"}"#, "msg", "café"),
+            (br#"{"e":"\uD83D\uDE00"}"#, "e", "😀"),
+            (br#"{"a":"line1\nline2\ttab\rret"}"#, "a", "line1\nline2\ttab\rret"),
+            (b"{\"a\":\"c:\\\\path\\\\file\"}", "a", "c:\\path\\file"),
+            (br#"{"url":"http:\/\/example.com"}"#, "url", "http://example.com"),
+            (br#"{"x":"hello world"}"#, "x", "hello world"),
+            (br#"{"m":"start\n\tmiddle \u0041 end"}"#, "m", "start\n\tmiddle A end"),
+        ];
+        for (buf, key, expected) in cases {
+            let builder = scan_default(buf);
+            assert_eq!(builder.rows.len(), 1, "buf: {:?}", core::str::from_utf8(buf));
+            assert!(
+                builder.rows[0].iter().any(|(k, v)| k == key && v == expected),
+                "expected {key}={expected} in {:?}", builder.rows[0]
+            );
+        }
     }
 
     #[test]
@@ -1456,10 +1362,7 @@ mod tests {
     #[test]
     fn array_value() {
         let buf = br#"{"tags":["a","b"],"x":1}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         let row = &builder.rows[0];
         assert!(row.iter().any(|(k, v)| k == "tags" && v == r#"["a","b"]"#));
@@ -1511,10 +1414,7 @@ mod tests {
     #[test]
     fn rejects_truex_suffix() {
         let buf = br#"{"x":truex}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         assert!(builder.rows[0].is_empty());
     }
@@ -1522,10 +1422,7 @@ mod tests {
     #[test]
     fn rejects_nullified_suffix() {
         let buf = br#"{"x":nullified}"#;
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf);
         assert_eq!(builder.rows.len(), 1);
         assert!(builder.rows[0].is_empty());
     }
@@ -1543,11 +1440,7 @@ mod tests {
         }
         buf_str.push_str(",\"b\":2}");
 
-        let buf = buf_str.as_bytes();
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf_str.as_bytes());
         assert_eq!(builder.rows.len(), 1);
         let row = &builder.rows[0];
         assert!(row.iter().any(|(k, v)| k == "b" && v == "int:2"));
@@ -1565,10 +1458,7 @@ mod tests {
         }
         buf.push_str(",\"b\":2}");
 
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf.as_bytes(), &config, &mut builder);
-
+        let builder = scan_default(buf.as_bytes());
         assert_eq!(builder.rows.len(), 1);
         let row = &builder.rows[0];
         assert!(
@@ -1611,11 +1501,7 @@ mod tests {
         }
         buf_str.push_str(",\"b\":2}");
 
-        let buf = buf_str.as_bytes();
-        let config = ScanConfig::default();
-        let mut builder = TestBuilder::new();
-        scan_streaming(buf, &config, &mut builder);
-
+        let builder = scan_default(buf_str.as_bytes());
         assert_eq!(builder.rows.len(), 1);
         let row = &builder.rows[0];
         // If it drops remaining lines, it won't see "b"
@@ -1863,13 +1749,9 @@ mod tests {
         let buf =
             b"{\"level\":\"INFO\",\"msg\":\"hello\"}\r\n{\"level\":\"WARN\",\"msg\":\"world\"}\r\n";
 
-        // extract_all=true captures all fields without listing them explicitly.
         let config = ScanConfig {
-            wanted_fields: alloc::vec![],
-            extract_all: true,
             line_field_name: Some("body".to_string()),
-            validate_utf8: false,
-            row_predicate: None,
+            ..ScanConfig::default()
         };
 
         let mut builder = TestBuilder::new();
@@ -1923,13 +1805,7 @@ mod tests {
     #[test]
     fn crlf_only_line_is_empty() {
         let buf = b"\r\n{\"x\":\"1\"}\r\n";
-        let config = ScanConfig {
-            wanted_fields: alloc::vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: None,
-        };
+        let config = ScanConfig::default();
         let mut builder = TestBuilder::new();
         scan_streaming(buf, &config, &mut builder);
 
@@ -1946,11 +1822,8 @@ mod tests {
     fn trailing_cr_after_newline_no_spurious_empty_row_with_line_capture() {
         let buf = b"{\"x\":\"1\"}\n\r";
         let config = ScanConfig {
-            wanted_fields: alloc::vec![],
-            extract_all: true,
             line_field_name: Some("body".to_string()),
-            validate_utf8: false,
-            row_predicate: None,
+            ..ScanConfig::default()
         };
         let mut builder = TestBuilder::new();
         scan_streaming(buf, &config, &mut builder);
@@ -1965,11 +1838,8 @@ mod tests {
     fn lone_carriage_return_emits_no_rows_even_with_line_capture() {
         let buf = b"\r";
         let config = ScanConfig {
-            wanted_fields: alloc::vec![],
-            extract_all: true,
             line_field_name: Some("body".to_string()),
-            validate_utf8: false,
-            row_predicate: None,
+            ..ScanConfig::default()
         };
         let mut builder = TestBuilder::new();
         scan_streaming(buf, &config, &mut builder);
@@ -1983,11 +1853,8 @@ mod tests {
     fn empty_lf_line_skipped_even_with_line_capture() {
         let buf = b"\n{\"x\":\"1\"}\n\n";
         let config = ScanConfig {
-            wanted_fields: alloc::vec![],
-            extract_all: true,
             line_field_name: Some("body".to_string()),
-            validate_utf8: false,
-            row_predicate: None,
+            ..ScanConfig::default()
         };
         let mut builder = TestBuilder::new();
         scan_streaming(buf, &config, &mut builder);
@@ -2016,13 +1883,7 @@ mod tests {
         // Integration: an array value inside a JSON object should parse correctly.
         // The number in `[1,2]` must not swallow the `]`.
         let input = b"{\"arr\":[1,2]}\n";
-        let config = ScanConfig {
-            wanted_fields: alloc::vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: None,
-        };
+        let config = ScanConfig::default();
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(
@@ -2038,20 +1899,12 @@ mod tests {
 
     #[test]
     fn predicate_filters_non_matching_rows() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         let input = b"{\"level\":\"info\",\"msg\":\"hello\"}\n{\"level\":\"error\",\"msg\":\"bad\"}\n{\"level\":\"debug\",\"msg\":\"trace\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "level".into(),
-                op: CmpOp::Eq,
-                value: ScalarValue::Str("error".into()),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "level".into(),
+            op: CmpOp::Eq,
+            value: ScalarValue::Str("error".into()),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
 
@@ -2067,20 +1920,12 @@ mod tests {
 
     #[test]
     fn predicate_passes_all_when_all_match() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         let input = b"{\"level\":\"error\",\"msg\":\"a\"}\n{\"level\":\"error\",\"msg\":\"b\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "level".into(),
-                op: CmpOp::Eq,
-                value: ScalarValue::Str("error".into()),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "level".into(),
+            op: CmpOp::Eq,
+            value: ScalarValue::Str("error".into()),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(builder.rows.len(), 2, "all rows should pass");
@@ -2088,20 +1933,12 @@ mod tests {
 
     #[test]
     fn predicate_filters_all_when_none_match() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         let input = b"{\"level\":\"info\"}\n{\"level\":\"debug\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "level".into(),
-                op: CmpOp::Eq,
-                value: ScalarValue::Str("error".into()),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "level".into(),
+            op: CmpOp::Eq,
+            value: ScalarValue::Str("error".into()),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(builder.rows.len(), 0, "no rows should pass");
@@ -2109,20 +1946,12 @@ mod tests {
 
     #[test]
     fn predicate_with_numeric_comparison() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         let input = b"{\"status\":200,\"msg\":\"ok\"}\n{\"status\":503,\"msg\":\"fail\"}\n{\"status\":404,\"msg\":\"miss\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "status".into(),
-                op: CmpOp::Ge,
-                value: ScalarValue::Int(500),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "status".into(),
+            op: CmpOp::Ge,
+            value: ScalarValue::Int(500),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(builder.rows.len(), 1, "only status>=500 should pass");
@@ -2135,27 +1964,19 @@ mod tests {
 
     #[test]
     fn predicate_and_chain() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         let input = b"{\"level\":\"error\",\"status\":503}\n{\"level\":\"error\",\"status\":200}\n{\"level\":\"info\",\"status\":503}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::And(vec![
-                ScanPredicate::Compare {
-                    field: "level".into(),
-                    op: CmpOp::Eq,
-                    value: ScalarValue::Str("error".into()),
-                },
-                ScanPredicate::Compare {
-                    field: "status".into(),
-                    op: CmpOp::Ge,
-                    value: ScalarValue::Int(500),
-                },
-            ])),
-        };
+        let config = config_with_predicate(ScanPredicate::And(vec![
+            ScanPredicate::Compare {
+                field: "level".into(),
+                op: CmpOp::Eq,
+                value: ScalarValue::Str("error".into()),
+            },
+            ScanPredicate::Compare {
+                field: "status".into(),
+                op: CmpOp::Ge,
+                value: ScalarValue::Int(500),
+            },
+        ]));
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(
@@ -2168,15 +1989,7 @@ mod tests {
     #[test]
     fn no_predicate_unchanged_behavior() {
         let input = b"{\"a\":\"1\"}\n{\"a\":\"2\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: None,
-        };
-        let mut builder = TestBuilder::new();
-        scan_streaming(input, &config, &mut builder);
+        let builder = scan_default(input);
         assert_eq!(builder.rows.len(), 2, "no predicate = all rows");
     }
 
@@ -2186,8 +1999,6 @@ mod tests {
 
     #[test]
     fn predicate_with_escape_crossing_64_byte_boundary() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         // Build a line where the "level" value crosses a 64-byte block boundary
         // by padding the key with enough characters. The escape \" in the value
         // forces the decode path.
@@ -2200,17 +2011,11 @@ mod tests {
         line.push_str("\":\"pad\",\"level\":\"err\\\"or\"}");
         line.push('\n');
 
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "level".into(),
-                op: CmpOp::Eq,
-                value: ScalarValue::Str("err\"or".into()),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "level".into(),
+            op: CmpOp::Eq,
+            value: ScalarValue::Str("err\"or".into()),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(line.as_bytes(), &config, &mut builder);
         assert_eq!(
@@ -2222,22 +2027,14 @@ mod tests {
 
     #[test]
     fn predicate_field_order_independence() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         // Same fields in different order — predicate should work regardless.
         let input =
             b"{\"msg\":\"hello\",\"level\":\"error\"}\n{\"level\":\"info\",\"msg\":\"world\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "level".into(),
-                op: CmpOp::Eq,
-                value: ScalarValue::Str("error".into()),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "level".into(),
+            op: CmpOp::Eq,
+            value: ScalarValue::Str("error".into()),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(builder.rows.len(), 1);
@@ -2250,22 +2047,14 @@ mod tests {
 
     #[test]
     fn predicate_duplicate_keys_first_write_wins() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         // Duplicate "level" key — first value should win for both
         // predicate evaluation and output.
         let input = b"{\"level\":\"error\",\"level\":\"info\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "level".into(),
-                op: CmpOp::Eq,
-                value: ScalarValue::Str("error".into()),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "level".into(),
+            op: CmpOp::Eq,
+            value: ScalarValue::Str("error".into()),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         // First "level" is "error" → predicate passes.
@@ -2279,22 +2068,14 @@ mod tests {
 
     #[test]
     fn predicate_duplicate_keys_different_types() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         // Same key appears as string then int — scanner creates conflict columns.
         // Predicate evaluates against the first occurrence (string "200").
         let input = b"{\"status\":\"200\",\"status\":503}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "status".into(),
-                op: CmpOp::Eq,
-                value: ScalarValue::Str("200".into()),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "status".into(),
+            op: CmpOp::Eq,
+            value: ScalarValue::Str("200".into()),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         // First "status" is string "200" → predicate matches.
@@ -2303,20 +2084,12 @@ mod tests {
 
     #[test]
     fn predicate_nested_json_is_not_null() {
-        use crate::scan_predicate::ScanPredicate;
-
         // Nested object should be treated as non-null.
         let input = b"{\"payload\":{\"key\":\"val\"},\"level\":\"error\"}\n{\"level\":\"info\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::IsNull {
-                field: "payload".into(),
-                negated: true, // IS NOT NULL
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::IsNull {
+            field: "payload".into(),
+            negated: true, // IS NOT NULL
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         // First row has payload (nested object) → IS NOT NULL passes.
@@ -2326,21 +2099,13 @@ mod tests {
 
     #[test]
     fn predicate_cross_type_string_vs_int() {
-        use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
-
         // JSON has status as string "503", predicate compares as int 503.
         let input = b"{\"status\":\"503\",\"msg\":\"fail\"}\n{\"status\":\"200\",\"msg\":\"ok\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Compare {
-                field: "status".into(),
-                op: CmpOp::Ge,
-                value: ScalarValue::Int(500),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Compare {
+            field: "status".into(),
+            op: CmpOp::Ge,
+            value: ScalarValue::Int(500),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         // String "503" should coerce to int 503 for comparison.
@@ -2349,23 +2114,15 @@ mod tests {
 
     #[test]
     fn predicate_in_list_filters_correctly() {
-        use crate::scan_predicate::{ScalarValue, ScanPredicate};
-
         let input = b"{\"level\":\"error\"}\n{\"level\":\"fatal\"}\n{\"level\":\"info\"}\n{\"level\":\"warn\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::InList {
-                field: "level".into(),
-                values: vec![
-                    ScalarValue::Str("error".into()),
-                    ScalarValue::Str("fatal".into()),
-                ],
-                negated: false,
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::InList {
+            field: "level".into(),
+            values: vec![
+                ScalarValue::Str("error".into()),
+                ScalarValue::Str("fatal".into()),
+            ],
+            negated: false,
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(
@@ -2377,19 +2134,11 @@ mod tests {
 
     #[test]
     fn predicate_contains_substring_match() {
-        use crate::scan_predicate::ScanPredicate;
-
         let input = b"{\"msg\":\"connection timeout after 30s\"}\n{\"msg\":\"request completed\"}\n{\"msg\":\"read timeout\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::Contains {
-                field: "msg".into(),
-                substring: "timeout".into(),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::Contains {
+            field: "msg".into(),
+            substring: "timeout".into(),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(builder.rows.len(), 2, "both timeout messages should pass");
@@ -2397,20 +2146,12 @@ mod tests {
 
     #[test]
     fn predicate_starts_with_prefix_match() {
-        use crate::scan_predicate::ScanPredicate;
-
         let input =
             b"{\"msg\":\"ERROR: disk full\"}\n{\"msg\":\"INFO: ok\"}\n{\"msg\":\"ERROR: oom\"}\n";
-        let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
-            line_field_name: None,
-            validate_utf8: false,
-            row_predicate: Some(ScanPredicate::StartsWith {
-                field: "msg".into(),
-                prefix: "ERROR".into(),
-            }),
-        };
+        let config = config_with_predicate(ScanPredicate::StartsWith {
+            field: "msg".into(),
+            prefix: "ERROR".into(),
+        });
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);
         assert_eq!(
@@ -2422,20 +2163,16 @@ mod tests {
 
     #[test]
     fn predicate_on_line_capture_field() {
-        use crate::scan_predicate::ScanPredicate;
-
         // When line_field_name is set and predicate references it,
         // the line content should be available for predicate evaluation.
         let input = b"{\"level\":\"error\"}\n{\"level\":\"info\"}\n";
         let config = ScanConfig {
-            wanted_fields: vec![],
-            extract_all: true,
             line_field_name: Some("body".into()),
-            validate_utf8: false,
             row_predicate: Some(ScanPredicate::IsNull {
                 field: "body".into(),
                 negated: true, // IS NOT NULL
             }),
+            ..ScanConfig::default()
         };
         let mut builder = TestBuilder::new();
         scan_streaming(input, &config, &mut builder);

--- a/crates/logfwd-core/src/json_scanner.rs
+++ b/crates/logfwd-core/src/json_scanner.rs
@@ -1132,8 +1132,8 @@ mod tests {
         }
     }
 
-    use alloc::string::ToString;
     use crate::scan_predicate::{CmpOp, ScalarValue, ScanPredicate};
+    use alloc::string::ToString;
 
     fn scan_default(buf: &[u8]) -> TestBuilder {
         let config = ScanConfig::default();
@@ -1286,18 +1286,38 @@ mod tests {
             (br#"{"a":"\u0041"}"#, "a", "A"),
             (br#"{"msg":"caf\u00e9"}"#, "msg", "café"),
             (br#"{"e":"\uD83D\uDE00"}"#, "e", "😀"),
-            (br#"{"a":"line1\nline2\ttab\rret"}"#, "a", "line1\nline2\ttab\rret"),
+            (
+                br#"{"a":"line1\nline2\ttab\rret"}"#,
+                "a",
+                "line1\nline2\ttab\rret",
+            ),
             (b"{\"a\":\"c:\\\\path\\\\file\"}", "a", "c:\\path\\file"),
-            (br#"{"url":"http:\/\/example.com"}"#, "url", "http://example.com"),
+            (
+                br#"{"url":"http:\/\/example.com"}"#,
+                "url",
+                "http://example.com",
+            ),
             (br#"{"x":"hello world"}"#, "x", "hello world"),
-            (br#"{"m":"start\n\tmiddle \u0041 end"}"#, "m", "start\n\tmiddle A end"),
+            (
+                br#"{"m":"start\n\tmiddle \u0041 end"}"#,
+                "m",
+                "start\n\tmiddle A end",
+            ),
         ];
         for (buf, key, expected) in cases {
             let builder = scan_default(buf);
-            assert_eq!(builder.rows.len(), 1, "buf: {:?}", core::str::from_utf8(buf));
+            assert_eq!(
+                builder.rows.len(),
+                1,
+                "buf: {:?}",
+                core::str::from_utf8(buf)
+            );
             assert!(
-                builder.rows[0].iter().any(|(k, v)| k == key && v == expected),
-                "expected {key}={expected} in {:?}", builder.rows[0]
+                builder.rows[0]
+                    .iter()
+                    .any(|(k, v)| k == key && v == expected),
+                "expected {key}={expected} in {:?}",
+                builder.rows[0]
             );
         }
     }

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -600,8 +600,7 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
 }
 
 /// Parse 4 ASCII digits at offset. Returns 0 on non-digit.
-// Only used by Kani proof harnesses; production paths use parse_4digits_checked.
-#[allow(dead_code)]
+#[cfg(kani)]
 #[inline(always)]
 #[cfg_attr(kani, kani::ensures(|result: &u16| *result <= 9999))]
 #[verified(kani = "verify_parse_4digits_contract")]
@@ -617,8 +616,7 @@ fn parse_4digits(s: &[u8], off: usize) -> u16 {
 }
 
 /// Parse 2 ASCII digits at offset. Returns 0 on non-digit.
-// Only used by Kani proof harnesses; production paths use parse_2digits_checked.
-#[allow(dead_code)]
+#[cfg(kani)]
 #[inline(always)]
 #[cfg_attr(kani, kani::ensures(|result: &u8| *result <= 99))]
 #[verified(kani = "verify_parse_2digits_contract")]

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -784,37 +784,35 @@ mod tests {
 
     #[test]
     fn test_parse_severity() {
-        assert!(matches!(parse_severity(b"INFO").0, Severity::Info));
-        assert!(matches!(parse_severity(b"info").0, Severity::Info));
-        assert!(matches!(parse_severity(b"WARN").0, Severity::Warn));
-        assert!(matches!(parse_severity(b"ERROR").0, Severity::Error));
-        assert!(matches!(parse_severity(b"DEBUG").0, Severity::Debug));
-        assert!(matches!(parse_severity(b"TRACE").0, Severity::Trace));
-        assert!(matches!(parse_severity(b"FATAL").0, Severity::Fatal));
-        assert!(matches!(
-            parse_severity(b"unknown").0,
-            Severity::Unspecified
-        ));
-    }
-
-    #[test]
-    fn test_parse_severity_aliases() {
-        // WARNING -> Warn (#1866)
-        assert!(matches!(parse_severity(b"WARNING").0, Severity::Warn));
-        assert!(matches!(parse_severity(b"warning").0, Severity::Warn));
-        assert!(matches!(parse_severity(b"Warning").0, Severity::Warn));
-        // ERR -> Error (#1912)
-        assert!(matches!(parse_severity(b"ERR").0, Severity::Error));
-        assert!(matches!(parse_severity(b"err").0, Severity::Error));
-        assert!(matches!(parse_severity(b"Err").0, Severity::Error));
-        // NOTICE -> Info (#1912)
-        assert!(matches!(parse_severity(b"NOTICE").0, Severity::Info));
-        assert!(matches!(parse_severity(b"notice").0, Severity::Info));
-        assert!(matches!(parse_severity(b"Notice").0, Severity::Info));
-        // CRITICAL -> Fatal (#1912)
-        assert!(matches!(parse_severity(b"CRITICAL").0, Severity::Fatal));
-        assert!(matches!(parse_severity(b"critical").0, Severity::Fatal));
-        assert!(matches!(parse_severity(b"Critical").0, Severity::Fatal));
+        let cases: &[(&[u8], Severity)] = &[
+            (b"INFO", Severity::Info),
+            (b"info", Severity::Info),
+            (b"WARN", Severity::Warn),
+            (b"ERROR", Severity::Error),
+            (b"DEBUG", Severity::Debug),
+            (b"TRACE", Severity::Trace),
+            (b"FATAL", Severity::Fatal),
+            (b"unknown", Severity::Unspecified),
+            // Aliases
+            (b"WARNING", Severity::Warn),
+            (b"warning", Severity::Warn),
+            (b"Warning", Severity::Warn),
+            (b"ERR", Severity::Error),
+            (b"err", Severity::Error),
+            (b"Err", Severity::Error),
+            (b"NOTICE", Severity::Info),
+            (b"notice", Severity::Info),
+            (b"Notice", Severity::Info),
+            (b"CRITICAL", Severity::Fatal),
+            (b"critical", Severity::Fatal),
+            (b"Critical", Severity::Fatal),
+        ];
+        for (input, expected) in cases {
+            assert!(
+                matches!(parse_severity(input).0, ref s if core::mem::discriminant(s) == core::mem::discriminant(expected)),
+                "parse_severity({:?}) expected {:?}", core::str::from_utf8(input), expected
+            );
+        }
     }
 
     #[test]

--- a/crates/logfwd-core/src/otlp.rs
+++ b/crates/logfwd-core/src/otlp.rs
@@ -810,7 +810,9 @@ mod tests {
         for (input, expected) in cases {
             assert!(
                 matches!(parse_severity(input).0, ref s if core::mem::discriminant(s) == core::mem::discriminant(expected)),
-                "parse_severity({:?}) expected {:?}", core::str::from_utf8(input), expected
+                "parse_severity({:?}) expected {:?}",
+                core::str::from_utf8(input),
+                expected
             );
         }
     }

--- a/crates/logfwd-core/src/reassembler.rs
+++ b/crates/logfwd-core/src/reassembler.rs
@@ -18,8 +18,9 @@
 /// Aggregates CRI partial lines into complete messages.
 ///
 /// Feed CRI message bytes with their P/F flag. The aggregator returns
-/// `Some(message)` when a complete message is ready (on F lines), or
-/// `None` for P lines (buffered internally).
+/// [`AggregateResult::Complete`] when a full message is ready (on F lines),
+/// [`AggregateResult::Pending`] for P lines (buffered internally), or
+/// [`AggregateResult::Truncated`] when the message exceeds the size limit.
 ///
 /// # Lifecycle
 ///

--- a/crates/logfwd-core/src/scan_config.rs
+++ b/crates/logfwd-core/src/scan_config.rs
@@ -1,4 +1,4 @@
-// scanner.rs — Scan configuration types for JSON field extraction.
+// scan_config.rs — Scan configuration types for JSON field extraction.
 //
 // Defines ScanConfig and FieldSpec, used by the Scanner and the SQL
 // transform layer.

--- a/crates/logfwd-diagnostics/src/diagnostics.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics.rs
@@ -2,6 +2,7 @@ mod metrics;
 mod models;
 mod policy;
 mod process;
+/// HTML rendering helpers for the diagnostics dashboard.
 pub(crate) mod render;
 mod server;
 mod telemetry;

--- a/crates/logfwd-diagnostics/src/diagnostics.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics.rs
@@ -2,7 +2,7 @@ mod metrics;
 mod models;
 mod policy;
 mod process;
-mod render;
+pub(crate) mod render;
 mod server;
 mod telemetry;
 

--- a/crates/logfwd-diagnostics/src/diagnostics/render.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics/render.rs
@@ -20,6 +20,7 @@ pub(crate) fn esc(s: &str) -> String {
     out
 }
 
+/// Returns the current wall-clock time as nanoseconds since the Unix epoch.
 pub(crate) fn now_nanos() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)

--- a/crates/logfwd-diagnostics/src/diagnostics/render.rs
+++ b/crates/logfwd-diagnostics/src/diagnostics/render.rs
@@ -1,7 +1,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Minimal JSON-string escaping (backslash, double-quote, control chars).
-pub(super) fn esc(s: &str) -> String {
+pub(crate) fn esc(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         match c {
@@ -20,7 +20,7 @@ pub(super) fn esc(s: &str) -> String {
     out
 }
 
-pub(super) fn now_nanos() -> u64 {
+pub(crate) fn now_nanos() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()

--- a/crates/logfwd-diagnostics/src/telemetry_buffer.rs
+++ b/crates/logfwd-diagnostics/src/telemetry_buffer.rs
@@ -24,7 +24,6 @@
 use std::collections::VecDeque;
 use std::fmt;
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // ---------------------------------------------------------------------------
 // Generic ring buffer
@@ -182,12 +181,7 @@ impl Default for TelemetryBuffers {
 // OTLP JSON serialization
 // ---------------------------------------------------------------------------
 
-fn now_nanos() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos() as u64
-}
+use crate::diagnostics::render::{esc as json_escape, now_nanos};
 
 /// Serialize metric points as an OTLP JSON `ExportMetricsServiceRequest`.
 ///
@@ -256,7 +250,7 @@ pub fn traces_to_otlp_json(spans: &[SpanPoint]) -> String {
 
     let mut spans_json = Vec::new();
     for s in spans {
-        let attrs = string_attrs_to_json(&s.attributes);
+        let attrs = attrs_to_json(&s.attributes);
         let status = if s.status_code == 0 {
             String::new()
         } else {
@@ -923,7 +917,7 @@ pub fn sample_health_transitions<S: std::hash::BuildHasher>(
 // JSON helpers
 // ---------------------------------------------------------------------------
 
-fn attrs_to_json(attrs: &[(&str, String)]) -> String {
+fn attrs_to_json<K: AsRef<str>>(attrs: &[(K, String)]) -> String {
     if attrs.is_empty() {
         return "\"attributes\":[]".to_string();
     }
@@ -932,48 +926,12 @@ fn attrs_to_json(attrs: &[(&str, String)]) -> String {
         .map(|(k, v)| {
             format!(
                 "{{\"key\":\"{}\",\"value\":{{\"stringValue\":\"{}\"}}}}",
-                json_escape(k),
+                json_escape(k.as_ref()),
                 json_escape(v)
             )
         })
         .collect();
     format!("\"attributes\":[{}]", kvs.join(","))
-}
-
-fn string_attrs_to_json(attrs: &[(String, String)]) -> String {
-    if attrs.is_empty() {
-        return "\"attributes\":[]".to_string();
-    }
-    let kvs: Vec<String> = attrs
-        .iter()
-        .map(|(k, v)| {
-            format!(
-                "{{\"key\":\"{}\",\"value\":{{\"stringValue\":\"{}\"}}}}",
-                json_escape(k),
-                json_escape(v)
-            )
-        })
-        .collect();
-    format!("\"attributes\":[{}]", kvs.join(","))
-}
-
-fn json_escape(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c if (c as u32) < 0x20 => {
-                use std::fmt::Write;
-                let _ = write!(out, "\\u{:04x}", c as u32);
-            }
-            c => out.push(c),
-        }
-    }
-    out
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/logfwd-io/src/enrichment.rs
+++ b/crates/logfwd-io/src/enrichment.rs
@@ -608,6 +608,15 @@ mod tests {
     use super::*;
     use arrow::array::Array;
 
+    fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("missing column: {name}"))
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap_or_else(|| panic!("column {name} is not StringArray"))
+    }
+
     // -- CRI path parsing ---------------------------------------------------
 
     #[test]
@@ -675,12 +684,7 @@ mod tests {
         let batch = table.snapshot().unwrap();
         assert_eq!(batch.num_rows(), 1);
         assert_eq!(batch.num_columns(), 2);
-        let env = batch
-            .column_by_name("environment")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let env = str_col(&batch, "environment");
         assert_eq!(env.value(0), "production");
     }
 
@@ -713,12 +717,7 @@ mod tests {
         assert_eq!(batch.num_rows(), 1);
         assert_eq!(batch.num_columns(), 3);
         for col_name in &["hostname", "os_type", "os_arch"] {
-            let col = batch
-                .column_by_name(col_name)
-                .unwrap_or_else(|| panic!("missing column: {col_name}"))
-                .as_any()
-                .downcast_ref::<StringArray>()
-                .unwrap();
+            let col = str_col(&batch, col_name);
             assert!(!col.value(0).is_empty(), "{col_name} should be non-empty");
         }
     }
@@ -744,12 +743,7 @@ mod tests {
         ]);
         let batch = table.snapshot().expect("should have data");
         assert_eq!(batch.num_rows(), 2);
-        let ns = batch
-            .column_by_name("namespace")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let ns = str_col(&batch, "namespace");
         assert_eq!(ns.value(0), "default");
         assert_eq!(ns.value(1), "monitoring");
     }
@@ -810,21 +804,11 @@ mod tests {
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 3);
 
-        let hostname = batch
-            .column_by_name("hostname")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let hostname = str_col(&batch, "hostname");
         assert_eq!(hostname.value(0), "web-1");
         assert_eq!(hostname.value(1), "api-2");
 
-        let team = batch
-            .column_by_name("team")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let team = str_col(&batch, "team");
         assert_eq!(team.value(0), "platform");
         assert_eq!(team.value(1), "backend");
     }
@@ -836,12 +820,7 @@ mod tests {
         table.load_from_reader(&csv_data[..]).unwrap();
         let batch = table.snapshot().unwrap();
         assert_eq!(batch.num_rows(), 2);
-        let c = batch
-            .column_by_name("c")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let c = str_col(&batch, "c");
         assert_eq!(c.value(0), "3");
         assert!(c.is_null(1)); // padded with NULL
     }
@@ -894,12 +873,7 @@ mod tests {
         assert_eq!(rows, 2);
 
         let batch = table.snapshot().unwrap();
-        let region = batch
-            .column_by_name("region")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let region = str_col(&batch, "region");
         assert_eq!(region.value(0), "us-east");
         assert_eq!(region.value(1), "eu-west");
     }
@@ -917,12 +891,7 @@ mod tests {
         let batch = table.snapshot().unwrap();
         assert_eq!(batch.num_rows(), 2);
 
-        let ip = batch
-            .column_by_name("ip")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let ip = str_col(&batch, "ip");
         assert_eq!(ip.value(0), "10.0.0.1");
         assert_eq!(ip.value(1), "10.0.0.2");
     }
@@ -938,21 +907,11 @@ mod tests {
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 3);
 
-        let a = batch
-            .column_by_name("a")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let a = str_col(&batch, "a");
         assert_eq!(a.value(0), "1");
         assert!(a.is_null(1)); // row 2 doesn't have "a"
 
-        let c = batch
-            .column_by_name("c")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let c = str_col(&batch, "c");
         assert!(c.is_null(0)); // row 1 doesn't have "c"
         assert_eq!(c.value(1), "4");
     }
@@ -964,20 +923,10 @@ mod tests {
         table.load_from_reader(&data[..]).unwrap();
 
         let batch = table.snapshot().unwrap();
-        let port = batch
-            .column_by_name("port")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let port = str_col(&batch, "port");
         assert_eq!(port.value(0), "8080");
 
-        let active = batch
-            .column_by_name("active")
-            .unwrap()
-            .as_any()
-            .downcast_ref::<StringArray>()
-            .unwrap();
+        let active = str_col(&batch, "active");
         assert_eq!(active.value(0), "true");
     }
 

--- a/crates/logfwd-io/src/enrichment.rs
+++ b/crates/logfwd-io/src/enrichment.rs
@@ -608,7 +608,7 @@ mod tests {
     use super::*;
     use arrow::array::Array;
 
-    fn str_col<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
+    fn get_str_col<'a>(batch: &'a RecordBatch, name: &str) -> &'a StringArray {
         batch
             .column_by_name(name)
             .unwrap_or_else(|| panic!("missing column: {name}"))
@@ -684,7 +684,7 @@ mod tests {
         let batch = table.snapshot().unwrap();
         assert_eq!(batch.num_rows(), 1);
         assert_eq!(batch.num_columns(), 2);
-        let env = str_col(&batch, "environment");
+        let env = get_str_col(&batch, "environment");
         assert_eq!(env.value(0), "production");
     }
 
@@ -717,7 +717,7 @@ mod tests {
         assert_eq!(batch.num_rows(), 1);
         assert_eq!(batch.num_columns(), 3);
         for col_name in &["hostname", "os_type", "os_arch"] {
-            let col = str_col(&batch, col_name);
+            let col = get_str_col(&batch, col_name);
             assert!(!col.value(0).is_empty(), "{col_name} should be non-empty");
         }
     }
@@ -743,7 +743,7 @@ mod tests {
         ]);
         let batch = table.snapshot().expect("should have data");
         assert_eq!(batch.num_rows(), 2);
-        let ns = str_col(&batch, "namespace");
+        let ns = get_str_col(&batch, "namespace");
         assert_eq!(ns.value(0), "default");
         assert_eq!(ns.value(1), "monitoring");
     }
@@ -804,11 +804,11 @@ mod tests {
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 3);
 
-        let hostname = str_col(&batch, "hostname");
+        let hostname = get_str_col(&batch, "hostname");
         assert_eq!(hostname.value(0), "web-1");
         assert_eq!(hostname.value(1), "api-2");
 
-        let team = str_col(&batch, "team");
+        let team = get_str_col(&batch, "team");
         assert_eq!(team.value(0), "platform");
         assert_eq!(team.value(1), "backend");
     }
@@ -820,7 +820,7 @@ mod tests {
         table.load_from_reader(&csv_data[..]).unwrap();
         let batch = table.snapshot().unwrap();
         assert_eq!(batch.num_rows(), 2);
-        let c = str_col(&batch, "c");
+        let c = get_str_col(&batch, "c");
         assert_eq!(c.value(0), "3");
         assert!(c.is_null(1)); // padded with NULL
     }
@@ -873,7 +873,7 @@ mod tests {
         assert_eq!(rows, 2);
 
         let batch = table.snapshot().unwrap();
-        let region = str_col(&batch, "region");
+        let region = get_str_col(&batch, "region");
         assert_eq!(region.value(0), "us-east");
         assert_eq!(region.value(1), "eu-west");
     }
@@ -891,7 +891,7 @@ mod tests {
         let batch = table.snapshot().unwrap();
         assert_eq!(batch.num_rows(), 2);
 
-        let ip = str_col(&batch, "ip");
+        let ip = get_str_col(&batch, "ip");
         assert_eq!(ip.value(0), "10.0.0.1");
         assert_eq!(ip.value(1), "10.0.0.2");
     }
@@ -907,11 +907,11 @@ mod tests {
         assert_eq!(batch.num_rows(), 2);
         assert_eq!(batch.num_columns(), 3);
 
-        let a = str_col(&batch, "a");
+        let a = get_str_col(&batch, "a");
         assert_eq!(a.value(0), "1");
         assert!(a.is_null(1)); // row 2 doesn't have "a"
 
-        let c = str_col(&batch, "c");
+        let c = get_str_col(&batch, "c");
         assert!(c.is_null(0)); // row 1 doesn't have "c"
         assert_eq!(c.value(1), "4");
     }
@@ -923,10 +923,10 @@ mod tests {
         table.load_from_reader(&data[..]).unwrap();
 
         let batch = table.snapshot().unwrap();
-        let port = str_col(&batch, "port");
+        let port = get_str_col(&batch, "port");
         assert_eq!(port.value(0), "8080");
 
-        let active = str_col(&batch, "active");
+        let active = get_str_col(&batch, "active");
         assert_eq!(active.value(0), "true");
     }
 

--- a/crates/logfwd-io/src/input.rs
+++ b/crates/logfwd-io/src/input.rs
@@ -388,7 +388,7 @@ pub enum FramedReadEvent {
     },
 }
 
-/// Trait for input sources that produce raw bytes.
+/// TLS settings for an input listener (cert, key, mutual auth).
 #[derive(Debug, Clone)]
 pub struct TlsInputConfig {
     pub cert_file: Option<String>,
@@ -397,6 +397,7 @@ pub struct TlsInputConfig {
     pub require_client_auth: bool,
 }
 
+/// Trait for input sources that produce raw bytes.
 pub trait InputSource: Send {
     /// Poll for new events. Returns empty vec if no new data.
     fn poll(&mut self) -> io::Result<Vec<InputEvent>>;

--- a/crates/logfwd-io/src/platform_sensor_filter.rs
+++ b/crates/logfwd-io/src/platform_sensor_filter.rs
@@ -48,28 +48,6 @@ mod tests {
     }
 
     #[test]
-    fn supported_event_types_match_public_event_kind_names() {
-        assert_eq!(
-            SUPPORTED_EVENT_TYPES,
-            &[
-                "exec",
-                "exit",
-                "tcp_connect",
-                "tcp_accept",
-                "file_open",
-                "file_delete",
-                "file_rename",
-                "setuid",
-                "setgid",
-                "module_load",
-                "ptrace",
-                "memfd_create",
-                "dns_query",
-            ]
-        );
-    }
-
-    #[test]
     fn no_filters_accepts_all_event_types() {
         assert!(is_event_type_enabled("exec", None, None));
         assert!(is_event_type_enabled("tcp_connect", None, None));

--- a/crates/logfwd-io/src/segment.rs
+++ b/crates/logfwd-io/src/segment.rs
@@ -901,6 +901,26 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use std::sync::Arc;
 
+    fn test_header(segment_id: u64) -> SegmentHeader {
+        SegmentHeader {
+            version: SEGMENT_VERSION,
+            flags: FLAG_ZSTD,
+            segment_id,
+            sql_hash: 0,
+            created_epoch_ms: 0,
+        }
+    }
+
+    fn test_header_with_hash(segment_id: u64, sql_hash: u64) -> SegmentHeader {
+        SegmentHeader {
+            version: SEGMENT_VERSION,
+            flags: FLAG_ZSTD,
+            segment_id,
+            sql_hash,
+            created_epoch_ms: 0,
+        }
+    }
+
     fn make_batch(n: usize) -> RecordBatch {
         let schema = Arc::new(Schema::new(vec![
             Field::new("msg", DataType::Utf8, false),
@@ -950,13 +970,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let batch = make_batch(100);
 
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&batch).unwrap();
         let seg = writer.finish().unwrap();
@@ -982,13 +996,7 @@ mod tests {
     fn segment_multi_batch_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
 
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(50)).unwrap();
         writer.append(&make_batch(30)).unwrap();
@@ -1011,13 +1019,7 @@ mod tests {
         let path = dir.path().join("seg-0000000001.lchk");
 
         // Write header only, no footer.
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         fs::write(&path, header.to_bytes()).unwrap();
 
         assert!(matches!(
@@ -1031,13 +1033,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let batch = make_batch(10);
 
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&batch).unwrap();
         let seg = writer.finish().unwrap();
@@ -1059,13 +1055,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let batch = make_batch(10);
 
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0xAAAA,
-            created_epoch_ms: 0,
-        };
+        let header = test_header_with_hash(1, 0xAAAA);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&batch).unwrap();
         let seg = writer.finish().unwrap();
@@ -1081,13 +1071,7 @@ mod tests {
         // A corrupt footer claiming an enormous data_size must be rejected
         // before any allocation happens, not cause OOM or panic.
         let dir = tempfile::tempdir().unwrap();
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(10)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1139,13 +1123,7 @@ mod tests {
     #[test]
     fn truncated_segment_returns_invalid_data() {
         let dir = tempfile::tempdir().unwrap();
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
 
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(10)).unwrap();
@@ -1176,27 +1154,14 @@ mod tests {
         fs::create_dir_all(&seg_dir).unwrap();
 
         // Write a valid segment.
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(&seg_dir, header).unwrap();
         writer.append(&make_batch(10)).unwrap();
         writer.finish().unwrap();
 
         // Write an incomplete segment (header only).
         let incomplete_path = seg_dir.join("seg-0000000002.lchk");
-        let header2 = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 2,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
-        fs::write(&incomplete_path, header2.to_bytes()).unwrap();
+        fs::write(&incomplete_path, test_header(2).to_bytes()).unwrap();
 
         let plan = recover_segments(&seg_dir, None).unwrap();
         assert_eq!(plan.segments.len(), 1);
@@ -1320,13 +1285,7 @@ mod tests {
     fn unsupported_version_is_not_treated_as_non_segment() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("seg-0000000001.lchk");
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(1)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1343,13 +1302,7 @@ mod tests {
     #[test]
     fn open_rejects_missing_required_zstd_flag() {
         let dir = tempfile::tempdir().unwrap();
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(1)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1366,13 +1319,7 @@ mod tests {
     #[test]
     fn open_rejects_unknown_header_flags() {
         let dir = tempfile::tempdir().unwrap();
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(1)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1428,13 +1375,7 @@ mod tests {
         fs::create_dir_all(&seg_dir).unwrap();
 
         let path = seg_dir.join("seg-0000000001.lchk");
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(&seg_dir, header).unwrap();
         writer.append(&make_batch(1)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1450,13 +1391,7 @@ mod tests {
     #[test]
     fn append_rejects_writes_beyond_read_limit() {
         let dir = tempfile::tempdir().unwrap();
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.data_size = MAX_SEGMENT_DATA_SIZE;
 
@@ -1471,13 +1406,7 @@ mod tests {
         let empty = make_batch(0);
         let nonempty = make_batch(5);
 
-        let header = SegmentHeader {
-            version: SEGMENT_VERSION,
-            flags: FLAG_ZSTD,
-            segment_id: 1,
-            sql_hash: 0,
-            created_epoch_ms: 0,
-        };
+        let header = test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&empty).unwrap();
         writer.append(&nonempty).unwrap();

--- a/crates/logfwd-io/src/segment.rs
+++ b/crates/logfwd-io/src/segment.rs
@@ -901,7 +901,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema};
     use std::sync::Arc;
 
-    fn test_header(segment_id: u64) -> SegmentHeader {
+    fn make_test_header(segment_id: u64) -> SegmentHeader {
         SegmentHeader {
             version: SEGMENT_VERSION,
             flags: FLAG_ZSTD,
@@ -911,7 +911,7 @@ mod tests {
         }
     }
 
-    fn test_header_with_hash(segment_id: u64, sql_hash: u64) -> SegmentHeader {
+    fn make_test_header_with_hash(segment_id: u64, sql_hash: u64) -> SegmentHeader {
         SegmentHeader {
             version: SEGMENT_VERSION,
             flags: FLAG_ZSTD,
@@ -970,7 +970,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let batch = make_batch(100);
 
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&batch).unwrap();
         let seg = writer.finish().unwrap();
@@ -996,7 +996,7 @@ mod tests {
     fn segment_multi_batch_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
 
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(50)).unwrap();
         writer.append(&make_batch(30)).unwrap();
@@ -1019,7 +1019,7 @@ mod tests {
         let path = dir.path().join("seg-0000000001.lchk");
 
         // Write header only, no footer.
-        let header = test_header(1);
+        let header = make_test_header(1);
         fs::write(&path, header.to_bytes()).unwrap();
 
         assert!(matches!(
@@ -1033,7 +1033,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let batch = make_batch(10);
 
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&batch).unwrap();
         let seg = writer.finish().unwrap();
@@ -1055,7 +1055,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let batch = make_batch(10);
 
-        let header = test_header_with_hash(1, 0xAAAA);
+        let header = make_test_header_with_hash(1, 0xAAAA);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&batch).unwrap();
         let seg = writer.finish().unwrap();
@@ -1071,7 +1071,7 @@ mod tests {
         // A corrupt footer claiming an enormous data_size must be rejected
         // before any allocation happens, not cause OOM or panic.
         let dir = tempfile::tempdir().unwrap();
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(10)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1123,7 +1123,7 @@ mod tests {
     #[test]
     fn truncated_segment_returns_invalid_data() {
         let dir = tempfile::tempdir().unwrap();
-        let header = test_header(1);
+        let header = make_test_header(1);
 
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(10)).unwrap();
@@ -1154,14 +1154,14 @@ mod tests {
         fs::create_dir_all(&seg_dir).unwrap();
 
         // Write a valid segment.
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(&seg_dir, header).unwrap();
         writer.append(&make_batch(10)).unwrap();
         writer.finish().unwrap();
 
         // Write an incomplete segment (header only).
         let incomplete_path = seg_dir.join("seg-0000000002.lchk");
-        fs::write(&incomplete_path, test_header(2).to_bytes()).unwrap();
+        fs::write(&incomplete_path, make_test_header(2).to_bytes()).unwrap();
 
         let plan = recover_segments(&seg_dir, None).unwrap();
         assert_eq!(plan.segments.len(), 1);
@@ -1285,7 +1285,7 @@ mod tests {
     fn unsupported_version_is_not_treated_as_non_segment() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("seg-0000000001.lchk");
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(1)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1302,7 +1302,7 @@ mod tests {
     #[test]
     fn open_rejects_missing_required_zstd_flag() {
         let dir = tempfile::tempdir().unwrap();
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(1)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1319,7 +1319,7 @@ mod tests {
     #[test]
     fn open_rejects_unknown_header_flags() {
         let dir = tempfile::tempdir().unwrap();
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&make_batch(1)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1375,7 +1375,7 @@ mod tests {
         fs::create_dir_all(&seg_dir).unwrap();
 
         let path = seg_dir.join("seg-0000000001.lchk");
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(&seg_dir, header).unwrap();
         writer.append(&make_batch(1)).unwrap();
         let seg = writer.finish().unwrap();
@@ -1391,7 +1391,7 @@ mod tests {
     #[test]
     fn append_rejects_writes_beyond_read_limit() {
         let dir = tempfile::tempdir().unwrap();
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.data_size = MAX_SEGMENT_DATA_SIZE;
 
@@ -1406,7 +1406,7 @@ mod tests {
         let empty = make_batch(0);
         let nonempty = make_batch(5);
 
-        let header = test_header(1);
+        let header = make_test_header(1);
         let mut writer = SegmentWriter::create(dir.path(), header).unwrap();
         writer.append(&empty).unwrap();
         writer.append(&nonempty).unwrap();

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -818,6 +818,23 @@ fn escape_json_raw(s: &str) -> String {
 mod tests {
     use super::*;
 
+    /// Build a `LokiSink` with default (empty) config for unit tests.
+    fn test_loki_sink() -> LokiSink {
+        let config = Arc::new(LokiConfig {
+            endpoint: "http://localhost".to_string(),
+            tenant_id: None,
+            static_labels: vec![],
+            label_columns: vec![],
+            headers: vec![],
+        });
+        LokiSink::new(
+            "test".to_string(),
+            config,
+            Arc::new(reqwest::Client::new()),
+            Arc::new(ComponentStats::new()),
+        )
+    }
+
     #[test]
     fn sort_dedup_already_sorted_no_op() {
         let mut entries: Vec<LokiEntry> =
@@ -1266,19 +1283,7 @@ mod tests {
         use arrow::array::Int64Array;
         use arrow::datatypes::{Field, Schema};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         // Batch uses the canonical "timestamp" name (OTLP receiver output).
         let schema = Arc::new(Schema::new(vec![
@@ -1319,19 +1324,7 @@ mod tests {
         use arrow::array::Int64Array;
         use arrow::datatypes::{Field, Schema};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         // @timestamp appears BEFORE _timestamp in the schema.
         // The sink must select _timestamp (1000) not @timestamp (100).
@@ -1379,19 +1372,7 @@ mod tests {
         use arrow::array::StringArray;
         use arrow::datatypes::{Field, Schema};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         // _timestamp column is Utf8 (scanner output from tailed log files and
         // star_to_flat output).  The expected nanosecond value for
@@ -1565,19 +1546,7 @@ mod tests {
         use arrow::array::Int64Array;
         use arrow::datatypes::{Field, Schema};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             field_names::TIMESTAMP_UNDERSCORE,
@@ -1614,19 +1583,7 @@ mod tests {
         use arrow::array::Int64Array;
         use arrow::datatypes::{Field, Schema};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         // Schema: @timestamp (index 0) BEFORE _timestamp (index 1).
         // The old `position(|f| underscore || at)` would incorrectly pick @timestamp
@@ -1782,19 +1739,7 @@ mod tests {
         use arrow::array::Int64Array;
         use arrow::datatypes::{Field, Schema};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             field_names::TIMESTAMP_UNDERSCORE,
@@ -1834,19 +1779,7 @@ mod tests {
         use arrow::array::TimestampNanosecondArray;
         use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         let expected_ns: i64 = 1_705_314_600_000_000_000;
         let schema = Arc::new(Schema::new(vec![
@@ -1889,19 +1822,7 @@ mod tests {
         use arrow::array::TimestampMicrosecondArray;
         use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         let raw_us: i64 = 1_705_314_600_000_000;
         let expected_ns: u64 = (raw_us * 1_000) as u64;
@@ -1935,19 +1856,7 @@ mod tests {
         use arrow::array::TimestampMillisecondArray;
         use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         let raw_ms: i64 = 1_705_314_600_000;
         let expected_ns: u64 = (raw_ms * 1_000_000) as u64;
@@ -1981,19 +1890,7 @@ mod tests {
         use arrow::array::TimestampSecondArray;
         use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         let raw_s: i64 = 1_705_314_600;
         let expected_ns: u64 = (raw_s * 1_000_000_000) as u64;
@@ -2027,19 +1924,7 @@ mod tests {
         use arrow::array::TimestampSecondArray;
         use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 
-        let config = Arc::new(LokiConfig {
-            endpoint: "http://localhost".to_string(),
-            tenant_id: None,
-            static_labels: vec![],
-            label_columns: vec![],
-            headers: vec![],
-        });
-        let sink = LokiSink::new(
-            "test".to_string(),
-            config,
-            Arc::new(reqwest::Client::new()),
-            Arc::new(ComponentStats::new()),
-        );
+        let sink = test_loki_sink();
 
         let schema = Arc::new(Schema::new(vec![Field::new(
             field_names::TIMESTAMP_UNDERSCORE,

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -50,13 +50,16 @@ fn input_type_exposes_public_source_paths(type_config: &InputTypeConfig) -> bool
 /// Calls `table.reload()` on a blocking thread every `interval_secs`.
 /// `kind` is used for log messages (e.g. "CSV", "JSONL", "KV file").
 #[cfg(feature = "datafusion")]
-fn spawn_enrichment_reload<T: Send + Sync + 'static>(
+fn spawn_enrichment_reload<T, E>(
     table: &Arc<T>,
     table_name: &str,
     kind: &'static str,
     interval_secs: u64,
-    reload: fn(&T) -> Result<usize, logfwd_io::InputError>,
-) {
+    reload: fn(&T) -> Result<usize, E>,
+) where
+    T: Send + Sync + 'static,
+    E: std::fmt::Display + Send + 'static,
+{
     let t = Arc::clone(table);
     let name = table_name.to_string();
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -68,7 +71,7 @@ fn spawn_enrichment_reload<T: Send + Sync + 'static>(
                 let t2 = Arc::clone(&t);
                 match tokio::task::spawn_blocking(move || reload(&t2)).await {
                     Ok(Ok(n)) => tracing::debug!(
-                        table = %name, count = n,
+                        table = %name, rows = n,
                         "{kind} enrichment table reloaded"
                     ),
                     Ok(Err(e)) => tracing::warn!(

--- a/crates/logfwd-runtime/src/pipeline/build.rs
+++ b/crates/logfwd-runtime/src/pipeline/build.rs
@@ -45,6 +45,51 @@ fn input_type_exposes_public_source_paths(type_config: &InputTypeConfig) -> bool
     )
 }
 
+/// Spawn a periodic reload task for a file-backed enrichment table.
+///
+/// Calls `table.reload()` on a blocking thread every `interval_secs`.
+/// `kind` is used for log messages (e.g. "CSV", "JSONL", "KV file").
+#[cfg(feature = "datafusion")]
+fn spawn_enrichment_reload<T: Send + Sync + 'static>(
+    table: &Arc<T>,
+    table_name: &str,
+    kind: &'static str,
+    interval_secs: u64,
+    reload: fn(&T) -> Result<usize, logfwd_io::InputError>,
+) {
+    let t = Arc::clone(table);
+    let name = table_name.to_string();
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_secs(interval_secs));
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let t2 = Arc::clone(&t);
+                match tokio::task::spawn_blocking(move || reload(&t2)).await {
+                    Ok(Ok(n)) => tracing::debug!(
+                        table = %name, count = n,
+                        "{kind} enrichment table reloaded"
+                    ),
+                    Ok(Err(e)) => tracing::warn!(
+                        table = %name, error = %e,
+                        "{kind} enrichment table reload failed"
+                    ),
+                    Err(e) => tracing::warn!(
+                        table = %name, error = %e,
+                        "{kind} enrichment table reload task panicked"
+                    ),
+                }
+            }
+        });
+    } else {
+        tracing::warn!(
+            table = %name,
+            "refresh_interval ignored: no active Tokio runtime"
+        );
+    }
+}
+
 impl Pipeline {
     /// Construct a pipeline from parsed YAML config.
     pub fn from_config(
@@ -237,39 +282,13 @@ impl Pipeline {
                         if let Some(interval_secs) =
                             cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
                         {
-                            let t = Arc::clone(&table);
-                            let name = cfg.table_name.clone();
-                            if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                                handle.spawn(async move {
-                                    let mut ticker =
-                                        tokio::time::interval(Duration::from_secs(interval_secs));
-                                    ticker.tick().await;
-                                    loop {
-                                        ticker.tick().await;
-                                        let t2 = Arc::clone(&t);
-                                        match tokio::task::spawn_blocking(move || t2.reload()).await
-                                        {
-                                            Ok(Ok(n)) => tracing::debug!(
-                                                table = %name, rows = n,
-                                                "CSV enrichment table reloaded"
-                                            ),
-                                            Ok(Err(e)) => tracing::warn!(
-                                                table = %name, error = %e,
-                                                "CSV enrichment table reload failed"
-                                            ),
-                                            Err(e) => tracing::warn!(
-                                                table = %name, error = %e,
-                                                "CSV enrichment table reload task panicked"
-                                            ),
-                                        }
-                                    }
-                                });
-                            } else {
-                                tracing::warn!(
-                                    table = %name,
-                                    "refresh_interval ignored: no active Tokio runtime"
-                                );
-                            }
+                            spawn_enrichment_reload(
+                                &table,
+                                &cfg.table_name,
+                                "CSV",
+                                interval_secs,
+                                crate::transform::enrichment::CsvFileTable::reload,
+                            );
                         }
                         enrichment_tables.push(table);
                     }
@@ -291,39 +310,13 @@ impl Pipeline {
                         if let Some(interval_secs) =
                             cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
                         {
-                            let t = Arc::clone(&table);
-                            let name = cfg.table_name.clone();
-                            if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                                handle.spawn(async move {
-                                    let mut ticker =
-                                        tokio::time::interval(Duration::from_secs(interval_secs));
-                                    ticker.tick().await;
-                                    loop {
-                                        ticker.tick().await;
-                                        let t2 = Arc::clone(&t);
-                                        match tokio::task::spawn_blocking(move || t2.reload()).await
-                                        {
-                                            Ok(Ok(n)) => tracing::debug!(
-                                                table = %name, rows = n,
-                                                "JSONL enrichment table reloaded"
-                                            ),
-                                            Ok(Err(e)) => tracing::warn!(
-                                                table = %name, error = %e,
-                                                "JSONL enrichment table reload failed"
-                                            ),
-                                            Err(e) => tracing::warn!(
-                                                table = %name, error = %e,
-                                                "JSONL enrichment table reload task panicked"
-                                            ),
-                                        }
-                                    }
-                                });
-                            } else {
-                                tracing::warn!(
-                                    table = %name,
-                                    "refresh_interval ignored: no active Tokio runtime"
-                                );
-                            }
+                            spawn_enrichment_reload(
+                                &table,
+                                &cfg.table_name,
+                                "JSONL",
+                                interval_secs,
+                                crate::transform::enrichment::JsonLinesFileTable::reload,
+                            );
                         }
                         enrichment_tables.push(table);
                     }
@@ -358,39 +351,13 @@ impl Pipeline {
                         if let Some(interval_secs) =
                             cfg.refresh_interval.map(logfwd_config::PositiveSecs::get)
                         {
-                            let t = Arc::clone(&table);
-                            let name = cfg.table_name.clone();
-                            if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                                handle.spawn(async move {
-                                    let mut ticker =
-                                        tokio::time::interval(Duration::from_secs(interval_secs));
-                                    ticker.tick().await;
-                                    loop {
-                                        ticker.tick().await;
-                                        let t2 = Arc::clone(&t);
-                                        match tokio::task::spawn_blocking(move || t2.reload()).await
-                                        {
-                                            Ok(Ok(n)) => tracing::debug!(
-                                                table = %name, columns = n,
-                                                "KV file enrichment table reloaded"
-                                            ),
-                                            Ok(Err(e)) => tracing::warn!(
-                                                table = %name, error = %e,
-                                                "KV file enrichment table reload failed"
-                                            ),
-                                            Err(e) => tracing::warn!(
-                                                table = %name, error = %e,
-                                                "KV file enrichment table reload task panicked"
-                                            ),
-                                        }
-                                    }
-                                });
-                            } else {
-                                tracing::warn!(
-                                    table = %name,
-                                    "refresh_interval ignored: no active Tokio runtime"
-                                );
-                            }
+                            spawn_enrichment_reload(
+                                &table,
+                                &cfg.table_name,
+                                "KV file",
+                                interval_secs,
+                                crate::transform::enrichment::KvFileTable::reload,
+                            );
                         }
                         enrichment_tables.push(table);
                     }

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -98,14 +98,7 @@ fn scan_maybe_blocking(
     scanner: &mut Scanner,
     buf: Bytes,
 ) -> Result<RecordBatch, arrow::error::ArrowError> {
-    #[cfg(feature = "turmoil")]
-    {
-        scanner.scan(buf)
-    }
-    #[cfg(not(feature = "turmoil"))]
-    {
-        tokio::task::block_in_place(|| scanner.scan(buf))
-    }
+    scanner.scan(buf)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/logfwd-runtime/src/pipeline/mod.rs
+++ b/crates/logfwd-runtime/src/pipeline/mod.rs
@@ -366,32 +366,8 @@ impl Pipeline {
     /// and the provided sink.
     #[cfg(feature = "turmoil")]
     pub fn for_simulation(name: &str, sink: Box<dyn logfwd_output::Sink>) -> Self {
-        let meter = opentelemetry::global::meter("test");
-        let metrics = Arc::new(PipelineMetrics::new(name, "SELECT * FROM logs", &meter));
         let factory = Arc::new(OnceAsyncFactory::new(name.to_string(), sink));
-        let pool = OutputWorkerPool::new(factory, 1, Duration::MAX, Arc::clone(&metrics));
-
-        // Start with empty inputs and input_transforms so that each with_input()
-        // call adds exactly one entry to both, keeping input_index in sync with
-        // the transform and accumulator vectors in run_async.
-        Pipeline {
-            name: name.to_string(),
-            inputs: vec![],
-            input_transforms: vec![],
-            processors: vec![],
-            pool,
-            metrics,
-            batch_target_bytes: 64 * 1024,
-            batch_timeout: Duration::from_millis(50),
-            poll_interval: Duration::from_millis(5),
-            resource_attrs: Arc::from([]),
-            machine: Some(PipelineMachine::new().start()),
-            checkpoint_store: None,
-            held_tickets: Vec::new(),
-            last_checkpoint_flush: tokio::time::Instant::now(),
-            checkpoint_flush_interval: build::DEFAULT_CHECKPOINT_FLUSH_INTERVAL,
-            pool_drain_timeout: Duration::from_secs(60),
-        }
+        Self::for_simulation_with_factory(name, factory, 1)
     }
 
     /// Create a pipeline for simulation testing with a custom sink factory

--- a/crates/logfwd-runtime/src/pipeline/run.rs
+++ b/crates/logfwd-runtime/src/pipeline/run.rs
@@ -13,6 +13,7 @@ use super::{ChannelMsg, Pipeline, now_nanos};
 use crate::worker_pool::AckItem;
 use logfwd_io::checkpoint::SourceCheckpoint;
 use logfwd_output::BatchMetadata;
+use logfwd_types::pipeline::SourceId;
 
 #[cfg(not(feature = "turmoil"))]
 use super::InputTransform;
@@ -271,17 +272,8 @@ impl Pipeline {
             let draining = machine.begin_drain();
             match draining.stop() {
                 Ok(stopped) => {
-                    // All in-flight batches resolved — persist final checkpoints.
-                    if let Some(ref mut store) = self.checkpoint_store {
-                        for (source_id, offset) in stopped.final_checkpoints() {
-                            store.update(SourceCheckpoint {
-                                source_id: source_id.0,
-                                path: None, // path is metadata, not required for restore
-                                offset: *offset,
-                            });
-                        }
-                        flush_checkpoint_with_retry(store.as_mut()).await;
-                    }
+                    self.persist_final_checkpoints(stopped.final_checkpoints())
+                        .await;
                 }
                 Err(still_draining) => {
                     let abandoned = still_draining.in_flight_count();
@@ -292,16 +284,8 @@ impl Pipeline {
                     let stopped = still_draining.force_stop();
                     // Persist what we have — committed checkpoints are still
                     // valid (they only reflect contiguously-acked batches).
-                    if let Some(ref mut store) = self.checkpoint_store {
-                        for (source_id, offset) in stopped.final_checkpoints() {
-                            store.update(SourceCheckpoint {
-                                source_id: source_id.0,
-                                path: None,
-                                offset: *offset,
-                            });
-                        }
-                        flush_checkpoint_with_retry(store.as_mut()).await;
-                    }
+                    self.persist_final_checkpoints(stopped.final_checkpoints())
+                        .await;
                 }
             }
         }
@@ -314,6 +298,23 @@ impl Pipeline {
         )
         .await;
         Ok(())
+    }
+
+    /// Persist final checkpoints from the stopped state machine.
+    async fn persist_final_checkpoints(
+        &mut self,
+        checkpoints: &std::collections::BTreeMap<SourceId, u64>,
+    ) {
+        if let Some(ref mut store) = self.checkpoint_store {
+            for (source_id, offset) in checkpoints {
+                store.update(SourceCheckpoint {
+                    source_id: source_id.0,
+                    path: None,
+                    offset: *offset,
+                });
+            }
+            flush_checkpoint_with_retry(store.as_mut()).await;
+        }
     }
 
     /// Apply a pool `AckItem` at the worker/checkpoint seam.

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -1050,6 +1050,13 @@ fn test_query_analyzer_column_refs_expression_forms() {
                 a.referenced_columns
             );
         }
+        assert_eq!(
+            a.referenced_columns.len(),
+            expected_cols.len(),
+            "SQL: {sql}\nExpected exactly {:?}, got: {:?}",
+            expected_cols,
+            a.referenced_columns
+        );
     }
 }
 

--- a/crates/logfwd-transform/src/tests.rs
+++ b/crates/logfwd-transform/src/tests.rs
@@ -497,31 +497,36 @@ fn test_enrichment_empty_table_skipped() {
 
 // --- FilterHints predicate pushdown tests ---
 
+/// Table-driven tests for simple severity/facility filter hints.
 #[test]
-fn test_filter_hints_severity_lte() {
-    let a = QueryAnalyzer::new("SELECT * FROM logs WHERE severity <= 4").unwrap();
-    let h = a.filter_hints();
-    assert_eq!(h.max_severity, Some(4));
-}
+fn test_filter_hints_simple_severity_and_facility() {
+    // Simple severity-only cases
+    let severity_cases: &[(&str, u8)] = &[
+        ("SELECT * FROM logs WHERE severity <= 4", 4),
+        ("SELECT * FROM logs WHERE severity < 5", 4), // < 5 becomes <= 4
+        ("SELECT * FROM logs WHERE severity = 3", 3),
+        ("SELECT * FROM logs WHERE 5 > severity", 4), // reversed comparison
+        (
+            "SELECT * FROM logs WHERE severity <= 4 AND severity <= 2",
+            2,
+        ), // tighter bound wins
+    ];
 
-#[test]
-fn test_filter_hints_severity_lt() {
-    let a = QueryAnalyzer::new("SELECT * FROM logs WHERE severity < 5").unwrap();
-    let h = a.filter_hints();
-    assert_eq!(h.max_severity, Some(4)); // < 5 becomes <= 4
-}
+    for (sql, expected_severity) in severity_cases {
+        let a = QueryAnalyzer::new(sql).unwrap();
+        let h = a.filter_hints();
+        assert_eq!(
+            h.max_severity,
+            Some(*expected_severity),
+            "severity mismatch for: {sql}"
+        );
+        assert!(h.facilities.is_none(), "no facilities expected for: {sql}");
+    }
 
-#[test]
-fn test_filter_hints_severity_eq() {
-    let a = QueryAnalyzer::new("SELECT * FROM logs WHERE severity = 3").unwrap();
-    let h = a.filter_hints();
-    assert_eq!(h.max_severity, Some(3));
-}
-
-#[test]
-fn test_filter_hints_facility_eq() {
+    // Simple facility-only case
     let a = QueryAnalyzer::new("SELECT * FROM logs WHERE facility = 16").unwrap();
     let h = a.filter_hints();
+    assert!(h.max_severity.is_none());
     assert_eq!(h.facilities, Some(vec![16]));
 }
 
@@ -601,22 +606,6 @@ fn test_filter_hints_or_pushable_only_still_not_pushed() {
     let a = QueryAnalyzer::new("SELECT * FROM logs WHERE severity <= 4 OR severity <= 2").unwrap();
     let h = a.filter_hints();
     assert!(h.max_severity.is_none());
-}
-
-#[test]
-fn test_filter_hints_reversed_gt() {
-    // "5 > severity" means severity < 5, i.e. severity <= 4
-    let a = QueryAnalyzer::new("SELECT * FROM logs WHERE 5 > severity").unwrap();
-    let h = a.filter_hints();
-    assert_eq!(h.max_severity, Some(4));
-}
-
-#[test]
-fn test_filter_hints_tighten_severity() {
-    // Multiple severity bounds should keep the tightest (minimum)
-    let a = QueryAnalyzer::new("SELECT * FROM logs WHERE severity <= 4 AND severity <= 2").unwrap();
-    let h = a.filter_hints();
-    assert_eq!(h.max_severity, Some(2)); // tighter bound wins
 }
 
 #[test]
@@ -1016,82 +1005,55 @@ fn test_where_int_in_list() {
 // Regression tests — QueryAnalyzer column-ref collection for #415 forms
 // -----------------------------------------------------------------------
 
-/// QueryAnalyzer must collect column refs from an IS NULL expression.
+/// Table-driven tests for QueryAnalyzer column-ref collection across expression forms.
 #[test]
-fn test_query_analyzer_is_null_column_refs() {
-    let a = QueryAnalyzer::new("SELECT level FROM logs WHERE status IS NULL").unwrap();
-    assert!(
-        a.referenced_columns.contains("status"),
-        "IS NULL expr must add 'status' to referenced_columns"
-    );
-    assert!(
-        a.referenced_columns.contains("level"),
-        "'level' from SELECT must be in referenced_columns"
-    );
+fn test_query_analyzer_column_refs_expression_forms() {
+    // (sql, expected columns that must be in referenced_columns)
+    let cases: &[(&str, &[&str])] = &[
+        (
+            "SELECT level FROM logs WHERE status IS NULL",
+            &["status", "level"],
+        ),
+        ("SELECT * FROM logs WHERE level LIKE 'ERR%'", &["level"]),
+        (
+            "SELECT * FROM logs WHERE status IN ('200', '404')",
+            &["status"],
+        ),
+        (
+            "SELECT a.message FROM logs a JOIN logs b ON a.level = b.level LIMIT 5",
+            &["message", "level"],
+        ),
+        (
+            "SELECT level FROM logs UNION ALL SELECT severity FROM logs",
+            &["level", "severity"],
+        ),
+        (
+            "SELECT message FROM logs a JOIN logs b USING (level)",
+            &["message", "level"],
+        ),
+        (
+            "SELECT q.level FROM (SELECT level, status, host FROM logs WHERE status = '500' ORDER BY host) q",
+            &["level", "status", "host"],
+        ),
+        (
+            "SELECT l.message FROM logs l JOIN (SELECT level, service FROM logs WHERE service = 'api') d ON l.level = d.level",
+            &["message", "level", "service"],
+        ),
+    ];
+
+    for (sql, expected_cols) in cases {
+        let a = QueryAnalyzer::new(sql).unwrap();
+        for col in *expected_cols {
+            assert!(
+                a.referenced_columns.contains(*col),
+                "SQL: {sql}\nExpected '{col}' in referenced_columns, got: {:?}",
+                a.referenced_columns
+            );
+        }
+    }
 }
 
-/// QueryAnalyzer must collect column refs from a LIKE expression.
-#[test]
-fn test_query_analyzer_like_column_refs() {
-    let a = QueryAnalyzer::new("SELECT * FROM logs WHERE level LIKE 'ERR%'").unwrap();
-    assert!(
-        a.referenced_columns.contains("level"),
-        "LIKE expr must add 'level' to referenced_columns"
-    );
-}
-
-/// QueryAnalyzer must collect column refs from an IN list expression.
-#[test]
-fn test_query_analyzer_in_list_column_refs() {
-    let a = QueryAnalyzer::new("SELECT * FROM logs WHERE status IN ('200', '404')").unwrap();
-    assert!(
-        a.referenced_columns.contains("status"),
-        "InList expr must add 'status' to referenced_columns"
-    );
-}
-
-#[test]
-fn test_query_analyzer_join_on_column_refs() {
-    let a =
-        QueryAnalyzer::new("SELECT a.message FROM logs a JOIN logs b ON a.level = b.level LIMIT 5")
-            .unwrap();
-    assert!(
-        a.referenced_columns.contains("message"),
-        "SELECT column must be in referenced_columns"
-    );
-    assert!(
-        a.referenced_columns.contains("level"),
-        "JOIN ON column must be in referenced_columns"
-    );
-}
-
-#[test]
-fn test_query_analyzer_union_column_refs() {
-    let a =
-        QueryAnalyzer::new("SELECT level FROM logs UNION ALL SELECT severity FROM logs").unwrap();
-    assert!(
-        a.referenced_columns.contains("level"),
-        "left branch column must be in referenced_columns"
-    );
-    assert!(
-        a.referenced_columns.contains("severity"),
-        "right branch column must be in referenced_columns"
-    );
-}
-
-#[test]
-fn test_query_analyzer_join_using_column_refs() {
-    let a = QueryAnalyzer::new("SELECT message FROM logs a JOIN logs b USING (level)").unwrap();
-    assert!(
-        a.referenced_columns.contains("message"),
-        "SELECT column must be in referenced_columns"
-    );
-    assert!(
-        a.referenced_columns.contains("level"),
-        "USING column must be in referenced_columns"
-    );
-}
-
+/// STRAIGHT_JOIN may not be supported — handle both parse success and expected error.
 #[test]
 fn test_query_analyzer_straight_join_on_column_refs() {
     let sql = "SELECT a.message FROM logs a STRAIGHT_JOIN logs b ON a.level = b.level";
@@ -1115,46 +1077,7 @@ fn test_query_analyzer_straight_join_on_column_refs() {
     }
 }
 
-#[test]
-fn test_query_analyzer_derived_subquery_column_refs() {
-    let a = QueryAnalyzer::new(
-        "SELECT q.level FROM (SELECT level, status, host FROM logs WHERE status = '500' ORDER BY host) q",
-    )
-    .unwrap();
-    assert!(
-        a.referenced_columns.contains("level"),
-        "derived SELECT column must be in referenced_columns"
-    );
-    assert!(
-        a.referenced_columns.contains("status"),
-        "derived WHERE column must be in referenced_columns"
-    );
-    assert!(
-        a.referenced_columns.contains("host"),
-        "derived ORDER BY column must be in referenced_columns"
-    );
-}
-
-#[test]
-fn test_query_analyzer_joined_derived_relation_column_refs() {
-    let a = QueryAnalyzer::new(
-        "SELECT l.message FROM logs l JOIN (SELECT level, service FROM logs WHERE service = 'api') d ON l.level = d.level",
-    )
-    .unwrap();
-    assert!(
-        a.referenced_columns.contains("message"),
-        "outer SELECT column must be in referenced_columns"
-    );
-    assert!(
-        a.referenced_columns.contains("level"),
-        "join key from derived relation must be in referenced_columns"
-    );
-    assert!(
-        a.referenced_columns.contains("service"),
-        "derived subquery column must be in referenced_columns"
-    );
-}
-
+/// Table-function and TABLE() syntax: args must appear in referenced_columns.
 #[test]
 fn test_query_analyzer_table_function_args_column_refs() {
     let with_table_args = QueryAnalyzer::new("SELECT message FROM logs(level, host)").unwrap();

--- a/crates/logfwd-transform/tests/it/scanner_datafusion_boundary.rs
+++ b/crates/logfwd-transform/tests/it/scanner_datafusion_boundary.rs
@@ -176,13 +176,13 @@ fn collect_i64_col(batch: &RecordBatch, name: &str) -> Vec<Option<i64>> {
 // Helper: run a test closure against all three string-type batch variants
 // ===========================================================================
 
-fn for_all_string_types(test_fn: impl Fn(RecordBatch)) {
-    for batch in [
-        make_utf8view_batch(),
-        make_dict_utf8_batch(),
-        make_dict_utf8view_batch(),
+fn for_all_string_types(test_fn: impl Fn(RecordBatch, &str)) {
+    for (batch, label) in [
+        (make_utf8view_batch(), "Utf8View"),
+        (make_dict_utf8_batch(), "Dict<Utf8>"),
+        (make_dict_utf8view_batch(), "Dict<Utf8View>"),
     ] {
-        test_fn(batch);
+        test_fn(batch, label);
     }
 }
 
@@ -193,14 +193,14 @@ fn for_all_string_types(test_fn: impl Fn(RecordBatch)) {
 /// WHERE clause on a string column must filter rows correctly (all string types).
 #[test]
 fn all_string_types_where_equals() {
-    for_all_string_types(|batch| {
+    for_all_string_types(|batch, label| {
         let mut t = SqlTransform::new("SELECT * FROM logs WHERE level_str = 'ERROR'").unwrap();
         let result = t.execute_blocking(batch).unwrap();
-        assert_eq!(result.num_rows(), 2, "expected 2 ERROR rows");
+        assert_eq!(result.num_rows(), 2, "[{label}] expected 2 ERROR rows");
         let levels = collect_string_col(&result, "level_str");
         assert!(
             levels.iter().all(|v| v == "ERROR"),
-            "all rows must be ERROR"
+            "[{label}] all rows must be ERROR"
         );
     });
 }
@@ -208,29 +208,29 @@ fn all_string_types_where_equals() {
 /// GROUP BY on a string column must produce one row per distinct value (all string types).
 #[test]
 fn all_string_types_group_by_count() {
-    for_all_string_types(|batch| {
+    for_all_string_types(|batch, label| {
         let mut t = SqlTransform::new(
             "SELECT level_str, COUNT(*) AS cnt FROM logs GROUP BY level_str ORDER BY level_str",
         )
         .unwrap();
         let result = t.execute_blocking(batch).unwrap();
-        assert_eq!(result.num_rows(), 3, "three distinct levels");
+        assert_eq!(result.num_rows(), 3, "[{label}] three distinct levels");
         let levels = collect_string_col(&result, "level_str");
-        assert_eq!(levels, ["DEBUG", "ERROR", "INFO"]);
+        assert_eq!(levels, ["DEBUG", "ERROR", "INFO"], "[{label}]");
         let counts = collect_i64_col(&result, "cnt");
-        assert_eq!(counts, [Some(1), Some(2), Some(1)]);
+        assert_eq!(counts, [Some(1), Some(2), Some(1)], "[{label}]");
     });
 }
 
 /// ORDER BY ASC on a string column must sort lexicographically (all string types).
 #[test]
 fn all_string_types_order_by_asc() {
-    for_all_string_types(|batch| {
+    for_all_string_types(|batch, label| {
         let mut t = SqlTransform::new("SELECT level_str FROM logs ORDER BY level_str ASC").unwrap();
         let result = t.execute_blocking(batch).unwrap();
-        assert_eq!(result.num_rows(), 4);
+        assert_eq!(result.num_rows(), 4, "[{label}]");
         let levels = collect_string_col(&result, "level_str");
-        assert_eq!(levels, ["DEBUG", "ERROR", "ERROR", "INFO"]);
+        assert_eq!(levels, ["DEBUG", "ERROR", "ERROR", "INFO"], "[{label}]");
     });
 }
 

--- a/crates/logfwd-transform/tests/it/scanner_datafusion_boundary.rs
+++ b/crates/logfwd-transform/tests/it/scanner_datafusion_boundary.rs
@@ -173,24 +173,70 @@ fn collect_i64_col(batch: &RecordBatch, name: &str) -> Vec<Option<i64>> {
 }
 
 // ===========================================================================
-// Section 1: Utf8View columns
+// Helper: run a test closure against all three string-type batch variants
 // ===========================================================================
 
-// --- WHERE ---
-
-/// WHERE clause on a Utf8View column must filter rows correctly.
-#[test]
-fn utf8view_where_equals() {
-    let batch = make_utf8view_batch();
-    let mut t = SqlTransform::new("SELECT * FROM logs WHERE level_str = 'ERROR'").unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    assert_eq!(result.num_rows(), 2, "expected 2 ERROR rows");
-    let levels = collect_string_col(&result, "level_str");
-    assert!(
-        levels.iter().all(|v| v == "ERROR"),
-        "all rows must be ERROR"
-    );
+fn for_all_string_types(test_fn: impl Fn(RecordBatch)) {
+    for batch in [
+        make_utf8view_batch(),
+        make_dict_utf8_batch(),
+        make_dict_utf8view_batch(),
+    ] {
+        test_fn(batch);
+    }
 }
+
+// ===========================================================================
+// Section 1: Tests that apply to ALL string-type variants
+// ===========================================================================
+
+/// WHERE clause on a string column must filter rows correctly (all string types).
+#[test]
+fn all_string_types_where_equals() {
+    for_all_string_types(|batch| {
+        let mut t = SqlTransform::new("SELECT * FROM logs WHERE level_str = 'ERROR'").unwrap();
+        let result = t.execute_blocking(batch).unwrap();
+        assert_eq!(result.num_rows(), 2, "expected 2 ERROR rows");
+        let levels = collect_string_col(&result, "level_str");
+        assert!(
+            levels.iter().all(|v| v == "ERROR"),
+            "all rows must be ERROR"
+        );
+    });
+}
+
+/// GROUP BY on a string column must produce one row per distinct value (all string types).
+#[test]
+fn all_string_types_group_by_count() {
+    for_all_string_types(|batch| {
+        let mut t = SqlTransform::new(
+            "SELECT level_str, COUNT(*) AS cnt FROM logs GROUP BY level_str ORDER BY level_str",
+        )
+        .unwrap();
+        let result = t.execute_blocking(batch).unwrap();
+        assert_eq!(result.num_rows(), 3, "three distinct levels");
+        let levels = collect_string_col(&result, "level_str");
+        assert_eq!(levels, ["DEBUG", "ERROR", "INFO"]);
+        let counts = collect_i64_col(&result, "cnt");
+        assert_eq!(counts, [Some(1), Some(2), Some(1)]);
+    });
+}
+
+/// ORDER BY ASC on a string column must sort lexicographically (all string types).
+#[test]
+fn all_string_types_order_by_asc() {
+    for_all_string_types(|batch| {
+        let mut t = SqlTransform::new("SELECT level_str FROM logs ORDER BY level_str ASC").unwrap();
+        let result = t.execute_blocking(batch).unwrap();
+        assert_eq!(result.num_rows(), 4);
+        let levels = collect_string_col(&result, "level_str");
+        assert_eq!(levels, ["DEBUG", "ERROR", "ERROR", "INFO"]);
+    });
+}
+
+// ===========================================================================
+// Section 2: Utf8View-only tests (WHERE variants, GROUP BY SUM, ORDER BY DESC, JOINs)
+// ===========================================================================
 
 /// WHERE clause with NOT EQUAL on a Utf8View column.
 #[test]
@@ -217,26 +263,6 @@ fn utf8view_where_like() {
     assert_eq!(msgs[0], "disk full");
 }
 
-// --- GROUP BY ---
-
-/// GROUP BY on a Utf8View column must produce one row per distinct value.
-#[test]
-fn utf8view_group_by_count() {
-    let batch = make_utf8view_batch();
-    let mut t = SqlTransform::new(
-        "SELECT level_str, COUNT(*) AS cnt FROM logs GROUP BY level_str ORDER BY level_str",
-    )
-    .unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    // Three distinct levels: DEBUG, ERROR, INFO (ORDER BY level_str ASC)
-    assert_eq!(result.num_rows(), 3, "three distinct levels");
-    let levels = collect_string_col(&result, "level_str");
-    assert_eq!(levels, ["DEBUG", "ERROR", "INFO"]);
-    let counts = collect_i64_col(&result, "cnt");
-    // DEBUG→1, ERROR→2, INFO→1
-    assert_eq!(counts, [Some(1), Some(2), Some(1)]);
-}
-
 /// GROUP BY with SUM on a Utf8View-keyed group.
 #[test]
 fn utf8view_group_by_sum() {
@@ -254,20 +280,6 @@ fn utf8view_group_by_sum() {
     assert_eq!(totals, [Some(20), Some(8), Some(10)]);
 }
 
-// --- ORDER BY ---
-
-/// ORDER BY on a Utf8View column must sort rows lexicographically.
-#[test]
-fn utf8view_order_by_asc() {
-    let batch = make_utf8view_batch();
-    let mut t = SqlTransform::new("SELECT level_str FROM logs ORDER BY level_str ASC").unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    assert_eq!(result.num_rows(), 4);
-    let levels = collect_string_col(&result, "level_str");
-    // Sorted ascending: DEBUG, ERROR, ERROR, INFO
-    assert_eq!(levels, ["DEBUG", "ERROR", "ERROR", "INFO"]);
-}
-
 /// ORDER BY DESC on a Utf8View column.
 #[test]
 fn utf8view_order_by_desc() {
@@ -276,11 +288,8 @@ fn utf8view_order_by_desc() {
     let result = t.execute_blocking(batch).unwrap();
     assert_eq!(result.num_rows(), 4);
     let levels = collect_string_col(&result, "level_str");
-    // Sorted descending: INFO, ERROR, ERROR, DEBUG
     assert_eq!(levels, ["INFO", "ERROR", "ERROR", "DEBUG"]);
 }
-
-// --- JOIN ---
 
 /// CROSS JOIN between a Utf8View-column table and a static enrichment table.
 #[test]
@@ -349,21 +358,8 @@ fn utf8view_hash_join_on_string_key() {
 }
 
 // ===========================================================================
-// Section 2: Dictionary<Int32, Utf8> columns
+// Section 3: Dictionary<Int32, Utf8>-specific tests (WHERE IN)
 // ===========================================================================
-
-// --- WHERE ---
-
-/// WHERE clause on a Dictionary<Int32, Utf8> column.
-#[test]
-fn dict_utf8_where_equals() {
-    let batch = make_dict_utf8_batch();
-    let mut t = SqlTransform::new("SELECT * FROM logs WHERE level_str = 'ERROR'").unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    assert_eq!(result.num_rows(), 2, "expected 2 ERROR rows");
-    let levels = collect_string_col(&result, "level_str");
-    assert!(levels.iter().all(|v| v == "ERROR"));
-}
 
 /// WHERE … IN (…) on a Dictionary<Int32, Utf8> column.
 #[test]
@@ -377,87 +373,6 @@ fn dict_utf8_where_in() {
     let mut levels = collect_string_col(&result, "level_str");
     levels.sort();
     assert_eq!(levels, ["DEBUG", "INFO"]);
-}
-
-// --- GROUP BY ---
-
-/// GROUP BY on a Dictionary<Int32, Utf8> column.
-#[test]
-fn dict_utf8_group_by_count() {
-    let batch = make_dict_utf8_batch();
-    let mut t = SqlTransform::new(
-        "SELECT level_str, COUNT(*) AS cnt FROM logs GROUP BY level_str ORDER BY level_str",
-    )
-    .unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    assert_eq!(result.num_rows(), 3);
-    let levels = collect_string_col(&result, "level_str");
-    assert_eq!(levels, ["DEBUG", "ERROR", "INFO"]);
-    let counts = collect_i64_col(&result, "cnt");
-    assert_eq!(counts, [Some(1), Some(2), Some(1)]);
-}
-
-// --- ORDER BY ---
-
-/// ORDER BY ASC on a Dictionary<Int32, Utf8> column.
-#[test]
-fn dict_utf8_order_by_asc() {
-    let batch = make_dict_utf8_batch();
-    let mut t = SqlTransform::new("SELECT level_str FROM logs ORDER BY level_str ASC").unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    assert_eq!(result.num_rows(), 4);
-    let levels = collect_string_col(&result, "level_str");
-    assert_eq!(levels, ["DEBUG", "ERROR", "ERROR", "INFO"]);
-}
-
-// ===========================================================================
-// Section 3: Dictionary<Int32, Utf8View> columns
-// ===========================================================================
-
-// --- WHERE ---
-
-/// WHERE clause on a Dictionary<Int32, Utf8View> column.
-///
-/// This is the most demanding variant: dictionary indexing over a view-based
-/// string type.  DataFusion's type coercion must be able to handle this.
-#[test]
-fn dict_utf8view_where_equals() {
-    let batch = make_dict_utf8view_batch();
-    let mut t = SqlTransform::new("SELECT * FROM logs WHERE level_str = 'ERROR'").unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    assert_eq!(result.num_rows(), 2, "expected 2 ERROR rows");
-    let levels = collect_string_col(&result, "level_str");
-    assert!(levels.iter().all(|v| v == "ERROR"));
-}
-
-// --- GROUP BY ---
-
-/// GROUP BY on a Dictionary<Int32, Utf8View> column.
-///
-/// Arrow 58 / DataFusion 53 added support for dictionary packing with Utf8View
-/// values, so this query now succeeds where it previously returned an error.
-#[test]
-fn dict_utf8view_group_by_count() {
-    let batch = make_dict_utf8view_batch();
-    let mut t = SqlTransform::new(
-        "SELECT level_str, COUNT(*) AS cnt FROM logs GROUP BY level_str ORDER BY level_str",
-    )
-    .unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    assert_eq!(result.num_rows(), 3, "expected 3 distinct levels");
-}
-
-// --- ORDER BY ---
-
-/// ORDER BY ASC on a Dictionary<Int32, Utf8View> column.
-#[test]
-fn dict_utf8view_order_by_asc() {
-    let batch = make_dict_utf8view_batch();
-    let mut t = SqlTransform::new("SELECT level_str FROM logs ORDER BY level_str ASC").unwrap();
-    let result = t.execute_blocking(batch).unwrap();
-    assert_eq!(result.num_rows(), 4);
-    let levels = collect_string_col(&result, "level_str");
-    assert_eq!(levels, ["DEBUG", "ERROR", "ERROR", "INFO"]);
 }
 
 // ===========================================================================

--- a/crates/logfwd-transform/tests/it/udf_tests.rs
+++ b/crates/logfwd-transform/tests/it/udf_tests.rs
@@ -125,245 +125,95 @@ fn test_hash_udf_large_utf8_with_null() {
 }
 
 #[test]
-fn test_hash_udf_missing_args() {
-    let udf = HashUdf::new();
-    let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::UInt64, true));
-    let args = ScalarFunctionArgs {
-        args: vec![],
-        number_rows: 0,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly one argument")
-    );
-}
+fn udf_rejects_wrong_arity() {
+    let mock_geo: Arc<dyn GeoDatabase> = Arc::new(MockGeoDatabase);
 
-#[test]
-fn test_hash_udf_extra_args() {
-    let udf = HashUdf::new();
-    let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::UInt64, true));
-    let scalar = ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(
-        "val".to_string(),
-    )));
-    let args = ScalarFunctionArgs {
-        args: vec![scalar.clone(), scalar],
-        number_rows: 1,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly one argument")
-    );
-}
+    // (name, udf, expected_arity, error_substring)
+    let cases: Vec<(&str, Box<dyn ScalarUDFImpl>, usize, &str)> = vec![
+        (
+            "hash",
+            Box::new(HashUdf::new()),
+            1,
+            "expects exactly one argument",
+        ),
+        (
+            "json_extract",
+            Box::new(JsonExtractUdf::new(JsonExtractMode::Str)),
+            2,
+            "expects exactly two arguments",
+        ),
+        (
+            "geo_lookup",
+            Box::new(GeoLookupUdf::new(Arc::clone(&mock_geo))),
+            1,
+            "expects exactly one argument",
+        ),
+        (
+            "grok",
+            Box::new(GrokUdf::new()),
+            2,
+            "expects exactly two arguments",
+        ),
+        (
+            "regexp_extract",
+            Box::new(RegexpExtractUdf::new()),
+            3,
+            "expects exactly three arguments",
+        ),
+    ];
 
-#[test]
-fn test_json_extract_udf_missing_args() {
-    let udf = JsonExtractUdf::new(JsonExtractMode::Str);
-    let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::Utf8, true));
-    let args = ScalarFunctionArgs {
-        args: vec![ColumnarValue::Scalar(
-            datafusion::common::ScalarValue::Utf8(Some("val".to_string())),
-        )],
-        number_rows: 1,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
+    let scalar = || {
+        ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(
+            "val".to_string(),
+        )))
     };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly two arguments")
-    );
-}
 
-#[test]
-fn test_json_extract_udf_extra_args() {
-    let udf = JsonExtractUdf::new(JsonExtractMode::Str);
-    let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::Utf8, true));
-    let scalar = ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(
-        "val".to_string(),
-    )));
-    let args = ScalarFunctionArgs {
-        args: vec![scalar.clone(), scalar.clone(), scalar],
-        number_rows: 1,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly two arguments")
-    );
-}
+    for (name, udf, expected_arity, error_msg) in cases {
+        // Return field type doesn't matter for arity validation.
+        let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::Utf8, true));
 
-#[test]
-fn test_geo_lookup_udf_missing_args() {
-    let udf = GeoLookupUdf::new(Arc::new(MockGeoDatabase));
-    let return_field = Arc::new(arrow::datatypes::Field::new(
-        "r",
-        DataType::Struct(arrow::datatypes::Fields::empty()),
-        true,
-    ));
-    let args = ScalarFunctionArgs {
-        args: vec![],
-        number_rows: 0,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly one argument")
-    );
-}
+        // Too few args
+        let too_few = if expected_arity > 0 {
+            (0..expected_arity - 1)
+                .map(|_| scalar())
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        };
+        let args = ScalarFunctionArgs {
+            args: too_few,
+            number_rows: 0,
+            return_field: Arc::clone(&return_field),
+            arg_fields: vec![],
+            config_options: Arc::new(ConfigOptions::default()),
+        };
+        let result = udf.invoke_with_args(args);
+        assert!(
+            result.is_err(),
+            "{name}: should reject too few args (expected {expected_arity})"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains(error_msg),
+            "{name}: error must contain '{error_msg}'"
+        );
 
-#[test]
-fn test_geo_lookup_udf_extra_args() {
-    let udf = GeoLookupUdf::new(Arc::new(MockGeoDatabase));
-    let return_field = Arc::new(arrow::datatypes::Field::new(
-        "r",
-        DataType::Struct(arrow::datatypes::Fields::empty()),
-        true,
-    ));
-    let scalar = ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(
-        "1.2.3.4".to_string(),
-    )));
-    let args = ScalarFunctionArgs {
-        args: vec![scalar.clone(), scalar],
-        number_rows: 1,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly one argument")
-    );
-}
-
-#[test]
-fn test_grok_udf_missing_args() {
-    let udf = GrokUdf::new();
-    let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::Utf8, true));
-    let args = ScalarFunctionArgs {
-        args: vec![ColumnarValue::Scalar(
-            datafusion::common::ScalarValue::Utf8(Some("val".to_string())),
-        )],
-        number_rows: 1,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly two arguments")
-    );
-}
-
-#[test]
-fn test_grok_udf_extra_args() {
-    let udf = GrokUdf::new();
-    let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::Utf8, true));
-    let scalar = ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(
-        "val".to_string(),
-    )));
-    let args = ScalarFunctionArgs {
-        args: vec![scalar.clone(), scalar.clone(), scalar],
-        number_rows: 1,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly two arguments")
-    );
-}
-
-#[test]
-fn test_regexp_extract_udf_missing_args() {
-    let udf = RegexpExtractUdf::new();
-    let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::Utf8, true));
-    let args = ScalarFunctionArgs {
-        args: vec![
-            ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(
-                "val".to_string(),
-            ))),
-            ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(
-                "pattern".to_string(),
-            ))),
-        ],
-        number_rows: 1,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly three arguments")
-    );
-}
-
-#[test]
-fn test_regexp_extract_udf_extra_args() {
-    let udf = RegexpExtractUdf::new();
-    let return_field = Arc::new(arrow::datatypes::Field::new("r", DataType::Utf8, true));
-    let scalar = ColumnarValue::Scalar(datafusion::common::ScalarValue::Utf8(Some(
-        "val".to_string(),
-    )));
-    let args = ScalarFunctionArgs {
-        args: vec![scalar.clone(), scalar.clone(), scalar.clone(), scalar],
-        number_rows: 1,
-        return_field: Arc::clone(&return_field),
-        arg_fields: vec![],
-        config_options: Arc::new(ConfigOptions::default()),
-    };
-    let result = udf.invoke_with_args(args);
-    assert!(result.is_err());
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("expects exactly three arguments")
-    );
+        // Too many args
+        let too_many = (0..=expected_arity).map(|_| scalar()).collect::<Vec<_>>();
+        let args = ScalarFunctionArgs {
+            args: too_many,
+            number_rows: 1,
+            return_field: Arc::clone(&return_field),
+            arg_fields: vec![],
+            config_options: Arc::new(ConfigOptions::default()),
+        };
+        let result = udf.invoke_with_args(args);
+        assert!(
+            result.is_err(),
+            "{name}: should reject too many args (expected {expected_arity})"
+        );
+        assert!(
+            result.unwrap_err().to_string().contains(error_msg),
+            "{name}: error must contain '{error_msg}'"
+        );
+    }
 }

--- a/dev-docs/CHANGE_MAP.md
+++ b/dev-docs/CHANGE_MAP.md
@@ -73,7 +73,7 @@ Do not duplicate the same reference data in multiple pages.
 Link to canonical docs instead.
 
 For ingest-path docs, keep the architectural vocabulary stable by treating the
-[Ingest Glossary](ARCHITECTURE.md#ingest-glossary) as canonical. User-facing
+[Ingest Glossary](ARCHITECTURE.md#ingest-vocabulary) as canonical. User-facing
 config still uses `inputs` / `outputs`, and implementation-local names
 (`InputEvent`, `FramedInput`, worker module names) should not leak into
 architecture diagrams unless the code name itself is the point of the

--- a/dev-docs/CRATE_RULES.md
+++ b/dev-docs/CRATE_RULES.md
@@ -8,7 +8,7 @@ Rules and constraints for each crate. Enforced by CI, not just convention.
 |------|-------------|
 | `#![no_std]` + alloc | Compiler. CI: `cargo build --target thumbv6m-none-eabi` |
 | `#![forbid(unsafe_code)]` | Compiler. Cannot be overridden with `#[allow]`. |
-| Only deps: memchr + wide + logfwd-kani | CI dependency allowlist check |
+| Only deps: memchr + wide + logfwd-kani + logfwd-lint-attrs | CI dependency allowlist check |
 | No panics | `clippy::unwrap_used`, `clippy::panic`, `clippy::indexing_slicing` = deny |
 | Every public item documented | `#![warn(missing_docs)]` at crate root |
 | No stdout/stderr writes | `clippy::print_stdout`, `clippy::print_stderr` = warn workspace-wide; no `#![allow]` opt-out |

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -355,7 +355,7 @@ logfwd-core is the proven kernel. All rules are CI-enforced.
 |------|-------------|
 | `#![no_std]` + alloc | Compiler. CI: `cargo build --target thumbv6m-none-eabi` |
 | `#![forbid(unsafe_code)]` | Compiler. Cannot be overridden with `#[allow]`. |
-| Only deps: memchr + wide | CI dependency allowlist check |
+| Only deps: memchr + wide + logfwd-kani + logfwd-lint-attrs | CI dependency allowlist check |
 | No panics | `clippy::unwrap_used`, `clippy::panic`, `clippy::indexing_slicing` = deny |
 | Every public fn has a proof | Required policy + review checks + CI Kani job with per-module inventory below |
 | No IO, threads, async | Structural (no_std removes the APIs) |


### PR DESCRIPTION
## Summary

Codebase-wide cleanup: removes duplicate code, fixes stale docs, and reduces test boilerplate across 46 files in 12 crates.

**Net: –1,715 lines** (1,056 insertions, 2,771 deletions)

### Commit 1: Production code cleanup (–279 lines)
- Extracted `validate_server_tls()` helper (logfwd-config)
- Extracted `scatter_int64/float64/bool` helpers in finish_batch (logfwd-arrow, –150 lines)
- Shared bench generators across 4 bench modules (logfwd-bench)
- Extracted `persist_final_checkpoints()` + `spawn_enrichment_reload()` (logfwd-runtime)
- Delegated `for_simulation()` → `for_simulation_with_factory()`
- Removed dead `max_clients` check (logfwd-config)
- Fixed misplaced doc comment (logfwd-io)

### Commit 2: Stale docs and dead code (–5 lines)
- Removed dead `cfg(not(turmoil))` branch, unused `_num_rows` variable
- Gated kani-only `parse_4digits`/`parse_2digits` behind `#[cfg(kani)]`
- Fixed wrong filename comment, outdated CriReassembler doc, broken anchor
- Added 8 missing crates to DEVELOPING.md workspace layout
- Synced logfwd-core dep list across 5 docs

### Commits 3-5: Test boilerplate reduction (–1,431 lines)
- **logfwd-core**: `scan_default()`, table-driven escape/severity tests, `config_with_predicate()`, `process_chunk_collect()`
- **logfwd-arrow**: deleted subset test, generalized conflict_schema helper, merged 4 alloc_profile runners → 2
- **logfwd-io**: `test_header()` + `str_col()` helpers, removed tautological test
- **logfwd-output**: `test_loki_sink()` fixture replacing 11 constructions
- **logfwd-transform**: parameterized `scanner_datafusion_boundary` over string types, table-driven UDF arity/filter_hints/column-ref tests
- **logfwd-diagnostics**: deduplicated `esc`/`json_escape` + `now_nanos` (production code), unified `attrs_to_json` with generic key type

### Verification
- `just fmt` ✅
- `just clippy` ✅ (zero warnings)
- `just test` ✅ (1591 passed, 1 pre-existing failure on main)

Closes #N/A — proactive cleanup

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove 279 lines of duplicate code across 9 crates by extracting shared helpers
> - Moves duplicate JSON log generators (`generate_simple`, `generate_wide`, `generate_narrow`) into `logfwd-bench`'s [lib.rs](https://github.com/strawgate/fastforward/pull/2603/files#diff-83e5fafdaccbd4bca623ff15f68ea3eae69b4869dca5f1fadf3f9c20ac53fd8f) and removes local copies from `e2e_profile`, `explore`, `rss`, and `sizes` modules.
> - Extracts shared TLS validation into `validate_server_tls` in [validate.rs](https://github.com/strawgate/fastforward/pull/2603/files#diff-a5a27c0440adfaf67fed8d11a446cf0f9c18d7b78b2a2b58e6731fe96699cf68), replacing inlined logic for both TCP and OTLP inputs.
> - Introduces test helpers across multiple crates (`assert_config_err!`, `scan_default`, `process_chunk_collect`, `make_struct_batch`, `get_str_col`, etc.) to replace repeated inline setup patterns.
> - Consolidates `spawn_enrichment_reload` in [build.rs](https://github.com/strawgate/fastforward/pull/2603/files#diff-9066bdb853d1e2fff1f2d2ad02a5eb7c17a2b62826ba724bbb990487b851ae83) and `persist_final_checkpoints` in [run.rs](https://github.com/strawgate/fastforward/pull/2603/files#diff-a7e68976fe8fc62748304781b50e2c43bb33186112618c7217524fa598e5a9d2) to deduplicate periodic reload and checkpoint flush logic.
> - Risk: In debug builds, the new `scatter_int64/float64/bool` helpers in [finish.rs](https://github.com/strawgate/fastforward/pull/2603/files#diff-f65c8b1e3bcfd5239d678de222f37ef520e74a209707d5ca6f47aab9647c0181) add `debug_assert` bounds checks that will panic on out-of-bounds row indices, whereas previously they were silently skipped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 883ba72.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->