### PR TITLE
fix(output): address output sink correctness issues

### DIFF
--- a/crates/logfwd-output/src/http_classify.rs
+++ b/crates/logfwd-output/src/http_classify.rs
@@ -88,7 +88,12 @@ pub fn classify_http_status(
         return Some(SendResult::Rejected(format!("HTTP {status}: {detail}")));
     }
 
-    // 1xx, 3xx, etc. — treat as transient
+    // 3xx Redirection — permanent configuration or destination change
+    if (300..400).contains(&status) {
+        return Some(SendResult::Rejected(format!("HTTP {status}: {detail}")));
+    }
+
+    // 1xx, etc. — treat as transient
     Some(SendResult::IoError(io::Error::other(format!(
         "unexpected HTTP {status}: {detail}"
     ))))
@@ -170,8 +175,17 @@ mod tests {
     }
 
     #[test]
-    fn unexpected_status_is_io_error() {
+    fn redirect_is_rejected() {
         let result = classify_http_status(301, None, "redirect");
+        assert!(
+            matches!(result, Some(SendResult::Rejected(ref r)) if r.contains("301")),
+            "expected Rejected containing '301', got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn unexpected_status_is_io_error() {
+        let result = classify_http_status(100, None, "continue");
         assert!(
             matches!(result, Some(SendResult::IoError(_))),
             "expected IoError, got: {result:?}"

--- a/crates/logfwd-output/src/loki.rs
+++ b/crates/logfwd-output/src/loki.rs
@@ -490,19 +490,27 @@ impl LokiSink {
     fn prepare_and_reserve_payloads(
         &self,
         stream_map: &mut StreamMap,
-    ) -> io::Result<Vec<PreparedPayload>> {
+    ) -> io::Result<(Vec<PreparedPayload>, HashMap<StreamLabels, u64>)> {
         let mut timestamp_state = self
             .last_timestamp_by_stream
             .lock()
             .map_err(|_e| io::Error::other("Loki timestamp state lock poisoned"))?;
         let payloads = Self::prepare_payloads(stream_map, &timestamp_state, LOKI_MAX_PAYLOAD_BYTES);
+
+        // Save the previous timestamps so we can roll back if the send fails.
+        let mut previous_timestamps = HashMap::new();
+        for prepared in &payloads {
+            if let Some(&prev) = timestamp_state.get(&prepared.stream_labels) {
+                previous_timestamps.insert(prepared.stream_labels.clone(), prev);
+            }
+        }
+
         // Reserve before awaiting network IO so concurrent workers cannot prepare
-        // overlapping timestamp ranges for the same Loki stream. A failed send may
-        // leave timestamp gaps, which Loki accepts; going backwards is rejected.
+        // overlapping timestamp ranges for the same Loki stream.
         for prepared in &payloads {
             timestamp_state.insert(prepared.stream_labels.clone(), prepared.last_timestamp_ns);
         }
-        Ok(payloads)
+        Ok((payloads, previous_timestamps))
     }
 
     async fn do_send(
@@ -566,15 +574,48 @@ impl super::sink::Sink for LokiSink {
                 Ok(m) => m,
                 Err(e) => return super::sink::SendResult::from_io_error(e),
             };
-            let payloads = match self.prepare_and_reserve_payloads(&mut stream_map) {
-                Ok(payloads) => payloads,
-                Err(e) => return super::sink::SendResult::from_io_error(e),
-            };
-            for prepared in payloads {
-                match self.do_send(prepared.payload, prepared.row_count).await {
-                    Ok(super::sink::SendResult::Ok) => {}
-                    Ok(other) => return other,
+            let (mut payloads, previous_timestamps) =
+                match self.prepare_and_reserve_payloads(&mut stream_map) {
+                    Ok(result) => result,
                     Err(e) => return super::sink::SendResult::from_io_error(e),
+                };
+            let mut all_payloads = std::mem::take(&mut payloads).into_iter();
+            while let Some(prepared) = all_payloads.next() {
+                let labels_for_rollback = prepared.stream_labels.clone();
+                let timestamp_for_rollback = prepared.last_timestamp_ns;
+                match self
+                    .do_send(prepared.payload, prepared.row_count)
+                    .await
+                {
+                    Ok(super::sink::SendResult::Ok) => {}
+                    outcome => {
+                        // Rollback reserved timestamps if we failed, so that
+                        // retries don't cause timestamp drift. Only revert if
+                        // the state is still exactly what we set it to. We revert
+                        // the failed payload and all remaining unsent payloads.
+                        if let Ok(mut state) = self.last_timestamp_by_stream.lock() {
+                            if state.get(&labels_for_rollback) == Some(&timestamp_for_rollback) {
+                                if let Some(prev) = previous_timestamps.get(&labels_for_rollback) {
+                                    state.insert(labels_for_rollback.clone(), *prev);
+                                } else {
+                                    state.remove(&labels_for_rollback);
+                                }
+                            }
+                            for p in all_payloads {
+                                if state.get(&p.stream_labels) == Some(&p.last_timestamp_ns) {
+                                    if let Some(prev) = previous_timestamps.get(&p.stream_labels) {
+                                        state.insert(p.stream_labels.clone(), *prev);
+                                    } else {
+                                        state.remove(&p.stream_labels);
+                                    }
+                                }
+                            }
+                        }
+                        return match outcome {
+                            Ok(other) => other,
+                            Err(e) => super::sink::SendResult::from_io_error(e),
+                        };
+                    }
                 }
             }
             super::sink::SendResult::Ok
@@ -868,6 +909,73 @@ mod tests {
     }
 
     #[test]
+    fn send_failure_rolls_back_timestamp_reservation() {
+        use crate::sink::{SendResult, Sink};
+        let mut server = mockito::Server::new();
+        let mock = server.mock("POST", "/loki/api/v1/push")
+            .with_status(500)
+            .create();
+
+        let factory = LokiSinkFactory::new(
+            "loki".to_string(),
+            server.url(),
+            None,
+            vec![("app".to_string(), "logfwd".to_string())],
+            vec![],
+            vec![],
+            Arc::new(ComponentStats::new()),
+        )
+        .expect("factory");
+        let mut sink = factory.create_sink();
+
+        // Create a batch with timestamp 100
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new(field_names::TIMESTAMP_UNDERSCORE, DataType::Int64, true),
+            arrow::datatypes::Field::new("message", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(arrow::array::Int64Array::from(vec![100i64])),
+                Arc::new(arrow::array::StringArray::from(vec!["hello"])),
+            ],
+        ).unwrap();
+        let metadata = BatchMetadata {
+            resource_attrs: Arc::from([]),
+            observed_time_ns: 99_999,
+        };
+
+        // First attempt (fails with 500)
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let result = rt.block_on(sink.send_batch(&batch, &metadata));
+        assert!(matches!(result, SendResult::IoError(_)));
+        mock.assert();
+
+        // Check state - timestamp should have been rolled back to None
+        let labels: StreamLabels = vec![("app".to_string(), "logfwd".to_string())];
+        {
+            let state = sink.last_timestamp_by_stream.lock().unwrap();
+            assert_eq!(state.get(&labels), None, "timestamp reservation should be rolled back on failure");
+        }
+
+        // Fix server to succeed
+        let mock_success = server.mock("POST", "/loki/api/v1/push")
+            .with_status(204)
+            .create();
+
+        // Retry same batch
+        let result2 = rt.block_on(sink.send_batch(&batch, &metadata));
+        assert!(matches!(result2, SendResult::Ok));
+        mock_success.assert();
+
+        // State should now have 100
+        {
+            let state = sink.last_timestamp_by_stream.lock().unwrap();
+            assert_eq!(state.get(&labels), Some(&100), "successful send should keep timestamp");
+        }
+    }
+
+    #[test]
     fn factory_created_sinks_share_timestamp_reservations() {
         let factory = LokiSinkFactory::new(
             "loki".to_string(),
@@ -888,14 +996,14 @@ mod tests {
             labels.clone(),
             vec![(100, "{\"message\":\"a\"}".to_string())],
         );
-        let first_payloads = sink1
+        let (first_payloads, _) = sink1
             .prepare_and_reserve_payloads(&mut first_stream_map)
             .expect("first payloads");
         assert_eq!(first_payloads[0].last_timestamp_ns, 100);
 
         let mut second_stream_map = StreamMap::new();
         second_stream_map.insert(labels, vec![(50, "{\"message\":\"b\"}".to_string())]);
-        let second_payloads = sink2
+        let (second_payloads, _) = sink2
             .prepare_and_reserve_payloads(&mut second_stream_map)
             .expect("second payloads");
         let parsed: serde_json::Value =

--- a/crates/logfwd-output/src/sink.rs
+++ b/crates/logfwd-output/src/sink.rs
@@ -236,18 +236,15 @@ fn finalize_fanout_outcome(
     }
 
     let mut first_rejection = None;
-    let mut all_rejected = true;
     for state in states {
-        if let ChildState::Rejected(reason) = state {
-            if first_rejection.is_none() {
-                first_rejection = Some(reason.clone());
-            }
-        } else {
-            all_rejected = false;
+        if let ChildState::Rejected(reason) = state
+            && first_rejection.is_none()
+        {
+            first_rejection = Some(reason.clone());
         }
     }
 
-    if all_rejected && let Some(reason) = first_rejection {
+    if let Some(reason) = first_rejection {
         SendResult::Rejected(reason)
     } else {
         SendResult::Ok
@@ -511,9 +508,9 @@ mod verification {
             finalize_fanout_outcome(&mixed_states, true, Some(io::Error::other("io")), None);
         assert!(matches!(io_only, SendResult::IoError(_)));
 
-        // Mixed Ok + Rejected with no pending/error → partial success → Ok.
+        // Mixed Ok + Rejected with no pending/error → partial success → Rejected.
         let partial_ok = finalize_fanout_outcome(&mixed_states, false, None, None);
-        assert!(matches!(partial_ok, SendResult::Ok));
+        assert!(matches!(partial_ok, SendResult::Rejected(_)));
 
         // All-rejected states → Rejected.
         let all_rejected_states = [
@@ -684,10 +681,10 @@ mod tests {
         let mut fanout = AsyncFanoutSink::new(vec![Box::new(s1), Box::new(s2), Box::new(s3)]);
 
         let result = fanout.send_batch(&empty_batch(), &empty_meta()).await;
-        // With #2102 fix, partial success returns Ok instead of Rejected
+        // Mixed Ok+Rejected should return Rejected so caller is notified.
         assert!(
-            matches!(result, SendResult::Ok),
-            "expected Ok (partial success), got {result:?}"
+            matches!(result, SendResult::Rejected(_)),
+            "expected Rejected (partial success), got {result:?}"
         );
         assert_eq!(*calls1.lock().unwrap(), 1, "s1 must be called");
         assert_eq!(*calls2.lock().unwrap(), 1, "s2 must be called");
@@ -1026,10 +1023,6 @@ mod tests {
             fn any_child_pending(&self) -> bool {
                 self.child_state.iter().any(|s| *s == "Pending")
             }
-
-            fn all_children_rejected(&self) -> bool {
-                self.child_state.iter().all(|s| *s == "Rejected")
-            }
         }
 
         fn apply_action(s: &mut FanoutTlaState, action: u8, child_idx: usize, new_behavior: u8) {
@@ -1153,25 +1146,25 @@ mod tests {
         fn assert_invariants(
             s: &FanoutTlaState,
         ) -> Result<(), proptest::test_runner::TestCaseError> {
-            // PartialSuccessIsOk
+            // AnyRejectionIsRejected
             if s.batch_phase == "Finalized"
                 && s.all_children_terminal()
-                && !s.all_children_rejected()
-            {
-                prop_assert!(
-                    s.fanout_result == "Ok",
-                    "PartialSuccessIsOk violated: result={} but not all rejected",
-                    s.fanout_result
-                );
-            }
-            // AllRejectedIsRejected
-            if s.batch_phase == "Finalized"
-                && s.all_children_terminal()
-                && s.all_children_rejected()
+                && s.child_state.iter().any(|st| *st == "Rejected")
             {
                 prop_assert!(
                     s.fanout_result == "Rejected",
-                    "AllRejectedIsRejected violated: result={}",
+                    "AnyRejectionIsRejected violated: result={}",
+                    s.fanout_result
+                );
+            }
+            // AllOkIsOk
+            if s.batch_phase == "Finalized"
+                && s.all_children_terminal()
+                && !s.child_state.iter().any(|st| *st == "Rejected")
+            {
+                prop_assert!(
+                    s.fanout_result == "Ok",
+                    "AllOkIsOk violated: result={}",
                     s.fanout_result
                 );
             }

--- a/crates/logfwd-types/src/io_action.rs
+++ b/crates/logfwd-types/src/io_action.rs
@@ -170,28 +170,40 @@ impl fmt::Display for IoAction {
 /// token, then retry with new credentials.
 ///
 /// Returns `None` for success (2xx) since success is not an error action.
-pub fn classify_http_status(status: u16, detail: &str) -> Option<IoAction> {
+pub fn classify_http_status(
+    status: u16,
+    retry_after_header: Option<&str>,
+    detail: &str,
+) -> Option<IoAction> {
     if (200..300).contains(&status) {
         return None; // success
     }
 
+    let delay = parse_retry_after(retry_after_header);
+
     if status == 429 {
-        return Some(IoAction::retry(format!(
-            "rate limited (HTTP 429): {detail}"
-        )));
+        let reason = format!("rate limited (HTTP 429): {detail}");
+        return Some(match delay {
+            Some(d) => IoAction::retry_after(reason, d),
+            None => IoAction::retry(reason),
+        });
     }
 
     // 408 Request Timeout — server explicitly says it timed out waiting.
     if status == 408 {
-        return Some(IoAction::retry(format!(
-            "request timeout (HTTP 408): {detail}"
-        )));
+        let reason = format!("request timeout (HTTP 408): {detail}");
+        return Some(match delay {
+            Some(d) => IoAction::retry_after(reason, d),
+            None => IoAction::retry(reason),
+        });
     }
 
     if (500..600).contains(&status) {
-        return Some(IoAction::retry(format!(
-            "server error (HTTP {status}): {detail}"
-        )));
+        let reason = format!("server error (HTTP {status}): {detail}");
+        return Some(match delay {
+            Some(d) => IoAction::retry_after(reason, d),
+            None => IoAction::retry(reason),
+        });
     }
 
     if (400..500).contains(&status) {
@@ -200,7 +212,14 @@ pub fn classify_http_status(status: u16, detail: &str) -> Option<IoAction> {
         )));
     }
 
-    // Unexpected status codes (1xx, 3xx) — treat as transient
+    // 3xx Redirection — permanent configuration or destination change
+    if (300..400).contains(&status) {
+        return Some(IoAction::reject(format!(
+            "redirect (HTTP {status}): {detail}"
+        )));
+    }
+
+    // Unexpected status codes (1xx, etc.) — treat as transient
     Some(IoAction::retry(format!(
         "unexpected HTTP {status}: {detail}"
     )))
@@ -222,41 +241,64 @@ mod tests {
 
     #[test]
     fn classify_2xx_is_none() {
-        assert!(classify_http_status(200, "ok").is_none());
-        assert!(classify_http_status(204, "no content").is_none());
+        assert!(classify_http_status(200, None, "ok").is_none());
+        assert!(classify_http_status(204, None, "no content").is_none());
     }
 
     #[test]
     fn classify_429_is_retry() {
-        let action = classify_http_status(429, "rate limited").unwrap();
+        let action = classify_http_status(429, None, "rate limited").unwrap();
         assert!(action.is_retryable());
+        assert_eq!(action.retry_after_hint(), None);
+    }
+
+    #[test]
+    fn classify_429_with_retry_after() {
+        let action = classify_http_status(429, Some("30"), "rate limited").unwrap();
+        assert!(action.is_retryable());
+        assert_eq!(action.retry_after_hint(), Some(Duration::from_secs(30)));
     }
 
     #[test]
     fn classify_408_is_retry() {
-        let action = classify_http_status(408, "request timeout").unwrap();
+        let action = classify_http_status(408, None, "request timeout").unwrap();
         assert!(action.is_retryable());
     }
 
     #[test]
     fn classify_401_is_reject() {
-        let action = classify_http_status(401, "unauthorized").unwrap();
+        let action = classify_http_status(401, None, "unauthorized").unwrap();
         assert!(action.is_rejected());
     }
 
     #[test]
     fn classify_5xx_is_retry() {
-        let action = classify_http_status(500, "internal error").unwrap();
+        let action = classify_http_status(500, None, "internal error").unwrap();
         assert!(action.is_retryable());
-        let action = classify_http_status(503, "unavailable").unwrap();
+        let action = classify_http_status(503, None, "unavailable").unwrap();
         assert!(action.is_retryable());
     }
 
     #[test]
+    fn classify_503_with_retry_after() {
+        let action = classify_http_status(503, Some("10"), "unavailable").unwrap();
+        assert!(action.is_retryable());
+        assert_eq!(action.retry_after_hint(), Some(Duration::from_secs(10)));
+    }
+
+    #[test]
     fn classify_4xx_is_reject() {
-        let action = classify_http_status(400, "bad request").unwrap();
+        let action = classify_http_status(400, None, "bad request").unwrap();
         assert!(action.is_rejected());
-        let action = classify_http_status(404, "not found").unwrap();
+        let action = classify_http_status(404, None, "not found").unwrap();
+        assert!(action.is_rejected());
+    }
+
+    #[test]
+    fn classify_3xx_is_reject() {
+        let action = classify_http_status(301, None, "redirect").unwrap();
+        assert!(action.is_rejected());
+        let action = classify_http_status(302, None, "found").unwrap();
         assert!(action.is_rejected());
     }
 

--- a/fix_test.sh
+++ b/fix_test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cat crates/logfwd-runtime/src/pipeline/pipeline_tests/failpoints.rs | grep -n -B 5 -A 20 "test_transform_filter_all_rows_does_not_crash"

--- a/fix_test2.sh
+++ b/fix_test2.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cat crates/logfwd-io/tests/it/otlp_receiver_contract.rs | head -n 150 | grep -n -B 5 -A 20 "poll receiver"

--- a/tla/FanoutSink.cfg
+++ b/tla/FanoutSink.cfg
@@ -14,8 +14,8 @@ CONSTANTS
 
 INVARIANTS
     TypeOK
-    PartialSuccessIsOk
-    AllRejectedIsRejected
+    AnyRejectionIsRejected
+    AllOkIsOk
     BatchPhaseConsistency
     RetryCountBound
     DeliveryCountConsistency

--- a/tla/FanoutSink.tla
+++ b/tla/FanoutSink.tla
@@ -165,10 +165,12 @@ EnvironmentChangesBehavior(c) ==
 \* Precondition: AllChildrenTerminal (no Pending children remain).
 \* This models the state after one full pass through all children where
 \* every child returned a terminal result (Ok, Rejected — not transient).
+AnyChildRejected == \E c \in Children : childState[c] = "Rejected"
+
 FinalizeTerminal ==
     /\ batchPhase = "Delivering"
     /\ AllChildrenTerminal
-    /\ fanoutResult' = IF AllChildrenRejected THEN "Rejected" ELSE "Ok"
+    /\ fanoutResult' = IF AnyChildRejected THEN "Rejected" ELSE "Ok"
     /\ batchPhase' = "Finalized"
     /\ batchCount' = batchCount + 1
     /\ UNCHANGED <<childState, sinkBehavior, retryCount, delivered, totalDelivered>>
@@ -254,16 +256,15 @@ Spec == Init /\ [][Next]_vars /\ Fairness
  * ======================================================================= *)
 
 
-\* PartialSuccessIsOk: if any child succeeded and not all rejected,
-\* result is Ok (not Rejected). Matches finalize_fanout_outcome().
-PartialSuccessIsOk ==
-    (batchPhase = "Finalized" /\ AllChildrenTerminal /\ ~AllChildrenRejected)
-        => fanoutResult = "Ok"
-
-\* AllRejectedIsRejected: if all children rejected, result is Rejected.
-AllRejectedIsRejected ==
-    (batchPhase = "Finalized" /\ AllChildrenTerminal /\ AllChildrenRejected)
+\* AnyRejectionIsRejected: if any child was rejected, overall result is Rejected.
+AnyRejectionIsRejected ==
+    (batchPhase = "Finalized" /\ AllChildrenTerminal /\ AnyChildRejected)
         => fanoutResult = "Rejected"
+
+\* AllOkIsOk: if all children succeeded (none rejected), result is Ok.
+AllOkIsOk ==
+    (batchPhase = "Finalized" /\ AllChildrenTerminal /\ ~AnyChildRejected)
+        => fanoutResult = "Ok"
 
 \* RetryNeverResetsTerminalChildren: retrying does not change Ok or
 \* Rejected children. This is the key anti-duplication invariant.

--- a/tla/README.md
+++ b/tla/README.md
@@ -498,8 +498,8 @@ when a retry re-sent data to children that had already accepted it.
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `PartialSuccessIsOk` | Safety | mixed Ok+Rejected (not all rejected) yields Ok result |
-| `AllRejectedIsRejected` | Safety | all children rejected yields Rejected result |
+| `AnyRejectionIsRejected` | Safety | any child rejected yields Rejected result |
+| `AllOkIsOk` | Safety | all children succeeded yields Ok result |
 | `BatchPhaseConsistency` | Safety | fanoutResult and batchPhase are always consistent |
 | `RetryCountBound` | Safety | retryCount never exceeds MaxRetries |
 | `DeliveryCountConsistency` | Safety | totalDelivered count is non-negative |
@@ -514,7 +514,7 @@ when a retry re-sent data to children that had already accepted it.
 | `FinalizedReachable` | Reachability | Finalized phase is reachable |
 | `ChildOkOccurs` | Reachability | at least one child succeeds |
 | `ChildRejectedOccurs` | Reachability | at least one child rejects |
-| `PartialSuccessReachable` | Reachability | mixed Ok+Rejected with Ok result is reachable |
+| `PartialSuccessReachable` | Reachability | mixed Ok+Rejected with Rejected result is reachable |
 | `AllRejectedReachable` | Reachability | all-rejected result is reachable |
 | `AllOkReachable` | Reachability | all-ok result is reachable |
 | `RetryNeededReachable` | Reachability | RetryNeeded result is reachable |


### PR DESCRIPTION
## Summary
- Correctness fixes for redirects, fanout, loki timestamps

## Changes
- 4 commits ahead of main

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix output sink correctness issues in HTTP classification, Loki timestamp rollback, and fanout rejection
> - Classifies 3xx HTTP responses as `Rejected` instead of transient `IoError` in both [`http_classify.rs`](https://github.com/strawgate/fastforward/pull/2674/files#diff-43e150ae9c0e7c4e9750fe9aa153a2a3b46730a86ff7c879a05bf3447ce7ff1c) and [`io_action.rs`](https://github.com/strawgate/fastforward/pull/2674/files#diff-6d3b8dbd840e95d459560bde3b3bda8397de0cea4ab8a8d01fcbceb59fa2e512); 1xx responses remain `IoError`.
> - Adds `Retry-After` header parsing to `classify_http_status` so 429/408/5xx responses can return a `retry_after` hint to callers.
> - Rolls back per-stream timestamp reservations in `LokiSink.send_batch` when a payload send fails, preventing timestamp drift on retry.
> - Changes `finalize_fanout_outcome` in [`sink.rs`](https://github.com/strawgate/fastforward/pull/2674/files#diff-a001cff3f8c308de7cbe300055a1ddb36ee2bf6dc7cf99c700984afc22c8c88e) to return `Rejected` if *any* child rejects, rather than only when *all* children reject.
> - Behavioral Change: fanout batches with mixed Ok/Rejected child results now surface as `Rejected` instead of `Ok`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9b689e2. 9 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->