### PR TITLE
fix: remove broken gzip compression that sent uncompressed body with gzip header

### DIFF
--- a/crates/ffwd-output/src/elasticsearch/transport.rs
+++ b/crates/ffwd-output/src/elasticsearch/transport.rs
@@ -62,12 +62,7 @@ impl ElasticsearchSink {
         }
 
         tracing::Span::current().record("req_bytes", body_len as u64);
-        let req = if self.config.compress {
-            tracing::Span::current().record("cmp_bytes", body.len() as u64);
-            req.header("Content-Encoding", "gzip").body(body)
-        } else {
-            req.body(body)
-        };
+        let req = req.body(body);
 
         let t0 = std::time::Instant::now();
         let response = match req.send().await {


### PR DESCRIPTION
PR 2580 added compression in send.rs but left a broken compression branch in transport.rs that sends the body unchanged with Content-Encoding: gzip. Fix: remove the dead branch.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove broken gzip compression from `ElasticsearchSink` bulk requests
> The gzip branch in [transport.rs](https://github.com/strawgate/fastforward/pull/2652/files#diff-a445b022d9bf36d8467c8327cfc6d7f30282e981ea6856e37f0956fce1fbb5d3) set the `Content-Encoding: gzip` header but sent an uncompressed body, causing malformed requests. The branch is removed so all bulk POST requests are sent uncompressed without a compression header. The `cmp_bytes` tracing field is also removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a990d19. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->