### PR TITLE
fix(kani): correct #[verified] attribute harness names

### DIFF
--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -188,7 +188,7 @@ pub fn encode_bytes_field(buf: &mut Vec<u8>, field_number: u32, data: &[u8]) {
 /// Wire type 2 = length-delimited. Used as a building block by
 /// `bytes_field_total_size`.
 #[inline(always)]
-#[verified(kani = "verify_tag_size")]
+#[verified(kani = "verify_tag_size_vs_oracle")]
 pub const fn tag_size(field_number: u32) -> usize {
     varint_len(((field_number as u64) << 3) | 2)
 }
@@ -196,7 +196,7 @@ pub const fn tag_size(field_number: u32) -> usize {
 /// Compute the total encoded size of a length-delimited field
 /// (tag varint + length varint + data), without writing anything.
 #[inline(always)]
-#[verified(kani = "verify_bytes_field_total_size")]
+#[verified(kani = "verify_bytes_field_total_size_vs_oracle")]
 pub const fn bytes_field_total_size(field_number: u32, data_len: usize) -> usize {
     tag_size(field_number) + varint_len(data_len as u64) + data_len
 }


### PR DESCRIPTION
## Summary

Fixes Kani compilation failures (E0425: cannot find value) caused by `#[verified(kani = ...)]` attributes referencing non-existent harness names:

- `verify_tag_size` → `verify_tag_size_vs_oracle`
- `verify_bytes_field_total_size` → `verify_bytes_field_total_size_vs_oracle`

These harnesses were renamed in a prior PR but the `#[verified]` attributes weren't updated to match. Kani CI was skipped on the main push that introduced the mismatch, so this went undetected until PRs triggered the full Kani suite.

## Test Plan

- `cargo clippy -p ffwd-core -- -D warnings` passes
- Kani compilation should now succeed (attributes resolve correctly)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `#[verified]` harness names in `otlp.rs` to match actual Kani harness identifiers
> Corrects the `kani` attribute values on `tag_size` and `bytes_field_total_size` in [otlp.rs](https://github.com/strawgate/fastforward/pull/2681/files#diff-0c866cb1824ef9b048e7add186b2a0bdfb2b199874e97e787f69cc78f9445b84) to reference the `_vs_oracle` harness names that match the actual Kani proof harnesses. No functional code changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56026e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->