### PR TITLE
fix: reject Loki label collisions after sanitization in config validation

### DIFF
--- a/crates/ffwd-config/src/validate/outputs.rs
+++ b/crates/ffwd-config/src/validate/outputs.rs
@@ -93,6 +93,22 @@ fn validate_elasticsearch_index(
     Ok(())
 }
 
+/// Sanitize a Loki label name the same way the Loki runtime does: replace
+/// any character that is not `[a-zA-Z0-9_]` (or not `[a-zA-Z_]` at position 0)
+/// with `_`.
+fn sanitize_loki_label_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len().max(1));
+    for (idx, ch) in name.chars().enumerate() {
+        let valid = if idx == 0 {
+            ch.is_ascii_alphabetic() || ch == '_'
+        } else {
+            ch.is_ascii_alphanumeric() || ch == '_'
+        };
+        out.push(if valid { ch } else { '_' });
+    }
+    if out.is_empty() { "_".to_string() } else { out }
+}
+
 fn validate_loki_labels(
     pipeline_name: &str,
     label: &str,
@@ -109,15 +125,54 @@ fn validate_loki_labels(
         }
     }
 
-    if let (Some(static_labels), Some(label_columns)) = (static_labels, label_columns)
-        && let Some(conflict) = label_columns
+    // Detect intra-map collisions within static_labels after sanitization.
+    if let Some(static_labels) = static_labels {
+        let mut seen: HashMap<String, &str> = HashMap::new();
+        for key in static_labels.keys() {
+            let sanitized = sanitize_loki_label_name(key);
+            if let Some(existing) = seen.get(&sanitized) {
+                return Err(ConfigError::Validation(format!(
+                    "pipeline '{pipeline_name}' output '{label}': loki static_labels key '{key}' sanitizes to '{sanitized}' which collides with existing key '{existing}'"
+                )));
+            }
+            seen.insert(sanitized, key.as_str());
+        }
+    }
+
+    // Detect intra-map collisions within label_columns after sanitization.
+    if let Some(label_columns) = label_columns {
+        let mut seen: HashMap<String, &str> = HashMap::new();
+        for col in label_columns {
+            let sanitized = sanitize_loki_label_name(col);
+            if let Some(existing) = seen.get(&sanitized) {
+                return Err(ConfigError::Validation(format!(
+                    "pipeline '{pipeline_name}' output '{label}': loki label_columns entry '{col}' sanitizes to '{sanitized}' which collides with existing entry '{existing}'"
+                )));
+            }
+            seen.insert(sanitized, col.as_str());
+        }
+    }
+
+    // Detect cross-map collisions between static_labels and label_columns
+    // after sanitization.
+    if let (Some(static_labels), Some(label_columns)) = (static_labels, label_columns) {
+        let mut sanitized_static: HashMap<String, &str> = HashMap::new();
+        for key in static_labels.keys() {
+            sanitized_static.insert(sanitize_loki_label_name(key), key.as_str());
+        }
+        if let Some(conflict) = label_columns
             .iter()
-            .map(String::as_str)
-            .find(|column| static_labels.contains_key(*column))
-    {
-        return Err(ConfigError::Validation(format!(
-            "pipeline '{pipeline_name}' output '{label}': loki label '{conflict}' is defined in both 'label_columns' and 'static_labels'"
-        )));
+            .find(|col| sanitized_static.contains_key(&sanitize_loki_label_name(col)))
+        {
+            let sanitized = sanitize_loki_label_name(conflict);
+            let static_key = sanitized_static
+                .get(&sanitized)
+                .copied()
+                .unwrap_or(conflict.as_str());
+            return Err(ConfigError::Validation(format!(
+                "pipeline '{pipeline_name}' output '{label}': loki label '{conflict}' (sanitizes to '{sanitized}') conflicts with 'static_labels' key '{static_key}'"
+            )));
+        }
     }
 
     Ok(())

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1271,10 +1271,79 @@ pipelines:
 ";
 
     let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(err.contains("conflicts with"), "unexpected error: {err}");
+}
+
+#[test]
+fn issue_2575_reject_loki_sanitized_label_collisions() {
+    let yaml = r"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: loki
+        endpoint: http://localhost:3100
+        static_labels:
+          service.name: my-service
+        label_columns:
+          - service_name
+";
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
     assert!(
-        err.contains("is defined in both 'label_columns' and 'static_labels'"),
-        "unexpected error: {err}"
+        err.contains("loki label") && err.contains("conflicts with"),
+        "sanitized collision should be rejected: {err}"
     );
+}
+
+#[test]
+fn issue_2575_reject_loki_intra_static_labels_collision() {
+    let yaml = r"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: loki
+        endpoint: http://localhost:3100
+        static_labels:
+          service.name: my-service
+          service-name: other-service
+        label_columns:
+          - level
+";
+
+    let err = Config::load_str(yaml).unwrap_err().to_string();
+    assert!(
+        err.contains("sanitizes to") && err.contains("collides with"),
+        "intra-static_labels collision should be rejected: {err}"
+    );
+}
+
+#[test]
+fn loki_sanitized_labels_non_colliding_static_and_columns_pass_validation() {
+    let yaml = r"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: loki
+        endpoint: http://localhost:3100
+        static_labels:
+          service.name: my-service
+        label_columns:
+          - level
+          - host
+";
+    Config::load_str(yaml).expect("non-colliding loki labels should pass");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #2575. The config validator checked raw label keys for collisions between `static_labels` and `label_columns`, but the Loki runtime sanitizes keys before building streams. This allowed configs like `service.name` (static) vs `service_name` (column) to pass validation, then collide at runtime when both become `service_name`.

## Changes

- **`validate/outputs.rs`**: Added `sanitize_loki_label_name()` (mirrors Loki runtime sanitization: non-`[a-zA-Z0-9_]` → `_`) and updated `validate_loki_labels()` to:
  - Detect intra-map collisions within `static_labels` after sanitization
  - Detect intra-map collisions within `label_columns` after sanitization
  - Detect cross-map collisions between `static_labels` and `label_columns` after sanitization
- **`validation_gaps.rs`**: Added regression tests for #2575 + positive test for non-colliding labels

## Testing

```
cargo test -p ffwd-config --test validation_gaps -- loki
# 4 tests passed
cargo clippy -p ffwd-config  # clean
```

## Compatibility

Breaking only for configs that were already broken at runtime (labels that would collide after sanitization). Now caught at config load time with a clear error message.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject Loki label collisions after sanitization in config validation
> - Adds `sanitize_loki_label_name` in [outputs.rs](https://github.com/strawgate/fastforward/pull/2621/files#diff-35f4ab88c44be7bef50941ddf494b2eb5e0ec52697749e4916735195f7e9146b) that mirrors Loki's runtime label sanitization (replaces invalid chars with `_`, ensures first char is alpha or `_`).
> - Extends `validate_loki_labels` to detect collisions between `static_labels` keys, between `label_columns` entries, and across both maps after sanitization, reporting the original and sanitized forms in error messages.
> - Replaces the previous exact-match conflict check with the new sanitization-aware logic.
> - Behavioral Change: configs where two label keys differ only by characters Loki treats as invalid (e.g. `service.name` vs `service_name`) now fail validation instead of being silently accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 127256b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->