### PR TITLE
fix: enable runtime auto-shutdown when inputs are exhausted

### DIFF
--- a/crates/logfwd-io/src/generator.rs
+++ b/crates/logfwd-io/src/generator.rs
@@ -790,7 +790,15 @@ impl InputSource for GeneratorInput {
     fn health(&self) -> ComponentHealth {
         // Generator input has no independent bind/startup/shutdown lifecycle.
         // It is either idle or emitting synthetic events under pipeline control.
-        ComponentHealth::Healthy
+        if self.done {
+            ComponentHealth::Stopped
+        } else {
+            ComponentHealth::Healthy
+        }
+    }
+
+    fn is_finished(&self) -> bool {
+        self.done
     }
 }
 

--- a/crates/logfwd/tests/it/finite_pipeline.rs
+++ b/crates/logfwd/tests/it/finite_pipeline.rs
@@ -1,0 +1,41 @@
+use logfwd_config::Config;
+use logfwd_runtime::pipeline::Pipeline;
+use opentelemetry::metrics::MeterProvider;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn finite_pipeline_shuts_down_automatically() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          total_events: 5
+          batch_size: 2
+    outputs:
+      - type: "null"
+"#;
+    let config = Config::load_str(yaml).expect("parse config");
+
+    let meter = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        .build()
+        .meter("test");
+    let mut pipeline =
+        Pipeline::from_config_with_data_dir("test", &config.pipelines["test"], &meter, None, None)
+            .unwrap();
+
+    let shutdown = CancellationToken::new();
+
+    // We expect the pipeline to return Ok(()) naturally, without us cancelling the token.
+    // Wrap in timeout to fail if it hangs.
+    let result = tokio::time::timeout(Duration::from_secs(30), pipeline.run_async(&shutdown)).await;
+
+    assert!(
+        result.is_ok(),
+        "Pipeline did not shut down automatically within timeout"
+    );
+    let result = result.unwrap();
+    assert!(result.is_ok(), "Pipeline failed with error: {result:?}");
+}

--- a/crates/logfwd/tests/it/main.rs
+++ b/crates/logfwd/tests/it/main.rs
@@ -1,3 +1,4 @@
 mod compliance;
 mod compliance_file;
+mod finite_pipeline;
 mod integration;


### PR DESCRIPTION
## Summary
- Enable runtime auto-shutdown when inputs are exhausted

## Changes
- 1 commit ahead of main

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enable auto-shutdown of runtime when generator inputs are exhausted
> - `GeneratorInput::health()` now returns `ComponentHealth::Stopped` (instead of always `Healthy`) once the generator has emitted all configured events, allowing the runtime to detect completion and shut down automatically.
> - Adds `GeneratorInput::is_finished()` to expose the internal `done` flag to callers.
> - Adds an integration test in [finite_pipeline.rs](https://github.com/strawgate/fastforward/pull/2673/files#diff-db74a3812da09d373e1ad16bfaa2cf118a92f9516fcd1188d75c2ebf88a93d6f) that runs a 5-event, batch-size-2 pipeline and asserts it exits within 30s without external cancellation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7cb48ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->