### PR TITLE
fix(dashboard): correct scan_sec metric to sum actual stage nanos counters

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -132,6 +132,11 @@ export function App() {
       return frame.rows[0]?.value ?? 0;
     };
 
+    const sumAll = (name: string): number => {
+      const frame = store.selectLatestValues({ metricName: name });
+      return frame.rows.reduce((acc, r) => acc + (r.value ?? 0), 0);
+    };
+
     // Like val(), but returns undefined when the metric is absent so optional
     // StatsResponse fields stay undefined instead of masking missing data as 0.
     const optVal = (name: string): number | undefined => {
@@ -150,13 +155,13 @@ export function App() {
       output_bytes: val("ffwd.output_bytes"),
       output_errors: val("ffwd.output_errors"),
       batches: val("ffwd.batches"),
-      scan_sec: val("ffwd.stage_nanos") / 1e9,
+      scan_sec: (sumAll("ffwd_stage_scan_nanos") + sumAll("ffwd_stage_transform_nanos") + sumAll("ffwd_stage_output_nanos")) / 1e9,
       transform_sec: 0,
       output_sec: 0,
       backpressure_stalls: val("ffwd.backpressure_stalls"),
       inflight_batches: val("ffwd.inflight_batches"),
-      channel_depth: optVal("ffwd.channel_depth"),
-      channel_capacity: optVal("ffwd.channel_capacity"),
+      channel_depth: undefined,
+      channel_capacity: undefined,
       mem_resident: optVal("process.memory.resident"),
       mem_allocated: optVal("process.memory.allocated"),
       mem_active: optVal("process.memory.active"),


### PR DESCRIPTION
Dashboard scan_sec was reading ffwd.stage_nanos which doesn't exist. Fix: sum ffwd_stage_scan_nanos + ffwd_stage_transform_nanos + ffwd_stage_output_nanos. Also set channel_depth/channel_capacity to undefined since they're not exported via OTel.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `scan_sec` metric to sum actual stage nanos counters in dashboard
> - Replaces the previous `scan_sec` computation (derived from a single `ffwd.stage_nanos` metric) with a sum of `ffwd_stage_scan_nanos`, `ffwd_stage_transform_nanos`, and `ffwd_stage_output_nanos`, divided by 1e9.
> - Adds a `sumAll(name)` helper in [app.tsx](https://github.com/strawgate/fastforward/pull/2653/files#diff-89253c48a25d00a0657e8bf6c6803d4d8d86374de5dbcca18905f910e2cd8255) to aggregate all latest values for a given metric name across rows.
> - Behavioral Change: `channel_depth` and `channel_capacity` are now set to `undefined` instead of being populated from metrics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46f4e26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->