### PR TITLE
refactor: rename LOGFWD_* env vars to FFWD_* (#2206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
   CARGO_BUILD_JOBS: "4"
   NEXTEST_TEST_THREADS: "4"
   RUST_TEST_THREADS: "4"
-  LOGFWD_DISABLE_DEFAULT_CHECKPOINTS: "1"
+  FFWD_DISABLE_DEFAULT_CHECKPOINTS: "1"
   TOKIO_WORKER_THREADS: "4"
   RAYON_NUM_THREADS: "4"
   # Disable sccache in CI — config.toml enables it for local dev builds.

--- a/book/src/content/docs/cli/reference.mdx
+++ b/book/src/content/docs/cli/reference.mdx
@@ -15,7 +15,7 @@ ff run --config pipeline.yaml
 
 The `--config` flag is optional. FastForward will automatically discover configuration files in this order:
 1. `--config <path>`
-2. `$LOGFWD_CONFIG`
+2. `$FFWD_CONFIG`
 3. `./ffwd.yaml`
 4. `~/.config/ffwd/config.yaml`
 5. `/etc/ffwd/config.yaml`

--- a/book/src/content/docs/configuration/inputs.md
+++ b/book/src/content/docs/configuration/inputs.md
@@ -41,7 +41,7 @@ input:
 
 ```bash
 cat app.log | ff send --config destination.yaml --format json
-kubectl logs pod/app | LOGFWD_CONFIG=destination.yaml ff send --format cri
+kubectl logs pod/app | FFWD_CONFIG=destination.yaml ff send --format cri
 ```
 
 Use `file` input for daemon-style tailing. `stdin` is finite command input; it does not watch paths or discover rotated files.

--- a/book/src/content/docs/configuration/reference.mdx
+++ b/book/src/content/docs/configuration/reference.mdx
@@ -733,7 +733,7 @@ enrichment:
     path: /etc/os-release
   - type: env_vars
     table_name: deploy_meta
-    prefix: LOGFWD_META_
+    prefix: FFWD_META_
   - type: csv
     table_name: assets
     path: /etc/ffwd/assets.csv
@@ -910,10 +910,10 @@ The prefix is stripped and the remainder lower-cased to form column names.
 enrichment:
   - type: env_vars
     table_name: deploy_meta
-    prefix: LOGFWD_META_
+    prefix: FFWD_META_
 ```
 
-With `LOGFWD_META_CLUSTER=prod` and `LOGFWD_META_REGION=us-east-1` set, the table
+With `FFWD_META_CLUSTER=prod` and `FFWD_META_REGION=us-east-1` set, the table
 exposes `cluster` and `region` columns.
 
 ```sql
@@ -1056,7 +1056,7 @@ When `server.diagnostics` is configured, FastForward exposes an HTTP API for mon
 | `/ready` | GET | Readiness probe. Returns 200 OK when required components are initialized and in a ready health state; returns 503 while components are still starting, stopping, stopped, failed, or otherwise not ready. |
 | `/admin/v1/status` | GET | Canonical rich status payload with live/ready state, component health, and per-pipeline counters. |
 | `/admin/v1/stats` | GET | Aggregate process stats (uptime, RSS, CPU, aggregate line counts). |
-| `/admin/v1/config` | GET | Currently loaded YAML configuration and its file path (disabled by default; enable with `LOGFWD_UNSAFE_EXPOSE_CONFIG=1`). May expose sensitive values; do not enable in shared or production environments unless strictly required. |
+| `/admin/v1/config` | GET | Currently loaded YAML configuration and its file path (disabled by default; enable with `FFWD_UNSAFE_EXPOSE_CONFIG=1`). May expose sensitive values; do not enable in shared or production environments unless strictly required. |
 | `/admin/v1/logs` | GET | Recent log lines from FastForward's own stderr (ring buffer). |
 | `/admin/v1/history` | GET | Time-series data (1-hour window) for dashboard charts. |
 | `/admin/v1/traces` | GET | Recent batch processing spans for detailed latency analysis. |
@@ -1113,7 +1113,7 @@ values directly from the environment without treating the env value as YAML:
 ```yaml
 pipelines:
   app:
-    workers: ${LOGFWD_WORKERS}
+    workers: ${FFWD_WORKERS}
 ```
 
 String fields remain strings even when the expanded value looks like a YAML

--- a/book/src/content/docs/deployment/monitoring.md
+++ b/book/src/content/docs/deployment/monitoring.md
@@ -44,7 +44,7 @@ curl -X PUT http://localhost:9090/admin/v1/log_level -H 'Content-Type: applicati
 | `GET /ready` | Readiness probe (200 once initialized) |
 | `GET /admin/v1/status` | Canonical rich status JSON (live, ready, component health, per-pipeline detail) |
 | `GET /admin/v1/stats` | Flattened JSON for polling/benchmarks |
-| `GET /admin/v1/config` | View active YAML configuration (disabled by default; enable with `LOGFWD_UNSAFE_EXPOSE_CONFIG=1`) |
+| `GET /admin/v1/config` | View active YAML configuration (disabled by default; enable with `FFWD_UNSAFE_EXPOSE_CONFIG=1`) |
 | `GET /admin/v1/logs` | View recent log lines from stderr |
 | `GET /admin/v1/history` | Time-series data for dashboard charts |
 | `GET /admin/v1/traces` | Detailed latency spans for recent batches |

--- a/book/src/content/docs/quick-start.mdx
+++ b/book/src/content/docs/quick-start.mdx
@@ -118,10 +118,10 @@ cat logs.json | ff send --config destination.yaml --format json --service checko
 ```
 
 Bare `ff` also enters send mode when stdin is piped, using the normal config
-search order. Set `LOGFWD_CONFIG` when you want an explicit destination config:
+search order. Set `FFWD_CONFIG` when you want an explicit destination config:
 
 ```bash
-cat logs.json | LOGFWD_CONFIG=destination.yaml ff --format json --service checkout
+cat logs.json | FFWD_CONFIG=destination.yaml ff --format json --service checkout
 ```
 
 ---

--- a/crates/ffwd-bench/src/bin/http_receiver_apples.rs
+++ b/crates/ffwd-bench/src/bin/http_receiver_apples.rs
@@ -13,8 +13,8 @@
 //!   cargo run --release --bin http_receiver_apples -p ffwd-bench
 //!
 //! Optional env vars:
-//!   LOGFWD_HTTP_BENCH_DURATION_SECS=6
-//!   LOGFWD_HTTP_BENCH_CONCURRENCY=8,32
+//!   FFWD_HTTP_BENCH_DURATION_SECS=6
+//!   FFWD_HTTP_BENCH_CONCURRENCY=8,32
 use std::convert::Infallible;
 use std::io::Read as _;
 use std::net::SocketAddr;
@@ -830,7 +830,7 @@ fn pseudo_hex(seed: u64, digits: usize) -> String {
 }
 
 fn read_duration_secs() -> u64 {
-    std::env::var("LOGFWD_HTTP_BENCH_DURATION_SECS")
+    std::env::var("FFWD_HTTP_BENCH_DURATION_SECS")
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .filter(|v| *v > 0)
@@ -838,7 +838,7 @@ fn read_duration_secs() -> u64 {
 }
 
 fn read_concurrency_list() -> Vec<usize> {
-    let raw = std::env::var("LOGFWD_HTTP_BENCH_CONCURRENCY").unwrap_or_else(|_| "8,32".to_string());
+    let raw = std::env::var("FFWD_HTTP_BENCH_CONCURRENCY").unwrap_or_else(|_| "8,32".to_string());
     let mut out = Vec::new();
     for part in raw.split(',') {
         if let Ok(v) = part.trim().parse::<usize>()

--- a/crates/ffwd-config/src/env.rs
+++ b/crates/ffwd-config/src/env.rs
@@ -174,10 +174,9 @@ mod tests {
     #[test]
     fn braced_env_var_expands() {
         let _guard = env_lock();
-        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_BRACED", "expanded");
+        let _var = EnvVarGuard::set("FFWD_ENV_TEST_BRACED", "expanded");
 
-        let expanded =
-            expand_env_vars("value=${LOGFWD_ENV_TEST_BRACED}").expect("env should expand");
+        let expanded = expand_env_vars("value=${FFWD_ENV_TEST_BRACED}").expect("env should expand");
 
         assert_eq!(expanded, "value=expanded");
     }
@@ -185,13 +184,12 @@ mod tests {
     #[test]
     fn missing_env_var_is_rejected() {
         let _guard = env_lock();
-        let _var = EnvVarGuard::unset("LOGFWD_ENV_TEST_MISSING");
+        let _var = EnvVarGuard::unset("FFWD_ENV_TEST_MISSING");
 
-        let err =
-            expand_env_vars("${LOGFWD_ENV_TEST_MISSING}").expect_err("missing env should fail");
+        let err = expand_env_vars("${FFWD_ENV_TEST_MISSING}").expect_err("missing env should fail");
 
         assert!(
-            err.to_string().contains("LOGFWD_ENV_TEST_MISSING"),
+            err.to_string().contains("FFWD_ENV_TEST_MISSING"),
             "error should name missing variable: {err}"
         );
     }
@@ -199,38 +197,38 @@ mod tests {
     #[test]
     fn unterminated_env_var_is_preserved() {
         let _guard = env_lock();
-        let expanded = expand_env_vars("value=${LOGFWD_ENV_TEST_UNTERMINATED")
+        let expanded = expand_env_vars("value=${FFWD_ENV_TEST_UNTERMINATED")
             .expect("unterminated variable should be preserved");
 
-        assert_eq!(expanded, "value=${LOGFWD_ENV_TEST_UNTERMINATED");
+        assert_eq!(expanded, "value=${FFWD_ENV_TEST_UNTERMINATED");
     }
 
     #[test]
     fn closed_vars_before_unterminated_tail_are_expanded() {
         let _guard = env_lock();
-        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_BRACED", "expanded");
+        let _var = EnvVarGuard::set("FFWD_ENV_TEST_BRACED", "expanded");
 
-        let expanded = expand_env_vars("${LOGFWD_ENV_TEST_BRACED}${LOGFWD_ENV_TEST_UNTERMINATED")
+        let expanded = expand_env_vars("${FFWD_ENV_TEST_BRACED}${FFWD_ENV_TEST_UNTERMINATED")
             .expect("closed variables before an unterminated tail should expand");
 
-        assert_eq!(expanded, "expanded${LOGFWD_ENV_TEST_UNTERMINATED",);
+        assert_eq!(expanded, "expanded${FFWD_ENV_TEST_UNTERMINATED",);
     }
 
     #[test]
     fn dollar_name_syntax_is_literal() {
         let _guard = env_lock();
-        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_SHORT", "expanded");
+        let _var = EnvVarGuard::set("FFWD_ENV_TEST_SHORT", "expanded");
 
         let expanded =
-            expand_env_vars("value=$LOGFWD_ENV_TEST_SHORT").expect("env should not expand");
+            expand_env_vars("value=$FFWD_ENV_TEST_SHORT").expect("env should not expand");
 
-        assert_eq!(expanded, "value=$LOGFWD_ENV_TEST_SHORT");
+        assert_eq!(expanded, "value=$FFWD_ENV_TEST_SHORT");
     }
 
     #[test]
     fn default_value_syntax_is_rejected() {
         let _guard = env_lock();
-        let err = expand_env_vars("value=${LOGFWD_ENV_TEST_DEFAULT:fallback}")
+        let err = expand_env_vars("value=${FFWD_ENV_TEST_DEFAULT:fallback}")
             .expect_err("default syntax should be rejected");
 
         assert!(
@@ -253,9 +251,9 @@ mod tests {
     #[test]
     fn backslashes_with_env_placeholder_are_literal() {
         let _guard = env_lock();
-        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_FILE", "app.log");
+        let _var = EnvVarGuard::set("FFWD_ENV_TEST_FILE", "app.log");
 
-        let expanded = expand_env_vars(r"C:\logs\${LOGFWD_ENV_TEST_FILE}")
+        let expanded = expand_env_vars(r"C:\logs\${FFWD_ENV_TEST_FILE}")
             .expect("backslashes should remain literal");
 
         assert_eq!(expanded, r"C:\logs\app.log");
@@ -264,9 +262,9 @@ mod tests {
     #[test]
     fn env_value_containing_placeholder_text_is_not_recursively_expanded() {
         let _guard = env_lock();
-        let _var = EnvVarGuard::set("LOGFWD_ENV_TEST_LITERAL", "${NOT_RECURSIVE}");
+        let _var = EnvVarGuard::set("FFWD_ENV_TEST_LITERAL", "${NOT_RECURSIVE}");
 
-        let expanded = expand_env_vars("${LOGFWD_ENV_TEST_LITERAL}")
+        let expanded = expand_env_vars("${FFWD_ENV_TEST_LITERAL}")
             .expect("env value should be inserted literally");
 
         assert_eq!(expanded, "${NOT_RECURSIVE}");

--- a/crates/ffwd-config/src/tests_config_parsing.rs
+++ b/crates/ffwd-config/src/tests_config_parsing.rs
@@ -163,18 +163,18 @@ server:
     fn env_var_substitution() {
         // SAFETY: this test is not run concurrently with other tests that
         // depend on the same environment variable.
-        unsafe { std::env::set_var("LOGFWD_TEST_ENDPOINT", "http://my-collector:4317") };
+        unsafe { std::env::set_var("FFWD_TEST_ENDPOINT", "http://my-collector:4317") };
         let yaml = single_pipeline_yaml(
             "type: file\npath: /var/log/test.log",
             None,
-            "type: otlp\nendpoint: ${LOGFWD_TEST_ENDPOINT}",
+            "type: otlp\nendpoint: ${FFWD_TEST_ENDPOINT}",
         );
         let cfg = Config::load_str(yaml).expect("env var substitution");
         let pipe = &cfg.pipelines["default"];
         assert_eq!(pipe.outputs[0].endpoint(), Some("http://my-collector:4317"));
         // SAFETY: this test is not run concurrently with other tests that
         // depend on the same environment variable.
-        unsafe { std::env::remove_var("LOGFWD_TEST_ENDPOINT") };
+        unsafe { std::env::remove_var("FFWD_TEST_ENDPOINT") };
     }
 
     #[test]
@@ -207,16 +207,16 @@ input:
   path: /var/log/test.log
 output:
   type: otlp
-  endpoint: ${LOGFWD_NONEXISTENT_VAR_12345}
+  endpoint: ${FFWD_NONEXISTENT_VAR_12345}
 ";
-        assert_config_err!(yaml, "LOGFWD_NONEXISTENT_VAR_12345", "not set");
+        assert_config_err!(yaml, "FFWD_NONEXISTENT_VAR_12345", "not set");
     }
 
     #[test]
     fn unterminated_env_var_preserved_as_is() {
         assert_eq!(
-            expand_env_vars("endpoint: ${LOGFWD_TEST_UNTERMINATED").unwrap(),
-            "endpoint: ${LOGFWD_TEST_UNTERMINATED"
+            expand_env_vars("endpoint: ${FFWD_TEST_UNTERMINATED").unwrap(),
+            "endpoint: ${FFWD_TEST_UNTERMINATED"
         );
     }
 

--- a/crates/ffwd-config/src/tests_output.rs
+++ b/crates/ffwd-config/src/tests_output.rs
@@ -222,10 +222,10 @@ mod tests {
     #[test]
     fn auth_env_var_bearer_token() {
         // SAFETY: test is not run concurrently with other tests that modify this var.
-        unsafe { std::env::set_var("LOGFWD_TEST_TOKEN", "env-bearer-token") };
+        unsafe { std::env::set_var("FFWD_TEST_TOKEN", "env-bearer-token") };
         let yaml = single_pipeline_yaml(
             "type: file\npath: /var/log/test.log",
-            "type: otlp\nendpoint: http://localhost:4318/v1/logs\nauth:\n  bearer_token: \"${LOGFWD_TEST_TOKEN}\"",
+            "type: otlp\nendpoint: http://localhost:4318/v1/logs\nauth:\n  bearer_token: \"${FFWD_TEST_TOKEN}\"",
         );
         let cfg = Config::load_str(yaml).expect("auth env var bearer");
         let pipe = &cfg.pipelines["default"];
@@ -233,7 +233,7 @@ mod tests {
         assert_eq!(auth.bearer_token.as_deref(), Some("env-bearer-token"));
         // SAFETY: this test is not run concurrently with other tests that
         // depend on the same environment variable.
-        unsafe { std::env::remove_var("LOGFWD_TEST_TOKEN") };
+        unsafe { std::env::remove_var("FFWD_TEST_TOKEN") };
     }
 
     #[test]

--- a/crates/ffwd-config/src/tests_server.rs
+++ b/crates/ffwd-config/src/tests_server.rs
@@ -50,9 +50,9 @@ input:
 output:
   type: stdout
 server:
-  diagnostics: ${LOGFWD_DIAG_ADDR}
+  diagnostics: ${FFWD_DIAG_ADDR}
 ";
-        assert_config_err!(yaml, "LOGFWD_DIAG_ADDR");
+        assert_config_err!(yaml, "FFWD_DIAG_ADDR");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/ffwd-config/src/tests_validation.rs
+++ b/crates/ffwd-config/src/tests_validation.rs
@@ -201,9 +201,9 @@ input:
   path: /var/log/test.log
 output:
   type: otlp
-  endpoint: ${LOGFWD_NONEXISTENT_ENDPOINT_VAR}
+  endpoint: ${FFWD_NONEXISTENT_ENDPOINT_VAR}
 ";
-        assert_config_err!(yaml, "LOGFWD_NONEXISTENT_ENDPOINT_VAR");
+        assert_config_err!(yaml, "FFWD_NONEXISTENT_ENDPOINT_VAR");
     }
 
     #[test]

--- a/crates/ffwd-config/src/types/enrichment.rs
+++ b/crates/ffwd-config/src/types/enrichment.rs
@@ -129,7 +129,7 @@ pub struct JsonlEnrichmentConfig {
 pub struct EnvVarsEnrichmentConfig {
     #[serde(deserialize_with = "deserialize_strict_string")]
     pub table_name: String,
-    /// Environment variable name prefix to filter on (e.g. `"LOGFWD_META_"`).
+    /// Environment variable name prefix to filter on (e.g. `"FFWD_META_"`).
     #[serde(deserialize_with = "deserialize_strict_string")]
     pub prefix: String,
 }

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -312,11 +312,11 @@ fn generator_attribute_scalar_types_are_preserved() {
 #[test]
 fn env_generator_attribute_values_remain_strings() {
     let _env_lock = env_lock();
-    let _count = EnvVarGuard::set("LOGFWD_ISSUE_1855_GENERATOR_COUNT", "7");
-    let _enabled = EnvVarGuard::set("LOGFWD_ISSUE_1855_GENERATOR_ENABLED", "true");
+    let _count = EnvVarGuard::set("FFWD_ISSUE_1855_GENERATOR_COUNT", "7");
+    let _enabled = EnvVarGuard::set("FFWD_ISSUE_1855_GENERATOR_ENABLED", "true");
 
     let yaml = single_pipeline_yaml(
-        "type: generator\ngenerator:\n  profile: record\n  attributes:\n    count: ${LOGFWD_ISSUE_1855_GENERATOR_COUNT}\n    enabled: ${LOGFWD_ISSUE_1855_GENERATOR_ENABLED}",
+        "type: generator\ngenerator:\n  profile: record\n  attributes:\n    count: ${FFWD_ISSUE_1855_GENERATOR_COUNT}\n    enabled: ${FFWD_ISSUE_1855_GENERATOR_ENABLED}",
         "type: stdout",
     );
 
@@ -345,9 +345,9 @@ fn env_generator_attribute_values_remain_strings() {
 #[test]
 fn env_expansion_preserves_yaml_hash_content() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855", "/var/log/my app #1.log");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855", "/var/log/my app #1.log");
 
-    let yaml = single_pipeline_yaml("type: file\npath: ${LOGFWD_ISSUE_1855}", "type: stdout");
+    let yaml = single_pipeline_yaml("type: file\npath: ${FFWD_ISSUE_1855}", "type: stdout");
 
     let config = Config::load_str(yaml).expect("config should parse after env expansion");
     let input = &config.pipelines["default"].inputs[0];
@@ -362,10 +362,10 @@ fn env_expansion_preserves_yaml_hash_content() {
 #[test]
 fn effective_yaml_preserves_yaml_hash_content() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_EFFECTIVE", "/var/log/my app #1.log");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_EFFECTIVE", "/var/log/my app #1.log");
 
     let yaml = single_pipeline_yaml(
-        "type: file\npath: ${LOGFWD_ISSUE_1855_EFFECTIVE}",
+        "type: file\npath: ${FFWD_ISSUE_1855_EFFECTIVE}",
         "type: stdout",
     );
 
@@ -389,12 +389,12 @@ fn effective_yaml_preserves_yaml_hash_content() {
 #[test]
 fn env_numeric_string_is_parsed_by_typed_schema() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_WORKERS", "4");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_WORKERS", "4");
 
     let yaml = r"
 pipelines:
   test:
-    workers: ${LOGFWD_ISSUE_1855_WORKERS}
+    workers: ${FFWD_ISSUE_1855_WORKERS}
     inputs:
       - type: generator
     outputs:
@@ -417,10 +417,10 @@ pipelines:
 #[test]
 fn env_bool_string_is_parsed_by_typed_schema() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_STRICT_PATH", "false");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_STRICT_PATH", "false");
 
     let yaml = single_pipeline_yaml(
-        "type: http\nlisten: 127.0.0.1:8080\nhttp:\n  strict_path: ${LOGFWD_ISSUE_1855_STRICT_PATH}",
+        "type: http\nlisten: 127.0.0.1:8080\nhttp:\n  strict_path: ${FFWD_ISSUE_1855_STRICT_PATH}",
         "type: stdout",
     );
 
@@ -439,11 +439,11 @@ fn env_bool_string_is_parsed_by_typed_schema() {
 #[test]
 fn env_bool_string_is_parsed_by_shared_tls_schema() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_TLS_SKIP_VERIFY", "true");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_TLS_SKIP_VERIFY", "true");
 
     let yaml = single_pipeline_yaml(
         "type: generator",
-        "type: otlp\nendpoint: http://127.0.0.1:4318\ntls:\n  insecure_skip_verify: ${LOGFWD_ISSUE_1855_TLS_SKIP_VERIFY}",
+        "type: otlp\nendpoint: http://127.0.0.1:4318\ntls:\n  insecure_skip_verify: ${FFWD_ISSUE_1855_TLS_SKIP_VERIFY}",
     );
 
     let config = Config::load_str(yaml).expect("config should parse env-backed TLS bool");
@@ -458,10 +458,10 @@ fn env_bool_string_is_parsed_by_shared_tls_schema() {
 #[test]
 fn quoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_QUOTED_PATH", "1234");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_QUOTED_PATH", "1234");
 
     let yaml = single_pipeline_yaml(
-        "type: file\npath: \"${LOGFWD_ISSUE_1855_QUOTED_PATH}\"",
+        "type: file\npath: \"${FFWD_ISSUE_1855_QUOTED_PATH}\"",
         "type: stdout",
     );
 
@@ -478,10 +478,10 @@ fn quoted_env_expansion_preserves_string_scalars() {
 #[test]
 fn tagged_quoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_TAGGED_PATH", "true");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_TAGGED_PATH", "true");
 
     let yaml = single_pipeline_yaml(
-        "type: file\npath: !!str \"${LOGFWD_ISSUE_1855_TAGGED_PATH}\"",
+        "type: file\npath: !!str \"${FFWD_ISSUE_1855_TAGGED_PATH}\"",
         "type: stdout",
     );
 
@@ -498,12 +498,12 @@ fn tagged_quoted_env_expansion_preserves_string_scalars() {
 #[test]
 fn tagged_unquoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_TAGGED_UNQUOTED", "123");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_TAGGED_UNQUOTED", "123");
 
     // Env substitution already produces string data; the explicit string tag
     // should preserve that behavior.
     let yaml = single_pipeline_yaml(
-        "type: file\npath: !str ${LOGFWD_ISSUE_1855_TAGGED_UNQUOTED}",
+        "type: file\npath: !str ${FFWD_ISSUE_1855_TAGGED_UNQUOTED}",
         "type: stdout",
     );
 
@@ -575,10 +575,10 @@ fn custom_yaml_tag_for_mapping_key_is_rejected() {
 #[test]
 fn anchored_quoted_env_expansion_preserves_string_scalars() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_ANCHORED_PATH", "true");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_ANCHORED_PATH", "true");
 
     let yaml = single_pipeline_yaml(
-        "type: file\npath: &path \"${LOGFWD_ISSUE_1855_ANCHORED_PATH}\"",
+        "type: file\npath: &path \"${FFWD_ISSUE_1855_ANCHORED_PATH}\"",
         "type: stdout",
     );
 
@@ -595,14 +595,14 @@ fn anchored_quoted_env_expansion_preserves_string_scalars() {
 #[test]
 fn mixed_env_uses_schema_for_types_and_strings_for_string_fields() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_MIXED", "4");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_MIXED", "4");
 
     let yaml = r#"
 pipelines:
   test:
-    workers: ${LOGFWD_ISSUE_1855_MIXED}
+    workers: ${FFWD_ISSUE_1855_MIXED}
     resource_attrs:
-      note: "${LOGFWD_ISSUE_1855_MIXED}"
+      note: "${FFWD_ISSUE_1855_MIXED}"
     inputs:
       - type: generator
     outputs:
@@ -635,14 +635,14 @@ fn plain_scalar_apostrophe_is_not_treated_as_quote_boundary() {
 #[test]
 fn block_scalar_mixed_indentation_expands() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_BLOCK_FIELD", "message");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_BLOCK_FIELD", "message");
 
     let yaml = r#"
 pipelines:
   test:
     transform: |
       {
-        "${LOGFWD_ISSUE_1855_BLOCK_FIELD}"
+        "${FFWD_ISSUE_1855_BLOCK_FIELD}"
       }
     inputs:
       - type: generator
@@ -686,15 +686,15 @@ pipelines:
 #[test]
 fn env_expanded_mapping_key_collision_is_rejected() {
     let _env_lock = env_lock();
-    let _env_a = EnvVarGuard::set("LOGFWD_ISSUE_1855_KEY_A", "prod");
-    let _env_b = EnvVarGuard::set("LOGFWD_ISSUE_1855_KEY_B", "prod");
+    let _env_a = EnvVarGuard::set("FFWD_ISSUE_1855_KEY_A", "prod");
+    let _env_b = EnvVarGuard::set("FFWD_ISSUE_1855_KEY_B", "prod");
 
     let yaml = r"
 pipelines:
   test:
     resource_attrs:
-      ${LOGFWD_ISSUE_1855_KEY_A}: one
-      ${LOGFWD_ISSUE_1855_KEY_B}: two
+      ${FFWD_ISSUE_1855_KEY_A}: one
+      ${FFWD_ISSUE_1855_KEY_B}: two
     inputs:
       - type: generator
     outputs:
@@ -712,11 +712,11 @@ pipelines:
 #[test]
 fn env_expansion_applies_to_mapping_keys() {
     let _env_lock = env_lock();
-    let _env = EnvVarGuard::set("LOGFWD_ISSUE_1855_PIPELINE", "from-env");
+    let _env = EnvVarGuard::set("FFWD_ISSUE_1855_PIPELINE", "from-env");
 
     let yaml = r"
 pipelines:
-  ${LOGFWD_ISSUE_1855_PIPELINE}:
+  ${FFWD_ISSUE_1855_PIPELINE}:
     inputs:
       - type: generator
     outputs:

--- a/crates/ffwd-diagnostics/src/diagnostics/server.rs
+++ b/crates/ffwd-diagnostics/src/diagnostics/server.rs
@@ -1015,7 +1015,7 @@ async fn serve_stats(State(state): State<Arc<DiagnosticsState>>) -> impl IntoRes
 
 async fn serve_config(State(state): State<Arc<DiagnosticsState>>) -> impl IntoResponse {
     if !state.config_endpoint_enabled {
-        let body = r#"{"error":"config_endpoint_disabled","message":"set LOGFWD_UNSAFE_EXPOSE_CONFIG=1 to enable /admin/v1/config"}"#;
+        let body = r#"{"error":"config_endpoint_disabled","message":"set FFWD_UNSAFE_EXPOSE_CONFIG=1 to enable /admin/v1/config"}"#;
         return (
             StatusCode::FORBIDDEN,
             [("content-type", "application/json")],

--- a/crates/ffwd-io/src/checkpoint.rs
+++ b/crates/ffwd-io/src/checkpoint.rs
@@ -159,7 +159,10 @@ pub fn default_data_dir() -> PathBuf {
         return PathBuf::from(dir);
     }
     if let Ok(dir) = std::env::var("LOGFWD_DATA_DIR") {
-        eprintln!("[ffwd] LOGFWD_DATA_DIR is deprecated; use FFWD_DATA_DIR instead");
+        #[allow(clippy::print_stderr)]
+        {
+            eprintln!("[ffwd] LOGFWD_DATA_DIR is deprecated; use FFWD_DATA_DIR instead");
+        }
         return PathBuf::from(dir);
     }
 

--- a/crates/ffwd-io/src/checkpoint.rs
+++ b/crates/ffwd-io/src/checkpoint.rs
@@ -159,6 +159,7 @@ pub fn default_data_dir() -> PathBuf {
         return PathBuf::from(dir);
     }
     if let Ok(dir) = std::env::var("LOGFWD_DATA_DIR") {
+        eprintln!("[ffwd] LOGFWD_DATA_DIR is deprecated; use FFWD_DATA_DIR instead");
         return PathBuf::from(dir);
     }
 

--- a/crates/ffwd-io/src/checkpoint.rs
+++ b/crates/ffwd-io/src/checkpoint.rs
@@ -154,7 +154,7 @@ impl CheckpointStore for FileCheckpointStore {
 ///   if `$HOME` is not set).
 pub fn default_data_dir() -> PathBuf {
     // Check for an explicit override via environment variable first.
-    if let Ok(dir) = std::env::var("LOGFWD_DATA_DIR") {
+    if let Ok(dir) = std::env::var("FFWD_DATA_DIR") {
         return PathBuf::from(dir);
     }
 

--- a/crates/ffwd-io/src/checkpoint.rs
+++ b/crates/ffwd-io/src/checkpoint.rs
@@ -154,7 +154,11 @@ impl CheckpointStore for FileCheckpointStore {
 ///   if `$HOME` is not set).
 pub fn default_data_dir() -> PathBuf {
     // Check for an explicit override via environment variable first.
+    // New name takes precedence; legacy name is a deprecated fallback.
     if let Ok(dir) = std::env::var("FFWD_DATA_DIR") {
+        return PathBuf::from(dir);
+    }
+    if let Ok(dir) = std::env::var("LOGFWD_DATA_DIR") {
         return PathBuf::from(dir);
     }
 

--- a/crates/ffwd-io/tests/it/checkpoint_state_machine.rs
+++ b/crates/ffwd-io/tests/it/checkpoint_state_machine.rs
@@ -433,7 +433,7 @@ fn build_checkpoint_state_machine_proptest_config() -> ProptestConfig {
         max_shrink_iters: 5_000,
         ..ProptestConfig::default()
     };
-    if cfg!(miri) || std::env::var_os("LOGFWD_DISABLE_PROPTEST_PERSISTENCE").is_some() {
+    if cfg!(miri) || std::env::var_os("FFWD_DISABLE_PROPTEST_PERSISTENCE").is_some() {
         config.failure_persistence = None;
     }
     config

--- a/crates/ffwd-io/tests/it/framed_buffered_equivalence.rs
+++ b/crates/ffwd-io/tests/it/framed_buffered_equivalence.rs
@@ -307,7 +307,7 @@ fn build_equivalence_proptest_config() -> ProptestConfig {
         max_shrink_iters: 5_000,
         ..ProptestConfig::default()
     };
-    if cfg!(miri) || std::env::var_os("LOGFWD_DISABLE_PROPTEST_PERSISTENCE").is_some() {
+    if cfg!(miri) || std::env::var_os("FFWD_DISABLE_PROPTEST_PERSISTENCE").is_some() {
         config.failure_persistence = None;
     }
     config

--- a/crates/ffwd-io/tests/it/framed_state_machine.rs
+++ b/crates/ffwd-io/tests/it/framed_state_machine.rs
@@ -463,7 +463,7 @@ fn build_framed_proptest_config() -> ProptestConfig {
         max_shrink_iters: 5_000,
         ..ProptestConfig::default()
     };
-    if cfg!(miri) || std::env::var_os("LOGFWD_DISABLE_PROPTEST_PERSISTENCE").is_some() {
+    if cfg!(miri) || std::env::var_os("FFWD_DISABLE_PROPTEST_PERSISTENCE").is_some() {
         config.failure_persistence = None;
     }
     config

--- a/crates/ffwd-runtime/src/bootstrap.rs
+++ b/crates/ffwd-runtime/src/bootstrap.rs
@@ -183,6 +183,7 @@ pub async fn run_pipelines(
     let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
     let env_filter = tracing_subscriber::EnvFilter::try_from_env("FFWD_LOG")
+        .or_else(|_| tracing_subscriber::EnvFilter::try_from_env("LOGFWD_LOG"))
         .or_else(|_| tracing_subscriber::EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     let fmt_layer = if options.json_logs_for_stderr {

--- a/crates/ffwd-runtime/src/bootstrap.rs
+++ b/crates/ffwd-runtime/src/bootstrap.rs
@@ -182,7 +182,7 @@ pub async fn run_pipelines(
     let tracer = tracer_provider.tracer("ffwd");
     let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
-    let env_filter = tracing_subscriber::EnvFilter::try_from_env("LOGFWD_LOG")
+    let env_filter = tracing_subscriber::EnvFilter::try_from_env("FFWD_LOG")
         .or_else(|_| tracing_subscriber::EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     let fmt_layer = if options.json_logs_for_stderr {
@@ -220,7 +220,7 @@ pub async fn run_pipelines(
     let diag_handle = if let Some(ref addr) = config.server.diagnostics {
         let mut server = ffwd_diagnostics::diagnostics::DiagnosticsServer::new(addr);
         server.set_config(options.config_path, options.config_yaml);
-        let expose_config = std::env::var("LOGFWD_UNSAFE_EXPOSE_CONFIG")
+        let expose_config = std::env::var("FFWD_UNSAFE_EXPOSE_CONFIG")
             .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
         server.set_config_endpoint_enabled(expose_config);
         server.set_trace_buffer(trace_buf);

--- a/crates/ffwd-runtime/src/bootstrap.rs
+++ b/crates/ffwd-runtime/src/bootstrap.rs
@@ -183,7 +183,11 @@ pub async fn run_pipelines(
     let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
     let env_filter = tracing_subscriber::EnvFilter::try_from_env("FFWD_LOG")
-        .or_else(|_| tracing_subscriber::EnvFilter::try_from_env("LOGFWD_LOG"))
+        .or_else(|_| {
+            tracing_subscriber::EnvFilter::try_from_env("LOGFWD_LOG").inspect(|_| {
+                eprintln!("[ffwd] LOGFWD_LOG is deprecated; use FFWD_LOG instead");
+            })
+        })
         .or_else(|_| tracing_subscriber::EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
     let fmt_layer = if options.json_logs_for_stderr {
@@ -222,6 +226,13 @@ pub async fn run_pipelines(
         let mut server = ffwd_diagnostics::diagnostics::DiagnosticsServer::new(addr);
         server.set_config(options.config_path, options.config_yaml);
         let expose_config = std::env::var("FFWD_UNSAFE_EXPOSE_CONFIG")
+            .or_else(|_| {
+                std::env::var("LOGFWD_UNSAFE_EXPOSE_CONFIG").inspect(|_| {
+                    tracing::warn!(
+                        "LOGFWD_UNSAFE_EXPOSE_CONFIG is deprecated; use FFWD_UNSAFE_EXPOSE_CONFIG instead"
+                    );
+                })
+            })
             .is_ok_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
         server.set_config_endpoint_enabled(expose_config);
         server.set_trace_buffer(trace_buf);

--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -996,6 +996,7 @@ mod tests {
 
     mod should_open_checkpoint_store_tests {
         use super::super::should_open_checkpoint_store;
+        use serial_test::serial;
         use std::path::Path;
 
         #[test]
@@ -1008,12 +1009,14 @@ mod tests {
         }
 
         #[test]
+        #[serial]
         fn ffwd_data_dir_env_opens() {
             let _guard = EnvGuard::set("FFWD_DATA_DIR", "/some/path");
             assert!(should_open_checkpoint_store(Path::new("/anywhere"), false));
         }
 
         #[test]
+        #[serial]
         fn logfwd_data_dir_env_opens() {
             let _guard = EnvGuard::set("LOGFWD_DATA_DIR", "/some/path");
             assert!(should_open_checkpoint_store(Path::new("/anywhere"), false));
@@ -1045,8 +1048,8 @@ mod tests {
         impl EnvGuard {
             fn set(key: &'static str, value: &str) -> Self {
                 let prev = std::env::var_os(key);
-                // SAFETY: each test using EnvGuard runs serially (cargo test
-                // default) and restores the value on drop.
+                // SAFETY: tests using EnvGuard are marked #[serial] to
+                // prevent concurrent env mutation. Value is restored on drop.
                 unsafe { std::env::set_var(key, value) };
                 Self { key, prev }
             }
@@ -1054,7 +1057,7 @@ mod tests {
 
         impl Drop for EnvGuard {
             fn drop(&mut self) {
-                // SAFETY: see set() above.
+                // SAFETY: #[serial] ensures exclusive access.
                 match &self.prev {
                     Some(v) => unsafe { std::env::set_var(self.key, v) },
                     None => unsafe { std::env::remove_var(self.key) },

--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -673,7 +673,7 @@ fn should_open_checkpoint_store(checkpoint_dir: &Path, has_explicit_data_dir: bo
         return true;
     }
 
-    if std::env::var_os("LOGFWD_DATA_DIR").is_some() {
+    if std::env::var_os("FFWD_DATA_DIR").is_some() {
         return true;
     }
 
@@ -681,7 +681,7 @@ fn should_open_checkpoint_store(checkpoint_dir: &Path, has_explicit_data_dir: bo
         return checkpoint_dir.exists();
     }
 
-    std::env::var_os("LOGFWD_DISABLE_DEFAULT_CHECKPOINTS").is_none()
+    std::env::var_os("FFWD_DISABLE_DEFAULT_CHECKPOINTS").is_none()
 }
 
 #[cfg(test)]

--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -993,4 +993,73 @@ mod tests {
             SourceMetadataPlan::default()
         );
     }
+
+    mod should_open_checkpoint_store_tests {
+        use super::super::should_open_checkpoint_store;
+        use std::path::Path;
+
+        #[test]
+        fn explicit_data_dir_always_opens() {
+            // Even with a nonexistent path, an explicit data dir should open.
+            assert!(should_open_checkpoint_store(
+                Path::new("/nonexistent"),
+                true
+            ));
+        }
+
+        #[test]
+        fn ffwd_data_dir_env_opens() {
+            let _guard = EnvGuard::set("FFWD_DATA_DIR", "/some/path");
+            assert!(should_open_checkpoint_store(Path::new("/anywhere"), false));
+        }
+
+        #[test]
+        fn logfwd_data_dir_env_opens() {
+            let _guard = EnvGuard::set("LOGFWD_DATA_DIR", "/some/path");
+            assert!(should_open_checkpoint_store(Path::new("/anywhere"), false));
+        }
+
+        #[test]
+        fn existing_dir_opens_in_test_mode() {
+            // In cfg(test), a pre-existing directory should open.
+            let dir = tempfile::tempdir().unwrap();
+            assert!(should_open_checkpoint_store(dir.path(), false));
+        }
+
+        #[test]
+        fn nonexistent_dir_skips_in_test_mode() {
+            // In cfg(test), a nonexistent directory should NOT open.
+            assert!(!should_open_checkpoint_store(
+                Path::new("/nonexistent/checkpoint/dir"),
+                false
+            ));
+        }
+
+        /// RAII guard that sets an env var for the duration of a test and
+        /// restores the previous value (or removes it) on drop.
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<std::ffi::OsString>,
+        }
+
+        impl EnvGuard {
+            fn set(key: &'static str, value: &str) -> Self {
+                let prev = std::env::var_os(key);
+                // SAFETY: each test using EnvGuard runs serially (cargo test
+                // default) and restores the value on drop.
+                unsafe { std::env::set_var(key, value) };
+                Self { key, prev }
+            }
+        }
+
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                // SAFETY: see set() above.
+                match &self.prev {
+                    Some(v) => unsafe { std::env::set_var(self.key, v) },
+                    None => unsafe { std::env::remove_var(self.key) },
+                }
+            }
+        }
+    }
 }

--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -673,7 +673,8 @@ fn should_open_checkpoint_store(checkpoint_dir: &Path, has_explicit_data_dir: bo
         return true;
     }
 
-    if std::env::var_os("FFWD_DATA_DIR").is_some() {
+    if std::env::var_os("FFWD_DATA_DIR").is_some() || std::env::var_os("LOGFWD_DATA_DIR").is_some()
+    {
         return true;
     }
 
@@ -682,6 +683,7 @@ fn should_open_checkpoint_store(checkpoint_dir: &Path, has_explicit_data_dir: bo
     }
 
     std::env::var_os("FFWD_DISABLE_DEFAULT_CHECKPOINTS").is_none()
+        && std::env::var_os("LOGFWD_DISABLE_DEFAULT_CHECKPOINTS").is_none()
 }
 
 #[cfg(test)]

--- a/crates/ffwd-runtime/src/pipeline/pipeline_tests/failpoints.rs
+++ b/crates/ffwd-runtime/src/pipeline/pipeline_tests/failpoints.rs
@@ -178,7 +178,7 @@ fn test_checkpoint_persisted_after_clean_shutdown() {
     // SAFETY: serialised by CHECKPOINT_ENV_MUTEX; spawned thread only
     // accesses metrics/shutdown, not environment variables.
     unsafe {
-        std::env::set_var("LOGFWD_DATA_DIR", dir.path());
+        std::env::set_var("FFWD_DATA_DIR", dir.path());
     }
 
     let mut pipeline = pipeline_with_sink(&log_path, Box::new(DevNullSink));
@@ -220,7 +220,7 @@ fn test_checkpoint_persisted_after_clean_shutdown() {
     // SAFETY: serialised by CHECKPOINT_ENV_MUTEX; spawned thread only
     // accesses metrics/shutdown, not environment variables.
     unsafe {
-        std::env::remove_var("LOGFWD_DATA_DIR");
+        std::env::remove_var("FFWD_DATA_DIR");
     }
 }
 
@@ -235,7 +235,7 @@ fn test_pipeline_resumes_from_checkpoint() {
     // SAFETY: serialised by CHECKPOINT_ENV_MUTEX; spawned thread only
     // accesses metrics/shutdown, not environment variables.
     unsafe {
-        std::env::set_var("LOGFWD_DATA_DIR", dir.path());
+        std::env::set_var("FFWD_DATA_DIR", dir.path());
     }
 
     // First run: write 20 lines, process them.
@@ -315,6 +315,6 @@ fn test_pipeline_resumes_from_checkpoint() {
     // SAFETY: serialised by CHECKPOINT_ENV_MUTEX; spawned thread only
     // accesses metrics/shutdown, not environment variables.
     unsafe {
-        std::env::remove_var("LOGFWD_DATA_DIR");
+        std::env::remove_var("FFWD_DATA_DIR");
     }
 }

--- a/crates/ffwd-test-utils/src/lib.rs
+++ b/crates/ffwd-test-utils/src/lib.rs
@@ -29,10 +29,10 @@ pub fn proptest_cases() -> u32 {
 /// These tests exercise real file IO, fsyncs, restarts, and replay logic, so
 /// the generic `PROPTEST_CASES` default of 256 is too slow for normal PR runs.
 ///
-/// Override with `LOGFWD_PROPTEST_STATE_MACHINE_CASES` when you want deeper coverage.
+/// Override with `FFWD_PROPTEST_STATE_MACHINE_CASES` when you want deeper coverage.
 /// If that env var is unset, we cap the general proptest budget at 16 cases.
 pub fn state_machine_proptest_cases() -> u32 {
-    std::env::var("LOGFWD_PROPTEST_STATE_MACHINE_CASES")
+    std::env::var("FFWD_PROPTEST_STATE_MACHINE_CASES")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or_else(|| proptest_cases().min(16))

--- a/crates/ffwd-transform/src/enrichment.rs
+++ b/crates/ffwd-transform/src/enrichment.rs
@@ -971,10 +971,10 @@ impl GeoReloadHandle {
 /// enrichment:
 ///   - type: env_vars
 ///     table_name: deploy_meta
-///     prefix: LOGFWD_META_
+///     prefix: FFWD_META_
 /// ```
 ///
-/// With `LOGFWD_META_CLUSTER=prod` and `LOGFWD_META_REGION=us-east-1` set,
+/// With `FFWD_META_CLUSTER=prod` and `FFWD_META_REGION=us-east-1` set,
 /// the table exposes `cluster` and `region` columns.
 ///
 /// SQL: `SELECT logs.*, m.cluster, m.region FROM logs CROSS JOIN deploy_meta AS m`
@@ -1012,7 +1012,7 @@ impl EnvTable {
         }
 
         // Reject duplicate column names after lowercase normalization (e.g.
-        // LOGFWD_META_REGION and LOGFWD_META_region both present would collide).
+        // FFWD_META_REGION and FFWD_META_region both present would collide).
         for w in pairs.windows(2) {
             if w[0].0 == w[1].0 {
                 return Err(TransformError::Enrichment(format!(
@@ -2413,11 +2413,11 @@ PRETTY_NAME="Ubuntu 22.04.4 LTS"
         // SAFETY: test sets and clears env vars; must not run in parallel with other
         // tests that read the same vars.
         unsafe {
-            std::env::set_var("LOGFWD_TEST_CLUSTER", "prod");
-            std::env::set_var("LOGFWD_TEST_REGION", "us-east-1");
+            std::env::set_var("FFWD_TEST_CLUSTER", "prod");
+            std::env::set_var("FFWD_TEST_REGION", "us-east-1");
         }
 
-        let table = EnvTable::from_prefix("deploy", "LOGFWD_TEST_").expect("should succeed");
+        let table = EnvTable::from_prefix("deploy", "FFWD_TEST_").expect("should succeed");
         assert_eq!(table.name(), "deploy");
         let batch = table.snapshot().unwrap();
         assert_eq!(batch.num_rows(), 1);
@@ -2437,17 +2437,17 @@ PRETTY_NAME="Ubuntu 22.04.4 LTS"
         // SAFETY: `remove_var` is unsafe because it mutates process-global
         // state and is unsound under concurrent access. This is safe here
         // because `cargo nextest` runs each test in its own process, and
-        // these variables use a unique `LOGFWD_TEST_` prefix not read by
+        // these variables use a unique `FFWD_TEST_` prefix not read by
         // any other test.
         unsafe {
-            std::env::remove_var("LOGFWD_TEST_CLUSTER");
-            std::env::remove_var("LOGFWD_TEST_REGION");
+            std::env::remove_var("FFWD_TEST_CLUSTER");
+            std::env::remove_var("FFWD_TEST_REGION");
         }
     }
 
     #[test]
     fn env_table_no_match_returns_error() {
-        let result = EnvTable::from_prefix("nothing", "LOGFWD_NONEXISTENT_PREFIX_XYZZY_12345_");
+        let result = EnvTable::from_prefix("nothing", "FFWD_NONEXISTENT_PREFIX_XYZZY_12345_");
         assert!(result.is_err());
     }
 
@@ -2457,17 +2457,17 @@ PRETTY_NAME="Ubuntu 22.04.4 LTS"
         // Set env vars that collide after lowercasing the suffix.
         // SAFETY: test is run single-threaded via `cargo nextest` (which isolates
         // each test in its own process) or `--test-threads=1`. The vars use a
-        // unique prefix (LOGFWD_DUPTEST_) to avoid collisions with real env.
+        // unique prefix (FFWD_DUPTEST_) to avoid collisions with real env.
         unsafe {
-            std::env::set_var("LOGFWD_DUPTEST_FOO", "a");
-            std::env::set_var("LOGFWD_DUPTEST_foo", "b");
+            std::env::set_var("FFWD_DUPTEST_FOO", "a");
+            std::env::set_var("FFWD_DUPTEST_foo", "b");
         }
-        let result = EnvTable::from_prefix("dup_test", "LOGFWD_DUPTEST_");
+        let result = EnvTable::from_prefix("dup_test", "FFWD_DUPTEST_");
         // Clean up before asserting.
         // SAFETY: this removes only the unique test variables set above.
         unsafe {
-            std::env::remove_var("LOGFWD_DUPTEST_FOO");
-            std::env::remove_var("LOGFWD_DUPTEST_foo");
+            std::env::remove_var("FFWD_DUPTEST_FOO");
+            std::env::remove_var("FFWD_DUPTEST_foo");
         }
         assert!(result.is_err());
         let msg = format!("{}", result.err().unwrap());

--- a/crates/ffwd/build.rs
+++ b/crates/ffwd/build.rs
@@ -72,25 +72,25 @@ fn build_date() -> String {
 
 fn main() {
     println!(
-        "cargo:rustc-env=LOGFWD_GIT_HASH={}",
+        "cargo:rustc-env=FFWD_GIT_HASH={}",
         git_string(&["rev-parse", "--short", "HEAD"])
     );
 
     let dirty = git_output(&["status", "--porcelain"]).is_some_and(|o| !o.is_empty());
     println!(
-        "cargo:rustc-env=LOGFWD_GIT_DIRTY={}",
+        "cargo:rustc-env=FFWD_GIT_DIRTY={}",
         if dirty { "-dirty" } else { "" }
     );
 
-    println!("cargo:rustc-env=LOGFWD_BUILD_DATE={}", build_date());
+    println!("cargo:rustc-env=FFWD_BUILD_DATE={}", build_date());
 
     println!(
-        "cargo:rustc-env=LOGFWD_TARGET={}",
+        "cargo:rustc-env=FFWD_TARGET={}",
         std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string())
     );
 
     println!(
-        "cargo:rustc-env=LOGFWD_PROFILE={}",
+        "cargo:rustc-env=FFWD_PROFILE={}",
         std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string())
     );
 

--- a/crates/ffwd/src/commands.rs
+++ b/crates/ffwd/src/commands.rs
@@ -661,7 +661,7 @@ pub(crate) fn resolve_config_path(config_path: Option<&str>) -> Result<String, C
 /// Search well-known locations for a ffwd config file.
 ///
 /// Search order:
-///   1. `$FFWD_CONFIG`
+///   1. `$FFWD_CONFIG` (or deprecated `$LOGFWD_CONFIG`)
 ///   2. `./ffwd.yaml`
 ///   3. `~/.config/ffwd/config.yaml`
 ///   4. `/etc/ffwd/config.yaml`
@@ -669,10 +669,17 @@ pub(crate) fn discover_config() -> Option<std::path::PathBuf> {
     use std::env;
     use std::path::PathBuf;
 
-    // 1. Environment variable
+    // 1. Environment variable (new name first, legacy fallback second)
     if let Ok(path) = env::var("FFWD_CONFIG") {
         let p = PathBuf::from(&path);
         if p.is_file() {
+            return Some(p);
+        }
+    }
+    if let Ok(path) = env::var("LOGFWD_CONFIG") {
+        let p = PathBuf::from(&path);
+        if p.is_file() {
+            tracing::warn!("LOGFWD_CONFIG is deprecated — use FFWD_CONFIG instead");
             return Some(p);
         }
     }

--- a/crates/ffwd/src/commands.rs
+++ b/crates/ffwd/src/commands.rs
@@ -654,14 +654,14 @@ pub(crate) fn resolve_config_path(config_path: Option<&str>) -> Result<String, C
         return Ok(path.to_string_lossy().to_string());
     }
     Err(CliError::Config(
-        "no config file found (use --config or set LOGFWD_CONFIG)".to_owned(),
+        "no config file found (use --config or set FFWD_CONFIG)".to_owned(),
     ))
 }
 
 /// Search well-known locations for a ffwd config file.
 ///
 /// Search order:
-///   1. `$LOGFWD_CONFIG`
+///   1. `$FFWD_CONFIG`
 ///   2. `./ffwd.yaml`
 ///   3. `~/.config/ffwd/config.yaml`
 ///   4. `/etc/ffwd/config.yaml`
@@ -670,7 +670,7 @@ pub(crate) fn discover_config() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
 
     // 1. Environment variable
-    if let Ok(path) = env::var("LOGFWD_CONFIG") {
+    if let Ok(path) = env::var("FFWD_CONFIG") {
         let p = PathBuf::from(&path);
         if p.is_file() {
             return Some(p);

--- a/crates/ffwd/src/main.rs
+++ b/crates/ffwd/src/main.rs
@@ -28,14 +28,14 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const LONG_VERSION: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     " (",
-    env!("LOGFWD_GIT_HASH"),
-    env!("LOGFWD_GIT_DIRTY"),
+    env!("FFWD_GIT_HASH"),
+    env!("FFWD_GIT_DIRTY"),
     " ",
-    env!("LOGFWD_BUILD_DATE"),
+    env!("FFWD_BUILD_DATE"),
     ", ",
-    env!("LOGFWD_TARGET"),
+    env!("FFWD_TARGET"),
     ", ",
-    env!("LOGFWD_PROFILE"),
+    env!("FFWD_PROFILE"),
     ")"
 );
 const CLI_AFTER_HELP: &str = r"Examples:
@@ -53,13 +53,13 @@ const CLI_AFTER_HELP: &str = r"Examples:
   ff completions bash
 
 Environment:
-  LOGFWD_CONFIG    Config file path (auto-discovered if not set)
-  LOGFWD_LOG       Set log filter (for example LOGFWD_LOG=debug)
-  RUST_LOG         Fallback if LOGFWD_LOG is not set
+  FFWD_CONFIG    Config file path (auto-discovered if not set)
+  FFWD_LOG       Set log filter (for example FFWD_LOG=debug)
+  RUST_LOG         Fallback if FFWD_LOG is not set
 
 Config Search Order:
   1. --config <path>
-  2. $LOGFWD_CONFIG
+  2. $FFWD_CONFIG
   3. ./ffwd.yaml
   4. ~/.config/ffwd/config.yaml
   5. /etc/ffwd/config.yaml

--- a/crates/ffwd/src/send.rs
+++ b/crates/ffwd/src/send.rs
@@ -163,7 +163,7 @@ fn yaml_string(value: &str) -> serde_yaml_ng::Value {
 pub(crate) fn resolve_send_config_path(config_path: Option<&str>) -> Result<String, CliError> {
     resolve_config_path(config_path).map_err(|err| match err {
         CliError::Config(_) => CliError::Config(
-            "no destination config file found (use `ff send --config <file>` or set LOGFWD_CONFIG)"
+            "no destination config file found (use `ff send --config <file>` or set FFWD_CONFIG)"
                 .to_owned(),
         ),
         CliError::Runtime(e) => CliError::Runtime(e),

--- a/dashboard/src/test/api.test.ts
+++ b/dashboard/src/test/api.test.ts
@@ -114,7 +114,7 @@ describe("api", () => {
         jsonResponse(
           {
             error: "config_endpoint_disabled",
-            message: "set LOGFWD_UNSAFE_EXPOSE_CONFIG=1 to enable /admin/v1/config",
+            message: "set FFWD_UNSAFE_EXPOSE_CONFIG=1 to enable /admin/v1/config",
           },
           403
         )
@@ -122,7 +122,7 @@ describe("api", () => {
       const result = await api.config();
       expect(result).toEqual({
         data: null,
-        errorMessage: "set LOGFWD_UNSAFE_EXPOSE_CONFIG=1 to enable /admin/v1/config",
+        errorMessage: "set FFWD_UNSAFE_EXPOSE_CONFIG=1 to enable /admin/v1/config",
       });
     });
   });

--- a/dev-docs/research/config-library-poc.md
+++ b/dev-docs/research/config-library-poc.md
@@ -61,7 +61,7 @@ YAML-aware placeholder expansion.
 ### `config`
 
 `config` supports layered configuration and environment overlays. The POC
-confirms `Environment::with_prefix("LOGFWD").prefix_separator("_").separator("__")`
+confirms `Environment::with_prefix("FFWD").prefix_separator("_").separator("__")`
 can override nested typed fields such as `FFWD_PIPELINES__APP__WORKERS=9`.
 
 It does not solve `${VAR}` interpolation inside YAML values. Unlike Figment, its

--- a/dev-docs/research/config-library-poc.md
+++ b/dev-docs/research/config-library-poc.md
@@ -49,8 +49,8 @@ enough to replace `Config::expand_env_yaml_str` or `Config::load_str`.
 ### `figment`
 
 Figment supports layered configuration and environment overlays. The POC
-confirms `Env::prefixed("LOGFWD_").split("__")` can override nested typed
-fields such as `LOGFWD_PIPELINES__APP__WORKERS=9`.
+confirms `Env::prefixed("FFWD_").split("__")` can override nested typed
+fields such as `FFWD_PIPELINES__APP__WORKERS=9`.
 
 It does not solve `${VAR}` interpolation inside YAML values. Its YAML provider
 also depends on `serde_yaml`.
@@ -62,7 +62,7 @@ YAML-aware placeholder expansion.
 
 `config` supports layered configuration and environment overlays. The POC
 confirms `Environment::with_prefix("LOGFWD").prefix_separator("_").separator("__")`
-can override nested typed fields such as `LOGFWD_PIPELINES__APP__WORKERS=9`.
+can override nested typed fields such as `FFWD_PIPELINES__APP__WORKERS=9`.
 
 It does not solve `${VAR}` interpolation inside YAML values. Unlike Figment, its
 YAML feature uses `yaml-rust2` rather than deprecated `serde_yaml`.
@@ -103,7 +103,7 @@ The production design should be:
    text, so YAML-specific values like `.nan` still reach semantic validation.
 4. Deserialize to `RawConfig` through `config`, letting the typed Rust schema
    parse env-backed strings into numeric, boolean, and enum fields.
-5. Add an optional `LOGFWD_` environment overlay source using `__` as the nested
+5. Add an optional `FFWD_` environment overlay source using `__` as the nested
    separator.
 6. Run existing semantic validation.
 

--- a/justfile
+++ b/justfile
@@ -128,11 +128,11 @@ clippy-all:
 
 # Tests — default-members only (skips datafusion)
 test:
-    LOGFWD_DISABLE_DEFAULT_CHECKPOINTS=1 cargo nextest run --profile ci
+    FFWD_DISABLE_DEFAULT_CHECKPOINTS=1 cargo nextest run --profile ci
 
 # Tests — full workspace (CI uses this)
 test-all:
-    LOGFWD_DISABLE_DEFAULT_CHECKPOINTS=1 cargo nextest run --workspace --profile ci
+    FFWD_DISABLE_DEFAULT_CHECKPOINTS=1 cargo nextest run --workspace --profile ci
 
 # Run semantic lints via dylint (hot_path_no_alloc, and any future
 # semantic lints defined in crates/ffwd-lints/).

--- a/tests/e2e/manifests/ff-config.yaml
+++ b/tests/e2e/manifests/ff-config.yaml
@@ -14,7 +14,7 @@ data:
       format: cri
 
     transform: >-
-      SELECT * FROM logs WHERE message_str LIKE '%LOGFWD_E2E_MARKER%'
+      SELECT * FROM logs WHERE message_str LIKE '%FFWD_E2E_MARKER%'
 
     output:
       type: http

--- a/tests/e2e/manifests/log-generator.yaml
+++ b/tests/e2e/manifests/log-generator.yaml
@@ -13,15 +13,15 @@ spec:
       args:
         - |
           sleep 5
-          echo '{"message":"LOGFWD_E2E_MARKER_001","level":"INFO","seq":1}'
-          echo '{"message":"LOGFWD_E2E_MARKER_002","level":"INFO","seq":2}'
-          echo '{"message":"LOGFWD_E2E_MARKER_003","level":"WARN","seq":3}'
-          echo '{"message":"LOGFWD_E2E_MARKER_004","level":"INFO","seq":4}'
-          echo '{"message":"LOGFWD_E2E_MARKER_005","level":"ERROR","seq":5}'
-          echo '{"message":"LOGFWD_E2E_MARKER_006","level":"INFO","seq":6}'
-          echo '{"message":"LOGFWD_E2E_MARKER_007","level":"DEBUG","seq":7}'
-          echo '{"message":"LOGFWD_E2E_MARKER_008","level":"INFO","seq":8}'
-          echo '{"message":"LOGFWD_E2E_MARKER_009","level":"WARN","seq":9}'
-          echo '{"message":"LOGFWD_E2E_MARKER_010","level":"INFO","seq":10}'
+          echo '{"message":"FFWD_E2E_MARKER_001","level":"INFO","seq":1}'
+          echo '{"message":"FFWD_E2E_MARKER_002","level":"INFO","seq":2}'
+          echo '{"message":"FFWD_E2E_MARKER_003","level":"WARN","seq":3}'
+          echo '{"message":"FFWD_E2E_MARKER_004","level":"INFO","seq":4}'
+          echo '{"message":"FFWD_E2E_MARKER_005","level":"ERROR","seq":5}'
+          echo '{"message":"FFWD_E2E_MARKER_006","level":"INFO","seq":6}'
+          echo '{"message":"FFWD_E2E_MARKER_007","level":"DEBUG","seq":7}'
+          echo '{"message":"FFWD_E2E_MARKER_008","level":"INFO","seq":8}'
+          echo '{"message":"FFWD_E2E_MARKER_009","level":"WARN","seq":9}'
+          echo '{"message":"FFWD_E2E_MARKER_010","level":"INFO","seq":10}'
           echo "log-generator: all 10 markers emitted"
           sleep 3600

--- a/tests/e2e/run_smoke_test.sh
+++ b/tests/e2e/run_smoke_test.sh
@@ -100,8 +100,8 @@ case "${1:-}" in
     if [ "${2:-}" = "-n" ] && [ "${3:-}" = "e2e-ff" ] && [ "${4:-}" = "log-generator" ]; then
       if [ -f "$STATE_DIR/log_generator_running" ]; then
         printf '%s\n' \
-          'LOGFWD_E2E_MARKER_001' \
-          'LOGFWD_E2E_MARKER_010' \
+          'FFWD_E2E_MARKER_001' \
+          'FFWD_E2E_MARKER_010' \
           'log-generator: all 10 markers emitted'
         printf 'ready' >"$STATE_DIR/marker_ready"
       fi


### PR DESCRIPTION
## Summary
- Phase 2 of the FastForward rebrand (issue #2206)
- Renames all `LOGFWD_*` environment variables to `FFWD_*`
- 33 files changed, 148 insertions, 150 deletions
- Zero remaining `LOGFWD_` references

## Env vars renamed
| Old | New |
|-----|-----|
| `LOGFWD_CONFIG` | `FFWD_CONFIG` |
| `LOGFWD_LOG` | `FFWD_LOG` |
| `LOGFWD_DATA_DIR` | `FFWD_DATA_DIR` |
| `LOGFWD_UNSAFE_EXPOSE_CONFIG` | `FFWD_UNSAFE_EXPOSE_CONFIG` |
| `LOGFWD_DISABLE_DEFAULT_CHECKPOINTS` | `FFWD_DISABLE_DEFAULT_CHECKPOINTS` |
| `LOGFWD_META_*` | `FFWD_META_*` |
| `LOGFWD_GIT_HASH` / `_DIRTY` / `_BUILD_DATE` / `_TARGET` / `_PROFILE` | `FFWD_*` |
| `LOGFWD_PIPELINES__*` / `LOGFWD_DIAG_ADDR` | `FFWD_*` |
| All test/bench vars (`LOGFWD_TEST_*`, `LOGFWD_ISSUE_*`, etc.) | `FFWD_*` |

## Test plan
- [ ] CI passes
- [ ] `FFWD_CONFIG=path ff run` works
- [ ] `FFWD_LOG=debug ff run` sets log level

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename `LOGFWD_*` environment variables to `FFWD_*` across the codebase
> - Renames all `LOGFWD_*` env vars to `FFWD_*` across source code, tests, docs, CI, and e2e manifests (e.g. `LOGFWD_CONFIG` → `FFWD_CONFIG`, `LOGFWD_LOG` → `FFWD_LOG`, `LOGFWD_DATA_DIR` → `FFWD_DATA_DIR`).
> - Legacy `LOGFWD_*` vars are still accepted at runtime with deprecation warnings emitted to stderr or via `tracing::warn` for key vars: `LOGFWD_CONFIG`, `LOGFWD_LOG`, `LOGFWD_DATA_DIR`, `LOGFWD_UNSAFE_EXPOSE_CONFIG`.
> - The 403 error message on the diagnostics config endpoint now instructs users to set `FFWD_UNSAFE_EXPOSE_CONFIG=1`.
> - Behavioral Change: any tooling or scripts that set `LOGFWD_*` vars will continue to work but produce deprecation warnings; `FFWD_*` vars take precedence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 245353f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->