### PR TITLE
fix: resolve CI failures on main (fmt, test, biome)

### DIFF
--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1405,7 +1405,8 @@ pipelines:
       - type: loki
         endpoint: http://localhost:3100/loki/api/v1/push
 ";
-    Config::load_str(yaml).expect("full push path in endpoint should be accepted (normalized by output)");
+    Config::load_str(yaml)
+        .expect("full push path in endpoint should be accepted (normalized by output)");
 }
 
 #[test]
@@ -1421,5 +1422,6 @@ pipelines:
       - type: loki
         endpoint: http://localhost:3100/loki/api/v1/push/
 ";
-    Config::load_str(yaml).expect("push path with trailing slash should be accepted (normalized by output)");
+    Config::load_str(yaml)
+        .expect("push path with trailing slash should be accepted (normalized by output)");
 }

--- a/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
@@ -637,6 +637,21 @@ pub(super) fn decode_log_record_fields<'a>(
                     "invalid wire type for LogRecord.attributes",
                 ));
             }
+            (7, WireField::Varint(_)) => {}
+            (7, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for LogRecord.dropped_attributes_count",
+                ));
+            }
+            (12, WireField::Len(value)) if !value.is_empty() => {
+                super::require_utf8(value, "invalid UTF-8 LogRecord.event_name")?;
+            }
+            (12, WireField::Len(_)) => {}
+            (12, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for LogRecord.event_name",
+                ));
+            }
             _ => {}
         }
         Ok(())

--- a/crates/ffwd-output/src/loki.rs
+++ b/crates/ffwd-output/src/loki.rs
@@ -2071,8 +2071,14 @@ mod loki_endpoint_normalization {
 
     #[test]
     fn endpoint_without_push_path_unchanged() {
-        assert_eq!(normalize_endpoint("http://localhost:3100"), "http://localhost:3100");
-        assert_eq!(normalize_endpoint("http://localhost:3100/"), "http://localhost:3100");
+        assert_eq!(
+            normalize_endpoint("http://localhost:3100"),
+            "http://localhost:3100"
+        );
+        assert_eq!(
+            normalize_endpoint("http://localhost:3100/"),
+            "http://localhost:3100"
+        );
         assert_eq!(
             normalize_endpoint("http://localhost:3100/loki/api/v1"),
             "http://localhost:3100/loki/api/v1"

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -155,7 +155,11 @@ export function App() {
       output_bytes: val("ffwd.output_bytes"),
       output_errors: val("ffwd.output_errors"),
       batches: val("ffwd.batches"),
-      scan_sec: (sumAll("ffwd_stage_scan_nanos") + sumAll("ffwd_stage_transform_nanos") + sumAll("ffwd_stage_output_nanos")) / 1e9,
+      scan_sec:
+        (sumAll("ffwd_stage_scan_nanos") +
+          sumAll("ffwd_stage_transform_nanos") +
+          sumAll("ffwd_stage_output_nanos")) /
+        1e9,
       transform_sec: 0,
       output_sec: 0,
       backpressure_stalls: val("ffwd.backpressure_stalls"),


### PR DESCRIPTION
## Summary

Fixes three CI failures on the main branch:

1. **Rust format** - Long lines in `ffwd-config/tests/validation_gaps.rs` and `ffwd-output/src/loki.rs` that `cargo fmt` wants wrapped
2. **Test failure** - `projected_invalid_log_record_dropped_attributes_wire_type_is_invalid` was failing because `generated.rs` was missing wire-type validation for field 7 (dropped_attributes_count) and field 12 (event_name). These fields fell through to the catch-all `_ => {}` arm instead of producing proper validation errors.
3. **Frontend biome** - Line too long in `dashboard/src/app.tsx` that biome wants broken up

## Test Plan

- `cargo fmt --check` passes
- All 86 OTLP projection tests pass locally
- `npx biome check .` passes in the dashboard directory
- `cargo clippy -p ffwd-io -- -D warnings` passes

Closes the CI failures introduced by the Loki endpoint normalization PR (#2679).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI failures by adding wire type validation in log record decoding and reformatting code
> - Adds match arms in [`generated.rs`](https://github.com/strawgate/fastforward/pull/2680/files#diff-eea92a0f2f0ab2e842f092756045f926c3976c4768f5f8ef7cacdafc17d696ad) to validate wire types for log record fields 7 (`dropped_attributes_count`) and 12 (`event_name`), including UTF-8 validation and error returns for invalid wire types.
> - Reformats test assertions in [`validation_gaps.rs`](https://github.com/strawgate/fastforward/pull/2680/files#diff-73ebf3fef05701db66e2b97c10eeffd3bd0e0cba5e330bf2d7671602d749a89d), [`loki.rs`](https://github.com/strawgate/fastforward/pull/2680/files#diff-8140208066b6b535b9404303db1dcb5c5c6ba541692b263348abb4a84a6dd488), and [`app.tsx`](https://github.com/strawgate/fastforward/pull/2680/files#diff-89253c48a25d00a0657e8bf6c6803d4d8d86374de5dbcca18905f910e2cd8255) to satisfy fmt and Biome linting rules; no logic changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9212ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->