### PR TITLE
refactor(kani): extract tag_size and bytes_field_total_size with oracle proofs

### DIFF
--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -183,13 +183,29 @@ pub fn encode_bytes_field(buf: &mut Vec<u8>, field_number: u32, data: &[u8]) {
     buf.extend_from_slice(data);
 }
 
+/// Compute the encoded size of a protobuf tag (`field_number << 3 | 2`).
+///
+/// Wire type 2 = length-delimited. Used as a building block by
+/// `bytes_field_total_size`.
+#[inline(always)]
+#[verified(kani = "verify_tag_size")]
+pub const fn tag_size(field_number: u32) -> usize {
+    varint_len(((field_number as u64) << 3) | 2)
+}
+
+/// Compute the total encoded size of a length-delimited field
+/// (tag varint + length varint + data), without writing anything.
+#[inline(always)]
+#[verified(kani = "verify_bytes_field_total_size")]
+pub const fn bytes_field_total_size(field_number: u32, data_len: usize) -> usize {
+    tag_size(field_number) + varint_len(data_len as u64) + data_len
+}
+
 /// Compute the encoded size of a length-delimited field (without writing).
 #[inline(always)]
 #[verified(kani = "verify_bytes_field_size")]
 pub const fn bytes_field_size(field_number: u32, data_len: usize) -> usize {
-    let tag_size = varint_len(((field_number as u64) << 3) | 2);
-    let len_size = varint_len(data_len as u64);
-    tag_size + len_size + data_len
+    bytes_field_total_size(field_number, data_len)
 }
 
 /// Write a fixed32 field (tag + 4 bytes little-endian).
@@ -1219,6 +1235,52 @@ mod verification {
         assert!(
             buf.len() == varint_len(value),
             "varint_len disagrees with encode_varint"
+        );
+    }
+
+    /// Oracle equivalence: varint_len matches varint_len_oracle for ALL u64 values.
+    ///
+    /// Two different algorithms are compared: the production `varint_len` uses
+    /// a match-with-ranges, while `varint_len_oracle` uses a count-the-shifts loop.
+    /// This proof guarantees they produce identical results for all 2^64 inputs.
+    #[kani::proof]
+    #[kani::unwind(12)]
+    #[kani::solver(kissat)]
+    pub(super) fn verify_varint_len_vs_oracle() {
+        let value: u64 = kani::any();
+        assert_eq!(
+            varint_len(value),
+            ffwd_kani::proto::varint_len_oracle(value),
+            "varint_len disagrees with varint_len_oracle"
+        );
+    }
+
+    /// Oracle equivalence: tag_size matches tag_size_oracle for all field numbers.
+    #[kani::proof]
+    #[kani::unwind(12)]
+    #[kani::solver(kissat)]
+    pub(super) fn verify_tag_size_vs_oracle() {
+        let field_number: u32 = kani::any();
+        kani::assume(field_number > 0 && field_number <= 0x1FFFFFFF);
+        assert_eq!(
+            tag_size(field_number),
+            ffwd_kani::proto::tag_size_oracle(field_number),
+            "tag_size disagrees with tag_size_oracle"
+        );
+    }
+
+    /// Oracle equivalence: bytes_field_total_size matches bytes_field_total_size_oracle.
+    #[kani::proof]
+    #[kani::unwind(12)]
+    #[kani::solver(kissat)]
+    pub(super) fn verify_bytes_field_total_size_vs_oracle() {
+        let field_number: u32 = kani::any();
+        let data_len: usize = kani::any();
+        kani::assume(field_number > 0 && field_number <= 0x1FFFFFFF);
+        assert_eq!(
+            bytes_field_total_size(field_number, data_len),
+            ffwd_kani::proto::bytes_field_total_size_oracle(field_number, data_len),
+            "bytes_field_total_size disagrees with oracle"
         );
     }
 

--- a/crates/ffwd-kani/src/proto.rs
+++ b/crates/ffwd-kani/src/proto.rs
@@ -15,6 +15,7 @@ pub fn varint_len_oracle(mut value: u64) -> usize {
 }
 
 /// Predict the size of a protobuf tag (`field_number << 3 | wire_type`).
+#[cfg_attr(kani, kani::ensures(|result: &usize| *result >= 1 && *result <= 10))]
 pub fn tag_size_oracle(field_number: u32) -> usize {
     let tag = (field_number as u64) << 3;
     varint_len_oracle(tag)
@@ -25,6 +26,10 @@ pub fn tag_size_oracle(field_number: u32) -> usize {
 ///
 /// Uses plain addition to match production semantics (overflow wraps in
 /// release mode, same as `ffwd-core::otlp::bytes_field_size`).
+#[cfg_attr(kani, kani::ensures(|result: &usize|
+    // tag + len varints each contribute 1-10 bytes
+    *result >= data_len + 2 && *result <= data_len + 20
+))]
 pub fn bytes_field_total_size_oracle(field_number: u32, data_len: usize) -> usize {
     let tag_size = tag_size_oracle(field_number);
     let len_size = varint_len_oracle(data_len as u64);
@@ -80,13 +85,24 @@ mod verification {
         kani::cover!(res == 10, "max-byte varint reachable");
     }
 
-    #[kani::proof]
+    #[kani::proof_for_contract(tag_size_oracle)]
     #[kani::unwind(12)]
-    fn verify_bytes_field_total_size_oracle_no_panic() {
+    fn verify_tag_size_oracle_contract() {
+        let field_number: u32 = kani::any();
+        kani::assume(field_number > 0 && field_number <= 0x1FFFFFFF);
+        let res = tag_size_oracle(field_number);
+        kani::cover!(res == 1, "single-byte tag reachable");
+        kani::cover!(res > 1, "multi-byte tag reachable");
+    }
+
+    #[kani::proof_for_contract(bytes_field_total_size_oracle)]
+    #[kani::unwind(12)]
+    fn verify_bytes_field_total_size_oracle_contract() {
         let field_number: u32 = kani::any();
         let data_len: usize = kani::any();
         kani::assume(field_number > 0 && field_number <= 0x1FFFFFFF);
         let res = bytes_field_total_size_oracle(field_number, data_len);
-        kani::cover!(res > data_len, "total size includes overhead");
+        kani::cover!(data_len == 0, "empty data reachable");
+        kani::cover!(data_len > 0, "non-empty data reachable");
     }
 }

--- a/dev-docs/references/kani-verification.md
+++ b/dev-docs/references/kani-verification.md
@@ -193,6 +193,7 @@ For fundamental oracles and assertions used across multiple crates, use the
 `ffwd-kani` crate. Key exports:
 
 - **`ffwd_kani::bytes::assert_bytes_eq`**: bounded loop-based slice comparison
+- **`ffwd_kani::bytes::eq_ignore_case_match`**: case-insensitive variable-length ASCII comparison — oracle for `ffwd_core::otlp::eq_ignore_case_match`
 - **`ffwd_kani::bytes::compute_real_quotes_oracle`**: reference quote-escape bitmask
 - **`ffwd_kani::bytes::prefix_xor_oracle`**: reference running XOR
 - **`ffwd_kani::datetime::jdn_days_from_epoch`**: Julian Day Number oracle
@@ -200,8 +201,9 @@ For fundamental oracles and assertions used across multiple crates, use the
 - **`ffwd_kani::hex::hex_decode_oracle`**: hex decode reference implementation
 - **`ffwd_kani::iter::find_byte`**: linear-scan byte search oracle
 - **`ffwd_kani::numeric::parse_int_oracle`**: i128-accumulator integer parser
-- **`ffwd_kani::proto::varint_len_oracle`**: varint encoded length predictor
-- **`ffwd_kani::proto::bytes_field_total_size_oracle`**: protobuf field size predictor
+- **`ffwd_kani::proto::varint_len_oracle`**: varint encoded length predictor — oracle for `ffwd_core::otlp::varint_len`
+- **`ffwd_kani::proto::tag_size_oracle`**: protobuf tag size predictor — oracle for `ffwd_core::otlp::tag_size`
+- **`ffwd_kani::proto::bytes_field_total_size_oracle`**: protobuf field size predictor — oracle for `ffwd_core::otlp::bytes_field_total_size`
 
 Add `ffwd-kani` as a dependency:
 

--- a/scripts/verify_kani_boundary_contract.py
+++ b/scripts/verify_kani_boundary_contract.py
@@ -48,7 +48,7 @@ def rust_files_with_kani() -> set[str]:
         if rel.startswith("crates/ffwd-core/"):
             continue
         text = path.read_text(encoding="utf-8")
-        if has_kani_cfg(text) or "#[kani::proof]" in text:
+        if has_kani_cfg(text) or "#[kani::proof]" in text or "#[kani::proof_for_contract" in text:
             result.add(rel)
     return result
 
@@ -89,7 +89,7 @@ def validate() -> list[str]:
 
         text = file_path.read_text(encoding="utf-8")
         has_kani_cfg_marker = has_kani_cfg(text)
-        has_kani_proof = "#[kani::proof]" in text
+        has_kani_proof = "#[kani::proof]" in text or "#[kani::proof_for_contract" in text
 
         if status == "required":
             if not has_kani_cfg_marker:


### PR DESCRIPTION
## Summary
- Extract `tag_size(field_number)` as a public `const fn` — replaces inline `varint_len(((field_number as u64) << 3) | 2)`
- Extract `bytes_field_total_size(field_number, data_len)` as a public `const fn`
- Wire `bytes_field_size` → `bytes_field_total_size` (delegation)
- Add `#[verified]` on both new functions
- Add oracle equivalence proofs for all three functions (varint_len, tag_size, bytes_field_total_size)
- Add `#[kani::ensures]` contracts to `tag_size_oracle` and `bytes_field_total_size_oracle` in ffwd-kani
- Replace orphan `verify_bytes_field_total_size_oracle_no_panic` with `#[proof_for_contract]`

## Why
1. **Modularity**: The production logic for tag-size and field-size computation is now in named, callable functions instead of being inlined
2. **Oracle proofs**: Enables direct Firecracker-style oracle equivalence proofs rather than encode-based only
3. **Script fix**: Boundary contract validation script now recognizes `#[kani::proof_for_contract]` as a valid proof attribute

## Testing
- Full `cargo clippy --workspace` passes with no warnings
- TOML formatting validated
- `just kani-boundary` passes

## Docs updated
- `dev-docs/references/kani-verification.md`: Updated oracle list to show active linkage

---
**Note**: The 3 orphan oracles (`skip_space`, `skip_until`, `is_ascii_printable`) remain for now — no production use case identified yet. The boundary-contract script fix (`verify_kani_boundary_contract.py`) ensures these don't regress.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `tag_size` and `bytes_field_total_size` from `otlp` with Kani oracle proofs
> - Extracts `tag_size` and `bytes_field_total_size` as new public `const` functions in [`otlp.rs`](https://github.com/strawgate/fastforward/pull/2666/files#diff-0c866cb1824ef9b048e7add186b2a0bdfb2b199874e97e787f69cc78f9445b84); `bytes_field_size` now delegates to `bytes_field_total_size`.
> - Adds Kani proofs in [`otlp.rs`](https://github.com/strawgate/fastforward/pull/2666/files#diff-0c866cb1824ef9b048e7add186b2a0bdfb2b199874e97e787f69cc78f9445b84) verifying these functions match their oracle counterparts in [`proto.rs`](https://github.com/strawgate/fastforward/pull/2666/files#diff-46e553dfc9d5f771809af029f30f9a7a01eaabac7625f59a8e65f2a194b90e8c) across all valid inputs.
> - Annotates `tag_size_oracle` and `bytes_field_total_size_oracle` in [`proto.rs`](https://github.com/strawgate/fastforward/pull/2666/files#diff-46e553dfc9d5f771809af029f30f9a7a01eaabac7625f59a8e65f2a194b90e8c) with `kani::ensures` contracts and converts existing proofs to `#[kani::proof_for_contract]`.
> - Updates the boundary contract validation script to recognize `#[kani::proof_for_contract]` as a valid proof annotation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d14bc59.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->