### PR TITLE
feat(ffwd-core): escalate indexing_slicing to deny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,11 @@ empty_drop = "warn"
 unnecessary_safety_comment = "warn"
 unnecessary_safety_doc = "warn"
 
+# Tier 6: restriction-group correctness lints (opt-in, warn-level for gradual adoption).
+unwrap_used = "warn"
+expect_used = "warn"
+indexing_slicing = "warn"
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(kani)',

--- a/crates/ffwd-core/src/byte_search.rs
+++ b/crates/ffwd-core/src/byte_search.rs
@@ -3,6 +3,7 @@
 //! These use plain byte loops instead of memchr so Kani can formally
 //! verify them. LLVM auto-vectorizes the loops, so runtime performance
 //! is comparable to hand-written SIMD.
+#![allow(clippy::indexing_slicing)]
 
 /// Find the first occurrence of `needle` in `haystack` starting at `from`.
 ///

--- a/crates/ffwd-core/src/byte_search.rs
+++ b/crates/ffwd-core/src/byte_search.rs
@@ -3,7 +3,6 @@
 //! These use plain byte loops instead of memchr so Kani can formally
 //! verify them. LLVM auto-vectorizes the loops, so runtime performance
 //! is comparable to hand-written SIMD.
-#![allow(clippy::indexing_slicing)]
 
 /// Find the first occurrence of `needle` in `haystack` starting at `from`.
 ///
@@ -12,6 +11,7 @@
 ///
 /// Formally verified by Kani for all 16-byte inputs (see proof below).
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
     let mut i = from;
     while i < haystack.len() {
@@ -26,8 +26,9 @@ pub fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
 /// Find the last occurrence of `needle` in `haystack[..end]`.
 ///
 /// Returns the index of the last match, or None if not found.
-/// Equivalent to `memchr::memrchr(needle, &haystack[..end])`.
+/// Equivalent to `memchr::memchr(needle, &haystack[..end])`.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn rfind_byte(haystack: &[u8], needle: u8, end: usize) -> Option<usize> {
     if end == 0 || haystack.is_empty() {
         return None;

--- a/crates/ffwd-core/src/cri.rs
+++ b/crates/ffwd-core/src/cri.rs
@@ -11,6 +11,7 @@
 //!
 //! Partial lines (flag "P") must be reassembled: concatenate all "P" chunks
 //! until an "F" chunk arrives, then emit the combined line.
+#![allow(clippy::indexing_slicing)]
 
 // Re-export reassembler types so bench/fuzz targets can reach them via
 // `ffwd_core::cri::CriReassembler` and `ffwd_core::cri::AggregateResult`.

--- a/crates/ffwd-core/src/cri.rs
+++ b/crates/ffwd-core/src/cri.rs
@@ -11,7 +11,6 @@
 //!
 //! Partial lines (flag "P") must be reassembled: concatenate all "P" chunks
 //! until an "F" chunk arrives, then emit the combined line.
-#![allow(clippy::indexing_slicing)]
 
 // Re-export reassembler types so bench/fuzz targets can reach them via
 // `ffwd_core::cri::CriReassembler` and `ffwd_core::cri::AggregateResult`.
@@ -36,6 +35,7 @@ pub struct CriLine<'a> {
 /// This is zero-copy — all returned slices point into the input `line`.
 /// Uses `byte_search::find_byte` (Kani-proven) instead of memchr.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_cri_line(line: &[u8]) -> Option<CriLine<'_>> {
     use crate::byte_search::find_byte;
 
@@ -205,6 +205,7 @@ pub fn process_cri_to_buf_with_plain_text_field(
 }
 
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn process_cri_chunk_lines<F>(
     chunk: &[u8],
     reassembler: &mut CriReassembler,
@@ -269,6 +270,7 @@ fn write_json_line_for_plain_text_field(
 /// Handles all characters that must be escaped in a JSON string value:
 /// double-quote, backslash, and ASCII control characters (U+0000–U+001F, U+007F).
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn json_escape_bytes(src: &[u8], dst: &mut Vec<u8>) {
     for &b in src {
         match b {
@@ -304,6 +306,7 @@ fn write_json_line(msg: &[u8], out: &mut Vec<u8>) {
 }
 
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn write_json_line_with_plain_text_field(
     msg: &[u8],
     plain_text_field_name: &str,

--- a/crates/ffwd-core/src/framer.rs
+++ b/crates/ffwd-core/src/framer.rs
@@ -13,6 +13,7 @@
 //! The framer uses plain byte loops (no memchr, no Vec) so Kani can prove
 //! it correct. LLVM auto-vectorizes the byte scan loop, so performance is
 //! comparable to hand-written SIMD.
+#![allow(clippy::indexing_slicing)]
 
 /// Maximum number of lines per frame operation.
 ///

--- a/crates/ffwd-core/src/framer.rs
+++ b/crates/ffwd-core/src/framer.rs
@@ -13,7 +13,6 @@
 //! The framer uses plain byte loops (no memchr, no Vec) so Kani can prove
 //! it correct. LLVM auto-vectorizes the byte scan loop, so performance is
 //! comparable to hand-written SIMD.
-#![allow(clippy::indexing_slicing)]
 
 /// Maximum number of lines per frame operation.
 ///
@@ -56,6 +55,7 @@ impl FrameOutput {
 
     /// Get the byte range of line `i`. Panics if `i >= len()`.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn line_range(&self, i: usize) -> (usize, usize) {
         assert!(i < self.count, "line index out of bounds");
         self.line_ranges[i]
@@ -80,6 +80,7 @@ impl NewlineFramer {
     ///
     /// Returns a `FrameOutput` with ranges of complete lines and the
     /// offset of any partial remainder.
+    #[allow(clippy::indexing_slicing)]
     pub fn frame(&self, input: &[u8]) -> FrameOutput {
         let mut output = FrameOutput {
             line_ranges: [(0, 0); MAX_LINES_PER_FRAME],

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -7,6 +7,7 @@
 // Line boundaries are found first (newline bitmask), then each line
 // is scanned independently. Within a line, the scanner iterates
 // through structural positions sequentially.
+#![allow(clippy::indexing_slicing)]
 
 use crate::scan_config::{ScanConfig, parse_int_fast};
 use crate::scan_predicate::ExtractedValue;

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -7,7 +7,6 @@
 // Line boundaries are found first (newline bitmask), then each line
 // is scanned independently. Within a line, the scanner iterates
 // through structural positions sequentially.
-#![allow(clippy::indexing_slicing)]
 
 use crate::scan_config::{ScanConfig, parse_int_fast};
 use crate::scan_predicate::ExtractedValue;
@@ -52,6 +51,7 @@ struct LineScratch {
 /// - The caller must have already invoked `begin_batch` on the builder before
 ///   this call (see [`ScanBuilder`] for the initialization contract).
 #[inline(never)]
+#[allow(clippy::indexing_slicing)]
 pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: &mut B) {
     if buf.is_empty() {
         return;
@@ -165,6 +165,7 @@ pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: 
 }
 
 /// Scan a single JSON line using pre-computed block bitmasks.
+#[allow(clippy::indexing_slicing)]
 fn scan_line<B: ScanBuilder>(
     buf: &[u8],
     start: usize,
@@ -432,6 +433,7 @@ impl PredicateScratch {
 /// fields are extracted into a scratch buffer for evaluation. If the predicate
 /// passes, deferred writes are replayed into the builder. If it fails, the
 /// row is skipped entirely (no begin_row/end_row).
+#[allow(clippy::indexing_slicing)]
 fn scan_line_with_predicate<B: ScanBuilder>(
     buf: &[u8],
     start: usize,
@@ -793,6 +795,7 @@ fn next_quote(from: usize, end: usize, blocks: &StoredBitmasks<'_>) -> Option<us
 
 /// Find the next non-whitespace position using space bitmask.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         match buf[pos] {
@@ -807,6 +810,7 @@ fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
 
 /// Skip a nested object/array using brace/bracket bitmasks.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn skip_nested(buf: &[u8], mut pos: usize, end: usize, blocks: &StoredBitmasks<'_>) -> usize {
     const MAX_TRACKED_DEPTH: u32 = 32;
     let mut depth: u32 = 0;
@@ -885,6 +889,7 @@ fn is_json_delimiter(b: u8) -> bool {
 /// Skip a bare value (used for malformed tokens).
 /// Stops at the first byte where `is_json_delimiter` returns true.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         if is_json_delimiter(buf[pos]) {
@@ -906,6 +911,7 @@ fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
 ///
 /// Invalid or truncated escape sequences are passed through unchanged
 /// to avoid data loss on malformed input.
+#[allow(clippy::indexing_slicing)]
 fn decode_json_escapes(input: &[u8], out: &mut alloc::vec::Vec<u8>) {
     out.clear();
     // Decoded output is always ≤ input length (escapes expand, never shrink).
@@ -966,6 +972,7 @@ fn decode_json_escapes(input: &[u8], out: &mut alloc::vec::Vec<u8>) {
 
 /// Decode a `\uXXXX` escape (possibly a surrogate pair) starting at `pos`.
 /// Appends the decoded UTF-8 bytes to `out` and returns the new position.
+#[allow(clippy::indexing_slicing)]
 fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>) -> usize {
     // Need at least 6 bytes: \uXXXX
     if pos + 6 > input.len() {
@@ -1022,6 +1029,7 @@ fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>
 
 /// Parse 4 ASCII hex digits into a `u16`.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn parse_hex4(bytes: &[u8]) -> Option<u16> {
     if bytes.len() < 4 {
         return None;

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -7,6 +7,7 @@
 // Line boundaries are found first (newline bitmask), then each line
 // is scanned independently. Within a line, the scanner iterates
 // through structural positions sequentially.
+#![allow(clippy::indexing_slicing)]
 
 use crate::scan_config::{ScanConfig, parse_int_fast};
 use crate::scan_predicate::ExtractedValue;
@@ -51,7 +52,6 @@ struct LineScratch {
 /// - The caller must have already invoked `begin_batch` on the builder before
 ///   this call (see [`ScanBuilder`] for the initialization contract).
 #[inline(never)]
-#[allow(clippy::indexing_slicing)]
 pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: &mut B) {
     if buf.is_empty() {
         return;
@@ -165,7 +165,6 @@ pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: 
 }
 
 /// Scan a single JSON line using pre-computed block bitmasks.
-#[allow(clippy::indexing_slicing)]
 fn scan_line<B: ScanBuilder>(
     buf: &[u8],
     start: usize,
@@ -433,7 +432,6 @@ impl PredicateScratch {
 /// fields are extracted into a scratch buffer for evaluation. If the predicate
 /// passes, deferred writes are replayed into the builder. If it fails, the
 /// row is skipped entirely (no begin_row/end_row).
-#[allow(clippy::indexing_slicing)]
 fn scan_line_with_predicate<B: ScanBuilder>(
     buf: &[u8],
     start: usize,
@@ -795,7 +793,6 @@ fn next_quote(from: usize, end: usize, blocks: &StoredBitmasks<'_>) -> Option<us
 
 /// Find the next non-whitespace position using space bitmask.
 #[inline]
-#[allow(clippy::indexing_slicing)]
 fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         match buf[pos] {
@@ -810,7 +807,6 @@ fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
 
 /// Skip a nested object/array using brace/bracket bitmasks.
 #[inline]
-#[allow(clippy::indexing_slicing)]
 fn skip_nested(buf: &[u8], mut pos: usize, end: usize, blocks: &StoredBitmasks<'_>) -> usize {
     const MAX_TRACKED_DEPTH: u32 = 32;
     let mut depth: u32 = 0;
@@ -889,7 +885,6 @@ fn is_json_delimiter(b: u8) -> bool {
 /// Skip a bare value (used for malformed tokens).
 /// Stops at the first byte where `is_json_delimiter` returns true.
 #[inline]
-#[allow(clippy::indexing_slicing)]
 fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         if is_json_delimiter(buf[pos]) {
@@ -911,7 +906,6 @@ fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
 ///
 /// Invalid or truncated escape sequences are passed through unchanged
 /// to avoid data loss on malformed input.
-#[allow(clippy::indexing_slicing)]
 fn decode_json_escapes(input: &[u8], out: &mut alloc::vec::Vec<u8>) {
     out.clear();
     // Decoded output is always ≤ input length (escapes expand, never shrink).
@@ -972,7 +966,6 @@ fn decode_json_escapes(input: &[u8], out: &mut alloc::vec::Vec<u8>) {
 
 /// Decode a `\uXXXX` escape (possibly a surrogate pair) starting at `pos`.
 /// Appends the decoded UTF-8 bytes to `out` and returns the new position.
-#[allow(clippy::indexing_slicing)]
 fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>) -> usize {
     // Need at least 6 bytes: \uXXXX
     if pos + 6 > input.len() {
@@ -1029,7 +1022,6 @@ fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>
 
 /// Parse 4 ASCII hex digits into a `u16`.
 #[inline]
-#[allow(clippy::indexing_slicing)]
 fn parse_hex4(bytes: &[u8]) -> Option<u16> {
     if bytes.len() < 4 {
         return None;

--- a/crates/ffwd-core/src/lib.rs
+++ b/crates/ffwd-core/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(missing_docs)]
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::panic)]
+#![deny(clippy::indexing_slicing)]
 
 extern crate alloc;
 

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -19,7 +19,6 @@
 //! Wire format: each field = tag_varint + value
 //!   tag = (field_number << 3) | wire_type
 //!   wire_type: 0=varint, 1=64-bit fixed, 2=length-delimited, 5=32-bit fixed
-#![allow(clippy::indexing_slicing)]
 
 // --- Protobuf field number constants ---
 //
@@ -210,6 +209,7 @@ pub fn encode_fixed32(buf: &mut Vec<u8>, field_number: u32, value: u32) {
 /// or the varint exceeds 10 bytes.
 #[allow_unproven]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn decode_varint(buf: &[u8], pos: usize) -> Result<(u64, usize), &'static str> {
     let mut value: u64 = 0;
     let mut shift: u32 = 0;
@@ -234,6 +234,7 @@ pub fn decode_varint(buf: &[u8], pos: usize) -> Result<(u64, usize), &'static st
 /// Decode a protobuf tag into `(field_number, wire_type, new_pos)`.
 #[allow_unproven]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn decode_tag(buf: &[u8], pos: usize) -> Result<(u32, u8, usize), &'static str> {
     let (tag, new_pos) = decode_varint(buf, pos)?;
     let field_number = (tag >> 3) as u32;
@@ -245,6 +246,7 @@ pub fn decode_tag(buf: &[u8], pos: usize) -> Result<(u32, u8, usize), &'static s
 /// position after the field value.
 #[allow_unproven]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn skip_field(buf: &[u8], wire_type: u8, pos: usize) -> Result<usize, &'static str> {
     match wire_type {
         0 => {

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -19,6 +19,7 @@
 //! Wire format: each field = tag_varint + value
 //!   tag = (field_number << 3) | wire_type
 //!   wire_type: 0=varint, 1=64-bit fixed, 2=length-delimited, 5=32-bit fixed
+#![allow(clippy::indexing_slicing)]
 
 // --- Protobuf field number constants ---
 //

--- a/crates/ffwd-core/src/reassembler.rs
+++ b/crates/ffwd-core/src/reassembler.rs
@@ -14,7 +14,6 @@
 //!
 //! The internal buffer reuses its capacity across P/F sequences via `clear()`,
 //! so allocation only happens once (on the first P line seen).
-#![allow(clippy::indexing_slicing)]
 
 /// Aggregates CRI partial lines into complete messages.
 ///
@@ -97,6 +96,7 @@ impl CriReassembler {
     /// Returns [`AggregateResult::Truncated`] instead of
     /// [`AggregateResult::Complete`] when any chunk in the current P/F
     /// sequence exceeded `max_message_size`. Callers should log a warning.
+    #[allow(clippy::indexing_slicing)]
     pub fn feed<'a>(&'a mut self, message: &'a [u8], is_full: bool) -> AggregateResult<'a> {
         if is_full {
             if self.pending.is_empty() {
@@ -175,6 +175,7 @@ impl CriReassembler {
     /// (timestamp + stream + flag) plus the message to be buffered. Using only
     /// `max_message_size` would truncate the raw line before the header is fully
     /// received, turning a valid split line into a parse error.
+    #[allow(clippy::indexing_slicing)]
     pub(crate) fn push_line_fragment(&mut self, bytes: &[u8]) {
         let remaining = self
             .raw_line_fragment_limit()

--- a/crates/ffwd-core/src/reassembler.rs
+++ b/crates/ffwd-core/src/reassembler.rs
@@ -14,6 +14,7 @@
 //!
 //! The internal buffer reuses its capacity across P/F sequences via `clear()`,
 //! so allocation only happens once (on the first P line seen).
+#![allow(clippy::indexing_slicing)]
 
 /// Aggregates CRI partial lines into complete messages.
 ///

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -2,6 +2,7 @@
 //
 // Defines ScanConfig and FieldSpec, used by the Scanner and the SQL
 // transform layer.
+#![allow(clippy::indexing_slicing)]
 
 use crate::scan_predicate::ScanPredicate;
 use alloc::{string::String, vec, vec::Vec};

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -2,7 +2,6 @@
 //
 // Defines ScanConfig and FieldSpec, used by the Scanner and the SQL
 // transform layer.
-#![allow(clippy::indexing_slicing)]
 
 use crate::scan_predicate::ScanPredicate;
 use alloc::{string::String, vec, vec::Vec};
@@ -85,6 +84,7 @@ impl ScanConfig {
 /// Parse a byte slice as a signed 64-bit integer.
 /// Returns None on overflow or non-digit bytes.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
     if bytes.is_empty() {
         return None;

--- a/crates/ffwd-core/src/structural_iter.rs
+++ b/crates/ffwd-core/src/structural_iter.rs
@@ -10,7 +10,6 @@
 // The iterator handles Stage 1 (SIMD detection) and escape processing
 // internally. Consumers see only unescaped, not-in-string structural
 // positions (plus quotes and newlines which are always yielded).
-#![allow(clippy::indexing_slicing)]
 
 use crate::structural::{ProcessedBlock, StreamingClassifier, find_structural_chars};
 
@@ -108,6 +107,7 @@ impl<'a> StructuralIter<'a> {
     }
 
     /// Load and process the block at the given index.
+    #[allow(clippy::indexing_slicing)]
     fn load_block(&mut self, idx: usize) {
         self.block_idx = idx;
         self.block_offset = idx * 64;
@@ -199,6 +199,7 @@ impl<'a> StructuralIter<'a> {
     ///
     /// Uses the space bitmask — O(1) per block, no byte scanning.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn next_non_space(&self, from: usize) -> usize {
         if from >= self.len {
             return self.len;

--- a/crates/ffwd-core/src/structural_iter.rs
+++ b/crates/ffwd-core/src/structural_iter.rs
@@ -10,6 +10,7 @@
 // The iterator handles Stage 1 (SIMD detection) and escape processing
 // internally. Consumers see only unescaped, not-in-string structural
 // positions (plus quotes and newlines which are always yielded).
+#![allow(clippy::indexing_slicing)]
 
 use crate::structural::{ProcessedBlock, StreamingClassifier, find_structural_chars};
 

--- a/crates/ffwd-lint-attrs/src/lib.rs
+++ b/crates/ffwd-lint-attrs/src/lib.rs
@@ -115,6 +115,7 @@ pub fn owned_by_actor(_attr: TokenStream, item: TokenStream) -> TokenStream {
     prepend_marker("__ffwd_owned_by_actor__", item)
 }
 
+#[allow(clippy::expect_used)]
 fn prepend_marker(marker: &str, item: TokenStream) -> TokenStream {
     let attr: TokenStream = format!("#[doc = \"{marker}\"]")
         .parse()

--- a/crates/ffwd-otap-proto/build.rs
+++ b/crates/ffwd-otap-proto/build.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::expect_used)]
 fn main() {
     ffwd_proto_build::compile_with_vendored_protoc(&["proto/otap.proto"], &["proto"])
         .expect("compile OTAP protobuf schema");

--- a/crates/ffwd-proto-build/src/lib.rs
+++ b/crates/ffwd-proto-build/src/lib.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 
 /// Compile one or more proto files with vendored `protoc`.
+#[allow(clippy::expect_used)]
 pub fn compile_with_vendored_protoc(
     protos: &[impl AsRef<Path>],
     includes: &[impl AsRef<Path>],

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ fmt-check:
 
 # Clippy — default-members only (skips datafusion, ~30s)
 clippy:
-    cargo clippy -- -D warnings
+    RUSTFLAGS="-W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing" cargo clippy
 
 # Clippy — full workspace including datafusion (~3min, CI uses this)
 clippy-all:

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ fmt-check:
 
 # Clippy — default-members only (skips datafusion, ~30s)
 clippy:
-    RUSTFLAGS="-W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing" cargo clippy
+    RUSTFLAGS="-W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing" cargo clippy -- -D warnings
 
 # Clippy — full workspace including datafusion (~3min, CI uses this)
 clippy-all:


### PR DESCRIPTION
Escalate `indexing_slicing` clippy lint to deny in ffwd-core. Internal hot-path uses annotated with `#[allow]`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deny `clippy::indexing_slicing` in `ffwd-core` and add workspace-level lint configuration
> - Adds `#![deny(clippy::indexing_slicing)]` to [ffwd-core/src/lib.rs](https://github.com/strawgate/fastforward/pull/2655/files#diff-e02348bfa289ce9f44a9ec9a1baba8b42657931f2f13cbf3431cd0e9ce635a88), making unchecked slice indexing a hard error across the crate.
> - Adds workspace-level `warn` lints for `unwrap_used`, `expect_used`, and `indexing_slicing` in [Cargo.toml](https://github.com/strawgate/fastforward/pull/2655/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542).
> - Annotates existing functions that use intentional slice indexing with `#[allow(clippy::indexing_slicing)]` rather than rewriting them, preserving current behavior.
> - Updates the `clippy` recipe in [justfile](https://github.com/strawgate/fastforward/pull/2655/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1) to pass these three lints as warnings via `RUSTFLAGS` before running `cargo clippy -D warnings`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e7ba87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->