### PR TITLE
part C: rename OTLP identity strings logfwd -> ff

### DIFF
--- a/crates/ffwd-diagnostics/src/telemetry_buffer.rs
+++ b/crates/ffwd-diagnostics/src/telemetry_buffer.rs
@@ -191,7 +191,7 @@ fn now_nanos() -> u64 {
 
 /// Serialize metric points as an OTLP JSON `ExportMetricsServiceRequest`.
 ///
-/// Groups all points under a single resource with `service.name = "ffwd"`.
+/// Groups all points under a single resource with `service.name = "ff"`.
 /// Each unique metric name becomes one Gauge metric with all its data points.
 pub fn metrics_to_otlp_json(points: &[MetricPoint]) -> String {
     if points.is_empty() {
@@ -243,7 +243,7 @@ pub fn metrics_to_otlp_json(points: &[MetricPoint]) -> String {
 
     let version = env!("CARGO_PKG_VERSION");
     format!(
-        "{{\"resourceMetrics\":[{{\"resource\":{{\"attributes\":[{{\"key\":\"service.name\",\"value\":{{\"stringValue\":\"ffwd\"}}}},{{\"key\":\"service.version\",\"value\":{{\"stringValue\":\"{version}\"}}}}]}},\"scopeMetrics\":[{{\"scope\":{{\"name\":\"ffwd.diagnostics\",\"version\":\"{version}\"}},\"metrics\":[{metrics}]}}]}}]}}",
+        "{{\"resourceMetrics\":[{{\"resource\":{{\"attributes\":[{{\"key\":\"service.name\",\"value\":{{\"stringValue\":\"ff\"}}}},{{\"key\":\"service.version\",\"value\":{{\"stringValue\":\"{version}\"}}}}]}},\"scopeMetrics\":[{{\"scope\":{{\"name\":\"ff.diagnostics\",\"version\":\"{version}\"}},\"metrics\":[{metrics}]}}]}}]}}",
         metrics = metrics_json.join(",")
     )
 }
@@ -281,7 +281,7 @@ pub fn traces_to_otlp_json(spans: &[SpanPoint]) -> String {
 
     let version = env!("CARGO_PKG_VERSION");
     format!(
-        "{{\"resourceSpans\":[{{\"resource\":{{\"attributes\":[{{\"key\":\"service.name\",\"value\":{{\"stringValue\":\"ffwd\"}}}},{{\"key\":\"service.version\",\"value\":{{\"stringValue\":\"{version}\"}}}}]}},\"scopeSpans\":[{{\"scope\":{{\"name\":\"ffwd.diagnostics\",\"version\":\"{version}\"}},\"spans\":[{spans}]}}]}}]}}",
+        "{{\"resourceSpans\":[{{\"resource\":{{\"attributes\":[{{\"key\":\"service.name\",\"value\":{{\"stringValue\":\"ff\"}}}},{{\"key\":\"service.version\",\"value\":{{\"stringValue\":\"{version}\"}}}}]}},\"scopeSpans\":[{{\"scope\":{{\"name\":\"ff.diagnostics\",\"version\":\"{version}\"}},\"spans\":[{spans}]}}]}}]}}",
         spans = spans_json.join(",")
     )
 }
@@ -305,7 +305,7 @@ pub fn logs_to_otlp_json(logs: &[LogPoint]) -> String {
 
     let version = env!("CARGO_PKG_VERSION");
     format!(
-        "{{\"resourceLogs\":[{{\"resource\":{{\"attributes\":[{{\"key\":\"service.name\",\"value\":{{\"stringValue\":\"ffwd\"}}}},{{\"key\":\"service.version\",\"value\":{{\"stringValue\":\"{version}\"}}}}]}},\"scopeLogs\":[{{\"scope\":{{\"name\":\"ffwd.diagnostics\",\"version\":\"{version}\"}},\"logRecords\":[{logs}]}}]}}]}}",
+        "{{\"resourceLogs\":[{{\"resource\":{{\"attributes\":[{{\"key\":\"service.name\",\"value\":{{\"stringValue\":\"ff\"}}}},{{\"key\":\"service.version\",\"value\":{{\"stringValue\":\"{version}\"}}}}]}},\"scopeLogs\":[{{\"scope\":{{\"name\":\"ff.diagnostics\",\"version\":\"{version}\"}},\"logRecords\":[{logs}]}}]}}]}}",
         logs = logs_json.join(",")
     )
 }
@@ -1012,7 +1012,7 @@ mod tests {
         assert_eq!(rm["resource"]["attributes"][0]["key"], "service.name");
         assert_eq!(
             rm["resource"]["attributes"][0]["value"]["stringValue"],
-            "ffwd"
+            "ff"
         );
 
         let metric = &rm["scopeMetrics"][0]["metrics"][0];

--- a/crates/ffwd-output/src/otlp_sink/tests/attributes.rs
+++ b/crates/ffwd-output/src/otlp_sink/tests/attributes.rs
@@ -213,11 +213,9 @@ fn scope_logs_has_instrumentation_scope() {
     let mut sink = make_sink();
     sink.encode_batch(&batch, &make_metadata());
 
-    // The InstrumentationScope name "ffwd" must be present in the encoded bytes.
-    assert!(
-        contains_bytes(&sink.encoder_buf, b"ffwd"),
-        "InstrumentationScope name 'ffwd' not found in encoded output"
-    );
+    // InstrumentationScope name is verified via protobuf decode in
+    // roundtrip::roundtrip_encode_decode_via_prost; a raw contains_bytes
+    // check for b"ff" would be trivially true on any non-trivial payload.
 
     // The InstrumentationScope version (from CARGO_PKG_VERSION) must also be present.
     let version = env!("CARGO_PKG_VERSION").as_bytes();

--- a/crates/ffwd-output/src/otlp_sink/tests/roundtrip.rs
+++ b/crates/ffwd-output/src/otlp_sink/tests/roundtrip.rs
@@ -100,7 +100,7 @@ fn roundtrip_encode_decode_via_prost() {
         .scope
         .as_ref()
         .expect("InstrumentationScope must be present");
-    assert_eq!(scope.name, "ffwd", "scope name must be 'ffwd'");
+    assert_eq!(scope.name, "ff", "scope name must be 'ff'");
     assert_eq!(
         scope.version,
         env!("CARGO_PKG_VERSION"),
@@ -405,7 +405,7 @@ fn unsupported_well_known_types_fall_back_to_attributes() {
     assert_eq!(lr.severity_number, 17);
     assert_eq!(lr.observed_time_unix_nano, metadata.observed_time_ns);
     let scope = sl.scope.as_ref().expect("scope must exist");
-    assert_eq!(scope.name, "ffwd");
+    assert_eq!(scope.name, "ff");
 
     let find_attr = |name: &str| lr.attributes.iter().find(|kv| kv.key == name);
 

--- a/crates/ffwd-output/src/otlp_sink/types.rs
+++ b/crates/ffwd-output/src/otlp_sink/types.rs
@@ -17,7 +17,7 @@ use super::Compression;
 // ---------------------------------------------------------------------------
 
 /// Name emitted in the OTLP `InstrumentationScope.name` field of every `ScopeLogs`.
-pub(super) const SCOPE_NAME: &[u8] = b"ffwd";
+pub(super) const SCOPE_NAME: &[u8] = b"ff";
 /// Version emitted in the OTLP `InstrumentationScope.version` field (from Cargo.toml).
 pub(super) const SCOPE_VERSION: &[u8] = env!("CARGO_PKG_VERSION").as_bytes();
 /// Default gRPC outbound message size guardrail.


### PR DESCRIPTION
Renames OTLP identity strings from `ffwd` to `ff` across telemetry and output crates.

## Changes
- **telemetry_buffer.rs**: `service.name` → `ff`, scope name → `ff.diagnostics` (metrics, traces, logs JSON export)
- **otlp_sink/types.rs**: `SCOPE_NAME` constant → `b"ff"`
- **otlp_sink/tests**: Updated scope name assertions; removed trivially-true `contains_bytes(b"ff")` check (roundtrip test validates via prost decode)

Relates to #2644

## Test plan
- `cargo test -p ffwd-output` — all pass
- `cargo test -p ffwd-diagnostics` — 72 pass, 23 ignored

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename OTLP identity strings from `ffwd` to `ff` in diagnostics and output
> Updates all hardcoded OTLP identity strings across the diagnostics and output crates to use `ff` instead of `ffwd`. Changes affect `service.name`, `scope name` fields in `metrics_to_otlp_json`, `traces_to_otlp_json`, and `logs_to_otlp_json` in [telemetry_buffer.rs](https://github.com/strawgate/fastforward/pull/2649/files#diff-adceefb974ce174915863b8a1e246e3146ca07c550963d8a8a89176bb4238c55), and the `SCOPE_NAME` constant in [types.rs](https://github.com/strawgate/fastforward/pull/2649/files#diff-2b3914b6b6eb9c89ed954f007546cd48a0231aa6ff82d0a8c5a0140669a53773). Associated tests are updated to match the new values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3dd056e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->