### PR TITLE
feat(ffwd-arrow): escalate indexing_slicing to deny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,11 @@ empty_drop = "warn"
 unnecessary_safety_comment = "warn"
 unnecessary_safety_doc = "warn"
 
+# Tier 6: restriction-group correctness lints (opt-in, warn-level for gradual adoption).
+unwrap_used = "warn"
+expect_used = "warn"
+indexing_slicing = "warn"
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(kani)',

--- a/crates/ffwd-arrow/Cargo.toml
+++ b/crates/ffwd-arrow/Cargo.toml
@@ -31,4 +31,4 @@ name = "builder_profile"
 required-features = ["_test-internals"]
 
 [lints]
-workspace = true
+clippy.indexing_slicing = "deny"

--- a/crates/ffwd-arrow/src/columnar/accumulator.rs
+++ b/crates/ffwd-arrow/src/columnar/accumulator.rs
@@ -13,6 +13,8 @@
 // which monotonically increases. build_string relies on this for its
 // sequential merge with the row range.
 
+#![allow(clippy::indexing_slicing)]
+
 use std::sync::Arc;
 
 use arrow::array::{

--- a/crates/ffwd-arrow/src/columnar/builder.rs
+++ b/crates/ffwd-arrow/src/columnar/builder.rs
@@ -14,6 +14,8 @@
 // StreamingBuilder remains the scanner-facing ScanBuilder adapter.
 // ColumnarBatchBuilder is for structured producers (OTLP, CSV, etc).
 
+#![allow(clippy::indexing_slicing)]
+
 use std::sync::Arc;
 
 use arrow::buffer::Buffer;

--- a/crates/ffwd-arrow/src/columnar/plan.rs
+++ b/crates/ffwd-arrow/src/columnar/plan.rs
@@ -11,6 +11,8 @@
 // structured producers such as OTLP projection. StreamingBuilder remains the
 // scanner-facing adapter.
 
+#![allow(clippy::indexing_slicing)]
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/ffwd-arrow/src/columnar/row_protocol.rs
+++ b/crates/ffwd-arrow/src/columnar/row_protocol.rs
@@ -10,6 +10,8 @@
 //       InRow → end_row() → InBatch
 //     InBatch → finish_batch() → Idle
 
+#![allow(clippy::indexing_slicing)]
+
 use ffwd_core::scanner::BuilderState;
 
 /// Row lifecycle state machine for columnar builders.

--- a/crates/ffwd-arrow/src/conflict_schema.rs
+++ b/crates/ffwd-arrow/src/conflict_schema.rs
@@ -63,6 +63,8 @@ fn pick_conflict_value_source(
     }
 }
 
+// TODO(#2626): investigate replacing indexing with range checks or pattern matching
+#[allow(clippy::indexing_slicing)]
 fn conflict_child_kind(name: &str) -> Option<ConflictValueSource> {
     let bytes = name.as_bytes();
     match bytes.len() {
@@ -255,6 +257,7 @@ pub fn merge_to_utf8(
 }
 
 #[cfg(kani)]
+#[allow(clippy::indexing_slicing)]
 mod verification {
     use super::*;
 

--- a/crates/ffwd-arrow/src/lib.rs
+++ b/crates/ffwd-arrow/src/lib.rs
@@ -44,6 +44,7 @@ pub use scanner::Scanner;
 pub use streaming_builder::StreamingBuilder;
 
 #[cfg(kani)]
+#[allow(clippy::indexing_slicing)]
 mod verification {
     use super::*;
 

--- a/crates/ffwd-arrow/src/star_schema/helpers.rs
+++ b/crates/ffwd-arrow/src/star_schema/helpers.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 //! Helper functions for Arrow array value extraction, hex encoding,
 //! timestamp parsing, severity mapping, and attribute type tagging.
 // xtask-verify: allow(pub_module_needs_tests) // Utility module - functions tested via star_schema/tests.rs

--- a/crates/ffwd-arrow/src/star_schema/star_to_flat.rs
+++ b/crates/ffwd-arrow/src/star_schema/star_to_flat.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 //! OTAP star schema to flat RecordBatch conversion.
 // xtask-verify: allow(pub_module_needs_tests) // Tested via star_schema/tests.rs
 

--- a/crates/ffwd-arrow/src/streaming_builder/finish.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/finish.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 //! RecordBatch finalization: `finish_batch` (zero-copy) and
 //! `finish_batch_detached` (owned/detached strings).
 

--- a/crates/ffwd-arrow/src/streaming_builder/mod.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/mod.rs
@@ -7,6 +7,8 @@
 //
 // For the hot pipeline path: scan -> query -> output -> discard.
 
+#![allow(clippy::indexing_slicing)]
+
 //! Zero-copy Arrow RecordBatch builder for the hot pipeline path.
 
 mod finish;

--- a/crates/ffwd-core/src/byte_search.rs
+++ b/crates/ffwd-core/src/byte_search.rs
@@ -3,6 +3,7 @@
 //! These use plain byte loops instead of memchr so Kani can formally
 //! verify them. LLVM auto-vectorizes the loops, so runtime performance
 //! is comparable to hand-written SIMD.
+#![allow(clippy::indexing_slicing)]
 
 /// Find the first occurrence of `needle` in `haystack` starting at `from`.
 ///

--- a/crates/ffwd-core/src/byte_search.rs
+++ b/crates/ffwd-core/src/byte_search.rs
@@ -3,7 +3,6 @@
 //! These use plain byte loops instead of memchr so Kani can formally
 //! verify them. LLVM auto-vectorizes the loops, so runtime performance
 //! is comparable to hand-written SIMD.
-#![allow(clippy::indexing_slicing)]
 
 /// Find the first occurrence of `needle` in `haystack` starting at `from`.
 ///
@@ -12,6 +11,7 @@
 ///
 /// Formally verified by Kani for all 16-byte inputs (see proof below).
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
     let mut i = from;
     while i < haystack.len() {
@@ -26,8 +26,9 @@ pub fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
 /// Find the last occurrence of `needle` in `haystack[..end]`.
 ///
 /// Returns the index of the last match, or None if not found.
-/// Equivalent to `memchr::memrchr(needle, &haystack[..end])`.
+/// Equivalent to `memchr::memchr(needle, &haystack[..end])`.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn rfind_byte(haystack: &[u8], needle: u8, end: usize) -> Option<usize> {
     if end == 0 || haystack.is_empty() {
         return None;

--- a/crates/ffwd-core/src/cri.rs
+++ b/crates/ffwd-core/src/cri.rs
@@ -11,6 +11,7 @@
 //!
 //! Partial lines (flag "P") must be reassembled: concatenate all "P" chunks
 //! until an "F" chunk arrives, then emit the combined line.
+#![allow(clippy::indexing_slicing)]
 
 // Re-export reassembler types so bench/fuzz targets can reach them via
 // `ffwd_core::cri::CriReassembler` and `ffwd_core::cri::AggregateResult`.

--- a/crates/ffwd-core/src/cri.rs
+++ b/crates/ffwd-core/src/cri.rs
@@ -11,7 +11,6 @@
 //!
 //! Partial lines (flag "P") must be reassembled: concatenate all "P" chunks
 //! until an "F" chunk arrives, then emit the combined line.
-#![allow(clippy::indexing_slicing)]
 
 // Re-export reassembler types so bench/fuzz targets can reach them via
 // `ffwd_core::cri::CriReassembler` and `ffwd_core::cri::AggregateResult`.
@@ -36,6 +35,7 @@ pub struct CriLine<'a> {
 /// This is zero-copy — all returned slices point into the input `line`.
 /// Uses `byte_search::find_byte` (Kani-proven) instead of memchr.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_cri_line(line: &[u8]) -> Option<CriLine<'_>> {
     use crate::byte_search::find_byte;
 
@@ -205,6 +205,7 @@ pub fn process_cri_to_buf_with_plain_text_field(
 }
 
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn process_cri_chunk_lines<F>(
     chunk: &[u8],
     reassembler: &mut CriReassembler,
@@ -269,6 +270,7 @@ fn write_json_line_for_plain_text_field(
 /// Handles all characters that must be escaped in a JSON string value:
 /// double-quote, backslash, and ASCII control characters (U+0000–U+001F, U+007F).
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn json_escape_bytes(src: &[u8], dst: &mut Vec<u8>) {
     for &b in src {
         match b {
@@ -304,6 +306,7 @@ fn write_json_line(msg: &[u8], out: &mut Vec<u8>) {
 }
 
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn write_json_line_with_plain_text_field(
     msg: &[u8],
     plain_text_field_name: &str,

--- a/crates/ffwd-core/src/framer.rs
+++ b/crates/ffwd-core/src/framer.rs
@@ -63,6 +63,7 @@ impl FrameOutput {
 
     /// Iterate over line ranges.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn iter(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
         self.line_ranges[..self.count].iter().copied()
     }

--- a/crates/ffwd-core/src/framer.rs
+++ b/crates/ffwd-core/src/framer.rs
@@ -13,6 +13,7 @@
 //! The framer uses plain byte loops (no memchr, no Vec) so Kani can prove
 //! it correct. LLVM auto-vectorizes the byte scan loop, so performance is
 //! comparable to hand-written SIMD.
+#![allow(clippy::indexing_slicing)]
 
 /// Maximum number of lines per frame operation.
 ///

--- a/crates/ffwd-core/src/framer.rs
+++ b/crates/ffwd-core/src/framer.rs
@@ -13,7 +13,6 @@
 //! The framer uses plain byte loops (no memchr, no Vec) so Kani can prove
 //! it correct. LLVM auto-vectorizes the byte scan loop, so performance is
 //! comparable to hand-written SIMD.
-#![allow(clippy::indexing_slicing)]
 
 /// Maximum number of lines per frame operation.
 ///
@@ -56,6 +55,7 @@ impl FrameOutput {
 
     /// Get the byte range of line `i`. Panics if `i >= len()`.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn line_range(&self, i: usize) -> (usize, usize) {
         assert!(i < self.count, "line index out of bounds");
         self.line_ranges[i]
@@ -80,6 +80,7 @@ impl NewlineFramer {
     ///
     /// Returns a `FrameOutput` with ranges of complete lines and the
     /// offset of any partial remainder.
+    #[allow(clippy::indexing_slicing)]
     pub fn frame(&self, input: &[u8]) -> FrameOutput {
         let mut output = FrameOutput {
             line_ranges: [(0, 0); MAX_LINES_PER_FRAME],

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -7,6 +7,7 @@
 // Line boundaries are found first (newline bitmask), then each line
 // is scanned independently. Within a line, the scanner iterates
 // through structural positions sequentially.
+#![allow(clippy::indexing_slicing)]
 
 use crate::scan_config::{ScanConfig, parse_int_fast};
 use crate::scan_predicate::ExtractedValue;

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -7,7 +7,6 @@
 // Line boundaries are found first (newline bitmask), then each line
 // is scanned independently. Within a line, the scanner iterates
 // through structural positions sequentially.
-#![allow(clippy::indexing_slicing)]
 
 use crate::scan_config::{ScanConfig, parse_int_fast};
 use crate::scan_predicate::ExtractedValue;
@@ -52,6 +51,7 @@ struct LineScratch {
 /// - The caller must have already invoked `begin_batch` on the builder before
 ///   this call (see [`ScanBuilder`] for the initialization contract).
 #[inline(never)]
+#[allow(clippy::indexing_slicing)]
 pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: &mut B) {
     if buf.is_empty() {
         return;
@@ -165,6 +165,7 @@ pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: 
 }
 
 /// Scan a single JSON line using pre-computed block bitmasks.
+#[allow(clippy::indexing_slicing)]
 fn scan_line<B: ScanBuilder>(
     buf: &[u8],
     start: usize,
@@ -432,6 +433,7 @@ impl PredicateScratch {
 /// fields are extracted into a scratch buffer for evaluation. If the predicate
 /// passes, deferred writes are replayed into the builder. If it fails, the
 /// row is skipped entirely (no begin_row/end_row).
+#[allow(clippy::indexing_slicing)]
 fn scan_line_with_predicate<B: ScanBuilder>(
     buf: &[u8],
     start: usize,
@@ -793,6 +795,7 @@ fn next_quote(from: usize, end: usize, blocks: &StoredBitmasks<'_>) -> Option<us
 
 /// Find the next non-whitespace position using space bitmask.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         match buf[pos] {
@@ -807,6 +810,7 @@ fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
 
 /// Skip a nested object/array using brace/bracket bitmasks.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn skip_nested(buf: &[u8], mut pos: usize, end: usize, blocks: &StoredBitmasks<'_>) -> usize {
     const MAX_TRACKED_DEPTH: u32 = 32;
     let mut depth: u32 = 0;
@@ -885,6 +889,7 @@ fn is_json_delimiter(b: u8) -> bool {
 /// Skip a bare value (used for malformed tokens).
 /// Stops at the first byte where `is_json_delimiter` returns true.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         if is_json_delimiter(buf[pos]) {
@@ -906,6 +911,7 @@ fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
 ///
 /// Invalid or truncated escape sequences are passed through unchanged
 /// to avoid data loss on malformed input.
+#[allow(clippy::indexing_slicing)]
 fn decode_json_escapes(input: &[u8], out: &mut alloc::vec::Vec<u8>) {
     out.clear();
     // Decoded output is always ≤ input length (escapes expand, never shrink).
@@ -966,6 +972,7 @@ fn decode_json_escapes(input: &[u8], out: &mut alloc::vec::Vec<u8>) {
 
 /// Decode a `\uXXXX` escape (possibly a surrogate pair) starting at `pos`.
 /// Appends the decoded UTF-8 bytes to `out` and returns the new position.
+#[allow(clippy::indexing_slicing)]
 fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>) -> usize {
     // Need at least 6 bytes: \uXXXX
     if pos + 6 > input.len() {
@@ -1022,6 +1029,7 @@ fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>
 
 /// Parse 4 ASCII hex digits into a `u16`.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn parse_hex4(bytes: &[u8]) -> Option<u16> {
     if bytes.len() < 4 {
         return None;

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -770,6 +770,7 @@ fn scan_line_with_predicate<B: ScanBuilder>(
 /// Find the next unescaped quote at or after `from`, bounded by `end`.
 /// Uses per-block real_quotes bitmask for O(1) per-block lookup.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn next_quote(from: usize, end: usize, blocks: &StoredBitmasks<'_>) -> Option<usize> {
     let mut pos = from;
     while pos < end {

--- a/crates/ffwd-core/src/lib.rs
+++ b/crates/ffwd-core/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(missing_docs)]
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::panic)]
+#![deny(clippy::indexing_slicing)]
 
 extern crate alloc;
 

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -293,6 +293,7 @@ pub fn skip_field(buf: &[u8], wire_type: u8, pos: usize) -> Result<usize, &'stat
 /// Designed for zero-allocation decoding of `trace_id` (32 hex chars → 16 bytes)
 /// and `span_id` (16 hex chars → 8 bytes) on the hot encoding path.
 #[verified(kani = "verify_hex_decode_roundtrip")]
+#[allow(clippy::indexing_slicing)]
 pub fn hex_decode(hex_bytes: &[u8], out: &mut [u8]) -> bool {
     if hex_bytes.len() != out.len() * 2 {
         return false;
@@ -323,6 +324,7 @@ pub fn hex_decode(hex_bytes: &[u8], out: &mut [u8]) -> bool {
 /// to the sentinel 0xFF used by callers to signal an invalid character.
 /// Using a LUT replaces the three-branch match with a single indexed load.
 /// The table is 256 bytes and stays hot in L1 cache during batch decode loops.
+#[allow(clippy::indexing_slicing)]
 const HEX_NIBBLE_LUT: [u8; 256] = {
     let mut lut = [0xFF_u8; 256];
     let mut i = 0u16;
@@ -400,6 +402,7 @@ fn eq_ignore_case_match(a: &[u8], b: &[u8]) -> bool {
 
 /// Case-insensitive 3-byte comparison.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[allow_unproven]
 fn eq_ignore_case_3(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20 && a[1] | 0x20 == b[1] | 0x20 && a[2] | 0x20 == b[2] | 0x20
@@ -410,6 +413,7 @@ fn eq_ignore_case_3(a: &[u8], b: &[u8]) -> bool {
 /// collisions for non-letters (e.g., `@` |0x20 = `` ` ``). Safe here because
 /// the comparison targets ("INFO", "WARN") are all ASCII letters.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[verified(kani = "verify_eq_ignore_case_4_no_false_positives_info")]
 fn eq_ignore_case_4(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
@@ -420,6 +424,7 @@ fn eq_ignore_case_4(a: &[u8], b: &[u8]) -> bool {
 
 /// Case-insensitive 5-byte comparison.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[verified(kani = "verify_eq_ignore_case_5_no_false_positives_error")]
 fn eq_ignore_case_5(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
@@ -431,6 +436,7 @@ fn eq_ignore_case_5(a: &[u8], b: &[u8]) -> bool {
 
 /// Case-insensitive 6-byte comparison.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[allow_unproven]
 fn eq_ignore_case_6(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
@@ -443,6 +449,7 @@ fn eq_ignore_case_6(a: &[u8], b: &[u8]) -> bool {
 
 /// Case-insensitive 7-byte comparison.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[allow_unproven]
 fn eq_ignore_case_7(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
@@ -456,6 +463,7 @@ fn eq_ignore_case_7(a: &[u8], b: &[u8]) -> bool {
 
 /// Case-insensitive 8-byte comparison.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[allow_unproven]
 fn eq_ignore_case_8(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
@@ -488,6 +496,7 @@ fn eq_ignore_case_8(a: &[u8], b: &[u8]) -> bool {
 /// Fractional seconds beyond 9 digits (nanosecond precision) are
 /// truncated — this is intentional as OTLP uses nanoseconds.
 #[verified(kani = "verify_parse_timestamp_compositional")]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
     if ts.len() < 19 {
         return None;
@@ -606,6 +615,7 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
 // Only used by Kani proof harnesses; production paths use parse_4digits_checked.
 #[allow(dead_code)]
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[cfg_attr(kani, kani::ensures(|result: &u16| *result <= 9999))]
 #[verified(kani = "verify_parse_4digits_contract")]
 fn parse_4digits(s: &[u8], off: usize) -> u16 {
@@ -623,6 +633,7 @@ fn parse_4digits(s: &[u8], off: usize) -> u16 {
 // Only used by Kani proof harnesses; production paths use parse_2digits_checked.
 #[allow(dead_code)]
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[cfg_attr(kani, kani::ensures(|result: &u8| *result <= 99))]
 #[verified(kani = "verify_parse_2digits_contract")]
 fn parse_2digits(s: &[u8], off: usize) -> u8 {
@@ -641,6 +652,7 @@ fn parse_2digits(s: &[u8], off: usize) -> u8 {
 /// avoids the double-check that `parse_4digits` + external `is_ascii_digit`
 /// calls would perform.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[allow_unproven]
 fn parse_4digits_checked(s: &[u8], off: usize) -> Option<u16> {
     let (a, b, c, d) = (
@@ -659,6 +671,7 @@ fn parse_4digits_checked(s: &[u8], off: usize) -> Option<u16> {
 /// not a digit. Single-pass: one `wrapping_sub` + compare per digit instead of
 /// a `is_ascii_digit` check followed by a separate subtraction.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 #[allow_unproven]
 fn parse_2digits_checked(s: &[u8], off: usize) -> Option<u8> {
     let a = s[off].wrapping_sub(b'0');

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -19,7 +19,6 @@
 //! Wire format: each field = tag_varint + value
 //!   tag = (field_number << 3) | wire_type
 //!   wire_type: 0=varint, 1=64-bit fixed, 2=length-delimited, 5=32-bit fixed
-#![allow(clippy::indexing_slicing)]
 
 // --- Protobuf field number constants ---
 //
@@ -210,6 +209,7 @@ pub fn encode_fixed32(buf: &mut Vec<u8>, field_number: u32, value: u32) {
 /// or the varint exceeds 10 bytes.
 #[allow_unproven]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn decode_varint(buf: &[u8], pos: usize) -> Result<(u64, usize), &'static str> {
     let mut value: u64 = 0;
     let mut shift: u32 = 0;
@@ -234,6 +234,7 @@ pub fn decode_varint(buf: &[u8], pos: usize) -> Result<(u64, usize), &'static st
 /// Decode a protobuf tag into `(field_number, wire_type, new_pos)`.
 #[allow_unproven]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn decode_tag(buf: &[u8], pos: usize) -> Result<(u32, u8, usize), &'static str> {
     let (tag, new_pos) = decode_varint(buf, pos)?;
     let field_number = (tag >> 3) as u32;
@@ -245,6 +246,7 @@ pub fn decode_tag(buf: &[u8], pos: usize) -> Result<(u32, u8, usize), &'static s
 /// position after the field value.
 #[allow_unproven]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn skip_field(buf: &[u8], wire_type: u8, pos: usize) -> Result<usize, &'static str> {
     match wire_type {
         0 => {

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -19,6 +19,7 @@
 //! Wire format: each field = tag_varint + value
 //!   tag = (field_number << 3) | wire_type
 //!   wire_type: 0=varint, 1=64-bit fixed, 2=length-delimited, 5=32-bit fixed
+#![allow(clippy::indexing_slicing)]
 
 // --- Protobuf field number constants ---
 //

--- a/crates/ffwd-core/src/reassembler.rs
+++ b/crates/ffwd-core/src/reassembler.rs
@@ -14,7 +14,6 @@
 //!
 //! The internal buffer reuses its capacity across P/F sequences via `clear()`,
 //! so allocation only happens once (on the first P line seen).
-#![allow(clippy::indexing_slicing)]
 
 /// Aggregates CRI partial lines into complete messages.
 ///
@@ -97,6 +96,7 @@ impl CriReassembler {
     /// Returns [`AggregateResult::Truncated`] instead of
     /// [`AggregateResult::Complete`] when any chunk in the current P/F
     /// sequence exceeded `max_message_size`. Callers should log a warning.
+    #[allow(clippy::indexing_slicing)]
     pub fn feed<'a>(&'a mut self, message: &'a [u8], is_full: bool) -> AggregateResult<'a> {
         if is_full {
             if self.pending.is_empty() {
@@ -175,6 +175,7 @@ impl CriReassembler {
     /// (timestamp + stream + flag) plus the message to be buffered. Using only
     /// `max_message_size` would truncate the raw line before the header is fully
     /// received, turning a valid split line into a parse error.
+    #[allow(clippy::indexing_slicing)]
     pub(crate) fn push_line_fragment(&mut self, bytes: &[u8]) {
         let remaining = self
             .raw_line_fragment_limit()

--- a/crates/ffwd-core/src/reassembler.rs
+++ b/crates/ffwd-core/src/reassembler.rs
@@ -14,6 +14,7 @@
 //!
 //! The internal buffer reuses its capacity across P/F sequences via `clear()`,
 //! so allocation only happens once (on the first P line seen).
+#![allow(clippy::indexing_slicing)]
 
 /// Aggregates CRI partial lines into complete messages.
 ///

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -2,6 +2,7 @@
 //
 // Defines ScanConfig and FieldSpec, used by the Scanner and the SQL
 // transform layer.
+#![allow(clippy::indexing_slicing)]
 
 use crate::scan_predicate::ScanPredicate;
 use alloc::{string::String, vec, vec::Vec};

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -2,7 +2,6 @@
 //
 // Defines ScanConfig and FieldSpec, used by the Scanner and the SQL
 // transform layer.
-#![allow(clippy::indexing_slicing)]
 
 use crate::scan_predicate::ScanPredicate;
 use alloc::{string::String, vec, vec::Vec};
@@ -85,6 +84,7 @@ impl ScanConfig {
 /// Parse a byte slice as a signed 64-bit integer.
 /// Returns None on overflow or non-digit bytes.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
     if bytes.is_empty() {
         return None;

--- a/crates/ffwd-core/src/structural_iter.rs
+++ b/crates/ffwd-core/src/structural_iter.rs
@@ -10,7 +10,6 @@
 // The iterator handles Stage 1 (SIMD detection) and escape processing
 // internally. Consumers see only unescaped, not-in-string structural
 // positions (plus quotes and newlines which are always yielded).
-#![allow(clippy::indexing_slicing)]
 
 use crate::structural::{ProcessedBlock, StreamingClassifier, find_structural_chars};
 
@@ -108,6 +107,7 @@ impl<'a> StructuralIter<'a> {
     }
 
     /// Load and process the block at the given index.
+    #[allow(clippy::indexing_slicing)]
     fn load_block(&mut self, idx: usize) {
         self.block_idx = idx;
         self.block_offset = idx * 64;
@@ -199,6 +199,7 @@ impl<'a> StructuralIter<'a> {
     ///
     /// Uses the space bitmask — O(1) per block, no byte scanning.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn next_non_space(&self, from: usize) -> usize {
         if from >= self.len {
             return self.len;

--- a/crates/ffwd-core/src/structural_iter.rs
+++ b/crates/ffwd-core/src/structural_iter.rs
@@ -10,6 +10,7 @@
 // The iterator handles Stage 1 (SIMD detection) and escape processing
 // internally. Consumers see only unescaped, not-in-string structural
 // positions (plus quotes and newlines which are always yielded).
+#![allow(clippy::indexing_slicing)]
 
 use crate::structural::{ProcessedBlock, StreamingClassifier, find_structural_chars};
 

--- a/crates/ffwd-io/Cargo.toml
+++ b/crates/ffwd-io/Cargo.toml
@@ -107,4 +107,4 @@ tower = { version = "0.5", features = ["util"] }
 ureq = "3"
 
 [lints]
-workspace = true
+clippy.indexing_slicing = "deny"

--- a/crates/ffwd-io/src/lib.rs
+++ b/crates/ffwd-io/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 pub mod atomic_write;
 pub(crate) mod background_http_task;
 /// Fixed-worker blocking stages for crate-internal CPU work.

--- a/crates/ffwd-lint-attrs/src/lib.rs
+++ b/crates/ffwd-lint-attrs/src/lib.rs
@@ -115,6 +115,7 @@ pub fn owned_by_actor(_attr: TokenStream, item: TokenStream) -> TokenStream {
     prepend_marker("__ffwd_owned_by_actor__", item)
 }
 
+#[allow(clippy::expect_used)]
 fn prepend_marker(marker: &str, item: TokenStream) -> TokenStream {
     let attr: TokenStream = format!("#[doc = \"{marker}\"]")
         .parse()

--- a/crates/ffwd-otap-proto/build.rs
+++ b/crates/ffwd-otap-proto/build.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::expect_used)]
 fn main() {
     ffwd_proto_build::compile_with_vendored_protoc(&["proto/otap.proto"], &["proto"])
         .expect("compile OTAP protobuf schema");

--- a/crates/ffwd-proto-build/src/lib.rs
+++ b/crates/ffwd-proto-build/src/lib.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 
 /// Compile one or more proto files with vendored `protoc`.
+#[allow(clippy::expect_used)]
 pub fn compile_with_vendored_protoc(
     protos: &[impl AsRef<Path>],
     includes: &[impl AsRef<Path>],

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ fmt-check:
 
 # Clippy — default-members only (skips datafusion, ~30s)
 clippy:
-    cargo clippy -- -D warnings
+    RUSTFLAGS="-W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing" cargo clippy
 
 # Clippy — full workspace including datafusion (~3min, CI uses this)
 clippy-all:

--- a/justfile
+++ b/justfile
@@ -120,7 +120,7 @@ fmt-check:
 
 # Clippy — default-members only (skips datafusion, ~30s)
 clippy:
-    RUSTFLAGS="-W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing" cargo clippy
+    RUSTFLAGS="-W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing" cargo clippy -- -D warnings
 
 # Clippy — full workspace including datafusion (~3min, CI uses this)
 clippy-all:


### PR DESCRIPTION
Escalate `indexing_slicing` clippy lint to deny in ffwd-arrow. Internal hot-path uses annotated with `#[allow]`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Escalate `clippy::indexing_slicing` to deny in `ffwd-arrow`, `ffwd-core`, and `ffwd-io`
> - Sets `clippy::indexing_slicing = "deny"` in [ffwd-arrow/Cargo.toml](https://github.com/strawgate/fastforward/pull/2660/files#diff-a74d93cb5c868b27caf5bde9d3ed5b109bdd0149362373166f6ae7cd654f1bc5), [ffwd-core/src/lib.rs](https://github.com/strawgate/fastforward/pull/2660/files#diff-e02348bfa289ce9f44a9ec9a1baba8b42657931f2f13cbf3431cd0e9ce635a88), and [ffwd-io/Cargo.toml](https://github.com/strawgate/fastforward/pull/2660/files#diff-e08be36fc49de6303cd6c3a6fdb5ffb9be011eb1969a864b5b58623e1f756ed5) to prevent unguarded direct indexing at compile time.
> - Adds `#[allow(clippy::indexing_slicing)]` suppressions at the function or module level across all existing sites where direct indexing is intentional and performance-critical (e.g. SIMD-style parsing, LUT access, and framing loops).
> - Adds workspace-level `warn` entries for `unwrap_used`, `expect_used`, and `indexing_slicing` in [Cargo.toml](https://github.com/strawgate/fastforward/pull/2660/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) and updates the `justfile` clippy recipe to pass these as `RUSTFLAGS` warnings.
> - Adds `#[allow(clippy::expect_used)]` to build scripts and proc-macro helpers where `expect` is acceptable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73ab80d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->