### PR TITLE
fix: migrate bench scenario configs to pipelines format

### DIFF
--- a/bench/scenarios/es-sender-streaming.yaml
+++ b/bench/scenarios/es-sender-streaming.yaml
@@ -1,9 +1,11 @@
-input:
-  type: generator
-output:
-  type: elasticsearch
-  endpoint: http://127.0.0.1:9200
-  index: ffwd-bench
-  request_mode: streaming
+pipelines:
+  default:
+    inputs:
+      - type: generator
+    outputs:
+      - type: elasticsearch
+        endpoint: http://127.0.0.1:9200
+        index: ffwd-bench
+        request_mode: streaming
 server:
   diagnostics: 127.0.0.1:9090

--- a/bench/scenarios/es-sender.yaml
+++ b/bench/scenarios/es-sender.yaml
@@ -1,8 +1,10 @@
-input:
-  type: generator
-output:
-  type: elasticsearch
-  endpoint: http://127.0.0.1:9200
-  index: ffwd-bench
+pipelines:
+  default:
+    inputs:
+      - type: generator
+    outputs:
+      - type: elasticsearch
+        endpoint: http://127.0.0.1:9200
+        index: ffwd-bench
 server:
   diagnostics: 127.0.0.1:9090


### PR DESCRIPTION
## Summary

Fixes the `all_yaml_examples_parse_and_validate_read_only` test failure on main after the #2606 crate rename merge.

Two bench scenario YAML files (`es-sender.yaml`, `es-sender-streaming.yaml`) still used the old flat `input`/`output` format that was removed in the config validation split (#2592). Migrates them to the `pipelines` format.

## What changed
- `bench/scenarios/es-sender.yaml` — flat → pipelines format
- `bench/scenarios/es-sender-streaming.yaml` — flat → pipelines format

## Test plan
- `cargo test -p ffwd -- all_yaml_examples_parse_and_validate_read_only` passes

Closes the Test (Linux) CI failure on main.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate bench scenario configs to pipelines format
> Updates [es-sender.yaml](https://github.com/strawgate/fastforward/pull/2613/files#diff-4f87ff1737107c96f7eb8dbc16eabdf608fbf16f76bd11f0418e1c254a8d5f00) and [es-sender-streaming.yaml](https://github.com/strawgate/fastforward/pull/2613/files#diff-dd0f8cd34ff66bedd6fc88d93765b374c34774d06eaf00766ff5162076174470) to use the `pipelines.default` block format. The previous top-level `input` and `output` keys are replaced with `pipelines.default.inputs` and `pipelines.default.outputs`, retaining the same endpoint, index, and `request_mode` settings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6ccfd34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->