### PR TITLE
config: extract sanitize_identifier to ffwd-config::validate::common

### DIFF
--- a/crates/ffwd-config/src/lib.rs
+++ b/crates/ffwd-config/src/lib.rs
@@ -20,7 +20,7 @@ mod load;
 mod serde_helpers;
 mod shared;
 mod types;
-mod validate;
+pub mod validate;
 
 pub use serde_helpers::{PositiveMillis, PositiveSecs};
 
@@ -45,7 +45,7 @@ pub use types::{
     ServerConfig, SourceMetadataStyle, StaticEnrichmentConfig, StdoutOutputConfig, StorageConfig,
     TcpOutputConfig, TcpTypeConfig, UdpOutputConfig, UdpTypeConfig,
 };
-pub use validate::validate_host_port;
+pub use validate::{sanitize_identifier, validate_host_port};
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/crates/ffwd-config/src/validate.rs
+++ b/crates/ffwd-config/src/validate.rs
@@ -28,6 +28,7 @@ use paths::{
 };
 use sensors::{is_sensor_family_supported, validate_sensor_event_type_filters};
 
+pub use common::sanitize_identifier;
 pub use endpoints::validate_host_port;
 
 impl Config {

--- a/crates/ffwd-config/src/validate/common.rs
+++ b/crates/ffwd-config/src/validate/common.rs
@@ -26,3 +26,16 @@ pub(super) fn output_path_for_feedback_loop(output: &OutputConfigV2) -> Option<&
         _ => None,
     }
 }
+
+pub fn sanitize_identifier(name: &str) -> String {
+    let mut out = String::with_capacity(name.len().max(1));
+    for (idx, ch) in name.chars().enumerate() {
+        let valid = if idx == 0 {
+            ch.is_ascii_alphabetic() || ch == '_'
+        } else {
+            ch.is_ascii_alphanumeric() || ch == '_'
+        };
+        out.push(if valid { ch } else { '_' });
+    }
+    if out.is_empty() { "_".to_string() } else { out }
+}

--- a/crates/ffwd-config/src/validate/common.rs
+++ b/crates/ffwd-config/src/validate/common.rs
@@ -1,3 +1,5 @@
+// xtask-verify: allow(pub_module_needs_tests) // sanitize_identifier tested via validate/tests.rs
+
 use crate::types::{ConfigError, OutputConfigV2};
 
 pub(super) const MAX_READ_BUF_SIZE: usize = 4_194_304;

--- a/crates/ffwd-config/src/validate/outputs.rs
+++ b/crates/ffwd-config/src/validate/outputs.rs
@@ -3,7 +3,7 @@ use crate::types::{
 };
 use std::collections::HashMap;
 
-use super::common::validation_message;
+use super::common::{sanitize_identifier, validation_message};
 use super::endpoints::{validate_endpoint_url, validate_host_port};
 
 fn validate_url_output_endpoint(
@@ -93,22 +93,6 @@ fn validate_elasticsearch_index(
     Ok(())
 }
 
-/// Sanitize a Loki label name the same way the Loki runtime does: replace
-/// any character that is not `[a-zA-Z0-9_]` (or not `[a-zA-Z_]` at position 0)
-/// with `_`.
-fn sanitize_loki_label_name(name: &str) -> String {
-    let mut out = String::with_capacity(name.len().max(1));
-    for (idx, ch) in name.chars().enumerate() {
-        let valid = if idx == 0 {
-            ch.is_ascii_alphabetic() || ch == '_'
-        } else {
-            ch.is_ascii_alphanumeric() || ch == '_'
-        };
-        out.push(if valid { ch } else { '_' });
-    }
-    if out.is_empty() { "_".to_string() } else { out }
-}
-
 fn validate_loki_labels(
     pipeline_name: &str,
     label: &str,
@@ -129,7 +113,7 @@ fn validate_loki_labels(
     if let Some(static_labels) = static_labels {
         let mut seen: HashMap<String, &str> = HashMap::new();
         for key in static_labels.keys() {
-            let sanitized = sanitize_loki_label_name(key);
+            let sanitized = sanitize_identifier(key);
             if let Some(existing) = seen.get(&sanitized) {
                 return Err(ConfigError::Validation(format!(
                     "pipeline '{pipeline_name}' output '{label}': loki static_labels key '{key}' sanitizes to '{sanitized}' which collides with existing key '{existing}'"
@@ -143,7 +127,7 @@ fn validate_loki_labels(
     if let Some(label_columns) = label_columns {
         let mut seen: HashMap<String, &str> = HashMap::new();
         for col in label_columns {
-            let sanitized = sanitize_loki_label_name(col);
+            let sanitized = sanitize_identifier(col);
             if let Some(existing) = seen.get(&sanitized) {
                 return Err(ConfigError::Validation(format!(
                     "pipeline '{pipeline_name}' output '{label}': loki label_columns entry '{col}' sanitizes to '{sanitized}' which collides with existing entry '{existing}'"
@@ -158,13 +142,13 @@ fn validate_loki_labels(
     if let (Some(static_labels), Some(label_columns)) = (static_labels, label_columns) {
         let mut sanitized_static: HashMap<String, &str> = HashMap::new();
         for key in static_labels.keys() {
-            sanitized_static.insert(sanitize_loki_label_name(key), key.as_str());
+            sanitized_static.insert(sanitize_identifier(key), key.as_str());
         }
         if let Some(conflict) = label_columns
             .iter()
-            .find(|col| sanitized_static.contains_key(&sanitize_loki_label_name(col)))
+            .find(|col| sanitized_static.contains_key(&sanitize_identifier(col)))
         {
-            let sanitized = sanitize_loki_label_name(conflict);
+            let sanitized = sanitize_identifier(conflict);
             let static_key = sanitized_static
                 .get(&sanitized)
                 .copied()

--- a/crates/ffwd-config/src/validate/tests.rs
+++ b/crates/ffwd-config/src/validate/tests.rs
@@ -1,6 +1,7 @@
 use crate::types::Config;
 
 use super::{is_glob_match_possible, validate_endpoint_url, validate_host_port};
+use crate::validate::sanitize_identifier;
 
 fn host_port_error(addr: &str) -> String {
     validate_host_port(addr).unwrap_err().to_string()
@@ -860,4 +861,46 @@ pipelines:
         err.contains("client_ca_file must not be empty"),
         "expected blank client CA rejection, got: {err}"
     );
+}
+
+#[test]
+fn sanitize_identifier_preserves_valid_identifiers() {
+    assert_eq!(sanitize_identifier("foo"), "foo");
+    assert_eq!(sanitize_identifier("_private"), "_private");
+    assert_eq!(sanitize_identifier("camelCase"), "camelCase");
+    assert_eq!(sanitize_identifier("snake_case"), "snake_case");
+    assert_eq!(sanitize_identifier("UPPER_CASE"), "UPPER_CASE");
+    assert_eq!(sanitize_identifier("mixed123"), "mixed123");
+    assert_eq!(sanitize_identifier("_leading_underscore"), "_leading_underscore");
+}
+
+#[test]
+fn sanitize_identifier_replaces_invalid_chars_with_underscore() {
+    assert_eq!(sanitize_identifier("foo-bar"), "foo_bar");
+    assert_eq!(sanitize_identifier("foo.bar"), "foo_bar");
+    assert_eq!(sanitize_identifier("foo bar"), "foo_bar");
+    assert_eq!(sanitize_identifier("foo:bar"), "foo_bar");
+    assert_eq!(sanitize_identifier("foo#1"), "foo_1");
+    assert_eq!(sanitize_identifier("foo!bar"), "foo_bar");
+    assert_eq!(sanitize_identifier("foo@bar"), "foo_bar");
+    assert_eq!(sanitize_identifier("123abc"), "_23abc");
+}
+
+#[test]
+fn sanitize_identifier_first_char_must_be_alphabetic_or_underscore() {
+    assert_eq!(sanitize_identifier("123"), "_23");
+    assert_eq!(sanitize_identifier("1abc"), "_abc");
+    assert_eq!(sanitize_identifier("1"), "_");
+    assert_eq!(sanitize_identifier("!abc"), "_abc");
+}
+
+#[test]
+fn sanitize_identifier_empty_returns_underscore() {
+    assert_eq!(sanitize_identifier(""), "_");
+}
+
+#[test]
+fn sanitize_identifier_preserves_all_underscores() {
+    assert_eq!(sanitize_identifier("__"), "__");
+    assert_eq!(sanitize_identifier("_foo_bar_baz_"), "_foo_bar_baz_");
 }

--- a/crates/ffwd-config/src/validate/tests.rs
+++ b/crates/ffwd-config/src/validate/tests.rs
@@ -871,7 +871,10 @@ fn sanitize_identifier_preserves_valid_identifiers() {
     assert_eq!(sanitize_identifier("snake_case"), "snake_case");
     assert_eq!(sanitize_identifier("UPPER_CASE"), "UPPER_CASE");
     assert_eq!(sanitize_identifier("mixed123"), "mixed123");
-    assert_eq!(sanitize_identifier("_leading_underscore"), "_leading_underscore");
+    assert_eq!(
+        sanitize_identifier("_leading_underscore"),
+        "_leading_underscore"
+    );
 }
 
 #[test]

--- a/crates/ffwd-output/src/loki.rs
+++ b/crates/ffwd-output/src/loki.rs
@@ -46,6 +46,7 @@ use arrow::array::AsArray;
 use arrow::datatypes::DataType;
 use arrow::record_batch::RecordBatch;
 
+use ffwd_config::validate::sanitize_identifier;
 use ffwd_core::otlp::parse_timestamp_nanos;
 use ffwd_types::diagnostics::ComponentStats;
 use ffwd_types::field_names;
@@ -68,25 +69,12 @@ type StreamMap = HashMap<StreamLabels, (String, Vec<LokiEntry>)>;
 
 type SharedTimestampState = Arc<Mutex<HashMap<StreamLabels, u64>>>;
 
-fn sanitize_loki_label_name(name: &str) -> String {
-    let mut out = String::with_capacity(name.len().max(1));
-    for (idx, ch) in name.chars().enumerate() {
-        let valid = if idx == 0 {
-            ch.is_ascii_alphabetic() || ch == '_'
-        } else {
-            ch.is_ascii_alphanumeric() || ch == '_'
-        };
-        out.push(if valid { ch } else { '_' });
-    }
-    if out.is_empty() { "_".to_string() } else { out }
-}
-
 fn sanitize_static_labels(static_labels: &[(String, String)]) -> io::Result<Vec<(String, String)>> {
     let mut sanitized = Vec::with_capacity(static_labels.len());
     let mut sanitized_sources: HashMap<String, String> =
         HashMap::with_capacity(static_labels.len());
     for (key, value) in static_labels {
-        let sanitized_key = sanitize_loki_label_name(key);
+        let sanitized_key = sanitize_identifier(key);
         if let Some(existing) = sanitized_sources.get(&sanitized_key) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -281,17 +269,12 @@ impl LokiSink {
             .config
             .static_labels
             .iter()
-            .map(|(key, _)| {
-                (
-                    sanitize_loki_label_name(key),
-                    format!("static label '{key}'"),
-                )
-            })
+            .map(|(key, _)| (sanitize_identifier(key), format!("static label '{key}'")))
             .collect();
         let mut label_col_infos: Vec<(String, &super::ColInfo)> = Vec::new();
         for label_col in &self.config.label_columns {
             if let Some(ci) = cols.iter().find(|c| &c.field_name == label_col) {
-                let sanitized = sanitize_loki_label_name(label_col);
+                let sanitized = sanitize_identifier(label_col);
                 if let Some(existing) = sanitized_label_sources.get(&sanitized) {
                     // Collision: two sources sanitize to the same key. Keep the
                     // first one and warn — erroring would make config validity
@@ -1250,13 +1233,13 @@ mod tests {
 
     #[test]
     fn test_label_sanitization() {
-        assert_eq!(sanitize_loki_label_name("valid_label_1"), "valid_label_1");
-        assert_eq!(sanitize_loki_label_name("my.label.name"), "my_label_name");
-        assert_eq!(sanitize_loki_label_name("1invalid_start"), "_invalid_start");
-        assert_eq!(sanitize_loki_label_name("a-b*c/d"), "a_b_c_d");
+        assert_eq!(sanitize_identifier("valid_label_1"), "valid_label_1");
+        assert_eq!(sanitize_identifier("my.label.name"), "my_label_name");
+        assert_eq!(sanitize_identifier("1invalid_start"), "_invalid_start");
+        assert_eq!(sanitize_identifier("a-b*c/d"), "a_b_c_d");
         // Empty input must produce a valid label name, not an empty string which
         // Loki would reject (labels must match ^[a-zA-Z_][a-zA-Z0-9_]*$).
-        assert_eq!(sanitize_loki_label_name(""), "_");
+        assert_eq!(sanitize_identifier(""), "_");
     }
 
     /// Regression test for #1670: canonical "timestamp" column must be used as
@@ -1430,17 +1413,11 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_loki_label_name_rewrites_invalid_chars() {
-        assert_eq!(sanitize_loki_label_name("service.name"), "service_name");
-        assert_eq!(
-            sanitize_loki_label_name("http.status_code"),
-            "http_status_code"
-        );
-        assert_eq!(
-            sanitize_loki_label_name("9invalid-prefix"),
-            "_invalid_prefix"
-        );
-        assert_eq!(sanitize_loki_label_name(""), "_");
+    fn sanitize_identifier_rewrites_invalid_chars() {
+        assert_eq!(sanitize_identifier("service.name"), "service_name");
+        assert_eq!(sanitize_identifier("http.status_code"), "http_status_code");
+        assert_eq!(sanitize_identifier("9invalid-prefix"), "_invalid_prefix");
+        assert_eq!(sanitize_identifier(""), "_");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Extract `sanitize_identifier` (formerly `sanitize_loki_label_name`) from `ffwd-output/src/loki.rs` and `ffwd-config/src/validate/outputs.rs` into a single canonical implementation at `ffwd-config::validate::common`.

Closes #2657 (partial — this extracts `sanitize_identifier`; `parse_host_port` dedup tracked separately in #2657).

## Changes

- `ffwd-config/src/validate/common.rs`: add `pub fn sanitize_identifier`
- `ffwd-config/src/validate.rs`: re-export `sanitize_identifier` from common
- `ffwd-config/src/lib.rs`: re-export `sanitize_identifier` at crate root (`ffwd_config::validate::sanitize_identifier`)
- `ffwd-config/src/validate/outputs.rs`: remove local `sanitize_loki_label_name`, use imported `sanitize_identifier`
- `ffwd-output/src/loki.rs`: remove local `sanitize_loki_label_name`, use `ffwd_config::validate::sanitize_identifier`

## Verification

- `just clippy` passes
- `cargo test -p ffwd-config -p ffwd-output` passes (307 + 2 tests)

Work unit: #2677
Related issues: #2657, #2658

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract `sanitize_identifier` to `ffwd-config::validate::common` as shared public API
> - Moves the `sanitize_loki_label_name` logic from both [outputs.rs](https://github.com/strawgate/fastforward/pull/2678/files#diff-35f4ab88c44be7bef50941ddf494b2eb5e0ec52697749e4916735195f7e9146b) and [loki.rs](https://github.com/strawgate/fastforward/pull/2678/files#diff-8140208066b6b535b9404303db1dcb5c5c6ba541692b263348abb4a84a6dd488) into a single shared `sanitize_identifier` function in [validate/common.rs](https://github.com/strawgate/fastforward/pull/2678/files#diff-bd8f6c7cf0dc064e84a9e80074cda0393b8b20de7bc2566b24186dd56755afd1).
> - Exposes the function publicly at `ffwd_config::sanitize_identifier` and `ffwd_config::validate::sanitize_identifier` via re-exports.
> - Both previous call sites now use the shared implementation; the local helper functions are removed.
> - Adds unit tests in [validate/tests.rs](https://github.com/strawgate/fastforward/pull/2678/files#diff-dd0717a01240ba650fb09a879caecba9cb034abe82be4aa4cac7cd13e3c13b82) covering valid identifiers, invalid character replacement, first-character rules, and empty input.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc6b661.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->