### PR TITLE
fix: add #[cfg(not(feature = turmoil))] guards to source_metadata tests

### DIFF
--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -825,6 +825,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "turmoil"))]
     #[test]
     fn source_metadata_enabled_allows_explicit_source_column() {
         let dir = tempfile::tempdir().unwrap();
@@ -864,6 +865,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "turmoil"))]
     #[test]
     fn public_source_path_style_rejects_inputs_without_source_paths() {
         let mut config = PipelineConfig {
@@ -901,6 +903,7 @@ mod tests {
             .expect("fastforward source id style does not require source paths");
     }
 
+    #[cfg(not(feature = "turmoil"))]
     #[test]
     fn public_source_path_style_allows_s3_key_snapshots() {
         let config = PipelineConfig {
@@ -955,6 +958,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "turmoil"))]
     #[test]
     fn fastforward_source_metadata_attaches_source_id_for_select_star() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Add missing `#[cfg(not(feature = "turmoil"))]` guards to 4 tests that use file I/O and source metadata attachment:

- `source_metadata_enabled_allows_explicit_source_column`
- `public_source_path_style_rejects_inputs_without_source_paths`
- `public_source_path_style_allows_s3_key_snapshots`
- `fastforward_source_metadata_attaches_source_id_for_select_star`

These tests fail when run with `--features turmoil` because:
1. They use file I/O (`tempfile`, `std::fs::write`)
2. They test source metadata attachment which is not supported in turmoil's single-thread simulation

## Testing

- All 246 tests pass without turmoil feature
- All 201 tests pass with `--features turmoil`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `#[cfg(not(feature = "turmoil"))]` guards to source_metadata tests in pipeline build
> Four tests in [build.rs](https://github.com/strawgate/fastforward/pull/2668/files#diff-b156cfbcf43f3be44134629e0984ba38c2133f151953bd7760612f5190394167) that test source metadata behavior are now excluded from compilation and execution when the `turmoil` feature is enabled, preventing build or test failures in that configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dba2376.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->