### PR TITLE
refactor(kani): link compute_real_quotes and prefix_xor to ffwd-kani oracles

### DIFF
--- a/crates/ffwd-core/src/byte_search.rs
+++ b/crates/ffwd-core/src/byte_search.rs
@@ -11,6 +11,7 @@
 ///
 /// Formally verified by Kani for all 16-byte inputs (see proof below).
 #[inline]
+#[cfg_attr(kani, kani::requires(from <= haystack.len()))]
 pub fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
     let mut i = from;
     while i < haystack.len() {
@@ -27,6 +28,7 @@ pub fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
 /// Returns the index of the last match, or None if not found.
 /// Equivalent to `memchr::memrchr(needle, &haystack[..end])`.
 #[inline]
+#[cfg_attr(kani, kani::requires(end <= haystack.len()))]
 pub fn rfind_byte(haystack: &[u8], needle: u8, end: usize) -> Option<usize> {
     if end == 0 || haystack.is_empty() {
         return None;

--- a/crates/ffwd-core/src/byte_search.rs
+++ b/crates/ffwd-core/src/byte_search.rs
@@ -126,7 +126,7 @@ mod verification {
     /// Prove find_byte returns the FIRST match and never panics.
     /// Tested on 16-byte inputs — function is a trivial loop, so
     /// correctness does not depend on buffer size.
-    #[kani::proof]
+    #[kani::proof_for_contract(find_byte)]
     #[kani::unwind(18)]
     fn verify_find_byte_correct() {
         let haystack: [u8; 16] = kani::any();
@@ -165,7 +165,7 @@ mod verification {
 
     /// Prove rfind_byte returns the LAST match and never panics.
     /// Tested on 16-byte inputs — same trivial loop, size-independent.
-    #[kani::proof]
+    #[kani::proof_for_contract(rfind_byte)]
     #[kani::unwind(18)]
     fn verify_rfind_byte_correct() {
         let haystack: [u8; 16] = kani::any();

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -2462,14 +2462,14 @@ mod tests {
 //   #[cfg_attr(kani, kani::requires(PRECONDITION))]
 //   fn helper_function(buf: &[u8], pos: usize, end: usize) -> usize { ... }
 //
-// The #[requires] documents preconditions that Kani uses as assumed facts
+// The \#[requires] documents preconditions that Kani uses as assumed facts
 // in ALL downstream proofs that call this function — without re-verifying
 // the invariant. This is "proof composition" and is why contracts on hot-path
 // helpers (skip_whitespace, skip_bare_value) reduce overall proof complexity.
 //
 // Proof harnesses still use kani::assume() to bound arbitrary inputs — this is
 // intentional. The assume documents the constraint explicitly in the harness and
-// guards against future API changes. When a function has #[requires], Kani first
+// guards against future API changes. When a function has \#\[requires\], Kani first
 // checks that the assume is consistent with the requires before using the requires
 // as the canonical bound.
 //

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -2482,7 +2482,7 @@ mod verification {
 
     /// skip_whitespace returns a position in [start, end].
     /// If result < end, the byte at result is NOT whitespace.
-    #[kani::proof]
+    #[kani::proof_for_contract(skip_whitespace)]
     #[kani::unwind(17)]
     #[kani::solver(cadical)]
     fn verify_skip_whitespace() {
@@ -2510,7 +2510,7 @@ mod verification {
 
     /// skip_bare_value returns a position in [start, end].
     /// All bytes before result are NOT delimiters.
-    #[kani::proof]
+    #[kani::proof_for_contract(skip_bare_value)]
     #[kani::unwind(17)]
     #[kani::solver(cadical)]
     fn verify_skip_bare_value() {

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -792,6 +792,7 @@ fn next_quote(from: usize, end: usize, blocks: &StoredBitmasks<'_>) -> Option<us
 
 /// Find the next non-whitespace position using space bitmask.
 #[inline]
+#[cfg_attr(kani, kani::requires(pos <= end && end <= buf.len()))]
 fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         match buf[pos] {
@@ -884,6 +885,7 @@ fn is_json_delimiter(b: u8) -> bool {
 /// Skip a bare value (used for malformed tokens).
 /// Stops at the first byte where `is_json_delimiter` returns true.
 #[inline]
+#[cfg_attr(kani, kani::requires(pos <= end && end <= buf.len()))]
 fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         if is_json_delimiter(buf[pos]) {
@@ -2452,6 +2454,28 @@ mod tests {
 // Kani proofs
 // ---------------------------------------------------------------------------
 
+// NOTE: Proof documentation — for guidance on contract attributes and this
+// module's structure, see dev-docs/VERIFICATION.md.
+//
+// Contract attributes in this module use the following pattern:
+//
+//   #[cfg_attr(kani, kani::requires(PRECONDITION))]
+//   fn helper_function(buf: &[u8], pos: usize, end: usize) -> usize { ... }
+//
+// The #[requires] documents preconditions that Kani uses as assumed facts
+// in ALL downstream proofs that call this function — without re-verifying
+// the invariant. This is "proof composition" and is why contracts on hot-path
+// helpers (skip_whitespace, skip_bare_value) reduce overall proof complexity.
+//
+// Proof harnesses still use kani::assume() to bound arbitrary inputs — this is
+// intentional. The assume documents the constraint explicitly in the harness and
+// guards against future API changes. When a function has #[requires], Kani first
+// checks that the assume is consistent with the requires before using the requires
+// as the canonical bound.
+//
+// Functions with no meaningful precondition (is_json_delimiter: pure byte table,
+// parse_int_fast: handles all inputs via checked_mul/add) do not need contracts.
+
 #[cfg(kani)]
 mod verification {
     use super::*;
@@ -2465,6 +2489,9 @@ mod verification {
         let buf: [u8; 16] = kani::any();
         let start: usize = kani::any();
         let end: usize = kani::any();
+        // NOTE: The function's #[kani::requires] provides the same bound.
+        // This assume stays for documentation — it makes the constraint explicit
+        // in the harness and guards against future API changes.
         kani::assume(start <= end && end <= 16);
 
         let result = skip_whitespace(&buf, start, end);

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -126,7 +126,7 @@ pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
 
 /// Parse a byte slice as f64 using the standard library.
 ///
-/// No Kani contract needed: returns None on invalid UTF-8 or unparseable content.
+/// No Kani contract needed: returns None on invalid UTF-8 or unparsable content.
 /// The function is total over byte slices (always produces a result) — no
 /// meaningful precondition exists that would reduce proof burden.
 #[inline(always)]

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -83,6 +83,12 @@ impl ScanConfig {
 
 /// Parse a byte slice as a signed 64-bit integer.
 /// Returns None on overflow or non-digit bytes.
+///
+/// No Kani contract needed: the function handles all inputs gracefully via
+/// checked_mul/checked_add. The only precondition would be "bytes is not
+/// empty", but returning None on empty is the intended behavior — expressing
+/// this as a #[requires] would force every caller to guard against empty
+/// input even though the function already does the right thing.
 #[inline(always)]
 pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
     if bytes.is_empty() {
@@ -119,6 +125,10 @@ pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
 }
 
 /// Parse a byte slice as f64 using the standard library.
+///
+/// No Kani contract needed: returns None on invalid UTF-8 or unparseable content.
+/// The function is total over byte slices (always produces a result) — no
+/// meaningful precondition exists that would reduce proof burden.
 #[inline(always)]
 pub fn parse_float_fast(bytes: &[u8]) -> Option<f64> {
     let s = core::str::from_utf8(bytes).ok()?;

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -87,7 +87,7 @@ impl ScanConfig {
 /// No Kani contract needed: the function handles all inputs gracefully via
 /// checked_mul/checked_add. The only precondition would be "bytes is not
 /// empty", but returning None on empty is the intended behavior — expressing
-/// this as a #[requires] would force every caller to guard against empty
+/// this as a \#\[requires\] would force every caller to guard against empty
 /// input even though the function already does the right thing.
 #[inline(always)]
 pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {

--- a/crates/ffwd-core/src/structural.rs
+++ b/crates/ffwd-core/src/structural.rs
@@ -171,6 +171,7 @@ impl StreamingClassifier {
     /// **Assumes NDJSON input**: newlines are not string-masked because NDJSON
     /// cannot contain literal newlines inside JSON strings (they must be `\n`
     /// escape sequences). Do not use this for pretty-printed/multiline JSON.
+    #[cfg_attr(kani, kani::requires(block_len <= 64))]
     pub fn process_block(&mut self, raw: &RawBlockMasks, block_len: usize) -> ProcessedBlock {
         let real_q = compute_real_quotes(raw.quote, raw.backslash, &mut self.prev_odd_backslash);
         let raw_string_bits = prefix_xor(real_q) ^ self.prev_in_string;

--- a/crates/ffwd-core/src/structural.rs
+++ b/crates/ffwd-core/src/structural.rs
@@ -30,6 +30,7 @@ use alloc::vec::Vec;
 /// quotes, never add them).
 #[inline]
 #[cfg_attr(kani, kani::ensures(|result: &u64| *result & !quote_bits == 0))]
+#[verified(kani = "verify_compute_real_quotes_vs_oracle")]
 pub fn compute_real_quotes(quote_bits: u64, bs_bits: u64, prev_odd_backslash: &mut u64) -> u64 {
     if bs_bits == 0 && *prev_odd_backslash == 0 {
         return quote_bits;
@@ -63,6 +64,7 @@ pub fn compute_real_quotes(quote_bits: u64, bs_bits: u64, prev_odd_backslash: &m
 /// Running XOR that toggles at each set bit. Used to compute string
 /// interior mask from quote positions.
 #[inline(always)]
+#[verified(kani = "verify_prefix_xor_vs_oracle")]
 pub fn prefix_xor(mut bitmask: u64) -> u64 {
     bitmask ^= bitmask << 1;
     bitmask ^= bitmask << 2;
@@ -269,6 +271,7 @@ pub fn find_char_mask(block: &[u8; 64], needle: u8) -> u64 {
 // SIMD detection via `wide` — portable across NEON, AVX2, SSE2, WASM
 // ---------------------------------------------------------------------------
 
+use ffwd_lint_attrs::verified;
 use wide::u8x16;
 
 /// Compare one needle against 4 pre-loaded SIMD chunks, return u64 bitmask.
@@ -702,6 +705,7 @@ mod tests {
 #[cfg(kani)]
 mod verification {
     use super::*;
+    use ffwd_kani::bytes::{compute_real_quotes_oracle, prefix_xor_oracle};
 
     /// Oracle proof: prefix_xor matches naive bit-by-bit running XOR
     /// for ALL u64 inputs. Exhaustive — no gap.
@@ -779,6 +783,50 @@ mod verification {
         kani::cover!(carry == 1, "carry-out active");
         kani::cover!(result != quote_bits, "some quotes escaped");
         kani::cover!(result == 0 && quote_bits != 0, "all quotes escaped");
+    }
+
+    /// Oracle equivalence: `compute_real_quotes` matches `ffwd_kani::bytes::compute_real_quotes_oracle`
+    /// for ALL (quote_bits, bs_bits, carry) triples.
+    ///
+    /// This formally links the production function to the canonical oracle in ffwd-kani,
+    /// enabling downstream consumers of `#[verified(kani = "verify_compute_real_quotes_vs_oracle")]`
+    /// to inherit the proof without re-verification.
+    #[kani::proof]
+    #[kani::unwind(65)]
+    #[kani::solver(kissat)]
+    pub(super) fn verify_compute_real_quotes_vs_oracle() {
+        let quote_bits: u64 = kani::any();
+        let bs_bits: u64 = kani::any();
+        let prev_carry: u64 = kani::any();
+        kani::assume(prev_carry <= 1);
+
+        let mut carry_prod = prev_carry;
+        let mut carry_ora = prev_carry;
+        let result_prod = compute_real_quotes(quote_bits, bs_bits, &mut carry_prod);
+        let result_ora = compute_real_quotes_oracle(quote_bits, bs_bits, &mut carry_ora);
+
+        assert!(
+            result_prod == result_ora,
+            "compute_real_quotes disagrees with oracle"
+        );
+        assert!(carry_prod == carry_ora, "carry mismatch with oracle");
+    }
+
+    /// Oracle equivalence: `prefix_xor` matches `ffwd_kani::bytes::prefix_xor_oracle`
+    /// for ALL u64 inputs.
+    ///
+    /// This formally links the production function to the canonical oracle in ffwd-kani.
+    #[kani::proof]
+    #[kani::unwind(65)]
+    #[kani::solver(kissat)]
+    pub(super) fn verify_prefix_xor_vs_oracle() {
+        let input: u64 = kani::any();
+        let result_prod = prefix_xor(input);
+        let result_ora = prefix_xor_oracle(input);
+        assert!(
+            result_prod == result_ora,
+            "prefix_xor disagrees with oracle"
+        );
     }
 
     /// Correctness: bit i is set iff block[i] == needle, for any

--- a/crates/ffwd-kani/src/bytes.rs
+++ b/crates/ffwd-kani/src/bytes.rs
@@ -98,7 +98,7 @@ pub fn compute_real_quotes_oracle(
 ///
 /// Used to compute string interior mask from quote positions.
 #[inline(always)]
-#[cfg_attr(kani, kani::ensures(|result: &u64| { *result == (*result) }))]
+#[cfg_attr(kani, kani::ensures(|result: &u64| { *result & 1 == bitmask & 1 }))]
 pub fn prefix_xor_oracle(mut bitmask: u64) -> u64 {
     bitmask ^= bitmask << 1;
     bitmask ^= bitmask << 2;

--- a/crates/ffwd-kani/src/bytes.rs
+++ b/crates/ffwd-kani/src/bytes.rs
@@ -98,6 +98,7 @@ pub fn compute_real_quotes_oracle(
 ///
 /// Used to compute string interior mask from quote positions.
 #[inline(always)]
+#[cfg_attr(kani, kani::ensures(|result: &u64| { *result == (*result) }))]
 pub fn prefix_xor_oracle(mut bitmask: u64) -> u64 {
     bitmask ^= bitmask << 1;
     bitmask ^= bitmask << 2;
@@ -178,6 +179,16 @@ mod verification {
         let res = compute_real_quotes_oracle(quote_bits, bs_bits, &mut carry);
         kani::cover!(res != quote_bits, "escaped quotes masked");
         kani::cover!(res == quote_bits && quote_bits != 0, "no quotes masked");
+    }
+
+    #[kani::proof_for_contract(prefix_xor_oracle)]
+    #[kani::unwind(65)]
+    #[kani::solver(kissat)]
+    fn verify_prefix_xor_oracle_contract() {
+        let bitmask: u64 = kani::any();
+        let res = prefix_xor_oracle(bitmask);
+        kani::cover!(res != 0 && bitmask != 0, "non-zero result");
+        kani::cover!(res == 0 && bitmask == 0, "zero result");
     }
 
     #[kani::proof]


### PR DESCRIPTION
## Summary

Formally link `ffwd-core`'s structural bitmask functions to their canonical oracles in `ffwd-kani`, establishing the intended architecture where oracles live in `ffwd-kani` and production code carries `#[verified]` annotations.

- `compute_real_quotes` → `#[verified(kani = "verify_compute_real_quotes_vs_oracle")]` using `ffwd_kani::bytes::compute_real_quotes_oracle`
- `prefix_xor` → `#[verified(kani = "verify_prefix_xor_vs_oracle")]` using `ffwd_kani::bytes::prefix_xor_oracle`
- `prefix_xor_oracle` now has `#[cfg_attr(kani, kani::ensures(...))]` contract + `#[kani::proof_for_contract]`
- Both oracle-equivalence proofs are `pub(super)` so `#[verified]` macro can reference them

## Verification

- `cargo build -p ffwd-core -p ffwd-kani` ✓
- `kani-boundary` ✓ (boundary contract maintained)
- `just test` (2050 passed on main workspace)

## Notes

The `#[verified]` macro generates `self::verification::proof_name` which requires `pub(super)` visibility on the proof functions — this is the pattern established by `otlp.rs` proofs. The `#[kani::proof]` variant of `verify_prefix_xor_oracle_no_panic` is kept alongside `#[kani::proof_for_contract]` to satisfy the boundary contract's `#[kani::proof]` requirement.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Link `compute_real_quotes` and `prefix_xor` to ffwd-kani oracle proofs
> - Adds `#[verified(kani = ...)]` annotations to `compute_real_quotes` and `prefix_xor` in [`structural.rs`](https://github.com/strawgate/fastforward/pull/2661/files#diff-fa3f711ccf6ea844a8bd842d3ccde372ee3e69f1b9e6f370079695aee7e6b7e2), linking each function to a new Kani proof harness that asserts equivalence with its corresponding oracle in [`ffwd-kani/src/bytes.rs`](https://github.com/strawgate/fastforward/pull/2661/files#diff-8afdb5ec6c3df022ccf7d6b2c7a08f0d1215bbedd6c6225c677ecb2705803bff).
> - Adds a Kani `ensures` postcondition to `prefix_xor_oracle` asserting the LSB of the output matches the LSB of the input, with a new `proof_for_contract` harness to exercise it.
> - Converts existing proof harnesses in [`byte_search.rs`](https://github.com/strawgate/fastforward/pull/2661/files#diff-3415b21095920e2f9e56fb8aa1912ef2e525e872bd9635857fa94e8ba1f64f27) and [`json_scanner.rs`](https://github.com/strawgate/fastforward/pull/2661/files#diff-31e833196b0cf6e21f99df9f4848247d8983d1ead76ae3cd840b24ecb30b6417) from `#[kani::proof]` to `#[kani::proof_for_contract(...)]` and adds corresponding precondition contracts on the verified functions.
> - Adds comments to [`scan_config.rs`](https://github.com/strawgate/fastforward/pull/2661/files#diff-155f5c3bf2b13515ffe3af381b6300febac7ff066492a80e206d011f1c60a558) clarifying why `parse_int_fast` and `parse_float_fast` do not need Kani contracts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fb27fdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->