### PR TITLE
refactor: formalize Transform trait with Box<dyn Transform> pipeline support

### DIFF
--- a/crates/ffwd-arrow/src/columnar/accumulator.rs
+++ b/crates/ffwd-arrow/src/columnar/accumulator.rs
@@ -500,6 +500,7 @@ pub struct FinalizationMode {
 /// (row, field), so `facts.len() == num_rows ∧ last == num_rows - 1` is
 /// sufficient.  When dedup is disabled duplicate writes are possible, breaking
 /// the pigeonhole premise, so we conservatively return false.
+#[allow(clippy::indexing_slicing)]
 fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
     dedup
         && facts.len() == num_rows
@@ -518,6 +519,7 @@ fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
 ///
 /// Returns `(values, dense)`. Callers use `dense` to decide whether a
 /// validity bitmap is needed.
+#[allow(clippy::indexing_slicing)]
 fn scatter_values<T: Default + Copy>(
     facts: &[(u32, T)],
     num_rows: usize,

--- a/crates/ffwd-arrow/src/columnar/builder.rs
+++ b/crates/ffwd-arrow/src/columnar/builder.rs
@@ -370,6 +370,7 @@ impl ColumnarBatchBuilder {
     /// silently ignored and the dedup slot is NOT consumed — a subsequent
     /// correct-type write to the same field will still succeed.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_i64(&mut self, handle: FieldHandle, value: i64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -384,6 +385,7 @@ impl ColumnarBatchBuilder {
 
     /// Write an f64 value for the given field in the current row.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_f64(&mut self, handle: FieldHandle, value: f64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -398,6 +400,7 @@ impl ColumnarBatchBuilder {
 
     /// Write a bool value for the given field in the current row.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_bool(&mut self, handle: FieldHandle, value: bool) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -421,6 +424,7 @@ impl ColumnarBatchBuilder {
     ///
     /// Returns `Err` if the string buffer would exceed u32 addressable range.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_str(&mut self, handle: FieldHandle, value: &str) -> Result<(), BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -444,6 +448,7 @@ impl ColumnarBatchBuilder {
     /// Write a `StringRef` directly (for zero-copy producers that already
     /// have offsets into an input buffer).
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_str_ref(&mut self, handle: FieldHandle, sref: StringRef) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -467,6 +472,7 @@ impl ColumnarBatchBuilder {
     ///
     /// Returns `Err` if the string buffer would exceed u32 addressable range.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_str_bytes(
         &mut self,
         handle: FieldHandle,
@@ -502,6 +508,7 @@ impl ColumnarBatchBuilder {
     /// exceed `u32::MAX`, or if extending the generated string buffer would
     /// overflow addressable `usize` space.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_hex_bytes_lower(
         &mut self,
         handle: FieldHandle,
@@ -538,6 +545,7 @@ impl ColumnarBatchBuilder {
     /// Returns `BuilderError::StringBufferOverflow` if the value is not within
     /// the original buffer bounds or the offset exceeds `u32::MAX`.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_input_ref(
         &mut self,
         handle: FieldHandle,

--- a/crates/ffwd-arrow/src/columnar/plan.rs
+++ b/crates/ffwd-arrow/src/columnar/plan.rs
@@ -202,6 +202,7 @@ impl BatchPlan {
     /// names are re-resolved from scratch each batch — matching
     /// `StreamingBuilder`'s `field_index.clear()` behavior. Without this,
     /// dynamic fields accumulate unboundedly across batches.
+    #[allow(clippy::indexing_slicing)]
     pub fn reset_dynamic(&mut self) {
         // Remove dynamic entries from the name index.
         for entry in &self.fields[self.num_planned..] {
@@ -220,6 +221,7 @@ impl BatchPlan {
     /// Planned fields must be declared before any dynamic fields are
     /// resolved. They form a stable prefix of the field list that
     /// `reset_dynamic` preserves.
+    #[allow(clippy::indexing_slicing)]
     pub fn declare_planned(
         &mut self,
         name: &str,
@@ -265,6 +267,7 @@ impl BatchPlan {
     /// For dynamic fields, the observed kind is accumulated (for conflict
     /// detection). For planned fields, the handle is returned as-is — the
     /// Dynamic accumulator in the builder handles type mixing uniformly.
+    #[allow(clippy::indexing_slicing)]
     pub fn resolve_dynamic(
         &mut self,
         name: &str,

--- a/crates/ffwd-arrow/src/streaming_builder/finish.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/finish.rs
@@ -22,6 +22,7 @@ impl StreamingBuilder {
     /// shares the input buffer via Bytes reference counting (zero-copy).
     /// When decoded strings exist, the original and decoded buffers are exposed
     /// as separate Arrow StringView blocks to avoid copying the whole input.
+    #[allow(clippy::indexing_slicing)]
     pub fn finish_batch(&mut self) -> Result<RecordBatch, ArrowError> {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -348,6 +349,7 @@ impl StreamingBuilder {
     /// This is the optimal persistence path: zero-copy scan speed during
     /// parsing, single bulk copy during finalization, and the resulting
     /// `StringArray` compresses efficiently via IPC zstd.
+    #[allow(clippy::indexing_slicing)]
     pub fn finish_batch_detached(&mut self) -> Result<RecordBatch, ArrowError> {
         debug_assert_eq!(
             self.lifecycle.state(),

--- a/crates/ffwd-arrow/src/streaming_builder/mod.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/mod.rs
@@ -261,6 +261,7 @@ impl StreamingBuilder {
     }
 
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn resolve_field(&mut self, key: &[u8]) -> usize {
         debug_assert!(
             self.lifecycle.state() == BuilderState::InBatch
@@ -311,6 +312,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_str_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -342,6 +344,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_validated_str_by_idx(&mut self, idx: usize, value: &[u8]) {
         self.append_str_by_idx(idx, value);
     }
@@ -353,6 +356,7 @@ impl StreamingBuilder {
     /// offset shifted by `buf.len()` so that `finish_batch` can select the
     /// decoded Arrow StringView block without copying the original input.
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_decoded_str_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -395,6 +399,7 @@ impl StreamingBuilder {
     /// Inner append path shared by `append_decoded_str_by_idx` (post-validation)
     /// and `append_prevalidated_str_by_idx` (type-guaranteed UTF-8).
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     fn append_decoded_str_inner(&mut self, idx: usize, value: &[u8]) {
         let Ok(len) = u32::try_from(value.len()) else {
             return;
@@ -426,11 +431,13 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_validated_decoded_str_by_idx(&mut self, idx: usize, value: &[u8]) {
         self.append_decoded_str_by_idx(idx, value);
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_int_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -475,6 +482,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_float_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -565,6 +573,7 @@ impl StreamingBuilder {
     /// first call has effect. This maintains the invariant that `line_views`
     /// has exactly one entry per row when `line_capture` is enabled.
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_line(&mut self, line: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -188,7 +188,7 @@ pub fn encode_bytes_field(buf: &mut Vec<u8>, field_number: u32, data: &[u8]) {
 /// Wire type 2 = length-delimited. Used as a building block by
 /// `bytes_field_total_size`.
 #[inline(always)]
-#[verified(kani = "verify_tag_size")]
+#[verified(kani = "verify_tag_size_vs_oracle")]
 pub const fn tag_size(field_number: u32) -> usize {
     varint_len(((field_number as u64) << 3) | 2)
 }
@@ -196,7 +196,7 @@ pub const fn tag_size(field_number: u32) -> usize {
 /// Compute the total encoded size of a length-delimited field
 /// (tag varint + length varint + data), without writing anything.
 #[inline(always)]
-#[verified(kani = "verify_bytes_field_total_size")]
+#[verified(kani = "verify_bytes_field_total_size_vs_oracle")]
 pub const fn bytes_field_total_size(field_number: u32, data_len: usize) -> usize {
     tag_size(field_number) + varint_len(data_len as u64) + data_len
 }

--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -481,10 +481,9 @@ impl Pipeline {
             // Determine the SQL for this input: per-input > pipeline-level > passthrough.
             let input_sql = input_cfg.sql.as_deref().unwrap_or(pipeline_sql);
 
-            let transform =
-                crate::transform::SqlTransform::new(input_sql).map_err(|e| e.to_string())?;
             #[cfg(feature = "datafusion")]
-            let mut transform = transform;
+            let mut transform = crate::transform::ConfiguredSqlTransform::new(input_sql)
+                .map_err(|e| e.to_string())?;
 
             // Wire up shared enrichment sources to this transform.
             #[cfg(feature = "datafusion")]
@@ -499,7 +498,20 @@ impl Pipeline {
                 }
             }
 
+            #[cfg(not(feature = "datafusion"))]
+            let transform = crate::transform::create_transform(input_sql)
+                .map_err(|e| e.to_string())?;
+
+            #[cfg(feature = "datafusion")]
+            let explicit_source_metadata_plan = transform.explicit_source_metadata_plan();
+            #[cfg(not(feature = "datafusion"))]
+            let explicit_source_metadata_plan = transform.explicit_source_metadata_plan();
+
+            #[cfg(feature = "datafusion")]
             let mut scan_config = transform.scan_config();
+            #[cfg(not(feature = "datafusion"))]
+            let mut scan_config = transform.scan_config();
+
             // Raw format sends plain text directly to the scanner, so capture
             // the original line in the canonical body field for downstream SQL
             // and sinks. Auto mode wraps plain-text fallback into JSON.
@@ -507,8 +519,9 @@ impl Pipeline {
                 scan_config.line_field_name = Some(field_names::BODY.to_string());
             }
             let scanner = ffwd_arrow::scanner::Scanner::new(scan_config);
-            let explicit_source_metadata_plan =
-                transform.analyzer().explicit_source_metadata_plan();
+
+            #[cfg(feature = "datafusion")]
+            let transform = transform.build().map_err(|e| e.to_string())?;
             if explicit_source_metadata_plan.has_any()
                 && input_cfg.source_metadata == SourceMetadataStyle::None
             {

--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -499,8 +499,8 @@ impl Pipeline {
             }
 
             #[cfg(not(feature = "datafusion"))]
-            let transform = crate::transform::create_transform(input_sql)
-                .map_err(|e| e.to_string())?;
+            let transform =
+                crate::transform::create_transform(input_sql).map_err(|e| e.to_string())?;
 
             // Build the transform into a trait object.
             #[cfg(feature = "datafusion")]

--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -502,14 +502,12 @@ impl Pipeline {
             let transform = crate::transform::create_transform(input_sql)
                 .map_err(|e| e.to_string())?;
 
+            // Build the transform into a trait object.
             #[cfg(feature = "datafusion")]
-            let explicit_source_metadata_plan = transform.explicit_source_metadata_plan();
-            #[cfg(not(feature = "datafusion"))]
-            let explicit_source_metadata_plan = transform.explicit_source_metadata_plan();
+            let transform = transform.build().map_err(|e| e.to_string())?;
 
-            #[cfg(feature = "datafusion")]
-            let mut scan_config = transform.scan_config();
-            #[cfg(not(feature = "datafusion"))]
+            // Get config and metadata plan from the unified transform type.
+            let explicit_source_metadata_plan = transform.explicit_source_metadata_plan();
             let mut scan_config = transform.scan_config();
 
             // Raw format sends plain text directly to the scanner, so capture
@@ -519,9 +517,6 @@ impl Pipeline {
                 scan_config.line_field_name = Some(field_names::BODY.to_string());
             }
             let scanner = ffwd_arrow::scanner::Scanner::new(scan_config);
-
-            #[cfg(feature = "datafusion")]
-            let transform = transform.build().map_err(|e| e.to_string())?;
             if explicit_source_metadata_plan.has_any()
                 && input_cfg.source_metadata == SourceMetadataStyle::None
             {

--- a/crates/ffwd-runtime/src/pipeline/cpu_worker.rs
+++ b/crates/ffwd-runtime/src/pipeline/cpu_worker.rs
@@ -27,12 +27,8 @@ use super::source_metadata::{cri_metadata_for_batch, source_metadata_for_batch};
 /// Run the CPU worker loop for one input.
 ///
 /// Receives raw bytes from the I/O worker, scans them into Arrow RecordBatches,
-/// runs the per-input SQL transform, and sends `ProcessedBatch` to the
-/// pipeline's main select loop.
-///
-/// Creates a lightweight tokio current-thread runtime for DataFusion SQL
-/// execution (which is async internally). The runtime is created once and
-/// reused for all batches.
+/// runs the per-input SQL transform via `execute_blocking`, and sends
+/// `ProcessedBatch` to the pipeline's main select loop.
 #[cfg(not(feature = "turmoil"))]
 pub(super) fn cpu_worker_loop(
     mut rx: mpsc::Receiver<IoWorkItem>,

--- a/crates/ffwd-runtime/src/pipeline/cpu_worker.rs
+++ b/crates/ffwd-runtime/src/pipeline/cpu_worker.rs
@@ -40,21 +40,6 @@ pub(super) fn cpu_worker_loop(
     mut transform: SourcePipeline,
     metrics: Arc<PipelineMetrics>,
 ) {
-    let rt = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(e) => {
-            tracing::error!(
-                input = transform.input_name.as_str(),
-                error = %e,
-                "cpu_worker: failed to create tokio runtime — input disabled"
-            );
-            return;
-        }
-    };
-
     /// After this many consecutive transform errors with no successes, escalate
     /// to ERROR with guidance — the SQL likely references columns the input
     /// format does not produce.
@@ -154,7 +139,7 @@ pub(super) fn cpu_worker_loop(
         }
 
         let t1 = Instant::now();
-        let result = match rt.block_on(transform.transform.execute(batch)) {
+        let result = match transform.transform.execute_blocking(batch) {
             Ok(r) => {
                 consecutive_transform_errors = 0;
                 r

--- a/crates/ffwd-runtime/src/pipeline/cpu_worker.rs
+++ b/crates/ffwd-runtime/src/pipeline/cpu_worker.rs
@@ -27,8 +27,8 @@ use super::source_metadata::{cri_metadata_for_batch, source_metadata_for_batch};
 /// Run the CPU worker loop for one input.
 ///
 /// Receives raw bytes from the I/O worker, scans them into Arrow RecordBatches,
-/// runs the per-input SQL transform via `execute_blocking`, and sends
-/// `ProcessedBatch` to the pipeline's main select loop.
+/// runs the per-input SQL transform via `execute_async` with a reused runtime,
+/// and sends `ProcessedBatch` to the pipeline's main select loop.
 #[cfg(not(feature = "turmoil"))]
 pub(super) fn cpu_worker_loop(
     mut rx: mpsc::Receiver<IoWorkItem>,
@@ -36,6 +36,21 @@ pub(super) fn cpu_worker_loop(
     mut transform: SourcePipeline,
     metrics: Arc<PipelineMetrics>,
 ) {
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            tracing::error!(
+                input = transform.input_name.as_str(),
+                error = %e,
+                "cpu_worker: failed to create tokio runtime — input disabled"
+            );
+            return;
+        }
+    };
+
     /// After this many consecutive transform errors with no successes, escalate
     /// to ERROR with guidance — the SQL likely references columns the input
     /// format does not produce.
@@ -135,7 +150,7 @@ pub(super) fn cpu_worker_loop(
         }
 
         let t1 = Instant::now();
-        let result = match transform.transform.execute_blocking(batch) {
+        let result = match rt.block_on(transform.transform.execute_async(batch)) {
             Ok(r) => {
                 consecutive_transform_errors = 0;
                 r

--- a/crates/ffwd-runtime/src/pipeline/input_pipeline_tests.rs
+++ b/crates/ffwd-runtime/src/pipeline/input_pipeline_tests.rs
@@ -302,8 +302,10 @@ fn append_cri_metadata_for_data_pads_prior_and_later_rows() {
     assert!(buffered.spans[2].values.is_none());
 }
 
+#[cfg(feature = "datafusion")]
 #[test]
 fn cri_metadata_columns_are_queryable_before_sql() {
+    use crate::transform::SqlTransform;
     let mut transform =
         SqlTransform::new("SELECT _timestamp, _stream, msg FROM logs").expect("sql");
     let mut scanner = Scanner::new(transform.scan_config());
@@ -314,12 +316,8 @@ fn cri_metadata_columns_are_queryable_before_sql() {
     metadata.append_value(b"2024-01-15T10:30:00Z", b"stdout");
     let attached = cri_metadata_for_batch(scanned, Some(metadata)).expect("attach");
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("runtime");
-    let result = rt
-        .block_on(transform.execute(attached))
+    let result = transform
+        .execute_blocking(attached)
         .expect("transform should see CRI metadata");
 
     let timestamp = result
@@ -1299,8 +1297,10 @@ fn source_metadata_attach_rejects_row_count_mismatch() {
     assert!(err.to_string().contains("row count mismatch"));
 }
 
+#[cfg(feature = "datafusion")]
 #[test]
 fn public_source_path_attached_before_sql_is_queryable() {
+    use crate::transform::SqlTransform;
     let mut transform = SqlTransform::new(r#"SELECT "file.path", msg FROM logs"#).expect("sql");
     let mut scanner = Scanner::new(transform.scan_config());
     let scanned = scanner
@@ -1324,12 +1324,8 @@ fn public_source_path_attached_before_sql_is_queryable() {
     )
     .expect("attach");
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("runtime");
-    let result = rt
-        .block_on(transform.execute(attached))
+    let result = transform
+        .execute_blocking(attached)
         .expect("transform should see source path");
     let source_path = result
         .column_by_name(field_names::ECS_FILE_PATH)
@@ -1340,8 +1336,10 @@ fn public_source_path_attached_before_sql_is_queryable() {
     assert_eq!(source_path.value(0), "/var/log/pods/ns_pod_uid/c/0.log");
 }
 
+#[cfg(feature = "datafusion")]
 #[test]
 fn select_star_includes_public_source_metadata_style_columns() {
+    use crate::transform::SqlTransform;
     let mut transform = SqlTransform::new(r#"SELECT * FROM logs"#).expect("sql");
     let mut scanner = Scanner::new(transform.scan_config());
     let scanned = scanner
@@ -1365,12 +1363,8 @@ fn select_star_includes_public_source_metadata_style_columns() {
     )
     .expect("attach");
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("runtime");
-    let result = rt
-        .block_on(transform.execute(attached))
+    let result = transform
+        .execute_blocking(attached)
         .expect("transform should preserve source metadata columns");
 
     assert_eq!(result.num_rows(), 1);
@@ -1378,8 +1372,10 @@ fn select_star_includes_public_source_metadata_style_columns() {
     assert!(result.column_by_name("msg").is_some());
 }
 
+#[cfg(feature = "datafusion")]
 #[test]
 fn select_star_does_not_attach_source_metadata() {
+    use crate::transform::SqlTransform;
     let mut transform = SqlTransform::new("SELECT * FROM logs").expect("sql");
     let mut scanner = Scanner::new(transform.scan_config());
     let scanned = scanner
@@ -1400,19 +1396,17 @@ fn select_star_does_not_attach_source_metadata() {
     )
     .expect("attach");
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("runtime");
-    let result = rt
-        .block_on(transform.execute(attached))
+    let result = transform
+        .execute_blocking(attached)
         .expect("transform should keep wildcard projection narrow");
 
     assert!(result.column_by_name(field_names::SOURCE_ID).is_none());
 }
 
+#[cfg(feature = "datafusion")]
 #[test]
 fn explicit_projection_preserves_new_source_metadata_columns() {
+    use crate::transform::SqlTransform;
     let mut transform = SqlTransform::new("SELECT msg, __source_id FROM logs").expect("sql");
     let mut scanner = Scanner::new(transform.scan_config());
     let scanned = scanner
@@ -1434,12 +1428,8 @@ fn explicit_projection_preserves_new_source_metadata_columns() {
     )
     .expect("attach");
 
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("runtime");
-    let result = rt
-        .block_on(transform.execute(attached))
+    let result = transform
+        .execute_blocking(attached)
         .expect("transform should preserve explicit source metadata");
 
     let source_id = result

--- a/crates/ffwd-runtime/src/pipeline/mod.rs
+++ b/crates/ffwd-runtime/src/pipeline/mod.rs
@@ -43,7 +43,7 @@ use ffwd_arrow::Scanner;
 #[cfg(test)]
 use self::checkpoint_policy::TicketDisposition;
 use crate::processor::Processor;
-use crate::transform::SqlTransform;
+use crate::transform::{create_transform, Transform};
 #[cfg(test)]
 use crate::worker_pool::AckItem;
 use crate::worker_pool::OutputWorkerPool;
@@ -127,11 +127,11 @@ pub(crate) struct ProcessedBatch {
 /// Per-input scanning + SQL transform pair.
 ///
 /// Each input gets its own `Scanner` (driven by `ScanConfig` derived from
-/// its SQL) and `SqlTransform`. This enables per-input field extraction,
+/// its SQL) and `Box<dyn Transform>`. This enables per-input field extraction,
 /// filtering, and schema reshaping with natural predicate pushdown.
 struct SourcePipeline {
     scanner: Scanner,
-    transform: SqlTransform,
+    transform: Box<dyn Transform>,
     input_name: String,
     #[cfg_attr(feature = "turmoil", allow(dead_code))]
     source_metadata_plan: SourceMetadataPlan,
@@ -222,7 +222,7 @@ impl Pipeline {
 
     /// Add an input source for testing. Bypasses config-based input construction.
     ///
-    /// Each new input gets its own passthrough `Scanner + SqlTransform` pair
+    /// Each new input gets its own passthrough `Scanner + Transform` pair
     /// (`SELECT * FROM logs`) to keep `input_transforms` in sync with `inputs`.
     #[must_use]
     pub fn with_input(mut self, name: &str, source: Box<dyn InputSource>) -> Self {
@@ -237,8 +237,8 @@ impl Pipeline {
         });
         // Keep input_transforms in sync: one transform per input.
         while self.input_transforms.len() < self.inputs.len() {
-            let transform =
-                SqlTransform::new("SELECT * FROM logs").expect("default passthrough SQL");
+            let transform = create_transform("SELECT * FROM logs")
+                .expect("default passthrough SQL");
             let scanner = Scanner::new(transform.scan_config());
             self.input_transforms.push(SourcePipeline {
                 scanner,

--- a/crates/ffwd-runtime/src/pipeline/mod.rs
+++ b/crates/ffwd-runtime/src/pipeline/mod.rs
@@ -237,8 +237,8 @@ impl Pipeline {
         });
         // Keep input_transforms in sync: one transform per input.
         while self.input_transforms.len() < self.inputs.len() {
-            let transform =
-                create_transform("SELECT * FROM logs").expect("default passthrough SQL");
+            let transform = create_transform("SELECT * FROM logs")
+                .expect("hardcoded passthrough 'SELECT * FROM logs' is always valid");
             let scanner = Scanner::new(transform.scan_config());
             self.input_transforms.push(SourcePipeline {
                 scanner,

--- a/crates/ffwd-runtime/src/pipeline/mod.rs
+++ b/crates/ffwd-runtime/src/pipeline/mod.rs
@@ -43,7 +43,7 @@ use ffwd_arrow::Scanner;
 #[cfg(test)]
 use self::checkpoint_policy::TicketDisposition;
 use crate::processor::Processor;
-use crate::transform::{create_transform, Transform};
+use crate::transform::{Transform, create_transform};
 #[cfg(test)]
 use crate::worker_pool::AckItem;
 use crate::worker_pool::OutputWorkerPool;
@@ -237,8 +237,8 @@ impl Pipeline {
         });
         // Keep input_transforms in sync: one transform per input.
         while self.input_transforms.len() < self.inputs.len() {
-            let transform = create_transform("SELECT * FROM logs")
-                .expect("default passthrough SQL");
+            let transform =
+                create_transform("SELECT * FROM logs").expect("default passthrough SQL");
             let scanner = Scanner::new(transform.scan_config());
             self.input_transforms.push(SourcePipeline {
                 scanner,

--- a/crates/ffwd-runtime/src/pipeline/submit.rs
+++ b/crates/ffwd-runtime/src/pipeline/submit.rs
@@ -223,7 +223,7 @@ pub(super) async fn scan_and_transform_for_send(
     }
 
     let t1 = tokio::time::Instant::now();
-    let result = match transform.transform.execute(batch).await {
+    let result = match transform.transform.execute_blocking(batch) {
         Ok(r) => r,
         Err(e) => {
             metrics.inc_transform_error();
@@ -264,7 +264,7 @@ pub(super) async fn transform_direct_batch_for_send(
     }
 
     let t0 = tokio::time::Instant::now();
-    let result = match transform.transform.execute(batch).await {
+    let result = match transform.transform.execute_blocking(batch) {
         Ok(r) => r,
         Err(e) => {
             metrics.inc_transform_error();

--- a/crates/ffwd-runtime/src/pipeline/submit.rs
+++ b/crates/ffwd-runtime/src/pipeline/submit.rs
@@ -223,13 +223,12 @@ pub(super) async fn scan_and_transform_for_send(
     }
 
     let t1 = tokio::time::Instant::now();
-    let result = match transform.transform.execute_blocking(batch) {
+    let result = match transform.transform.execute_async(batch).await {
         Ok(r) => r,
         Err(e) => {
             metrics.inc_transform_error();
             metrics.inc_dropped_batch();
             tracing::warn!(input = transform.input_name.as_str(), error = %e, "transform error");
-            // Checkpoints dropped — at-least-once: data re-read on restart.
             return None;
         }
     };
@@ -264,16 +263,12 @@ pub(super) async fn transform_direct_batch_for_send(
     }
 
     let t0 = tokio::time::Instant::now();
-    let result = match transform.transform.execute_blocking(batch) {
+    let result = match transform.transform.execute_async(batch).await {
         Ok(r) => r,
         Err(e) => {
             metrics.inc_transform_error();
             metrics.inc_dropped_batch();
-            tracing::warn!(
-                input = transform.input_name.as_str(),
-                error = %e,
-                "transform error"
-            );
+            tracing::warn!(input = transform.input_name.as_str(), error = %e, "transform error");
             return None;
         }
     };

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -4,6 +4,7 @@
 //! Implementations are DataFusion-based SQL transforms and a passthrough stub.
 
 use arrow::record_batch::RecordBatch;
+
 use ffwd_core::scan_config::ScanConfig;
 use ffwd_types::source_metadata::SourceMetadataPlan;
 
@@ -25,43 +26,52 @@ pub mod udf {
 
 /// Unified error type for transform operations.
 #[derive(Debug, Clone)]
-pub struct TransformError {
-    message: String,
-}
-
-impl TransformError {
-    pub fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-        }
-    }
-
+pub enum TransformError {
+    Message(String),
     #[cfg(feature = "datafusion")]
-    pub fn from_df_error(e: ffwd_transform::TransformError) -> Self {
-        Self::new(e.to_string())
-    }
+    DataFusion(String),
 }
 
 impl std::fmt::Display for TransformError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.message)
+        match self {
+            TransformError::Message(msg) => write!(f, "{msg}"),
+            #[cfg(feature = "datafusion")]
+            TransformError::DataFusion(msg) => write!(f, "datafusion error: {msg}"),
+        }
     }
 }
 
 impl std::error::Error for TransformError {}
 
+impl TransformError {
+    pub fn new(message: impl Into<String>) -> Self {
+        TransformError::Message(message.into())
+    }
+
+    #[cfg(feature = "datafusion")]
+    pub fn from_df_error(e: ffwd_transform::TransformError) -> Self {
+        TransformError::DataFusion(e.to_string())
+    }
+}
+
 /// Transform trait for pipeline batch processing.
 ///
 /// Implementations handle SQL transform execution against Arrow RecordBatches.
 pub trait Transform: Send {
+    /// Execute the transform on a record batch.
     fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError>;
 
+    /// Return the scan configuration for field pushdown.
     fn scan_config(&self) -> ScanConfig;
 
+    /// Return the source metadata columns required by this transform.
     fn source_metadata_plan(&self) -> SourceMetadataPlan;
 
+    /// Return source metadata columns explicitly referenced in the SQL.
     fn explicit_source_metadata_plan(&self) -> SourceMetadataPlan;
 
+    /// Validate the transform plan by executing against a dummy batch.
     fn validate_plan(&mut self) -> Result<(), TransformError>;
 }
 
@@ -90,16 +100,19 @@ pub struct ConfiguredSqlTransform {
 
 #[cfg(feature = "datafusion")]
 impl ConfiguredSqlTransform {
+    /// Create a new configured transform from SQL.
     pub fn new(sql: &str) -> Result<Self, TransformError> {
         SqlTransform::new(sql)
             .map(|inner| Self { inner })
             .map_err(TransformError::from_df_error)
     }
 
+    /// Set the geo-IP database for the `geo_lookup()` UDF.
     pub fn set_geo_database(&mut self, db: std::sync::Arc<dyn enrichment::GeoDatabase>) {
         self.inner.set_geo_database(db);
     }
 
+    /// Add an enrichment table to be registered alongside `logs`.
     pub fn add_enrichment_table(
         &mut self,
         table: std::sync::Arc<dyn enrichment::EnrichmentTable>,
@@ -109,14 +122,17 @@ impl ConfiguredSqlTransform {
             .map_err(TransformError::from_df_error)
     }
 
+    /// Return the scan configuration for field pushdown.
     pub fn scan_config(&self) -> ScanConfig {
         self.inner.scan_config()
     }
 
+    /// Return source metadata columns explicitly referenced in the SQL.
     pub fn explicit_source_metadata_plan(&self) -> SourceMetadataPlan {
         self.inner.analyzer().explicit_source_metadata_plan()
     }
 
+    /// Build into a `Box<dyn Transform>`.
     pub fn build(self) -> Result<Box<dyn Transform>, TransformError> {
         Ok(Box::new(self.inner) as Box<dyn Transform>)
     }
@@ -126,9 +142,15 @@ impl ConfiguredSqlTransform {
 mod passthrough {
     use super::*;
 
+    /// Passthrough transform that returns batches unchanged.
+    ///
+    /// Used when datafusion is disabled; only accepts `SELECT * FROM logs`.
     pub struct PassthroughTransform;
 
     impl PassthroughTransform {
+        /// Create a new passthrough transform.
+        ///
+        /// Returns an error if the SQL is not `SELECT * FROM logs`.
         pub fn new(sql: &str) -> Result<Self, TransformError> {
             if !is_passthrough_sql(sql) {
                 let preview = sql.trim().lines().next().unwrap_or("").trim();

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -3,6 +3,9 @@
 //! Defines the `Transform` trait that abstracts SQL transform execution.
 //! Implementations are DataFusion-based SQL transforms and a passthrough stub.
 
+use std::future::Future;
+use std::pin::Pin;
+
 use arrow::record_batch::RecordBatch;
 
 use ffwd_core::scan_config::ScanConfig;
@@ -59,7 +62,16 @@ impl TransformError {
 ///
 /// Implementations handle SQL transform execution against Arrow RecordBatches.
 pub trait Transform: Send {
-    /// Execute the transform on a record batch.
+    /// Execute the transform on a record batch asynchronously.
+    ///
+    /// This method enables direct `.await` usage in async contexts, avoiding
+    /// the overhead of creating a runtime per call in turmoil/simulation.
+    fn execute_async(
+        &mut self,
+        batch: RecordBatch,
+    ) -> Pin<Box<dyn futures_util::Future<Output = Result<RecordBatch, TransformError>> + Send + '_>>;
+
+    /// Execute the transform on a record batch synchronously.
     fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError>;
 
     /// Return the scan configuration for field pushdown.
@@ -164,6 +176,13 @@ mod passthrough {
     }
 
     impl Transform for PassthroughTransform {
+        fn execute_async(
+            &mut self,
+            batch: RecordBatch,
+        ) -> Pin<Box<dyn Future<Output = Result<RecordBatch, TransformError>> + Send + '_>> {
+            Box::pin(std::future::ready(Ok(batch)))
+        }
+
         fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError> {
             Ok(batch)
         }
@@ -208,6 +227,17 @@ mod passthrough {
 
 #[cfg(feature = "datafusion")]
 impl Transform for SqlTransform {
+    fn execute_async(
+        &mut self,
+        batch: RecordBatch,
+    ) -> Pin<Box<dyn Future<Output = Result<RecordBatch, TransformError>> + Send + '_>> {
+        let fut = async move {
+            let result = SqlTransform::execute(self, batch).await;
+            result.map_err(TransformError::from_df_error)
+        };
+        Box::pin(fut)
+    }
+
     fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError> {
         use ffwd_transform::SqlTransform as DfSqlTransform;
         DfSqlTransform::execute_blocking(self, batch).map_err(TransformError::from_df_error)

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -267,3 +267,73 @@ impl Transform for SqlTransform {
 
 #[cfg(not(feature = "datafusion"))]
 pub use passthrough::PassthroughTransform;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transform_error_new_creates_message_variant() {
+        let err = TransformError::new("something went wrong");
+        assert_eq!(err.to_string(), "transform error: something went wrong");
+    }
+
+    #[test]
+    fn transform_error_display_formats_correctly() {
+        let err = TransformError::Message("test error".to_string());
+        assert!(err.to_string().contains("test error"));
+    }
+
+    /// Tests for the `PassthroughTransform` — only compiled when DataFusion is absent.
+    #[cfg(not(feature = "datafusion"))]
+    mod passthrough_tests {
+        use super::*;
+
+        #[test]
+        fn passthrough_accepts_select_star() {
+            assert!(PassthroughTransform::new("SELECT * FROM logs").is_ok());
+        }
+
+        #[test]
+        fn passthrough_accepts_empty_sql() {
+            assert!(PassthroughTransform::new("").is_ok());
+        }
+
+        #[test]
+        fn passthrough_accepts_select_star_with_semicolon() {
+            assert!(PassthroughTransform::new("SELECT * FROM logs;").is_ok());
+        }
+
+        #[test]
+        fn passthrough_rejects_non_passthrough_sql() {
+            let err = PassthroughTransform::new("SELECT id FROM logs").unwrap_err();
+            assert!(err.to_string().contains("DataFusion"));
+        }
+
+        #[test]
+        fn passthrough_execute_blocking_passes_batch_through() {
+            use arrow::array::Int32Array;
+            use arrow::datatypes::{DataType, Field, Schema};
+            use std::sync::Arc;
+
+            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+            let batch = arrow::record_batch::RecordBatch::try_new(
+                schema,
+                vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+            )
+            .expect("valid test batch");
+
+            let mut transform =
+                PassthroughTransform::new("SELECT * FROM logs").expect("passthrough sql");
+            let result = transform.execute_blocking(batch).expect("execute");
+            assert_eq!(result.num_rows(), 3);
+        }
+
+        #[test]
+        fn passthrough_validate_plan_succeeds() {
+            let mut transform =
+                PassthroughTransform::new("SELECT * FROM logs").expect("passthrough sql");
+            assert!(transform.validate_plan().is_ok());
+        }
+    }
+}

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -232,8 +232,9 @@ impl Transform for SqlTransform {
         &mut self,
         batch: RecordBatch,
     ) -> Pin<Box<dyn Future<Output = Result<RecordBatch, TransformError>> + Send + '_>> {
+        use ffwd_transform::SqlTransform as DfSqlTransform;
         let fut = async move {
-            let result = SqlTransform::execute(self, batch).await;
+            let result = DfSqlTransform::execute(self, batch).await;
             result.map_err(TransformError::from_df_error)
         };
         Box::pin(fut)

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -180,7 +180,8 @@ mod passthrough {
         fn execute_async(
             &mut self,
             batch: RecordBatch,
-        ) -> Pin<Box<dyn Future<Output = Result<RecordBatch, TransformError>> + Send + '_>> {
+        ) -> Pin<Box<dyn Future<Output = Result<RecordBatch, TransformError>> + Send + '_>>
+        {
             Box::pin(std::future::ready(Ok(batch)))
         }
 

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -1,3 +1,12 @@
+//! Transform abstraction for pipeline processing.
+//!
+//! Defines the `Transform` trait that abstracts SQL transform execution.
+//! Implementations are DataFusion-based SQL transforms and a passthrough stub.
+
+use arrow::record_batch::RecordBatch;
+use ffwd_core::scan_config::ScanConfig;
+use ffwd_types::source_metadata::SourceMetadataPlan;
+
 #[cfg(feature = "datafusion")]
 pub use ffwd_transform::SqlTransform;
 
@@ -11,53 +20,115 @@ pub mod udf {
     pub mod geo_lookup {
         pub use ffwd_transform::udf::geo_lookup::MmdbDatabase;
     }
-    /// CSV IP-range geo database backend for runtime pipeline wiring.
     pub use ffwd_transform::udf::CsvRangeDatabase;
+}
+
+/// Unified error type for transform operations.
+#[derive(Debug, Clone)]
+pub struct TransformError {
+    message: String,
+}
+
+impl TransformError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    #[cfg(feature = "datafusion")]
+    pub fn from_df_error(e: ffwd_transform::TransformError) -> Self {
+        Self::new(e.to_string())
+    }
+}
+
+impl std::fmt::Display for TransformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for TransformError {}
+
+/// Transform trait for pipeline batch processing.
+///
+/// Implementations handle SQL transform execution against Arrow RecordBatches.
+pub trait Transform: Send {
+    fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError>;
+
+    fn scan_config(&self) -> ScanConfig;
+
+    fn source_metadata_plan(&self) -> SourceMetadataPlan;
+
+    fn explicit_source_metadata_plan(&self) -> SourceMetadataPlan;
+
+    fn validate_plan(&mut self) -> Result<(), TransformError>;
+}
+
+/// Create a new transform based on the datafusion feature flag.
+///
+/// When datafusion is enabled, delegates to DataFusion SqlTransform.
+/// When disabled, creates a passthrough transform that only accepts `SELECT * FROM logs`.
+#[cfg(feature = "datafusion")]
+pub fn create_transform(sql: &str) -> Result<Box<dyn Transform>, TransformError> {
+    ConfiguredSqlTransform::new(sql)?.build()
+}
+
+#[cfg(not(feature = "datafusion"))]
+pub fn create_transform(sql: &str) -> Result<Box<dyn Transform>, TransformError> {
+    PassthroughTransform::new(sql).map(|t| Box::new(t) as Box<dyn Transform>)
+}
+
+/// Builder for DataFusion SqlTransform with enrichment configuration.
+///
+/// Allows setting geo database and enrichment tables before building
+/// a `Box<dyn Transform>` for the pipeline.
+#[cfg(feature = "datafusion")]
+pub struct ConfiguredSqlTransform {
+    inner: SqlTransform,
+}
+
+#[cfg(feature = "datafusion")]
+impl ConfiguredSqlTransform {
+    pub fn new(sql: &str) -> Result<Self, TransformError> {
+        SqlTransform::new(sql)
+            .map(|inner| Self { inner })
+            .map_err(TransformError::from_df_error)
+    }
+
+    pub fn set_geo_database(&mut self, db: std::sync::Arc<dyn enrichment::GeoDatabase>) {
+        self.inner.set_geo_database(db);
+    }
+
+    pub fn add_enrichment_table(
+        &mut self,
+        table: std::sync::Arc<dyn enrichment::EnrichmentTable>,
+    ) -> Result<(), TransformError> {
+        self.inner
+            .add_enrichment_table(table)
+            .map_err(TransformError::from_df_error)
+    }
+
+    pub fn scan_config(&self) -> ScanConfig {
+        self.inner.scan_config()
+    }
+
+    pub fn explicit_source_metadata_plan(&self) -> SourceMetadataPlan {
+        self.inner.analyzer().explicit_source_metadata_plan()
+    }
+
+    pub fn build(self) -> Result<Box<dyn Transform>, TransformError> {
+        Ok(Box::new(self.inner) as Box<dyn Transform>)
+    }
 }
 
 #[cfg(not(feature = "datafusion"))]
 mod passthrough {
-    use std::collections::HashSet;
-    use std::fmt;
+    use super::*;
 
-    use arrow::record_batch::RecordBatch;
-    use ffwd_core::scan_config::ScanConfig;
-    use ffwd_types::source_metadata::SourceMetadataPlan;
+    pub struct PassthroughTransform;
 
-    /// Error returned when passthrough transform construction or execution fails.
-    #[derive(Debug, Clone)]
-    pub struct TransformError {
-        message: String,
-    }
-
-    impl TransformError {
-        fn new(message: impl Into<String>) -> Self {
-            Self {
-                message: message.into(),
-            }
-        }
-    }
-
-    impl fmt::Display for TransformError {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str(&self.message)
-        }
-    }
-
-    impl std::error::Error for TransformError {}
-
-    /// Minimal analyzer surface for passthrough builds without DataFusion support.
-    pub struct QueryAnalyzer {
-        /// Referenced columns inferred from the parsed query.
-        pub referenced_columns: HashSet<String>,
-    }
-
-    /// Passthrough SQL transform stub used when the `datafusion` feature is disabled.
-    pub struct SqlTransform {
-        analyzer: QueryAnalyzer,
-    }
-
-    impl SqlTransform {
+    impl PassthroughTransform {
         pub fn new(sql: &str) -> Result<Self, TransformError> {
             if !is_passthrough_sql(sql) {
                 let preview = sql.trim().lines().next().unwrap_or("").trim();
@@ -66,25 +137,16 @@ mod passthrough {
                      (default) or add `--features datafusion` (unsupported SQL: {preview})"
                 )));
             }
-            Ok(Self {
-                analyzer: QueryAnalyzer {
-                    referenced_columns: HashSet::new(),
-                },
-            })
+            Ok(Self)
         }
+    }
 
-        pub async fn execute(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError> {
+    impl Transform for PassthroughTransform {
+        fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError> {
             Ok(batch)
         }
 
-        pub fn execute_blocking(
-            &mut self,
-            batch: RecordBatch,
-        ) -> Result<RecordBatch, TransformError> {
-            Ok(batch)
-        }
-
-        pub fn scan_config(&self) -> ScanConfig {
+        fn scan_config(&self) -> ScanConfig {
             ScanConfig {
                 wanted_fields: vec![],
                 extract_all: true,
@@ -94,35 +156,16 @@ mod passthrough {
             }
         }
 
-        pub fn analyzer(&self) -> &QueryAnalyzer {
-            &self.analyzer
+        fn source_metadata_plan(&self) -> SourceMetadataPlan {
+            SourceMetadataPlan::default()
         }
 
-        pub fn validate_plan(&mut self) -> Result<(), TransformError> {
+        fn explicit_source_metadata_plan(&self) -> SourceMetadataPlan {
+            SourceMetadataPlan::default()
+        }
+
+        fn validate_plan(&mut self) -> Result<(), TransformError> {
             Ok(())
-        }
-    }
-
-    impl QueryAnalyzer {
-        /// Return the metadata columns the passthrough transform needs.
-        ///
-        /// The passthrough transform accepts only `SELECT * FROM logs`, which
-        /// never widens results with source metadata.
-        pub fn source_metadata_plan(&self) -> SourceMetadataPlan {
-            SourceMetadataPlan::default()
-        }
-
-        /// Return metadata columns explicitly referenced by SQL.
-        ///
-        /// The passthrough analyzer has no SQL expression tree, so it reports
-        /// no explicit metadata references.
-        pub fn explicit_source_metadata_plan(&self) -> SourceMetadataPlan {
-            SourceMetadataPlan::default()
-        }
-
-        /// Return whether the transform needs source paths attached.
-        pub fn source_path_required(&self) -> bool {
-            self.source_metadata_plan().has_source_path()
         }
     }
 
@@ -141,5 +184,31 @@ mod passthrough {
     }
 }
 
+#[cfg(feature = "datafusion")]
+impl Transform for SqlTransform {
+    fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError> {
+        use ffwd_transform::SqlTransform as DfSqlTransform;
+        DfSqlTransform::execute_blocking(self, batch).map_err(TransformError::from_df_error)
+    }
+
+    fn scan_config(&self) -> ScanConfig {
+        use ffwd_transform::SqlTransform as DfSqlTransform;
+        DfSqlTransform::scan_config(self)
+    }
+
+    fn source_metadata_plan(&self) -> SourceMetadataPlan {
+        self.analyzer().source_metadata_plan()
+    }
+
+    fn explicit_source_metadata_plan(&self) -> SourceMetadataPlan {
+        self.analyzer().explicit_source_metadata_plan()
+    }
+
+    fn validate_plan(&mut self) -> Result<(), TransformError> {
+        use ffwd_transform::SqlTransform as DfSqlTransform;
+        DfSqlTransform::validate_plan(self).map_err(TransformError::from_df_error)
+    }
+}
+
 #[cfg(not(feature = "datafusion"))]
-pub use passthrough::{QueryAnalyzer, SqlTransform, TransformError};
+pub use passthrough::PassthroughTransform;

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -28,31 +28,25 @@ pub mod udf {
 }
 
 /// Unified error type for transform operations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum TransformError {
+    #[error("transform error: {0}")]
     Message(String),
     #[cfg(feature = "datafusion")]
+    #[error("datafusion error: {0}")]
     DataFusion(String),
 }
 
-impl std::fmt::Display for TransformError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TransformError::Message(msg) => write!(f, "{msg}"),
-            #[cfg(feature = "datafusion")]
-            TransformError::DataFusion(msg) => write!(f, "datafusion error: {msg}"),
-        }
-    }
-}
-
-impl std::error::Error for TransformError {}
-
 impl TransformError {
+    /// Creates a new error with a message.
+    #[must_use]
     pub fn new(message: impl Into<String>) -> Self {
         TransformError::Message(message.into())
     }
 
+    /// Creates an error from a DataFusion transform error.
     #[cfg(feature = "datafusion")]
+    #[must_use]
     pub fn from_df_error(e: ffwd_transform::TransformError) -> Self {
         TransformError::DataFusion(e.to_string())
     }
@@ -72,6 +66,9 @@ pub trait Transform: Send {
     ) -> Pin<Box<dyn futures_util::Future<Output = Result<RecordBatch, TransformError>> + Send + '_>>;
 
     /// Execute the transform on a record batch synchronously.
+    ///
+    /// For callers that cannot use async (e.g., plain thread context),
+    /// this delegates to [`execute_async`](Self::execute_async) via a runtime.
     fn execute_blocking(&mut self, batch: RecordBatch) -> Result<RecordBatch, TransformError>;
 
     /// Return the scan configuration for field pushdown.
@@ -96,6 +93,10 @@ pub fn create_transform(sql: &str) -> Result<Box<dyn Transform>, TransformError>
     ConfiguredSqlTransform::new(sql)?.build()
 }
 
+/// Create a new transform based on the datafusion feature flag.
+///
+/// When datafusion is enabled, delegates to DataFusion SqlTransform.
+/// When disabled, creates a passthrough transform that only accepts `SELECT * FROM logs`.
 #[cfg(not(feature = "datafusion"))]
 pub fn create_transform(sql: &str) -> Result<Box<dyn Transform>, TransformError> {
     PassthroughTransform::new(sql).map(|t| Box::new(t) as Box<dyn Transform>)


### PR DESCRIPTION
## Summary

Formalizes the `Transform` trait in `ffwd-runtime` to properly abstract SQL transform execution from the pipeline.

- Define `Transform` trait with `execute_blocking`, `scan_config`, `source_metadata_plan`, `explicit_source_metadata_plan`, `validate_plan` methods
- Implement `Transform` for both `PassthroughTransform` (no-datafusion) and `SqlTransform` (datafusion)
- Add `create_transform()` factory returning `Box<dyn Transform>`
- Add `ConfiguredSqlTransform` builder for DataFusion-specific setup (geo_database, enrichment tables)
- Pipeline now uses `Box<dyn Transform>` instead of concrete `SqlTransform` type
- Update cpu_worker and submit to use `execute_blocking` directly
- Add `#[cfg(feature = "datafusion")]` guards to tests that use `SqlTransform`

## Motivation

Previously, the pipeline was tightly coupled to the concrete `SqlTransform` type. This refactor:
- Eliminates the cfg-gated passthrough stub pattern
- Formalizes the Transform abstraction for the pipeline
- Makes it possible to add new Transform implementations without pipeline changes

## Trade-off

Async `execute()` was removed from the trait because `impl Trait` in return type causes dyn incompatibility. All callers now use `execute_blocking()` which handles async internally via `block_in_place`.

## Testing

- All 246 tests pass
- clippy passes with `-D warnings`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Formalize `Transform` trait with `Box<dyn Transform>` pipeline support
> - Introduces a `Transform` trait in [`transform.rs`](https://github.com/strawgate/fastforward/pull/2667/files#diff-82fa3bfc4e6200ef08023428759d2794a7c92ef67b4c202edcb2b52a30de1bdf) with `execute_async`, `execute_blocking`, `scan_config`, and plan introspection methods, replacing direct use of `SqlTransform` throughout the pipeline.
> - Adds `TransformError` as a unified error type (wrapping DataFusion errors when the `datafusion` feature is enabled) and a `create_transform` factory function as the single construction entrypoint.
> - `SourcePipeline.transform` now holds a `Box<dyn Transform>` instead of a concrete `SqlTransform`; call sites in `build.rs`, `mod.rs`, `submit.rs`, and `cpu_worker.rs` are updated accordingly.
> - Under non-datafusion builds, `PassthroughTransform` enforces that only `SELECT * FROM logs` is accepted, returning `TransformError` for any other SQL.
> - Adds `#[allow(clippy::indexing_slicing)]` attributes across several Arrow builder and columnar methods to suppress pre-existing clippy warnings without changing logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f624333.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->