### PR TITLE
fix(diagnostics): update telemetry test to expect 'ff' not 'ffwd'

### DIFF
--- a/crates/ffwd-diagnostics/src/diagnostics/server.rs
+++ b/crates/ffwd-diagnostics/src/diagnostics/server.rs
@@ -2502,7 +2502,7 @@ output:
             resource["attributes"][0]["key"], "service.name",
             "resource must have service.name"
         );
-        assert_eq!(resource["attributes"][0]["value"]["stringValue"], "ffwd");
+        assert_eq!(resource["attributes"][0]["value"]["stringValue"], "ff");
 
         let metrics = &rm[0]["scopeMetrics"][0]["metrics"];
         assert!(


### PR DESCRIPTION
## Summary
Fix `telemetry_metrics_endpoint_returns_valid_otlp` test that expects `"ffwd"` but the OTLP identity was renamed to `"ff"` in commit `0833757f` ("part C: rename OTLP identity strings logfwd -> ff"). The test was not updated in that commit.

## Changes
- `crates/ffwd-diagnostics/src/diagnostics/server.rs:2505`: `"ffwd"` → `"ff"`

## Context
The `telemetry_buffer.rs` already documents `service.name = "ff"` (line 194). This test was simply missed during the rename.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix telemetry test to expect `ff` as `service.name` instead of `ffwd`
> Updates the assertion in [server.rs](https://github.com/strawgate/fastforward/pull/2662/files#diff-493b68b9fa45e66c3b882115b6ec6415a954ed8b7ea153a3e919f472a02a071b) to match the current service name value. The expected `service.name` resource attribute in the OTLP metrics payload changed from `"ffwd"` to `"ff"`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1e6faec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->