### PR TITLE
fix: reject negative RetryConfig.max_attempts (closes #2584)

### DIFF
--- a/.macroscope/check-run-agents/kani-proof-review.md
+++ b/.macroscope/check-run-agents/kani-proof-review.md
@@ -41,23 +41,29 @@ For every proof harness added or modified in this PR, check ALL of these:
 
 - Harness is inside `#[cfg(kani)] mod verification { }`, NOT `#[cfg(test)]`
 - Named `verify_<function>_<property>`
-- Has `#[kani::proof]` attribute
+- Has `#[kani::proof]` attribute OR `#[kani::proof_for_contract]` attribute
+
+Note: `#[kani::proof_for_contract]` is a valid proof marker — it includes `#[kani::proof]` internally.
 
 ### Unwind bounds
 
-- Every loop in the harness (and in called functions within bounded scope) has `#[kani::unwind(N)]`
-- The bound N is correct: N = max_iterations + 1 (one extra for the termination check)
+- Every loop in the harness has `#[kani::unwind(N)]` where N = max_iterations + 1 (margin for termination check)
+- For loop-free proofs, use `#[kani::unwind(0)]`
+- If no `#[kani::unwind]` is present and the harness contains loops, flag as UNSOUND
 
 ### Vacuity guards
 
 - If `kani::assume()` is used, there are at least 2 `kani::cover!()` statements
 - Cover statements exercise interesting paths (both positive and negative/empty cases)
+- If `kani::any_where(|v| predicate)` is used, cover statements should confirm the predicate's interesting cases are reachable
 - If any cover could be UNSATISFIABLE given the assumes, flag vacuity risk
 
 ### Oracle independence
 
 - If an oracle (reference implementation) is present, it does NOT call the function under test or reuse its internal logic
 - The oracle must be an independent reimplementation
+- Flag if the oracle is a "golden-copy" (structurally identical to production) — document the limitation in the oracle's doc comment
+- If a different-algorithm oracle exists (e.g., JDN Fliegel-Van Flandern vs Hinnant), prefer it for cross-validation
 
 ### Input sizing
 
@@ -70,18 +76,18 @@ For every proof harness added or modified in this PR, check ALL of these:
 - Comment justifying solver choice if present
 
 ### Anti-patterns — flag these
+
 - `Vec::new()`, `Vec::with_capacity(kani::any())`, or `vec![x; kani::any()]` in `#[cfg(kani)]` blocks (causes spurious alloc failures — use `kani::any::<[u8; N]>()` or `kani::vec::any_vec::<T, N>()`)
 - `kani::any()` immediately followed by `kani::assume()` on the same variable — should be `kani::any_where(|v| ...)`
 - Tautological assertions: `assert!(true)`, `assert!(x == x)`
 - Proof that only checks crash-freedom with no behavioral assertion
-
-### Staleness
-- If a production function's signature changed in this PR but its proof harness still uses old argument types/counts
+- Missing `#[kani::unwind]` on looped harness (unless loop-free and using `#[kani::unwind(0)]`)
 
 ## Step 4 — Check coverage obligations
 
 - For new `pub fn` in `crates/ffwd-core/src/`: a corresponding `verify_*` harness must exist (exempt: async fns, trivial getters/setters with no logic)
-- For files in `kani-boundary-contract.toml` with status `required`: verify `#[kani::proof]` markers are present
+- For files in `kani-boundary-contract.toml` with status `required`: `#[kani::proof]` OR `#[kani::proof_for_contract]` satisfies the marker requirement
+- If contracts (`#[requires]` / `#[ensures]`) are used, corresponding `#[kani::proof_for_contract]` harnesses must exist
 
 ## Step 5 — Report
 
@@ -90,7 +96,7 @@ Post inline comments on specific lines where issues are found. Use these severit
 - **UNSOUND**: Missing unwind bound, vacuous proof (all covers likely UNSAT), oracle calls function under test
 - **INCOMPLETE**: Missing proof for new public function in ffwd-core, missing cover statements when assume is used
 - **STYLE**: Naming convention violation, `any()` + `assume()` instead of `any_where()`, missing solver annotation on likely-slow proof
-- **STALE**: Proof arguments don't match current function signature
+- **LIMITATION**: Oracle is golden-copy style but limitation is not documented
 
 In the check run summary, report:
 - Count of proofs added / modified / deleted

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,11 +217,6 @@ empty_drop = "warn"
 unnecessary_safety_comment = "warn"
 unnecessary_safety_doc = "warn"
 
-# Tier 6: restriction-group correctness lints (opt-in, warn-level for gradual adoption).
-unwrap_used = "warn"
-expect_used = "warn"
-indexing_slicing = "warn"
-
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(kani)',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,6 +217,11 @@ empty_drop = "warn"
 unnecessary_safety_comment = "warn"
 unnecessary_safety_doc = "warn"
 
+# Tier 6: restriction-group correctness lints (opt-in, warn-level for gradual adoption).
+unwrap_used = "warn"
+expect_used = "warn"
+indexing_slicing = "warn"
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(kani)',

--- a/crates/ffwd-arrow/src/columnar/accumulator.rs
+++ b/crates/ffwd-arrow/src/columnar/accumulator.rs
@@ -500,11 +500,10 @@ pub struct FinalizationMode {
 /// (row, field), so `facts.len() == num_rows ∧ last == num_rows - 1` is
 /// sufficient.  When dedup is disabled duplicate writes are possible, breaking
 /// the pigeonhole premise, so we conservatively return false.
-#[allow(clippy::indexing_slicing)]
 fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
     dedup
         && facts.len() == num_rows
-        && (num_rows == 0 || facts[num_rows - 1].0 as usize == num_rows - 1)
+        && (num_rows == 0 || facts.get(num_rows - 1).is_some_and(|f| f.0 as usize == num_rows - 1))
 }
 
 // ---------------------------------------------------------------------------
@@ -519,7 +518,6 @@ fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
 ///
 /// Returns `(values, dense)`. Callers use `dense` to decide whether a
 /// validity bitmap is needed.
-#[allow(clippy::indexing_slicing)]
 fn scatter_values<T: Default + Copy>(
     facts: &[(u32, T)],
     num_rows: usize,
@@ -529,17 +527,19 @@ fn scatter_values<T: Default + Copy>(
     let mut values = vec![T::default(); num_rows];
     if dense {
         debug_assert!(
-            facts.is_empty() || facts[0].0 == 0,
+            facts.first().is_none_or(|f| f.0 == 0),
             "dense path requires consecutive rows starting at 0"
         );
         for (i, &(_, v)) in facts.iter().enumerate() {
-            values[i] = v;
+            if let Some(slot) = values.get_mut(i) {
+                *slot = v;
+            }
         }
     } else {
         for &(row, v) in facts {
             let r = row as usize;
-            if r < num_rows {
-                values[r] = v;
+            if let Some(slot) = values.get_mut(r) {
+                *slot = v;
             }
         }
     }
@@ -551,14 +551,13 @@ fn scatter_values<T: Default + Copy>(
 /// Returns raw bytes where bit `i` is **set** (1) iff row `i` is valid
 /// (has at least one fact). This follows Arrow convention: 1 = valid, 0 = null.
 /// Arrow-free — just a `Vec<u8>` that callers wrap in `NullBuffer`.
-#[allow(clippy::indexing_slicing)]
 fn validity_bitmap_bits<T>(facts: &[(u32, T)], num_rows: usize) -> Vec<u8> {
     let byte_len = num_rows.div_ceil(8);
     let mut bits = vec![0u8; byte_len];
     for &(row, _) in facts {
         let r = row as usize;
-        if r < num_rows {
-            bits[r >> 3] |= 1 << (r & 7);
+        if r < num_rows && let Some(byte) = bits.get_mut(r >> 3) {
+            *byte |= 1 << (r & 7);
         }
     }
     bits
@@ -589,7 +588,6 @@ fn build_int64(facts: &[(u32, i64)], num_rows: usize, dedup: bool) -> (ArrayRef,
     )
 }
 
-#[allow(clippy::indexing_slicing)]
 fn build_float64(facts: &[(u32, f64)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
     let (values, dense) = scatter_values(facts, num_rows, dedup);
     let nulls = if dense {
@@ -603,7 +601,6 @@ fn build_float64(facts: &[(u32, f64)], num_rows: usize, dedup: bool) -> (ArrayRe
     )
 }
 
-#[allow(clippy::indexing_slicing)]
 fn build_bool(facts: &[(u32, bool)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
     let (values, dense) = scatter_values(facts, num_rows, dedup);
     let nulls = if dense {

--- a/crates/ffwd-arrow/src/columnar/accumulator.rs
+++ b/crates/ffwd-arrow/src/columnar/accumulator.rs
@@ -500,6 +500,7 @@ pub struct FinalizationMode {
 /// (row, field), so `facts.len() == num_rows ∧ last == num_rows - 1` is
 /// sufficient.  When dedup is disabled duplicate writes are possible, breaking
 /// the pigeonhole premise, so we conservatively return false.
+#[allow(clippy::indexing_slicing)]
 fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
     dedup
         && facts.len() == num_rows
@@ -518,6 +519,7 @@ fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
 ///
 /// Returns `(values, dense)`. Callers use `dense` to decide whether a
 /// validity bitmap is needed.
+#[allow(clippy::indexing_slicing)]
 fn scatter_values<T: Default + Copy>(
     facts: &[(u32, T)],
     num_rows: usize,
@@ -549,6 +551,7 @@ fn scatter_values<T: Default + Copy>(
 /// Returns raw bytes where bit `i` is **set** (1) iff row `i` is valid
 /// (has at least one fact). This follows Arrow convention: 1 = valid, 0 = null.
 /// Arrow-free — just a `Vec<u8>` that callers wrap in `NullBuffer`.
+#[allow(clippy::indexing_slicing)]
 fn validity_bitmap_bits<T>(facts: &[(u32, T)], num_rows: usize) -> Vec<u8> {
     let byte_len = num_rows.div_ceil(8);
     let mut bits = vec![0u8; byte_len];
@@ -572,6 +575,7 @@ fn sparse_null_buffer<T>(facts: &[(u32, T)], num_rows: usize) -> NullBuffer {
     NullBuffer::new(arrow::buffer::BooleanBuffer::new(buf, 0, num_rows))
 }
 
+#[allow(clippy::indexing_slicing)]
 fn build_int64(facts: &[(u32, i64)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
     let (values, dense) = scatter_values(facts, num_rows, dedup);
     let nulls = if dense {
@@ -585,6 +589,7 @@ fn build_int64(facts: &[(u32, i64)], num_rows: usize, dedup: bool) -> (ArrayRef,
     )
 }
 
+#[allow(clippy::indexing_slicing)]
 fn build_float64(facts: &[(u32, f64)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
     let (values, dense) = scatter_values(facts, num_rows, dedup);
     let nulls = if dense {
@@ -598,6 +603,7 @@ fn build_float64(facts: &[(u32, f64)], num_rows: usize, dedup: bool) -> (ArrayRe
     )
 }
 
+#[allow(clippy::indexing_slicing)]
 fn build_bool(facts: &[(u32, bool)], num_rows: usize, dedup: bool) -> (ArrayRef, DataType) {
     let (values, dense) = scatter_values(facts, num_rows, dedup);
     let nulls = if dense {
@@ -611,6 +617,7 @@ fn build_bool(facts: &[(u32, bool)], num_rows: usize, dedup: bool) -> (ArrayRef,
     )
 }
 
+#[allow(clippy::indexing_slicing)]
 fn build_string(
     facts: &[(u32, StringRef)],
     num_rows: usize,
@@ -647,6 +654,7 @@ fn build_string(
 /// Caller guarantees all bytes referenced by `facts` are valid UTF-8 (validated
 /// at the ingestion boundary — scanner, OTLP decoder, or Rust's type system
 /// via `write_str(&str)`).
+#[allow(clippy::indexing_slicing)]
 fn build_string_view_trusted(
     facts: &[(u32, StringRef)],
     num_rows: usize,
@@ -742,6 +750,7 @@ fn build_string_view_trusted(
 ///
 /// Strings ≤ 12 bytes are inlined. Longer strings reference a buffer block.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 fn make_string_view(
     sref: StringRef,
     original_buf: &[u8],
@@ -818,6 +827,7 @@ fn make_string_view(
 ///
 /// Copies string bytes into a contiguous values buffer. Used when the ingestion
 /// boundary has not validated UTF-8 (e.g., raw external input).
+#[allow(clippy::indexing_slicing)]
 fn build_string_array_validated(
     facts: &[(u32, StringRef)],
     num_rows: usize,
@@ -944,6 +954,7 @@ fn read_str_bytes<'a>(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::indexing_slicing)]
 fn build_conflict_struct(
     name: &str,
     num_rows: usize,

--- a/crates/ffwd-arrow/src/columnar/accumulator.rs
+++ b/crates/ffwd-arrow/src/columnar/accumulator.rs
@@ -503,7 +503,10 @@ pub struct FinalizationMode {
 fn is_dense<T>(facts: &[(u32, T)], num_rows: usize, dedup: bool) -> bool {
     dedup
         && facts.len() == num_rows
-        && (num_rows == 0 || facts.get(num_rows - 1).is_some_and(|f| f.0 as usize == num_rows - 1))
+        && (num_rows == 0
+            || facts
+                .get(num_rows - 1)
+                .is_some_and(|f| f.0 as usize == num_rows - 1))
 }
 
 // ---------------------------------------------------------------------------
@@ -556,7 +559,9 @@ fn validity_bitmap_bits<T>(facts: &[(u32, T)], num_rows: usize) -> Vec<u8> {
     let mut bits = vec![0u8; byte_len];
     for &(row, _) in facts {
         let r = row as usize;
-        if r < num_rows && let Some(byte) = bits.get_mut(r >> 3) {
+        if r < num_rows
+            && let Some(byte) = bits.get_mut(r >> 3)
+        {
             *byte |= 1 << (r & 7);
         }
     }

--- a/crates/ffwd-arrow/src/columnar/builder.rs
+++ b/crates/ffwd-arrow/src/columnar/builder.rs
@@ -654,7 +654,6 @@ impl ColumnarBatchBuilder {
     }
 
     /// Core materialization — shared by all finalization paths.
-    #[allow(clippy::indexing_slicing)]
     fn materialize_all(
         &self,
         num_rows: usize,
@@ -664,7 +663,11 @@ impl ColumnarBatchBuilder {
         let mut arrays = Vec::with_capacity(self.plan.len());
 
         for (handle, name, _field_mode) in self.plan.fields() {
-            let col = &self.columns[handle.index()];
+            let col = self.columns.get(handle.index()).ok_or_else(|| {
+                BuilderError::Arrow(ArrowError::InvalidArgumentError(
+                    "columnar plan/storage invariant violated".to_string(),
+                ))
+            })?;
             match col.materialize(name, num_rows, mode.clone(), self.dedup_enabled)? {
                 Some((field, array)) => {
                     schema_fields.push(field);

--- a/crates/ffwd-arrow/src/columnar/builder.rs
+++ b/crates/ffwd-arrow/src/columnar/builder.rs
@@ -154,6 +154,7 @@ fn checked_hex_encoded_len(
 }
 
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn encode_hex_lower_into(out: &mut Vec<u8>, value: &[u8], encoded_len: usize) {
     const HEX: &[u8; 16] = b"0123456789abcdef";
 
@@ -345,6 +346,7 @@ impl ColumnarBatchBuilder {
     /// For fields ≥64, falls back to per-column `last_row` tracking.
     /// Both paths are correct; the bitmask path is faster for common cases.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     fn is_duplicate(&mut self, handle: FieldHandle) -> bool {
         let idx = handle.index();
         if check_dup_bits(self.lifecycle.written_bits_mut(), idx) {
@@ -370,6 +372,7 @@ impl ColumnarBatchBuilder {
     /// silently ignored and the dedup slot is NOT consumed — a subsequent
     /// correct-type write to the same field will still succeed.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_i64(&mut self, handle: FieldHandle, value: i64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -384,6 +387,7 @@ impl ColumnarBatchBuilder {
 
     /// Write an f64 value for the given field in the current row.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_f64(&mut self, handle: FieldHandle, value: f64) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -398,6 +402,7 @@ impl ColumnarBatchBuilder {
 
     /// Write a bool value for the given field in the current row.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_bool(&mut self, handle: FieldHandle, value: bool) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -421,6 +426,7 @@ impl ColumnarBatchBuilder {
     ///
     /// Returns `Err` if the string buffer would exceed u32 addressable range.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_str(&mut self, handle: FieldHandle, value: &str) -> Result<(), BuilderError> {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -444,6 +450,7 @@ impl ColumnarBatchBuilder {
     /// Write a `StringRef` directly (for zero-copy producers that already
     /// have offsets into an input buffer).
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_str_ref(&mut self, handle: FieldHandle, sref: StringRef) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -467,6 +474,7 @@ impl ColumnarBatchBuilder {
     ///
     /// Returns `Err` if the string buffer would exceed u32 addressable range.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_str_bytes(
         &mut self,
         handle: FieldHandle,
@@ -502,6 +510,7 @@ impl ColumnarBatchBuilder {
     /// exceed `u32::MAX`, or if extending the generated string buffer would
     /// overflow addressable `usize` space.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_hex_bytes_lower(
         &mut self,
         handle: FieldHandle,
@@ -538,6 +547,7 @@ impl ColumnarBatchBuilder {
     /// Returns `BuilderError::StringBufferOverflow` if the value is not within
     /// the original buffer bounds or the offset exceeds `u32::MAX`.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_input_ref(
         &mut self,
         handle: FieldHandle,
@@ -594,6 +604,7 @@ impl ColumnarBatchBuilder {
     /// remains whatever it was before (null if unwritten, or the prior value
     /// if already written in this row).
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn write_null(&mut self, handle: FieldHandle) {
         debug_assert_eq!(self.lifecycle.state(), BuilderState::InRow);
         debug_assert!(handle.index() < self.columns.len());
@@ -643,6 +654,7 @@ impl ColumnarBatchBuilder {
     }
 
     /// Core materialization — shared by all finalization paths.
+    #[allow(clippy::indexing_slicing)]
     fn materialize_all(
         &self,
         num_rows: usize,

--- a/crates/ffwd-arrow/src/columnar/plan.rs
+++ b/crates/ffwd-arrow/src/columnar/plan.rs
@@ -202,6 +202,7 @@ impl BatchPlan {
     /// names are re-resolved from scratch each batch — matching
     /// `StreamingBuilder`'s `field_index.clear()` behavior. Without this,
     /// dynamic fields accumulate unboundedly across batches.
+    #[allow(clippy::indexing_slicing)]
     pub fn reset_dynamic(&mut self) {
         // Remove dynamic entries from the name index.
         for entry in &self.fields[self.num_planned..] {
@@ -220,6 +221,7 @@ impl BatchPlan {
     /// Planned fields must be declared before any dynamic fields are
     /// resolved. They form a stable prefix of the field list that
     /// `reset_dynamic` preserves.
+    #[allow(clippy::indexing_slicing)]
     pub fn declare_planned(
         &mut self,
         name: &str,
@@ -265,6 +267,7 @@ impl BatchPlan {
     /// For dynamic fields, the observed kind is accumulated (for conflict
     /// detection). For planned fields, the handle is returned as-is — the
     /// Dynamic accumulator in the builder handles type mixing uniformly.
+    #[allow(clippy::indexing_slicing)]
     pub fn resolve_dynamic(
         &mut self,
         name: &str,

--- a/crates/ffwd-arrow/src/columnar/plan.rs
+++ b/crates/ffwd-arrow/src/columnar/plan.rs
@@ -202,13 +202,11 @@ impl BatchPlan {
     /// names are re-resolved from scratch each batch — matching
     /// `StreamingBuilder`'s `field_index.clear()` behavior. Without this,
     /// dynamic fields accumulate unboundedly across batches.
-    #[allow(clippy::indexing_slicing)]
     pub fn reset_dynamic(&mut self) {
-        // Remove dynamic entries from the name index.
-        for entry in &self.fields[self.num_planned..] {
+        let (_, dynamic_fields) = self.fields.split_at(self.num_planned);
+        for entry in dynamic_fields {
             self.index.remove(&entry.name);
         }
-        // Truncate the field list to planned-only.
         self.fields.truncate(self.num_planned);
     }
 
@@ -221,25 +219,30 @@ impl BatchPlan {
     /// Planned fields must be declared before any dynamic fields are
     /// resolved. They form a stable prefix of the field list that
     /// `reset_dynamic` preserves.
-    #[allow(clippy::indexing_slicing)]
     pub fn declare_planned(
         &mut self,
         name: &str,
         kind: FieldKind,
     ) -> Result<FieldHandle, PlanError> {
         if let Some(&handle) = self.index.get(name) {
-            let entry = &self.fields[handle.index()];
-            match &entry.mode {
-                FieldSchemaMode::Planned(existing_kind) if *existing_kind == kind => Ok(handle),
-                FieldSchemaMode::Planned(existing_kind) => Err(PlanError::KindMismatch {
+            if let Some(entry) = self.fields.get(handle.index()) {
+                match &entry.mode {
+                    FieldSchemaMode::Planned(existing_kind) if *existing_kind == kind => Ok(handle),
+                    FieldSchemaMode::Planned(existing_kind) => Err(PlanError::KindMismatch {
+                        field: name.to_string(),
+                        declared: *existing_kind,
+                        requested: kind,
+                    }),
+                    FieldSchemaMode::Dynamic { .. } => Err(PlanError::ModeMismatch {
+                        field: name.to_string(),
+                        reason: "field already exists as dynamic",
+                    }),
+                }
+            } else {
+                Err(PlanError::ModeMismatch {
                     field: name.to_string(),
-                    declared: *existing_kind,
-                    requested: kind,
-                }),
-                FieldSchemaMode::Dynamic { .. } => Err(PlanError::ModeMismatch {
-                    field: name.to_string(),
-                    reason: "field already exists as dynamic",
-                }),
+                    reason: "field handle index out of bounds",
+                })
             }
         } else {
             if self.fields.len() != self.num_planned {
@@ -267,23 +270,23 @@ impl BatchPlan {
     /// For dynamic fields, the observed kind is accumulated (for conflict
     /// detection). For planned fields, the handle is returned as-is — the
     /// Dynamic accumulator in the builder handles type mixing uniformly.
-    #[allow(clippy::indexing_slicing)]
     pub fn resolve_dynamic(
         &mut self,
         name: &str,
         kind: FieldKind,
     ) -> Result<FieldHandle, PlanError> {
         if let Some(&handle) = self.index.get(name) {
-            let entry = &mut self.fields[handle.index()];
-            match &mut entry.mode {
-                FieldSchemaMode::Dynamic { .. } => {
-                    entry.mode.observe(kind);
-                }
-                FieldSchemaMode::Planned(_) => {
-                    // Pre-registered fields accept dynamic resolution: the
-                    // underlying Dynamic accumulator handles all types, and
-                    // dedup ensures first-write-wins when canonical and
-                    // attribute names collide.
+            if let Some(entry) = self.fields.get_mut(handle.index()) {
+                match &mut entry.mode {
+                    FieldSchemaMode::Dynamic { .. } => {
+                        entry.mode.observe(kind);
+                    }
+                    FieldSchemaMode::Planned(_) => {
+                        // Pre-registered fields accept dynamic resolution: the
+                        // underlying Dynamic accumulator handles all types, and
+                        // dedup ensures first-write-wins when canonical and
+                        // attribute names collide.
+                    }
                 }
             }
             Ok(handle)

--- a/crates/ffwd-arrow/src/conflict_schema.rs
+++ b/crates/ffwd-arrow/src/conflict_schema.rs
@@ -63,6 +63,7 @@ fn pick_conflict_value_source(
     }
 }
 
+#[allow(clippy::indexing_slicing)]
 fn conflict_child_kind(name: &str) -> Option<ConflictValueSource> {
     let bytes = name.as_bytes();
     match bytes.len() {

--- a/crates/ffwd-arrow/src/conflict_schema.rs
+++ b/crates/ffwd-arrow/src/conflict_schema.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::indexing_slicing)]
 //! Schema normalization for type-conflict batches.
 //!
 //! The Arrow builders now emit a `Struct` column for each field that contains
@@ -65,25 +64,11 @@ fn pick_conflict_value_source(
 }
 
 fn conflict_child_kind(name: &str) -> Option<ConflictValueSource> {
-    let bytes = name.as_bytes();
-    match bytes.len() {
-        3 if bytes[0] == b'i' && bytes[1] == b'n' && bytes[2] == b't' => {
-            Some(ConflictValueSource::Int)
-        }
-        3 if bytes[0] == b's' && bytes[1] == b't' && bytes[2] == b'r' => {
-            Some(ConflictValueSource::Str)
-        }
-        4 if bytes[0] == b'b' && bytes[1] == b'o' && bytes[2] == b'o' && bytes[3] == b'l' => {
-            Some(ConflictValueSource::Bool)
-        }
-        5 if bytes[0] == b'f'
-            && bytes[1] == b'l'
-            && bytes[2] == b'o'
-            && bytes[3] == b'a'
-            && bytes[4] == b't' =>
-        {
-            Some(ConflictValueSource::Float)
-        }
+    match name.as_bytes() {
+        b"int" => Some(ConflictValueSource::Int),
+        b"str" => Some(ConflictValueSource::Str),
+        b"bool" => Some(ConflictValueSource::Bool),
+        b"float" => Some(ConflictValueSource::Float),
         _ => None,
     }
 }

--- a/crates/ffwd-arrow/src/conflict_schema.rs
+++ b/crates/ffwd-arrow/src/conflict_schema.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::indexing_slicing)]
 //! Schema normalization for type-conflict batches.
 //!
 //! The Arrow builders now emit a `Struct` column for each field that contains
@@ -63,7 +64,6 @@ fn pick_conflict_value_source(
     }
 }
 
-#[allow(clippy::indexing_slicing)]
 fn conflict_child_kind(name: &str) -> Option<ConflictValueSource> {
     let bytes = name.as_bytes();
     match bytes.len() {

--- a/crates/ffwd-arrow/src/lib.rs
+++ b/crates/ffwd-arrow/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::indexing_slicing)]
+
 //! Arrow integration layer for ffwd.
 //!
 //! Implements ffwd-core's `ScanBuilder` trait using Apache Arrow types.

--- a/crates/ffwd-arrow/src/materialize.rs
+++ b/crates/ffwd-arrow/src/materialize.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::indexing_slicing)]
 // materialize.rs — Detach a RecordBatch from its input buffer.
 //
 // StreamingBuilder produces StringViewArray columns that reference the

--- a/crates/ffwd-arrow/src/materialize.rs
+++ b/crates/ffwd-arrow/src/materialize.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::indexing_slicing)]
 // materialize.rs — Detach a RecordBatch from its input buffer.
 //
 // StreamingBuilder produces StringViewArray columns that reference the

--- a/crates/ffwd-arrow/src/star_schema/helpers.rs
+++ b/crates/ffwd-arrow/src/star_schema/helpers.rs
@@ -152,6 +152,7 @@ pub(super) fn str_value_at(arr: &dyn Array, row: usize) -> String {
     }
 }
 
+#[allow(clippy::indexing_slicing)]
 pub(super) fn hex_encode_lower(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut out = String::with_capacity(bytes.len() * 2);
@@ -208,6 +209,7 @@ pub(super) fn build_fixed_binary_array<const N: usize>(
 }
 
 /// Parse a hex string to a fixed-size byte array.
+#[allow(clippy::indexing_slicing)]
 pub(super) fn hex_to_fixed<const N: usize>(hex: &str) -> Option<[u8; N]> {
     let hex = hex.trim();
     if hex.len() != N * 2 {

--- a/crates/ffwd-arrow/src/star_schema/star_to_flat.rs
+++ b/crates/ffwd-arrow/src/star_schema/star_to_flat.rs
@@ -744,7 +744,6 @@ fn scatter_resource_attrs(
     }
 }
 
-#[allow(clippy::indexing_slicing)]
 fn collect_resource_template_values<T: Clone>(
     values: &[Option<T>],
     resource_ids: &UInt32Array,
@@ -755,8 +754,8 @@ fn collect_resource_template_values<T: Clone>(
         let rid = resource_ids.value(row);
         if let std::collections::hash_map::Entry::Vacant(e) = map.entry(rid) {
             let rid_row = rid as usize;
-            if rid_row < num_rows {
-                e.insert(values[rid_row].clone());
+            if let Some(v) = values.get(rid_row) {
+                e.insert(v.clone());
             }
         }
     }
@@ -858,7 +857,6 @@ fn scatter_scope_attrs(
     }
 }
 
-#[allow(clippy::indexing_slicing)]
 pub(super) fn collect_template_values_by_id<T: Clone>(
     values: &[Option<T>],
     ids: &UInt32Array,
@@ -869,8 +867,8 @@ pub(super) fn collect_template_values_by_id<T: Clone>(
         let id = ids.value(row);
         if let std::collections::hash_map::Entry::Vacant(e) = map.entry(id) {
             let template_row = id as usize;
-            if template_row < values.len() {
-                e.insert(values[template_row].clone());
+            if let Some(v) = values.get(template_row) {
+                e.insert(v.clone());
             }
         }
     }

--- a/crates/ffwd-arrow/src/star_schema/star_to_flat.rs
+++ b/crates/ffwd-arrow/src/star_schema/star_to_flat.rs
@@ -131,6 +131,7 @@ impl TypedColumn {
 /// 3. Maps well-known LOGS fields back: time_unix_nano → `_timestamp`,
 ///    severity_text → `level`, body_str → `message`.
 /// 4. Combines into a single flat `RecordBatch`.
+#[allow(clippy::indexing_slicing)]
 pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
     let num_rows = star.logs.num_rows();
 
@@ -459,6 +460,7 @@ pub fn star_to_flat(star: &StarSchema) -> Result<RecordBatch, ArrowError> {
 /// Existing columns listed in `protected_existing_cols` are canonical fact
 /// columns; attrs with the same flat name are skipped because flat batches
 /// cannot represent duplicate column names.
+#[allow(clippy::indexing_slicing)]
 fn unpivot_attrs_to_flat(
     attrs_batch: &RecordBatch,
     flat_cols: &mut Vec<(String, TypedColumn)>,
@@ -660,6 +662,7 @@ fn unpivot_attrs_to_flat(
 /// After `unpivot_attrs_to_flat`, resource attrs are only populated at the
 /// row index matching the parent_id. This function copies those values to
 /// every row whose resource_id matches.
+#[allow(clippy::indexing_slicing)]
 fn scatter_resource_attrs(
     flat_cols: &mut [(String, TypedColumn)],
     col_index: &HashMap<String, usize>,
@@ -741,6 +744,7 @@ fn scatter_resource_attrs(
     }
 }
 
+#[allow(clippy::indexing_slicing)]
 fn collect_resource_template_values<T: Clone>(
     values: &[Option<T>],
     resource_ids: &UInt32Array,
@@ -761,6 +765,7 @@ fn collect_resource_template_values<T: Clone>(
 
 /// Scatter scope attribute values from template rows (indexed by scope_id) to
 /// all rows that share the same scope_id.
+#[allow(clippy::indexing_slicing)]
 fn scatter_scope_attrs(
     flat_cols: &mut [(String, TypedColumn)],
     col_index: &HashMap<String, usize>,
@@ -853,6 +858,7 @@ fn scatter_scope_attrs(
     }
 }
 
+#[allow(clippy::indexing_slicing)]
 pub(super) fn collect_template_values_by_id<T: Clone>(
     values: &[Option<T>],
     ids: &UInt32Array,

--- a/crates/ffwd-arrow/src/streaming_builder/finish.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/finish.rs
@@ -1,4 +1,6 @@
 //! RecordBatch finalization: `finish_batch` (zero-copy) and
+#![allow(clippy::indexing_slicing)]
+//! RecordBatch finalization: `finish_batch` (zero-copy) and
 //! `finish_batch_detached` (owned/detached strings).
 
 use std::sync::Arc;

--- a/crates/ffwd-arrow/src/streaming_builder/finish.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/finish.rs
@@ -1,4 +1,3 @@
-//! RecordBatch finalization: `finish_batch` (zero-copy) and
 #![allow(clippy::indexing_slicing)]
 //! RecordBatch finalization: `finish_batch` (zero-copy) and
 //! `finish_batch_detached` (owned/detached strings).

--- a/crates/ffwd-arrow/src/streaming_builder/finish.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/finish.rs
@@ -22,6 +22,7 @@ impl StreamingBuilder {
     /// shares the input buffer via Bytes reference counting (zero-copy).
     /// When decoded strings exist, the original and decoded buffers are exposed
     /// as separate Arrow StringView blocks to avoid copying the whole input.
+    #[allow(clippy::indexing_slicing)]
     pub fn finish_batch(&mut self) -> Result<RecordBatch, ArrowError> {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -348,6 +349,7 @@ impl StreamingBuilder {
     /// This is the optimal persistence path: zero-copy scan speed during
     /// parsing, single bulk copy during finalization, and the resulting
     /// `StringArray` compresses efficiently via IPC zstd.
+    #[allow(clippy::indexing_slicing)]
     pub fn finish_batch_detached(&mut self) -> Result<RecordBatch, ArrowError> {
         debug_assert_eq!(
             self.lifecycle.state(),

--- a/crates/ffwd-arrow/src/streaming_builder/mod.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/mod.rs
@@ -53,7 +53,6 @@ fn new_emitted_name_set() -> EmittedNameSet {
     EmittedNameSet::new()
 }
 
-#[allow(clippy::indexing_slicing)]
 pub(crate) fn append_string_view(
     builder: &mut StringViewBuilder,
     original_block: u32,

--- a/crates/ffwd-arrow/src/streaming_builder/mod.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/mod.rs
@@ -217,7 +217,6 @@ impl StreamingBuilder {
     /// Asserts that `buf.len()` fits in a u32, because string-view
     /// offsets are stored as u32. Buffers larger than 4 GiB would produce
     /// silently truncated offsets without this guard.
-    #[allow(clippy::indexing_slicing)]
     pub fn begin_batch(&mut self, buf: bytes::Bytes) {
         debug_assert!(
             matches!(
@@ -237,8 +236,10 @@ impl StreamingBuilder {
         // Only clear the slots that were active in the previous batch.
         // This preserves the inner-Vec capacity of each FieldColumns for
         // hot-path reuse while still bounding memory under key churn.
-        for fc in &mut self.fields[..self.num_active] {
-            fc.clear();
+        for i in 0..self.num_active {
+            if let Some(fc) = self.fields.get_mut(i) {
+                fc.clear();
+            }
         }
         // Discard all name→index mappings so resolve_field rebuilds them from
         // scratch.  Combined with resetting num_active, this prevents the
@@ -262,7 +263,6 @@ impl StreamingBuilder {
     }
 
     #[inline]
-    #[allow(clippy::indexing_slicing)]
     pub fn resolve_field(&mut self, key: &[u8]) -> usize {
         debug_assert!(
             self.lifecycle.state() == BuilderState::InBatch
@@ -273,11 +273,9 @@ impl StreamingBuilder {
             return idx;
         }
         let idx = self.num_active;
-        if idx < self.fields.len() {
-            // Reuse an existing slot — its data was cleared in begin_batch.
-            // Only the name needs updating.
-            self.fields[idx].name.clear();
-            self.fields[idx].name.extend_from_slice(key);
+        if let Some(field) = self.fields.get_mut(idx) {
+            field.name.clear();
+            field.name.extend_from_slice(key);
         } else {
             self.fields.push(FieldColumns::new(key));
         }

--- a/crates/ffwd-arrow/src/streaming_builder/mod.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/mod.rs
@@ -53,6 +53,7 @@ fn new_emitted_name_set() -> EmittedNameSet {
     EmittedNameSet::new()
 }
 
+#[allow(clippy::indexing_slicing)]
 pub(crate) fn append_string_view(
     builder: &mut StringViewBuilder,
     original_block: u32,
@@ -217,6 +218,7 @@ impl StreamingBuilder {
     /// Asserts that `buf.len()` fits in a u32, because string-view
     /// offsets are stored as u32. Buffers larger than 4 GiB would produce
     /// silently truncated offsets without this guard.
+    #[allow(clippy::indexing_slicing)]
     pub fn begin_batch(&mut self, buf: bytes::Bytes) {
         debug_assert!(
             matches!(
@@ -261,6 +263,7 @@ impl StreamingBuilder {
     }
 
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn resolve_field(&mut self, key: &[u8]) -> usize {
         debug_assert!(
             self.lifecycle.state() == BuilderState::InBatch
@@ -311,6 +314,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_str_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -353,6 +357,7 @@ impl StreamingBuilder {
     /// offset shifted by `buf.len()` so that `finish_batch` can select the
     /// decoded Arrow StringView block without copying the original input.
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_decoded_str_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -377,6 +382,7 @@ impl StreamingBuilder {
     /// **Caller contract**: `value` must be valid UTF-8. Violating this produces
     /// corrupt Arrow arrays (undefined behaviour in downstream consumers).
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_prevalidated_str_by_idx(&mut self, idx: usize, value: &str) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -395,6 +401,7 @@ impl StreamingBuilder {
     /// Inner append path shared by `append_decoded_str_by_idx` (post-validation)
     /// and `append_prevalidated_str_by_idx` (type-guaranteed UTF-8).
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     fn append_decoded_str_inner(&mut self, idx: usize, value: &[u8]) {
         let Ok(len) = u32::try_from(value.len()) else {
             return;
@@ -431,6 +438,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_int_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -454,6 +462,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_i64_value_by_idx(&mut self, idx: usize, value: i64) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -475,6 +484,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_float_by_idx(&mut self, idx: usize, value: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -498,6 +508,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_f64_value_by_idx(&mut self, idx: usize, value: f64) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -519,6 +530,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_bool_by_idx(&mut self, idx: usize, value: bool) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -540,6 +552,7 @@ impl StreamingBuilder {
     }
 
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_null_by_idx(&mut self, idx: usize) {
         debug_assert_eq!(
             self.lifecycle.state(),
@@ -565,6 +578,7 @@ impl StreamingBuilder {
     /// first call has effect. This maintains the invariant that `line_views`
     /// has exactly one entry per row when `line_capture` is enabled.
     #[inline(always)]
+    #[allow(clippy::indexing_slicing)]
     pub fn append_line(&mut self, line: &[u8]) {
         debug_assert_eq!(
             self.lifecycle.state(),

--- a/crates/ffwd-arrow/src/streaming_builder/tests.rs
+++ b/crates/ffwd-arrow/src/streaming_builder/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for the streaming zero-copy Arrow RecordBatch builder.
 
+#![allow(clippy::indexing_slicing)]
+
 #[cfg(test)]
 mod tests {
     use super::super::*;

--- a/crates/ffwd-config-wasm/src/lib.rs
+++ b/crates/ffwd-config-wasm/src/lib.rs
@@ -1,6 +1,77 @@
 use ffwd_config::{Config, docspec};
 use wasm_bindgen::prelude::*;
 
+#[cfg(test)]
+mod tests {
+    use ffwd_config::docspec::{input_template, output_template, INPUT_TEMPLATES, OUTPUT_TEMPLATES};
+
+    #[test]
+    fn all_input_template_ids_return_some() {
+        for template in INPUT_TEMPLATES {
+            assert!(
+                input_template(template.id).is_some(),
+                "input_template({:?}) should return Some, but returned None",
+                template.id
+            );
+        }
+    }
+
+    #[test]
+    fn all_output_template_ids_return_some() {
+        for template in OUTPUT_TEMPLATES {
+            assert!(
+                output_template(template.id).is_some(),
+                "output_template({:?}) should return Some, but returned None",
+                template.id
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_input_template_id_returns_none() {
+        assert!(input_template("nonexistent_template_id").is_none());
+        assert!(input_template("").is_none());
+    }
+
+    #[test]
+    fn invalid_output_template_id_returns_none() {
+        assert!(output_template("nonexistent_template_id").is_none());
+        assert!(output_template("").is_none());
+    }
+
+    #[test]
+    fn known_input_templates_have_snippets() {
+        let known = ["file_json", "file_cri", "udp_raw", "tcp_json", "otlp_receiver"];
+        for id in known {
+            let template = input_template(id);
+            assert!(
+                template.is_some(),
+                "known input template {id} should exist"
+            );
+            assert!(
+                !template.unwrap().snippet.is_empty(),
+                "input template {id} should have a non-empty snippet"
+            );
+        }
+    }
+
+    #[test]
+    fn known_output_templates_have_snippets() {
+        let known = ["otlp", "loki", "elasticsearch", "stdout", "file", "null"];
+        for id in known {
+            let template = output_template(id);
+            assert!(
+                template.is_some(),
+                "known output template {id} should exist"
+            );
+            assert!(
+                !template.unwrap().snippet.is_empty(),
+                "output template {id} should have a non-empty snippet"
+            );
+        }
+    }
+}
+
 // ── Template data ──────────────────────────────────────────────────────────
 // Shared input/output templates live in `ffwd-config::docspec`.
 

--- a/crates/ffwd-config/src/shared.rs
+++ b/crates/ffwd-config/src/shared.rs
@@ -60,7 +60,7 @@ pub struct TlsServerConfig {
 #[serde(deny_unknown_fields)]
 pub struct RetryConfig {
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_attempts: Option<i32>,
+    pub max_attempts: Option<u32>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub initial_backoff_secs: Option<PositiveSecs>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]

--- a/crates/ffwd-config/src/shared.rs
+++ b/crates/ffwd-config/src/shared.rs
@@ -59,6 +59,9 @@ pub struct TlsServerConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RetryConfig {
+    /// Maximum retry attempts for the sink.
+    /// `None` uses the sink default.
+    /// `Some(0)` means no retry limit.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_attempts: Option<u32>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1405,7 +1405,8 @@ pipelines:
       - type: loki
         endpoint: http://localhost:3100/loki/api/v1/push
 ";
-    Config::load_str(yaml).expect("full push path in endpoint should be accepted (normalized by output)");
+    Config::load_str(yaml)
+        .expect("full push path in endpoint should be accepted (normalized by output)");
 }
 
 #[test]
@@ -1421,5 +1422,6 @@ pipelines:
       - type: loki
         endpoint: http://localhost:3100/loki/api/v1/push/
 ";
-    Config::load_str(yaml).expect("push path with trailing slash should be accepted (normalized by output)");
+    Config::load_str(yaml)
+        .expect("push path with trailing slash should be accepted (normalized by output)");
 }

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1,4 +1,4 @@
-use ffwd_config::Config;
+use ffwd_config::{Config, OutputConfigV2};
 use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
@@ -1467,11 +1467,19 @@ pipelines:
         retry:
           max_attempts: 3
 "#;
-    let result = Config::load_str(yaml);
-    assert!(
-        result.is_ok(),
-        "elasticsearch with max_attempts=3 should be accepted, but got: {:?}",
-        result
+    let config = Config::load_str(yaml)
+        .expect("elasticsearch with max_attempts=3 should be accepted");
+    let output = config.pipelines.get("test")
+        .expect("pipeline 'test' should exist")
+        .outputs.first()
+        .expect("output #0 should exist");
+    let OutputConfigV2::Elasticsearch(es) = output else {
+        panic!("output #0 should be Elasticsearch");
+    };
+    assert_eq!(
+        es.retry.as_ref().and_then(|r| r.max_attempts),
+        Some(3),
+        "elasticsearch retry.max_attempts should be Some(3)"
     );
 }
 
@@ -1490,10 +1498,18 @@ pipelines:
         retry:
           max_attempts: 0
 "#;
-    let result = Config::load_str(yaml);
-    assert!(
-        result.is_ok(),
-        "elasticsearch with max_attempts=0 should be accepted (zero means no retry limit), but got: {:?}",
-        result
+    let config = Config::load_str(yaml)
+        .expect("elasticsearch with max_attempts=0 should be accepted");
+    let output = config.pipelines.get("test")
+        .expect("pipeline 'test' should exist")
+        .outputs.first()
+        .expect("output #0 should exist");
+    let OutputConfigV2::Elasticsearch(es) = output else {
+        panic!("output #0 should be Elasticsearch");
+    };
+    assert_eq!(
+        es.retry.as_ref().and_then(|r| r.max_attempts),
+        Some(0),
+        "elasticsearch retry.max_attempts should be Some(0)"
     );
 }

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1425,3 +1425,75 @@ pipelines:
     Config::load_str(yaml)
         .expect("push path with trailing slash should be accepted (normalized by output)");
 }
+
+#[test]
+fn issue_2584_retry_max_attempts_rejects_negative_values() {
+    for max_attempts in [-1, -100] {
+        let yaml = format!(
+            r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: {max_attempts}
+"#,
+        );
+        let result = Config::load_str(&yaml);
+        assert!(
+            result.is_err(),
+            "elasticsearch with max_attempts={max_attempts} should be rejected, but got Ok"
+        );
+    }
+}
+
+#[test]
+fn issue_2584_retry_max_attempts_accepts_positive_values() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: 3
+"#;
+    let result = Config::load_str(yaml);
+    assert!(
+        result.is_ok(),
+        "elasticsearch with max_attempts=3 should be accepted, but got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn issue_2584_retry_max_attempts_accepts_zero() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: 0
+"#;
+    let result = Config::load_str(yaml);
+    assert!(
+        result.is_ok(),
+        "elasticsearch with max_attempts=0 should be accepted (zero means no retry limit), but got: {:?}",
+        result
+    );
+}

--- a/crates/ffwd-core/Cargo.toml
+++ b/crates/ffwd-core/Cargo.toml
@@ -33,3 +33,6 @@ harness = false
 
 [lints]
 workspace = true
+
+[lints.clippy]
+indexing_slicing = "deny"

--- a/crates/ffwd-core/Cargo.toml
+++ b/crates/ffwd-core/Cargo.toml
@@ -31,8 +31,5 @@ tempfile = "3"
 name = "scanner"
 harness = false
 
-[lints]
-workspace = true
-
 [lints.clippy]
 indexing_slicing = "deny"

--- a/crates/ffwd-core/Cargo.toml
+++ b/crates/ffwd-core/Cargo.toml
@@ -31,5 +31,5 @@ tempfile = "3"
 name = "scanner"
 harness = false
 
-[lints.clippy]
-indexing_slicing = "deny"
+[lints]
+workspace = true

--- a/crates/ffwd-core/src/byte_search.rs
+++ b/crates/ffwd-core/src/byte_search.rs
@@ -12,6 +12,7 @@
 /// Formally verified by Kani for all 16-byte inputs (see proof below).
 #[inline]
 #[cfg_attr(kani, kani::requires(from <= haystack.len()))]
+#[allow(clippy::indexing_slicing)]
 pub fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
     let mut i = from;
     while i < haystack.len() {
@@ -29,6 +30,7 @@ pub fn find_byte(haystack: &[u8], needle: u8, from: usize) -> Option<usize> {
 /// Equivalent to `memchr::memrchr(needle, &haystack[..end])`.
 #[inline]
 #[cfg_attr(kani, kani::requires(end <= haystack.len()))]
+#[allow(clippy::indexing_slicing)]
 pub fn rfind_byte(haystack: &[u8], needle: u8, end: usize) -> Option<usize> {
     if end == 0 || haystack.is_empty() {
         return None;

--- a/crates/ffwd-core/src/cri.rs
+++ b/crates/ffwd-core/src/cri.rs
@@ -36,6 +36,7 @@ pub struct CriLine<'a> {
 /// This is zero-copy — all returned slices point into the input `line`.
 /// Uses `byte_search::find_byte` (Kani-proven) instead of memchr.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_cri_line(line: &[u8]) -> Option<CriLine<'_>> {
     use crate::byte_search::find_byte;
 
@@ -205,6 +206,7 @@ pub fn process_cri_to_buf_with_plain_text_field(
 }
 
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn process_cri_chunk_lines<F>(
     chunk: &[u8],
     reassembler: &mut CriReassembler,

--- a/crates/ffwd-core/src/framer.rs
+++ b/crates/ffwd-core/src/framer.rs
@@ -55,6 +55,7 @@ impl FrameOutput {
 
     /// Get the byte range of line `i`. Panics if `i >= len()`.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn line_range(&self, i: usize) -> (usize, usize) {
         assert!(i < self.count, "line index out of bounds");
         self.line_ranges[i]
@@ -62,6 +63,7 @@ impl FrameOutput {
 
     /// Iterate over line ranges.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn iter(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
         self.line_ranges[..self.count].iter().copied()
     }
@@ -79,6 +81,7 @@ impl NewlineFramer {
     ///
     /// Returns a `FrameOutput` with ranges of complete lines and the
     /// offset of any partial remainder.
+    #[allow(clippy::indexing_slicing)]
     pub fn frame(&self, input: &[u8]) -> FrameOutput {
         let mut output = FrameOutput {
             line_ranges: [(0, 0); MAX_LINES_PER_FRAME],

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -52,6 +52,7 @@ struct LineScratch {
 ///   this call (see [`ScanBuilder`] for the initialization contract).
 #[inline(never)]
 #[allow(clippy::indexing_slicing)]
+#[allow(clippy::expect_used)]
 pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: &mut B) {
     if buf.is_empty() {
         return;

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -51,6 +51,7 @@ struct LineScratch {
 /// - The caller must have already invoked `begin_batch` on the builder before
 ///   this call (see [`ScanBuilder`] for the initialization contract).
 #[inline(never)]
+#[allow(clippy::indexing_slicing)]
 pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: &mut B) {
     if buf.is_empty() {
         return;
@@ -164,6 +165,7 @@ pub fn scan_streaming<B: ScanBuilder>(buf: &[u8], config: &ScanConfig, builder: 
 }
 
 /// Scan a single JSON line using pre-computed block bitmasks.
+#[allow(clippy::indexing_slicing)]
 fn scan_line<B: ScanBuilder>(
     buf: &[u8],
     start: usize,
@@ -431,6 +433,7 @@ impl PredicateScratch {
 /// fields are extracted into a scratch buffer for evaluation. If the predicate
 /// passes, deferred writes are replayed into the builder. If it fails, the
 /// row is skipped entirely (no begin_row/end_row).
+#[allow(clippy::indexing_slicing)]
 fn scan_line_with_predicate<B: ScanBuilder>(
     buf: &[u8],
     start: usize,
@@ -767,6 +770,7 @@ fn scan_line_with_predicate<B: ScanBuilder>(
 /// Find the next unescaped quote at or after `from`, bounded by `end`.
 /// Uses per-block real_quotes bitmask for O(1) per-block lookup.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn next_quote(from: usize, end: usize, blocks: &StoredBitmasks<'_>) -> Option<usize> {
     let mut pos = from;
     while pos < end {
@@ -793,6 +797,7 @@ fn next_quote(from: usize, end: usize, blocks: &StoredBitmasks<'_>) -> Option<us
 /// Find the next non-whitespace position using space bitmask.
 #[inline]
 #[cfg_attr(kani, kani::requires(pos <= end && end <= buf.len()))]
+#[allow(clippy::indexing_slicing)]
 fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         match buf[pos] {
@@ -807,6 +812,7 @@ fn skip_whitespace(buf: &[u8], mut pos: usize, end: usize) -> usize {
 
 /// Skip a nested object/array using brace/bracket bitmasks.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn skip_nested(buf: &[u8], mut pos: usize, end: usize, blocks: &StoredBitmasks<'_>) -> usize {
     const MAX_TRACKED_DEPTH: u32 = 32;
     let mut depth: u32 = 0;
@@ -886,6 +892,7 @@ fn is_json_delimiter(b: u8) -> bool {
 /// Stops at the first byte where `is_json_delimiter` returns true.
 #[inline]
 #[cfg_attr(kani, kani::requires(pos <= end && end <= buf.len()))]
+#[allow(clippy::indexing_slicing)]
 fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
     while pos < end {
         if is_json_delimiter(buf[pos]) {
@@ -907,6 +914,7 @@ fn skip_bare_value(buf: &[u8], mut pos: usize, end: usize) -> usize {
 ///
 /// Invalid or truncated escape sequences are passed through unchanged
 /// to avoid data loss on malformed input.
+#[allow(clippy::indexing_slicing)]
 fn decode_json_escapes(input: &[u8], out: &mut alloc::vec::Vec<u8>) {
     out.clear();
     // Decoded output is always ≤ input length (escapes expand, never shrink).
@@ -967,6 +975,7 @@ fn decode_json_escapes(input: &[u8], out: &mut alloc::vec::Vec<u8>) {
 
 /// Decode a `\uXXXX` escape (possibly a surrogate pair) starting at `pos`.
 /// Appends the decoded UTF-8 bytes to `out` and returns the new position.
+#[allow(clippy::indexing_slicing)]
 fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>) -> usize {
     // Need at least 6 bytes: \uXXXX
     if pos + 6 > input.len() {
@@ -1023,6 +1032,7 @@ fn decode_unicode_escape(input: &[u8], pos: usize, out: &mut alloc::vec::Vec<u8>
 
 /// Parse 4 ASCII hex digits into a `u16`.
 #[inline]
+#[allow(clippy::indexing_slicing)]
 fn parse_hex4(bytes: &[u8]) -> Option<u16> {
     if bytes.len() < 4 {
         return None;

--- a/crates/ffwd-core/src/lib.rs
+++ b/crates/ffwd-core/src/lib.rs
@@ -8,6 +8,7 @@
 #![warn(missing_docs)]
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::panic)]
+#![deny(clippy::indexing_slicing)]
 
 extern crate alloc;
 

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -121,6 +121,7 @@ use ffwd_lint_attrs::{allow_unproven, trust_boundary, verified};
 /// Encode a varint into buf at offset, return new offset.
 #[inline(always)]
 #[verified(kani = "verify_varint_len_matches_encode")]
+#[allow(clippy::indexing_slicing)]
 pub fn encode_varint(buf: &mut Vec<u8>, mut value: u64) {
     loop {
         if value < 0x80 {
@@ -136,6 +137,7 @@ pub fn encode_varint(buf: &mut Vec<u8>, mut value: u64) {
 #[inline(always)]
 #[allow(clippy::match_overlapping_arm)]
 #[verified(kani = "verify_varint_len_matches_encode")]
+#[allow(clippy::indexing_slicing)]
 pub const fn varint_len(value: u64) -> usize {
     match value {
         0..=0x7F => 1,
@@ -154,6 +156,7 @@ pub const fn varint_len(value: u64) -> usize {
 /// Write a protobuf tag (field_number + wire_type).
 #[inline(always)]
 #[verified(kani = "verify_encode_tag")]
+#[allow(clippy::indexing_slicing)]
 pub fn encode_tag(buf: &mut Vec<u8>, field_number: u32, wire_type: u8) {
     encode_varint(buf, ((field_number as u64) << 3) | wire_type as u64);
 }
@@ -161,6 +164,7 @@ pub fn encode_tag(buf: &mut Vec<u8>, field_number: u32, wire_type: u8) {
 /// Write a fixed64 field (tag + 8 bytes little-endian).
 #[inline(always)]
 #[verified(kani = "verify_encode_fixed64")]
+#[allow(clippy::indexing_slicing)]
 pub fn encode_fixed64(buf: &mut Vec<u8>, field_number: u32, value: u64) {
     encode_tag(buf, field_number, 1); // wire type 1 = 64-bit
     buf.extend_from_slice(&value.to_le_bytes());
@@ -169,6 +173,7 @@ pub fn encode_fixed64(buf: &mut Vec<u8>, field_number: u32, value: u64) {
 /// Write a varint field (tag + varint value).
 #[inline(always)]
 #[verified(kani = "verify_encode_varint_field")]
+#[allow(clippy::indexing_slicing)]
 pub fn encode_varint_field(buf: &mut Vec<u8>, field_number: u32, value: u64) {
     encode_tag(buf, field_number, 0); // wire type 0 = varint
     encode_varint(buf, value);
@@ -177,6 +182,7 @@ pub fn encode_varint_field(buf: &mut Vec<u8>, field_number: u32, value: u64) {
 /// Write a length-delimited field (tag + length + bytes).
 #[inline(always)]
 #[verified(kani = "verify_encode_bytes_field_content")]
+#[allow(clippy::indexing_slicing)]
 pub fn encode_bytes_field(buf: &mut Vec<u8>, field_number: u32, data: &[u8]) {
     encode_tag(buf, field_number, 2); // wire type 2 = length-delimited
     encode_varint(buf, data.len() as u64);
@@ -204,6 +210,7 @@ pub const fn bytes_field_total_size(field_number: u32, data_len: usize) -> usize
 /// Compute the encoded size of a length-delimited field (without writing).
 #[inline(always)]
 #[verified(kani = "verify_bytes_field_size")]
+#[allow(clippy::indexing_slicing)]
 pub const fn bytes_field_size(field_number: u32, data_len: usize) -> usize {
     bytes_field_total_size(field_number, data_len)
 }
@@ -226,6 +233,7 @@ pub fn encode_fixed32(buf: &mut Vec<u8>, field_number: u32, value: u32) {
 /// of at most 1 to avoid u64 overflow.
 #[verified(kani = "verify_decode_varint_vs_oracle")]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn decode_varint(buf: &[u8], pos: usize) -> Result<(u64, usize), &'static str> {
     let mut value: u64 = 0;
     let mut shift: u32 = 0;
@@ -250,6 +258,7 @@ pub fn decode_varint(buf: &[u8], pos: usize) -> Result<(u64, usize), &'static st
 /// Decode a protobuf tag into `(field_number, wire_type, new_pos)`.
 #[allow_unproven]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn decode_tag(buf: &[u8], pos: usize) -> Result<(u32, u8, usize), &'static str> {
     let (tag, new_pos) = decode_varint(buf, pos)?;
     let field_number = (tag >> 3) as u32;
@@ -261,6 +270,7 @@ pub fn decode_tag(buf: &[u8], pos: usize) -> Result<(u32, u8, usize), &'static s
 /// position after the field value.
 #[allow_unproven]
 #[trust_boundary]
+#[allow(clippy::indexing_slicing)]
 pub fn skip_field(buf: &[u8], wire_type: u8, pos: usize) -> Result<usize, &'static str> {
     match wire_type {
         0 => {
@@ -307,6 +317,7 @@ pub fn skip_field(buf: &[u8], wire_type: u8, pos: usize) -> Result<usize, &'stat
 /// Designed for zero-allocation decoding of `trace_id` (32 hex chars → 16 bytes)
 /// and `span_id` (16 hex chars → 8 bytes) on the hot encoding path.
 #[verified(kani = "verify_hex_decode_roundtrip")]
+#[allow(clippy::indexing_slicing)]
 pub fn hex_decode(hex_bytes: &[u8], out: &mut [u8]) -> bool {
     if hex_bytes.len() != out.len() * 2 {
         return false;
@@ -337,6 +348,7 @@ pub fn hex_decode(hex_bytes: &[u8], out: &mut [u8]) -> bool {
 /// to the sentinel 0xFF used by callers to signal an invalid character.
 /// Using a LUT replaces the three-branch match with a single indexed load.
 /// The table is 256 bytes and stays hot in L1 cache during batch decode loops.
+#[allow(clippy::indexing_slicing)]
 const HEX_NIBBLE_LUT: [u8; 256] = {
     let mut lut = [0xFF_u8; 256];
     let mut i = 0u16;
@@ -379,6 +391,7 @@ pub enum Severity {
 /// Fast severity lookup from first byte + length. No string comparison needed.
 #[inline(always)]
 #[verified(kani = "verify_parse_severity_no_false_positives")]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_severity(text: &[u8]) -> (Severity, &[u8]) {
     // Exact case-insensitive match against the 6 standard severity strings
     // plus common aliases used by syslog and application logs.
@@ -415,6 +428,7 @@ fn eq_ignore_case_match(a: &[u8], b: &[u8]) -> bool {
 /// Case-insensitive 3-byte comparison.
 #[inline(always)]
 #[allow_unproven]
+#[allow(clippy::indexing_slicing)]
 fn eq_ignore_case_3(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20 && a[1] | 0x20 == b[1] | 0x20 && a[2] | 0x20 == b[2] | 0x20
 }
@@ -425,6 +439,7 @@ fn eq_ignore_case_3(a: &[u8], b: &[u8]) -> bool {
 /// the comparison targets ("INFO", "WARN") are all ASCII letters.
 #[inline(always)]
 #[verified(kani = "verify_eq_ignore_case_4_no_false_positives_info")]
+#[allow(clippy::indexing_slicing)]
 fn eq_ignore_case_4(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
         && a[1] | 0x20 == b[1] | 0x20
@@ -435,6 +450,7 @@ fn eq_ignore_case_4(a: &[u8], b: &[u8]) -> bool {
 /// Case-insensitive 5-byte comparison.
 #[inline(always)]
 #[verified(kani = "verify_eq_ignore_case_5_no_false_positives_error")]
+#[allow(clippy::indexing_slicing)]
 fn eq_ignore_case_5(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
         && a[1] | 0x20 == b[1] | 0x20
@@ -445,6 +461,8 @@ fn eq_ignore_case_5(a: &[u8], b: &[u8]) -> bool {
 
 /// Case-insensitive 6-byte comparison.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
+#[allow_unproven]
 #[verified(kani = "verify_eq_ignore_case_6_no_false_positives_notice")]
 fn eq_ignore_case_6(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
@@ -457,6 +475,8 @@ fn eq_ignore_case_6(a: &[u8], b: &[u8]) -> bool {
 
 /// Case-insensitive 7-byte comparison.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
+#[allow_unproven]
 #[verified(kani = "verify_eq_ignore_case_7_no_false_positives_warning")]
 fn eq_ignore_case_7(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
@@ -470,6 +490,8 @@ fn eq_ignore_case_7(a: &[u8], b: &[u8]) -> bool {
 
 /// Case-insensitive 8-byte comparison.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
+#[allow_unproven]
 #[verified(kani = "verify_eq_ignore_case_8_no_false_positives_critical")]
 fn eq_ignore_case_8(a: &[u8], b: &[u8]) -> bool {
     a[0] | 0x20 == b[0] | 0x20
@@ -502,6 +524,7 @@ fn eq_ignore_case_8(a: &[u8], b: &[u8]) -> bool {
 /// Fractional seconds beyond 9 digits (nanosecond precision) are
 /// truncated — this is intentional as OTLP uses nanoseconds.
 #[verified(kani = "verify_parse_timestamp_compositional")]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
     if ts.len() < 19 {
         return None;
@@ -622,6 +645,7 @@ pub fn parse_timestamp_nanos(ts: &[u8]) -> Option<u64> {
 #[inline(always)]
 #[cfg_attr(kani, kani::ensures(|result: &u16| *result <= 9999))]
 #[verified(kani = "verify_parse_4digits_contract")]
+#[allow(clippy::indexing_slicing)]
 fn parse_4digits(s: &[u8], off: usize) -> u16 {
     if off + 4 > s.len() {
         return 0;
@@ -639,6 +663,7 @@ fn parse_4digits(s: &[u8], off: usize) -> u16 {
 #[inline(always)]
 #[cfg_attr(kani, kani::ensures(|result: &u8| *result <= 99))]
 #[verified(kani = "verify_parse_2digits_contract")]
+#[allow(clippy::indexing_slicing)]
 fn parse_2digits(s: &[u8], off: usize) -> u8 {
     if off + 2 > s.len() {
         return 0;
@@ -656,6 +681,7 @@ fn parse_2digits(s: &[u8], off: usize) -> u8 {
 /// calls would perform.
 #[inline(always)]
 #[allow_unproven]
+#[allow(clippy::indexing_slicing)]
 fn parse_4digits_checked(s: &[u8], off: usize) -> Option<u16> {
     let (a, b, c, d) = (
         s[off].wrapping_sub(b'0'),
@@ -674,6 +700,7 @@ fn parse_4digits_checked(s: &[u8], off: usize) -> Option<u16> {
 /// a `is_ascii_digit` check followed by a separate subtraction.
 #[inline(always)]
 #[allow_unproven]
+#[allow(clippy::indexing_slicing)]
 fn parse_2digits_checked(s: &[u8], off: usize) -> Option<u8> {
     let a = s[off].wrapping_sub(b'0');
     let b = s[off + 1].wrapping_sub(b'0');

--- a/crates/ffwd-core/src/reassembler.rs
+++ b/crates/ffwd-core/src/reassembler.rs
@@ -96,6 +96,7 @@ impl CriReassembler {
     /// Returns [`AggregateResult::Truncated`] instead of
     /// [`AggregateResult::Complete`] when any chunk in the current P/F
     /// sequence exceeded `max_message_size`. Callers should log a warning.
+    #[allow(clippy::indexing_slicing)]
     pub fn feed<'a>(&'a mut self, message: &'a [u8], is_full: bool) -> AggregateResult<'a> {
         if is_full {
             if self.pending.is_empty() {
@@ -174,6 +175,7 @@ impl CriReassembler {
     /// (timestamp + stream + flag) plus the message to be buffered. Using only
     /// `max_message_size` would truncate the raw line before the header is fully
     /// received, turning a valid split line into a parse error.
+    #[allow(clippy::indexing_slicing)]
     pub(crate) fn push_line_fragment(&mut self, bytes: &[u8]) {
         let remaining = self
             .raw_line_fragment_limit()

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -90,6 +90,7 @@ impl ScanConfig {
 /// this as a `#[requires]` would force every caller to guard against empty
 /// input even though the function already does the right thing.
 #[inline(always)]
+#[allow(clippy::indexing_slicing)]
 pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
     if bytes.is_empty() {
         return None;

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -92,7 +92,11 @@ impl ScanConfig {
 #[inline(always)]
 pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
     let (&first, rest) = bytes.split_first()?;
-    let (neg, digits) = if first == b'-' { (true, rest) } else { (false, bytes) };
+    let (neg, digits) = if first == b'-' {
+        (true, rest)
+    } else {
+        (false, bytes)
+    };
     if digits.is_empty() {
         return None;
     }

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -90,22 +90,15 @@ impl ScanConfig {
 /// this as a `#[requires]` would force every caller to guard against empty
 /// input even though the function already does the right thing.
 #[inline(always)]
-#[allow(clippy::indexing_slicing)]
 pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
-    if bytes.is_empty() {
-        return None;
-    }
-    let (neg, start) = if bytes[0] == b'-' {
-        (true, 1)
-    } else {
-        (false, 0)
-    };
-    if start >= bytes.len() {
+    let (&first, rest) = bytes.split_first()?;
+    let (neg, digits) = if first == b'-' { (true, rest) } else { (false, bytes) };
+    if digits.is_empty() {
         return None;
     }
     let mut acc: i64 = 0;
     if neg {
-        for &b in &bytes[start..] {
+        for &b in digits {
             if !b.is_ascii_digit() {
                 return None;
             }
@@ -114,7 +107,7 @@ pub fn parse_int_fast(bytes: &[u8]) -> Option<i64> {
         }
         Some(acc)
     } else {
-        for &b in &bytes[start..] {
+        for &b in digits {
             if !b.is_ascii_digit() {
                 return None;
             }

--- a/crates/ffwd-core/src/scan_predicate.rs
+++ b/crates/ffwd-core/src/scan_predicate.rs
@@ -120,7 +120,6 @@ impl ScanPredicate {
     /// Returns `None` if the entire predicate references the field.
     /// For AND chains, strips only the matching conjuncts and returns
     /// the remainder (or None if all stripped).
-    #[allow(clippy::expect_used)]
     pub fn strip_field(self, field_name: &str) -> Option<Self> {
         if !self.references_field(field_name.as_bytes()) {
             return Some(self);
@@ -133,7 +132,7 @@ impl ScanPredicate {
                     .collect();
                 match remaining.len() {
                     0 => None,
-                    1 => Some(remaining.into_iter().next().expect("len checked")),
+                    1 => remaining.into_iter().next(),
                     _ => Some(ScanPredicate::And(remaining)),
                 }
             }

--- a/crates/ffwd-core/src/scan_predicate.rs
+++ b/crates/ffwd-core/src/scan_predicate.rs
@@ -120,6 +120,7 @@ impl ScanPredicate {
     /// Returns `None` if the entire predicate references the field.
     /// For AND chains, strips only the matching conjuncts and returns
     /// the remainder (or None if all stripped).
+    #[allow(clippy::expect_used)]
     pub fn strip_field(self, field_name: &str) -> Option<Self> {
         if !self.references_field(field_name.as_bytes()) {
             return Some(self);

--- a/crates/ffwd-core/src/structural.rs
+++ b/crates/ffwd-core/src/structural.rs
@@ -290,6 +290,7 @@ fn cmp4(c0: u8x16, c1: u8x16, c2: u8x16, c3: u8x16, needle: u8) -> u64 {
 /// then runs 10 comparisons against the loaded data. u8x16 maps to a single
 /// native register on both NEON (128-bit) and SSE2 (128-bit). The `wide`
 /// crate handles platform dispatch at compile time.
+#[allow(clippy::expect_used)]
 pub fn find_structural_chars(block: &[u8; 64]) -> RawBlockMasks {
     let c0 = u8x16::new(block[0..16].try_into().expect("block is 64 bytes"));
     let c1 = u8x16::new(block[16..32].try_into().expect("block is 64 bytes"));

--- a/crates/ffwd-core/src/structural_iter.rs
+++ b/crates/ffwd-core/src/structural_iter.rs
@@ -107,6 +107,7 @@ impl<'a> StructuralIter<'a> {
     }
 
     /// Load and process the block at the given index.
+    #[allow(clippy::indexing_slicing)]
     fn load_block(&mut self, idx: usize) {
         self.block_idx = idx;
         self.block_offset = idx * 64;
@@ -198,6 +199,7 @@ impl<'a> StructuralIter<'a> {
     ///
     /// Uses the space bitmask — O(1) per block, no byte scanning.
     #[inline]
+    #[allow(clippy::indexing_slicing)]
     pub fn next_non_space(&self, from: usize) -> usize {
         if from >= self.len {
             return self.len;

--- a/crates/ffwd-core/src/structural_iter.rs
+++ b/crates/ffwd-core/src/structural_iter.rs
@@ -107,21 +107,26 @@ impl<'a> StructuralIter<'a> {
     }
 
     /// Load and process the block at the given index.
-    #[allow(clippy::indexing_slicing)]
     fn load_block(&mut self, idx: usize) {
         self.block_idx = idx;
         self.block_offset = idx * 64;
-        let remaining = self.len - self.block_offset;
+        let remaining = self.len.saturating_sub(self.block_offset);
         let block_len = remaining.min(64);
 
         let block: [u8; 64] = if remaining >= 64 {
             debug_assert!(remaining >= 64);
             let mut block = [0u8; 64];
-            block.copy_from_slice(&self.buf[self.block_offset..self.block_offset + 64]);
+            if let Some(src) = self.buf.get(self.block_offset..self.block_offset + 64) {
+                block.copy_from_slice(src);
+            }
             block
         } else {
             let mut padded = [b' '; 64];
-            padded[..remaining].copy_from_slice(&self.buf[self.block_offset..]);
+            if let Some(src) = self.buf.get(self.block_offset..self.block_offset + remaining)
+                && let Some(dst) = padded.get_mut(..src.len())
+            {
+                dst.copy_from_slice(src);
+            }
             padded
         };
 
@@ -199,7 +204,6 @@ impl<'a> StructuralIter<'a> {
     ///
     /// Uses the space bitmask — O(1) per block, no byte scanning.
     #[inline]
-    #[allow(clippy::indexing_slicing)]
     pub fn next_non_space(&self, from: usize) -> usize {
         if from >= self.len {
             return self.len;
@@ -228,9 +232,10 @@ impl<'a> StructuralIter<'a> {
         // Fallback: byte scan (for positions in blocks we haven't loaded)
         let mut pos = from;
         while pos < self.len {
-            match self.buf[pos] {
-                b' ' => pos += 1,
-                _ => return pos,
+            match self.buf.get(pos) {
+                Some(b' ') => pos += 1,
+                Some(_) => return pos,
+                None => break,
             }
         }
         pos

--- a/crates/ffwd-core/src/structural_iter.rs
+++ b/crates/ffwd-core/src/structural_iter.rs
@@ -122,7 +122,9 @@ impl<'a> StructuralIter<'a> {
             block
         } else {
             let mut padded = [b' '; 64];
-            if let Some(src) = self.buf.get(self.block_offset..self.block_offset + remaining)
+            if let Some(src) = self
+                .buf
+                .get(self.block_offset..self.block_offset + remaining)
                 && let Some(dst) = padded.get_mut(..src.len())
             {
                 dst.copy_from_slice(src);

--- a/crates/ffwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/ffwd-io/src/arrow_ipc_receiver.rs
@@ -11,8 +11,6 @@
 //! `application/vnd.apache.arrow.stream+lz4` (lz4 compressed).
 //! Also supports `Content-Encoding: zstd` and `Content-Encoding: lz4` headers.
 
-#![allow(clippy::indexing_slicing)]
-
 use std::io;
 use std::io::Read as _;
 use std::sync::mpsc;
@@ -359,12 +357,14 @@ fn decompress_zstd(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>
 /// size against `max_message_size_bytes` *before* calling it to prevent a
 /// forged prefix from triggering an unbounded allocation (DoS vector).
 fn decompress_lz4(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>, InputError> {
-    if body.len() < 4 {
+    let &[a, b, c, d] = body.get(..4).ok_or_else(|| {
+        InputError::Receiver("lz4 decompression failed: missing size prefix".to_string())
+    })? else {
         return Err(InputError::Receiver(
             "lz4 decompression failed: missing size prefix".to_string(),
         ));
-    }
-    let declared_len = u32::from_le_bytes([body[0], body[1], body[2], body[3]]) as usize;
+    };
+    let declared_len = u32::from_le_bytes([a, b, c, d]) as usize;
     if declared_len > max_message_size_bytes {
         return Err(InputError::Receiver(
             "decompressed payload too large".to_string(),

--- a/crates/ffwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/ffwd-io/src/arrow_ipc_receiver.rs
@@ -357,9 +357,7 @@ fn decompress_zstd(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>
 /// size against `max_message_size_bytes` *before* calling it to prevent a
 /// forged prefix from triggering an unbounded allocation (DoS vector).
 fn decompress_lz4(body: &[u8], max_message_size_bytes: usize) -> Result<Vec<u8>, InputError> {
-    let &[a, b, c, d] = body.get(..4).ok_or_else(|| {
-        InputError::Receiver("lz4 decompression failed: missing size prefix".to_string())
-    })? else {
+    let Some(&[a, b, c, d]) = body.get(..4) else {
         return Err(InputError::Receiver(
             "lz4 decompression failed: missing size prefix".to_string(),
         ));

--- a/crates/ffwd-io/src/arrow_ipc_receiver.rs
+++ b/crates/ffwd-io/src/arrow_ipc_receiver.rs
@@ -11,6 +11,8 @@
 //! `application/vnd.apache.arrow.stream+lz4` (lz4 compressed).
 //! Also supports `Content-Encoding: zstd` and `Content-Encoding: lz4` headers.
 
+#![allow(clippy::indexing_slicing)]
+
 use std::io;
 use std::io::Read as _;
 use std::sync::mpsc;

--- a/crates/ffwd-io/src/blocking_stage.rs
+++ b/crates/ffwd-io/src/blocking_stage.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::io;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;

--- a/crates/ffwd-io/src/compress.rs
+++ b/crates/ffwd-io/src/compress.rs
@@ -2,6 +2,8 @@
 //! The key optimization is reusing the ZSTD_CCtx across chunks — context
 //! creation is expensive (~128KB allocation), but reset is nearly free.
 
+#![allow(clippy::indexing_slicing)]
+
 use std::io;
 
 /// Compressed chunk with its header, ready for wire transmission.

--- a/crates/ffwd-io/src/format.rs
+++ b/crates/ffwd-io/src/format.rs
@@ -5,6 +5,8 @@
 //! and framing, allowing any transport (file, TCP, UDP) to use any format
 //! (JSON, CRI, Raw) via composition.
 
+#![allow(clippy::indexing_slicing)]
+
 use crate::input::CriMetadata;
 use bytes::{BufMut, BytesMut};
 use ffwd_core::cri::parse_cri_line;

--- a/crates/ffwd-io/src/framed.rs
+++ b/crates/ffwd-io/src/framed.rs
@@ -9,6 +9,8 @@
 //! interleaved data from multiple files (or TCP connections) never
 //! cross-contaminates partial lines or CRI P/F aggregation state.
 
+#![allow(clippy::indexing_slicing)]
+
 use bytes::{Bytes, BytesMut};
 
 use crate::filter_hints::FilterHints;

--- a/crates/ffwd-io/src/generator.rs
+++ b/crates/ffwd-io/src/generator.rs
@@ -3,6 +3,8 @@
 //! Produces JSON log lines at a configurable rate. Used for benchmarking
 //! and testing pipelines without external data sources.
 
+#![allow(clippy::indexing_slicing)]
+
 include!("generator/types.rs");
 include!("generator/logs.rs");
 include!("generator/input.rs");

--- a/crates/ffwd-io/src/generator/encoding.rs
+++ b/crates/ffwd-io/src/generator/encoding.rs
@@ -1,7 +1,6 @@
 // Arrow batch generation helpers for benchmarking.
 // xtask-verify: allow(pub_module_needs_tests) // generate_arrow_batch tested via generator/tests/basic.rs
 
-#[allow(clippy::indexing_slicing)]
 fn write_json_u64_field(out: &mut Vec<u8>, key: &str, value: u64, first: &mut bool) {
     if !*first {
         out.push(b',');

--- a/crates/ffwd-io/src/generator/encoding.rs
+++ b/crates/ffwd-io/src/generator/encoding.rs
@@ -1,6 +1,8 @@
 // Arrow batch generation helpers for benchmarking.
 // xtask-verify: allow(pub_module_needs_tests) // generate_arrow_batch tested via generator/tests/basic.rs
 
+#[allow(clippy::indexing_slicing)]
+
 fn write_json_u64_field(out: &mut Vec<u8>, key: &str, value: u64, first: &mut bool) {
     if !*first {
         out.push(b',');

--- a/crates/ffwd-io/src/generator/encoding.rs
+++ b/crates/ffwd-io/src/generator/encoding.rs
@@ -2,7 +2,6 @@
 // xtask-verify: allow(pub_module_needs_tests) // generate_arrow_batch tested via generator/tests/basic.rs
 
 #[allow(clippy::indexing_slicing)]
-
 fn write_json_u64_field(out: &mut Vec<u8>, key: &str, value: u64, first: &mut bool) {
     if !*first {
         out.push(b',');

--- a/crates/ffwd-io/src/generator/logs.rs
+++ b/crates/ffwd-io/src/generator/logs.rs
@@ -2,7 +2,6 @@
 // xtask-verify: allow(pub_module_needs_tests) // parse_iso8601_to_epoch_ms tested via generator/tests/timestamps.rs
 
 #[allow(clippy::indexing_slicing)]
-
 /// Write the message field value (without key or quotes) into a buffer.
 ///
 /// Used by both JSON serialization and Arrow field extraction.

--- a/crates/ffwd-io/src/generator/logs.rs
+++ b/crates/ffwd-io/src/generator/logs.rs
@@ -1,6 +1,8 @@
 // Log event generation helpers.
 // xtask-verify: allow(pub_module_needs_tests) // parse_iso8601_to_epoch_ms tested via generator/tests/timestamps.rs
 
+#[allow(clippy::indexing_slicing)]
+
 /// Write the message field value (without key or quotes) into a buffer.
 ///
 /// Used by both JSON serialization and Arrow field extraction.

--- a/crates/ffwd-io/src/generator/types.rs
+++ b/crates/ffwd-io/src/generator/types.rs
@@ -1,5 +1,3 @@
-#[allow(clippy::indexing_slicing)]
-
 use std::collections::HashMap;
 use std::io;
 use std::io::Write;

--- a/crates/ffwd-io/src/generator/types.rs
+++ b/crates/ffwd-io/src/generator/types.rs
@@ -1,3 +1,5 @@
+#[allow(clippy::indexing_slicing)]
+
 use std::collections::HashMap;
 use std::io;
 use std::io::Write;

--- a/crates/ffwd-io/src/http_input.rs
+++ b/crates/ffwd-io/src/http_input.rs
@@ -4,6 +4,8 @@
 //! optionally compressed request bodies, and forwards newline-delimited bytes
 //! to the pipeline scanner path as [`crate::input::SourceEvent::Data`].
 
+#![allow(clippy::indexing_slicing)]
+
 use std::io;
 use std::io::Read as _;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};

--- a/crates/ffwd-io/src/input.rs
+++ b/crates/ffwd-io/src/input.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::io::{self, Read};
 use std::ops::Range;
 use std::path::PathBuf;

--- a/crates/ffwd-io/src/journald_input.rs
+++ b/crates/ffwd-io/src/journald_input.rs
@@ -10,6 +10,8 @@
 //! processes them identically. The `backend` config controls selection:
 //! `auto` (default) tries native first then falls back to subprocess.
 
+#![allow(clippy::indexing_slicing)]
+
 use std::io::{self, BufRead, BufReader, Read};
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;

--- a/crates/ffwd-io/src/lib.rs
+++ b/crates/ffwd-io/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 pub mod atomic_write;
 pub(crate) mod background_http_task;
 /// Fixed-worker blocking stages for crate-internal CPU work.

--- a/crates/ffwd-io/src/lib.rs
+++ b/crates/ffwd-io/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::indexing_slicing)]
+#![deny(clippy::indexing_slicing)]
 
 pub mod atomic_write;
 pub(crate) mod background_http_task;

--- a/crates/ffwd-io/src/otap_receiver.rs
+++ b/crates/ffwd-io/src/otap_receiver.rs
@@ -8,6 +8,8 @@
 //! The protobuf is hand-decoded (no tonic codegen) following the same pattern
 //! as `otlp_receiver.rs`. Responds with a hand-encoded `BatchStatus` protobuf.
 
+#![allow(clippy::indexing_slicing)]
+
 use std::io;
 use std::sync::mpsc;
 use std::sync::{

--- a/crates/ffwd-io/src/otlp_receiver/convert.rs
+++ b/crates/ffwd-io/src/otlp_receiver/convert.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use arrow::record_batch::RecordBatch;
 use base64::Engine as _;
 use bytes::Bytes;

--- a/crates/ffwd-io/src/otlp_receiver/projection.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 //! Experimental OTLP logs wire projection into Arrow.
 //!
 //! This module decodes the common OTLP logs protobuf shape directly into

--- a/crates/ffwd-io/src/otlp_receiver/projection/wire.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/wire.rs
@@ -4,6 +4,7 @@
 //! skipping logic that the higher-level OTLP decoder builds on.
 
 use ffwd_arrow::columnar::plan::FieldHandle;
+use wide::u8x16;
 
 use super::ProjectionError;
 
@@ -31,6 +32,83 @@ pub(super) enum StringStorage {
     Decoded,
     #[cfg(any(feature = "otlp-research", test))]
     InputView,
+}
+
+/// Skip a varint starting at the beginning of the slice.
+/// Returns the number of bytes consumed.
+pub(super) fn skip_varint_simd(buf: &[u8]) -> Result<usize, ProjectionError> {
+    let mut pos = 0;
+    while pos + 16 <= buf.len() {
+        let chunk = u8x16::from(&buf[pos..pos + 16]);
+        // A byte is terminal if its value is < 128 (high bit not set).
+        let mask = chunk.simd_lt(u8x16::splat(128)).to_bitmask();
+        if mask != 0 {
+            return Ok(pos + (mask.trailing_zeros() as usize) + 1);
+        }
+        pos += 16;
+    }
+    // Fallback to scalar for tail.
+    while pos < buf.len() {
+        let b = buf[pos];
+        pos += 1;
+        if b < 128 {
+            return Ok(pos);
+        }
+    }
+    Err(ProjectionError::Invalid("truncated varint"))
+}
+
+/// Fast skip of a length-delimited field.
+/// Returns the number of bytes consumed (varint len + payload len).
+pub(super) fn skip_len_simd(input: &[u8]) -> Result<usize, ProjectionError> {
+    let mut input_ptr = input;
+    let len = read_varint(&mut input_ptr)? as usize;
+    let varint_consumed = input.len() - input_ptr.len();
+    if input_ptr.len() < len {
+        return Err(ProjectionError::Invalid("truncated length-delimited field"));
+    }
+    Ok(varint_consumed + len)
+}
+
+/// Fast structural scan using GB/s SIMD to count LogRecords and Attributes.
+///
+/// Returns (log_record_count, total_attribute_count).
+pub(super) fn count_structural_density_simd(input: &[u8]) -> (usize, usize) {
+    // 0x12 = Tag 2 (log_records), Wire 2
+    // 0x32 = Tag 6 (attributes), Wire 2
+    let logs = memchr::memchr_iter(0x12, input).count();
+    let attrs = memchr::memchr_iter(0x32, input).count();
+    (logs, attrs)
+}
+
+/// Speculative warp decoder for standard OTLP LogRecords.
+///
+/// If the first 21+ bytes match the expected OTLP LogRecord "Skeleton"
+/// (timestamp fixed64, observed_timestamp fixed64, severity_number varint),
+/// it decodes them in a single SIMD pass and returns the number of bytes consumed.
+pub(super) fn try_decode_log_record_warp(
+    input: &[u8],
+    out_ts: &mut Option<u64>,
+    out_obs_ts: &mut Option<u64>,
+    out_sev: &mut Option<u64>,
+) -> Option<usize> {
+    if input.len() < 21 {
+        return None;
+    }
+    // Expected skeleton:
+    // [0x09, TS(8)], [0x59, OBS_TS(8)], [0x10, SEV(1)]
+    // Tag 0x09 = (1 << 3) | 1 (TimeUnixNano)
+    // Tag 0x59 = (11 << 3) | 1 (ObservedTimeUnixNano)
+    // Tag 0x10 = (2 << 3) | 0 (SeverityNumber)
+    if input[0] == 0x09 && input[9] == 0x59 && input[18] == 0x10 {
+        if input[19] < 128 {
+            *out_ts = Some(u64::from_le_bytes(input[1..9].try_into().unwrap()));
+            *out_obs_ts = Some(u64::from_le_bytes(input[10..18].try_into().unwrap()));
+            *out_sev = Some(input[19] as u64);
+            return Some(20);
+        }
+    }
+    None
 }
 
 pub(super) fn for_each_field<'a>(
@@ -159,52 +237,34 @@ fn skip_group(input: &mut &[u8], start_field: u32) -> Result<(), ProjectionError
     Err(ProjectionError::Invalid("unterminated protobuf group"))
 }
 
+#[inline(always)]
 pub(super) fn read_varint(input: &mut &[u8]) -> Result<u64, ProjectionError> {
     let mut result = 0u64;
-    for index in 0..10 {
-        let Some((&byte, rest)) = input.split_first() else {
-            return Err(ProjectionError::Invalid("truncated varint"));
-        };
+    for i in 0..10 {
+        let (b, rest) = input
+            .split_first()
+            .ok_or(ProjectionError::Invalid("truncated varint"))?;
         *input = rest;
-        if index == 9 && byte > 0x01 {
-            return Err(ProjectionError::Invalid("varint overflow"));
-        }
-        result |= u64::from(byte & 0x7f) << (index * 7);
-        if byte & 0x80 == 0 {
+        result |= (*b as u64 & 0x7F) << (i * 7);
+        if *b < 128 {
             return Ok(result);
         }
     }
     Err(ProjectionError::Invalid("varint overflow"))
 }
 
-pub(super) fn require_utf8<'a>(
-    bytes: &'a [u8],
-    context: &'static str,
-) -> Result<&'a [u8], ProjectionError> {
-    if simdutf8::basic::from_utf8(bytes).is_err() {
-        return Err(ProjectionError::Invalid(context));
-    }
-    Ok(bytes)
+pub(super) fn require_utf8(input: &[u8]) -> Result<&str, ProjectionError> {
+    simdutf8::basic::from_utf8(input).map_err(|_e| ProjectionError::Invalid("invalid utf8"))
 }
 
-pub(super) fn subslice_range(
-    parent: &[u8],
-    child: &[u8],
-) -> Result<(usize, usize), ProjectionError> {
-    let parent_start = parent.as_ptr() as usize;
-    let child_start = child.as_ptr() as usize;
-    let Some(child_end) = child_start.checked_add(child.len()) else {
-        return Err(ProjectionError::Invalid("invalid protobuf subslice"));
-    };
-    let Some(parent_end) = parent_start.checked_add(parent.len()) else {
-        return Err(ProjectionError::Invalid("invalid protobuf parent slice"));
-    };
-    if child_start < parent_start || child_end > parent_end {
-        return Err(ProjectionError::Invalid(
-            "protobuf field outside parent slice",
-        ));
-    }
-    Ok((child_start - parent_start, child.len()))
+pub(super) fn validate_utf8(input: &[u8]) -> Result<&[u8], ProjectionError> {
+    simdutf8::basic::from_utf8(input).map_err(|_e| ProjectionError::Invalid("invalid utf8"))?;
+    Ok(input)
+}
+
+pub(super) fn subslice_range(parent: &[u8], child: &[u8]) -> (usize, usize) {
+    let start = child.as_ptr() as usize - parent.as_ptr() as usize;
+    (start, child.len())
 }
 
 #[derive(Default)]

--- a/crates/ffwd-io/src/platform_sensor.rs
+++ b/crates/ffwd-io/src/platform_sensor.rs
@@ -9,6 +9,7 @@
 // Ring buffer events are 8-byte aligned by the kernel, so casting from *const u8
 // to a repr(C) struct pointer is safe despite clippy's alignment warning.
 #![allow(clippy::cast_ptr_alignment)]
+#![allow(clippy::indexing_slicing)]
 
 use std::io;
 use std::net::Ipv4Addr;

--- a/crates/ffwd-io/src/s3_input/mod.rs
+++ b/crates/ffwd-io/src/s3_input/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 //! High-performance S3 (and S3-compatible) object storage input.
 //!
 //! # Discovery modes

--- a/crates/ffwd-io/src/segment.rs
+++ b/crates/ffwd-io/src/segment.rs
@@ -11,6 +11,8 @@
 //! Missing footer = incomplete segment (crashed mid-write). Invalid footer
 //! = corrupt segment. Both are deleted during recovery.
 
+#![allow(clippy::indexing_slicing)]
+
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};

--- a/crates/ffwd-io/src/tail/identity.rs
+++ b/crates/ffwd-io/src/tail/identity.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing)]
+
 use std::fs::File;
 use std::io::{self, Read, Seek, SeekFrom};
 use std::path::Path;

--- a/crates/ffwd-io/src/tail/lifecycle.rs
+++ b/crates/ffwd-io/src/tail/lifecycle.rs
@@ -2,7 +2,6 @@
 // are defined ahead of their first use.  Suppress dead-code warnings for the
 // entire module until the remaining transitions are wired up.
 #![allow(dead_code)]
-
 #![allow(clippy::indexing_slicing)]
 
 use std::fs::File;

--- a/crates/ffwd-io/src/tail/lifecycle.rs
+++ b/crates/ffwd-io/src/tail/lifecycle.rs
@@ -3,6 +3,8 @@
 // entire module until the remaining transitions are wired up.
 #![allow(dead_code)]
 
+#![allow(clippy::indexing_slicing)]
+
 use std::fs::File;
 use std::io;
 use std::path::PathBuf;

--- a/crates/ffwd-io/src/tcp_input.rs
+++ b/crates/ffwd-io/src/tcp_input.rs
@@ -5,6 +5,8 @@
 //! monotonic counter so that `FramedInput`'s per-source remainder tracking
 //! can distinguish data from different peers.
 
+#![allow(clippy::indexing_slicing)]
+
 include!("tcp_input/transport.rs");
 include!("tcp_input/options.rs");
 include!("tcp_input/listener.rs");

--- a/crates/ffwd-io/src/tcp_input/input_source.rs
+++ b/crates/ffwd-io/src/tcp_input/input_source.rs
@@ -1,5 +1,4 @@
 #[allow(clippy::indexing_slicing)]
-
 impl InputSource for TcpInput {
     fn poll(&mut self) -> io::Result<Vec<SourceEvent>> {
         let mut under_pressure = false;

--- a/crates/ffwd-io/src/tcp_input/input_source.rs
+++ b/crates/ffwd-io/src/tcp_input/input_source.rs
@@ -1,3 +1,5 @@
+#[allow(clippy::indexing_slicing)]
+
 impl InputSource for TcpInput {
     fn poll(&mut self) -> io::Result<Vec<SourceEvent>> {
         let mut under_pressure = false;

--- a/crates/ffwd-io/src/tcp_input/transport.rs
+++ b/crates/ffwd-io/src/tcp_input/transport.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::indexing_slicing)]
 use std::io::{self, Read};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Once;

--- a/crates/ffwd-io/src/tcp_input/transport.rs
+++ b/crates/ffwd-io/src/tcp_input/transport.rs
@@ -1,4 +1,3 @@
-#[allow(clippy::indexing_slicing)]
 use std::io::{self, Read};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Once;

--- a/crates/ffwd-io/src/udp_input.rs
+++ b/crates/ffwd-io/src/udp_input.rs
@@ -1,6 +1,8 @@
 //! UDP input source. Listens on a UDP socket and produces one SourceEvent
 //! per received datagram (or batch of datagrams).
 
+#![allow(clippy::indexing_slicing)]
+
 use std::io;
 use std::net::{SocketAddr, UdpSocket};
 use std::sync::Arc;

--- a/crates/ffwd-kani/src/bytes.rs
+++ b/crates/ffwd-kani/src/bytes.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::indexing_slicing)]
 //! Byte-level comparison and bitmask helpers for Kani proofs.
 
 extern crate alloc;

--- a/crates/ffwd-kani/src/hex.rs
+++ b/crates/ffwd-kani/src/hex.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::indexing_slicing)]
 //! Reference hex encoding/decoding implementations.
 
 /// Reference hex nibble decoder (branch-based, not LUT).

--- a/crates/ffwd-kani/src/iter.rs
+++ b/crates/ffwd-kani/src/iter.rs
@@ -1,5 +1,3 @@
-//! Byte and slice iteration reference implementations.
-//!
 #![allow(clippy::indexing_slicing)]
 //! Byte and slice iteration reference implementations.
 //!

--- a/crates/ffwd-kani/src/iter.rs
+++ b/crates/ffwd-kani/src/iter.rs
@@ -1,5 +1,8 @@
 //! Byte and slice iteration reference implementations.
 //!
+#![allow(clippy::indexing_slicing)]
+//! Byte and slice iteration reference implementations.
+//!
 //! Simple linear-scan implementations used as comparison targets for
 //! verifying the optimized (memchr-accelerated) production implementations.
 

--- a/crates/ffwd-kani/src/numeric.rs
+++ b/crates/ffwd-kani/src/numeric.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::indexing_slicing)]
 //! Reference numeric parsing implementations.
 
 /// Reference integer parser using `i128` accumulator to detect overflow.

--- a/crates/ffwd-lint-attrs/src/lib.rs
+++ b/crates/ffwd-lint-attrs/src/lib.rs
@@ -115,7 +115,6 @@ pub fn owned_by_actor(_attr: TokenStream, item: TokenStream) -> TokenStream {
     prepend_marker("__ffwd_owned_by_actor__", item)
 }
 
-#[allow(clippy::expect_used)]
 fn prepend_marker(marker: &str, item: TokenStream) -> TokenStream {
     let attr: TokenStream = match format!("#[doc = \"{marker}\"]").parse() {
         Ok(t) => t,

--- a/crates/ffwd-lint-attrs/src/lib.rs
+++ b/crates/ffwd-lint-attrs/src/lib.rs
@@ -117,9 +117,10 @@ pub fn owned_by_actor(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[allow(clippy::expect_used)]
 fn prepend_marker(marker: &str, item: TokenStream) -> TokenStream {
-    let attr: TokenStream = format!("#[doc = \"{marker}\"]")
-        .parse()
-        .expect("valid marker attribute");
+    let attr: TokenStream = match format!("#[doc = \"{marker}\"]").parse() {
+        Ok(t) => t,
+        Err(_) => unreachable!("hardcoded doc attribute format is valid"),
+    };
     let mut out = attr;
     out.extend(item);
     out

--- a/crates/ffwd-lint-attrs/src/lib.rs
+++ b/crates/ffwd-lint-attrs/src/lib.rs
@@ -115,6 +115,7 @@ pub fn owned_by_actor(_attr: TokenStream, item: TokenStream) -> TokenStream {
     prepend_marker("__ffwd_owned_by_actor__", item)
 }
 
+#[allow(clippy::expect_used)]
 fn prepend_marker(marker: &str, item: TokenStream) -> TokenStream {
     let attr: TokenStream = format!("#[doc = \"{marker}\"]")
         .parse()

--- a/crates/ffwd-otap-proto/build.rs
+++ b/crates/ffwd-otap-proto/build.rs
@@ -1,5 +1,4 @@
-#[allow(clippy::expect_used)]
-fn main() {
-    ffwd_proto_build::compile_with_vendored_protoc(&["proto/otap.proto"], &["proto"])
-        .expect("compile OTAP protobuf schema");
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ffwd_proto_build::compile_with_vendored_protoc(&["proto/otap.proto"], &["proto"])?;
+    Ok(())
 }

--- a/crates/ffwd-otap-proto/build.rs
+++ b/crates/ffwd-otap-proto/build.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::expect_used)]
 fn main() {
     ffwd_proto_build::compile_with_vendored_protoc(&["proto/otap.proto"], &["proto"])
         .expect("compile OTAP protobuf schema");

--- a/crates/ffwd-otap-proto/src/lib.rs
+++ b/crates/ffwd-otap-proto/src/lib.rs
@@ -9,3 +9,88 @@
 pub mod otap {
     include!(concat!(env!("OUT_DIR"), "/otap.rs"));
 }
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use prost::Message as _; // Required for encode_to_vec and decode.
+    use super::otap::{
+        ArrowPayload, ArrowPayloadType, BatchArrowRecords, BatchStatus, StatusCode,
+    };
+
+    fn roundtrip<T: prost::Message + Default + PartialEq>(msg: &T) -> bool {
+        let encoded = msg.encode_to_vec();
+        let decoded = T::decode(encoded.as_slice()).ok();
+        decoded.as_ref() == Some(msg)
+    }
+
+    #[test]
+    fn batch_arrow_records_roundtrip() {
+        let batch = BatchArrowRecords {
+            batch_id: 42,
+            arrow_payloads: vec![
+                ArrowPayload {
+                    schema_id: "schema-1".into(),
+                    r#type: ArrowPayloadType::Logs.into(),
+                    record: b"test record data".to_vec(),
+                },
+                ArrowPayload {
+                    schema_id: "schema-2".into(),
+                    r#type: ArrowPayloadType::LogAttrs.into(),
+                    record: b"another record".to_vec(),
+                },
+            ],
+            headers: b"header bytes".to_vec(),
+        };
+        assert!(roundtrip(&batch));
+    }
+
+    #[test]
+    fn arrow_payload_type_enum_variants() {
+        for variant in [
+            ArrowPayloadType::Logs,
+            ArrowPayloadType::LogAttrs,
+            ArrowPayloadType::ResourceAttrs,
+            ArrowPayloadType::ScopeAttrs,
+        ] {
+            let payload = ArrowPayload {
+                schema_id: "test".into(),
+                r#type: variant.into(),
+                record: vec![],
+            };
+            assert!(roundtrip(&payload), "roundtrip failed for {variant:?}");
+        }
+    }
+
+    #[test]
+    fn status_code_enum_variants() {
+        for variant in [StatusCode::Ok, StatusCode::Unavailable, StatusCode::InvalidArgument] {
+            let status = BatchStatus {
+                batch_id: 1,
+                status_code: variant.into(),
+                status_message: "test message".into(),
+            };
+            assert!(roundtrip(&status), "roundtrip failed for {variant:?}");
+        }
+    }
+
+    #[test]
+    fn batch_status_roundtrip() {
+        let status = BatchStatus {
+            batch_id: 99,
+            status_code: StatusCode::Unavailable.into(),
+            status_message: "service unavailable".into(),
+        };
+        assert!(roundtrip(&status));
+    }
+
+    #[test]
+    fn arrow_payload_empty_record_roundtrip() {
+        let payload = ArrowPayload {
+            schema_id: "empty".into(),
+            r#type: ArrowPayloadType::Logs.into(),
+            record: vec![],
+        };
+        assert!(roundtrip(&payload));
+    }
+}

--- a/crates/ffwd-output/src/loki.rs
+++ b/crates/ffwd-output/src/loki.rs
@@ -2071,8 +2071,14 @@ mod loki_endpoint_normalization {
 
     #[test]
     fn endpoint_without_push_path_unchanged() {
-        assert_eq!(normalize_endpoint("http://localhost:3100"), "http://localhost:3100");
-        assert_eq!(normalize_endpoint("http://localhost:3100/"), "http://localhost:3100");
+        assert_eq!(
+            normalize_endpoint("http://localhost:3100"),
+            "http://localhost:3100"
+        );
+        assert_eq!(
+            normalize_endpoint("http://localhost:3100/"),
+            "http://localhost:3100"
+        );
         assert_eq!(
             normalize_endpoint("http://localhost:3100/loki/api/v1"),
             "http://localhost:3100/loki/api/v1"

--- a/crates/ffwd-proto-build/src/lib.rs
+++ b/crates/ffwd-proto-build/src/lib.rs
@@ -6,12 +6,12 @@
 use std::path::Path;
 
 /// Compile one or more proto files with vendored `protoc`.
-#[allow(clippy::expect_used)]
 pub fn compile_with_vendored_protoc(
     protos: &[impl AsRef<Path>],
     includes: &[impl AsRef<Path>],
 ) -> std::io::Result<()> {
-    let protoc = protoc_bin_vendored::protoc_bin_path().expect("vendored protoc path");
+    let protoc = protoc_bin_vendored::protoc_bin_path()
+        .map_err(|e| std::io::Error::other(format!("vendored protoc path: {e}")))?;
     let mut config = prost_build::Config::new();
     config.protoc_executable(protoc);
     config.compile_protos(protos, includes)

--- a/crates/ffwd-proto-build/src/lib.rs
+++ b/crates/ffwd-proto-build/src/lib.rs
@@ -6,6 +6,7 @@
 use std::path::Path;
 
 /// Compile one or more proto files with vendored `protoc`.
+#[allow(clippy::expect_used)]
 pub fn compile_with_vendored_protoc(
     protos: &[impl AsRef<Path>],
     includes: &[impl AsRef<Path>],

--- a/dev-docs/CRATE_RULES.md
+++ b/dev-docs/CRATE_RULES.md
@@ -30,6 +30,7 @@ Rules and constraints for each crate. Enforced by CI, not just convention.
 | Rule | Enforcement |
 |------|-------------|
 | unsafe allowed (SIMD only) | Code review. SIMD impls only. |
+| `#![deny(clippy::indexing_slicing)]` at crate root | `#![deny]` in lib.rs. Hot-path SIMD and batch builder functions use `#[allow]` for internally-controlled indexing. Non-SIMD external data paths should use `.get()` where feasible. |
 | Implements core's ScanBuilder + CharDetector traits | Compilation |
 | proptest: SIMD output == scalar output | CI test suite |
 | Deps: core + arrow + bytes | Cargo.toml |

--- a/dev-docs/CRATE_RULES.md
+++ b/dev-docs/CRATE_RULES.md
@@ -22,6 +22,7 @@ Rules and constraints for each crate. Enforced by CI, not just convention.
 | `#![no_std]` | Compiler |
 | Zero external dependencies | Cargo.toml |
 | Oracle functions are reference implementations only — never called in production paths | Code review |
+| Every oracle documented at its definition site: what it computes, what it verifies (if any), known limitations | Code review |
 | Every public item documented | `#![warn(missing_docs)]` at crate root |
 | Internal Kani proofs verify oracle correctness | CI Kani job |
 

--- a/dev-docs/VERIFICATION.md
+++ b/dev-docs/VERIFICATION.md
@@ -190,7 +190,7 @@ Non-core Kani scope is explicitly tracked in:
 
 Status values in the contract:
 
-- `required` — this seam must include in-file Kani harnesses (`#[cfg(kani)]` + `#[kani::proof]`)
+- `required` — this seam must include in-file Kani harnesses (`#[cfg(kani)]` + `#[kani::proof]` or `#[kani::proof_for_contract]`)
 - `recommended` — pure seam where Kani is encouraged, but not a hard gate
 - `exempt` — intentionally not a Kani target, usually because the file is async/IO-heavy or still mixes shell code with policy
 
@@ -250,9 +250,12 @@ Every Kani proof MUST:
 1. Use `#[cfg(kani)]` for proof modules; use `#[cfg_attr(kani, kani::requires(...))]` /
    `#[cfg_attr(kani, kani::ensures(...))]` for function contracts on production code
 2. Follow naming: `verify_<function>_<property>`
-3. Add `#[kani::unwind(N)]` for any loops (N = max iterations + 1 or 2)
+3. Add `#[kani::unwind(N)]` for any loops (N = max iterations + 1 or 2);
+   use `#[kani::unwind(0)]` for loop-free proofs
 4. Use appropriate input sizes (8–32 bytes for parsing, full range for bitmasks)
 5. Add `kani::cover!()` to guard against vacuous proofs
+6. For files listed in `kani-boundary-contract.toml` with status `required`,
+   `#[kani::proof_for_contract]` also satisfies the proof marker requirement
 
 ### Best practices
 

--- a/dev-docs/references/kani-verification.md
+++ b/dev-docs/references/kani-verification.md
@@ -20,13 +20,14 @@ practical Kani execution details.
 ## Mental Model (Read First)
 
 1. `kani::any()` is universal quantification, not sampling.
-   - A passing proof means all values in the bounded domain satisfy assertions.
+   - A passing proof means ALL values in the bounded domain satisfy assertions.
 2. Loops are bounded by unwind depth.
-   - Use `#[kani::unwind(N)]` when loops exist.
-3. `kani::assume()` shrinks the explored domain.
-   - Over-constraining can make proofs vacuous.
+   - Use `#[kani::unwind(N)]` when loops exist. N = max_iterations + 1 (margin for termination check).
+3. `kani::assume()` shrinks the explored domain — over-constraining makes proofs vacuous.
 4. Kani auto-checks memory-safety classes (panic/overflow/oob/etc) in harnesses,
    but behavioral correctness still needs explicit assertions and meaningful oracles.
+5. `kani::any_where(|x| predicate)` generates a value satisfying the predicate —
+   prefer this over `kani::any()` + separate `assume()`.
 
 ## Repository Policy (Kani-Specific)
 
@@ -34,10 +35,11 @@ Follow these defaults unless `dev-docs/VERIFICATION.md` says otherwise:
 
 - Put harnesses in `#[cfg(kani)] mod verification` in the same file.
 - Name harnesses `verify_<function>_<property>`.
-- Add `#[kani::unwind(N)]` on looped harnesses.
-- Add `kani::cover!` in non-trivial harnesses.
+- Add `#[kani::unwind(N)]` on looped harnesses. For loop-free proofs, use `#[kani::unwind(0)]`.
+- Add `kani::cover!` in non-trivial harnesses to confirm interesting paths are reachable.
+- Prefer `kani::any_where(|v| predicate)` over `kani::any()` + `kani::assume(predicate)`.
 - If using `kani::assume()`, add 2+ `kani::cover!()` guards for vacuity checks.
-- Prefer `kani::any_where()` over broad `any()` plus many detached `assume()` calls.
+- `#[kani::proof_for_contract]` counts as a valid proof marker for boundary-contract purposes.
 
 Proofs are typically required for:
 - Parser/framer primitives in `ffwd-core`
@@ -62,8 +64,10 @@ just kani-boundary
 Focused iteration:
 
 ```bash
-RUSTC_WRAPPER="" cargo kani -p ffwd-core --harness verify_my_harness -Z function-contracts -Z mem-predicates -Z stubbing
-RUSTC_WRAPPER="" cargo kani -p ffwd-core -Z function-contracts -Z mem-predicates -Z stubbing
+RUSTC_WRAPPER="" cargo kani -p ffwd-core --harness verify_my_harness \
+  -Z function-contracts -Z mem-predicates -Z stubbing
+RUSTC_WRAPPER="" cargo kani -p ffwd-core \
+  -Z function-contracts -Z mem-predicates -Z stubbing
 ```
 
 Guardrail and contract checks:
@@ -83,7 +87,7 @@ mod verification {
     use super::*;
 
     #[kani::proof]
-    #[kani::unwind(N)] // Choose N from the maximum loop iterations (+1 or +2 margin)
+    #[kani::unwind(17)] // max 16 bytes + 1 for termination check
     fn verify_my_fn_no_panic() {
         let input: [u8; 16] = kani::any();
         let _ = my_fn(&input);
@@ -100,11 +104,12 @@ mod verification {
     use super::*;
 
     fn oracle(input: &[u8]) -> u64 {
+        // Independent reference implementation — must NOT call `my_fn`
         input.iter().map(|b| *b as u64).sum()
     }
 
     #[kani::proof]
-    #[kani::unwind(N)] // Choose N from the maximum loop iterations (+1 or +2 margin)
+    #[kani::unwind(17)]
     fn verify_my_fn_matches_oracle() {
         let input: [u8; 16] = kani::any();
         assert_eq!(my_fn(&input), oracle(&input));
@@ -113,7 +118,32 @@ mod verification {
 }
 ```
 
-### 3) State transition invariants
+### 3) Loop-free proof
+
+```rust
+#[kani::proof]
+#[kani::unwind(0)] // no loops — no unwind needed
+fn verify_my_const_fn() {
+    let x: u64 = kani::any();
+    assert!(my_const_fn(x) >= 1);
+}
+```
+
+### 4) `any_where` pattern (preferred over `any` + `assume`)
+
+```rust
+// Prefer this:
+let len: usize = kani::any_where(|&l: &usize| l <= 16);
+
+// Over this:
+let len: usize = kani::any();
+kani::assume(len <= 16);
+```
+
+`any_where` keeps the constraint co-located with value generation and avoids
+a two-step generate-then-constrain pattern.
+
+### 5) State transition invariants
 
 ```rust
 #[cfg(kani)]
@@ -121,7 +151,7 @@ mod verification {
     use super::*;
 
     #[kani::proof]
-    #[kani::unwind(N)] // Choose N from the maximum loop iterations (+1 or +2 margin)
+    #[kani::unwind(N)]
     fn verify_transition_preserves_invariant() {
         let state = State::arbitrary();
         let next = step(state);
@@ -131,51 +161,123 @@ mod verification {
 }
 ```
 
-### 4) Symbolic ordering/permutation exploration
-
-For order-sensitive logic, model operation ordering symbolically with
-`any_where()` rather than hardcoding one sequence.
-
-Repository examples:
-- `crates/ffwd-types/src/pipeline/lifecycle.rs`
-
-### 5) Compositional contracts (`proof_for_contract` + `stub_verified`)
+### 6) Compositional contracts (`proof_for_contract` + `stub_verified`)
 
 Use contracts to keep deep call chains tractable.
 
-Repository examples:
-- `crates/ffwd-core/src/structural.rs`
-- `crates/ffwd-core/src/otlp.rs`
-
 Workflow:
-1. Add `#[cfg_attr(kani, kani::requires(...))]` / `ensures(...)` contracts.
-2. Add `#[kani::proof_for_contract(fn_name)]` harnesses.
+1. Add `#[cfg_attr(kani, kani::requires(...))]` / `ensures(...)` contracts to the production function.
+2. Add `#[kani::proof_for_contract(fn_name)]` harnesses to verify the contract.
 3. In higher-level harnesses, use `#[kani::stub_verified(fn_name)]`.
 
 This reduces solver state explosion by replacing re-proving callees with their
 already-verified contracts.
 
+```rust
+// Production function with contract
+#[cfg_attr(kani, kani::ensures(|result: &usize| *result >= 1 && *result <= 10))]
+pub fn varint_len(value: u64) -> usize { ... }
+
+// Proof harness
+#[kani::proof_for_contract(varint_len)]
+#[kani::unwind(12)]
+fn verify_varint_len_contract() {
+    let val: u64 = kani::any();
+    let res = varint_len(val);
+    kani::cover!(res == 1, "single-byte");
+    kani::cover!(res == 10, "max-byte");
+}
+
+// Caller harness using stub
+#[kani::proof]
+#[kani::stub_verified(varint_len)]
+fn verify_deep_caller() { ... }
+```
+
+Repository examples:
+- `crates/ffwd-core/src/structural.rs` — `compute_real_quotes` + `prefix_xor`
+- `crates/ffwd-core/src/otlp.rs` — `varint_len`, `tag_size`, `bytes_field_total_size`
+- `crates/ffwd-core/src/json_scanner.rs` — `skip_whitespace`, `skip_bare_value`
+
 ## Solver And Bound Tuning
 
-- Start with default solver.
-- If a harness is consistently above ~10s, add `#[kani::solver(kissat)]` with a short
-  inline comment explaining why the override is needed.
-- Keep unwind bounds realistic and explicit; too high inflates solve time,
-  too low yields inconclusive behavior.
-- Prefer proving smaller pure components compositionally over one monolith.
+| Solver | Best for | Notes |
+|--------|---------|-------|
+| default (CADical) | General purpose | Default for most proofs |
+| `kissat` | Arithmetic-heavy: varint, bitmask, shift-heavy code | 47% of slow proofs benefit; up to 265x speedup |
+| `z3` | Bit-vector heavy, old proof infrastructure | Fallback |
+| `bitwuzla` | Bit-vector arithmetic | Try if kissat/z3 slow |
+
+```rust
+#[kani::proof]
+#[kani::solver(kissat)] // arithmetic-heavy varint bit ops
+fn verify_varint_len() { ... }
+```
+
+Unwind bound guide:
+- `#[kani::unwind(0)]` — loop-free proof, no unwind needed
+- `#[kani::unwind(N)]` — N = max loop iterations + 1 (margin for termination check)
+- Too low: Kani reports "underunwind" or inconclusive behavior
+- Too high: solver time increases without benefit
+- Add +1 or +2 margin over exact loop count to cover termination check
+
+## Vacuity Detection
+
+A proof can pass trivially if assumptions or constraints make the domain empty.
+Detect vacuity with `kani::cover!`:
+
+```rust
+let len: usize = kani::any();
+kani::assume(len <= 16);
+// MUST have at least 2 cover statements:
+kani::cover!(len == 0, "empty case reachable");
+kani::cover!(len > 0, "non-empty case reachable");
+```
+
+If a cover reports **UNSATISFIABLE**, the proof is vacuous — the constrained
+domain is empty and the assertions are meaningless.
+
+When to specifically check for vacuity:
+- After any `kani::assume()`
+- When inputs are bounded with `kani::any_where()`
+- In proofs with contracts (`#[requires]`, `#[ensures]`)
+
+## Golden-Copy Oracle Limitation
+
+Oracle equivalence proofs compare a production implementation against a reference
+("oracle") implementation. The oracle must be **structurally independent** — if
+both use the same algorithm or share internal logic, the proof cannot detect a
+bug that infects both.
+
+**Limitation:** A golden-copy oracle (structurally identical to production) will
+NOT catch shared-logic bugs, implementation mistakes that both copies share, or
+compiler bugs in shared helper functions.
+
+**Mitigation strategies:**
+1. **Encode-based verification** — prove properties by encoding and checking output
+   (e.g., `encode_varint` then verify decoded length matches `varint_len`).
+   This catches algorithmic mistakes without needing a second implementation.
+2. **Cross-validation** — keep both encode-based and oracle-based proofs. If both
+   pass, confidence is much higher.
+3. **Different-algorithm oracle** — if possible, use a fundamentally different
+   algorithm (e.g., Fliegel-Van Flandern JDN vs Hinnant date conversion).
+4. **Document the limitation** in the oracle's doc comment when the oracle is
+   golden-copy style.
+
+Repository example of cross-validation:
+- `verify_varint_len_matches_encode` (encode-based) + `verify_varint_len_vs_oracle`
+  (oracle-based) both prove `varint_len` — neither alone is sufficient.
 
 ## Failure Triage
 
-- `cover!` unsat:
-  - assumptions are over-constrained; relax domain.
-- Timeout/very slow solve:
-  - lower input width, split proof, add contracts/stubs, try `kissat`.
-- Loop-related failure:
-  - revisit `#[kani::unwind(N)]` and loop assumptions.
-- Oracle mismatch:
-  - validate oracle independence from production implementation.
-- Proof passes but seems weak:
-  - add branch-specific assertions and additional covers.
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `cover!` UNSATISFIABLE | Over-constrained domain | Relax `kani::assume()` bounds or use `any_where` |
+| Timeout / very slow solve | Large input width or deep call chain | Lower input width, split proof, add contracts/stubs, try `kissat` |
+| Loop-related failure | Under-unwind or missing `#[kani::unwind]` | Increase unwind bound |
+| Oracle mismatch | Oracle/production logic mismatch | Validate oracle independence; check for off-by-one in position tracking |
+| Proof passes but seems weak | Missing behavioral assertions | Add branch-specific assertions and additional covers |
+| "No orbits found" / spurious alloc failures | `Vec::new()` or `vec![x; kani::any()]` in harness | Use `kani::any::<[u8; N]>()` or `kani::vec::any_vec::<T, N>()` |
 
 ## Review Checklist (Kani PRs)
 
@@ -183,8 +285,9 @@ already-verified contracts.
 - Is the property behavioral (not tautological)?
 - Are assumptions minimal and visible?
 - Do covers demonstrate interesting-path reachability?
-- Are unwind bounds justified?
+- Are unwind bounds justified? Is `#[kani::unwind(0)]` used for loop-free proofs?
 - If contracts/stubs are used, are there corresponding `proof_for_contract` harnesses?
+- Is the oracle independent from the production function (golden-copy limitation documented)?
 - If behavior/invariants changed, were docs and guardrails updated?
 
 ## Shared Verification Utilities (`ffwd-kani`)
@@ -212,8 +315,20 @@ Add `ffwd-kani` as a dependency:
 ffwd-kani = { version = "0.1.0", path = "../ffwd-kani" }
 ```
 
-Oracle functions are only called from `#[cfg(kani)]` and `#[cfg(test)]` blocks—
+Oracle functions are only called from `#[cfg(kani)]` and `#[cfg(test)]` blocks —
 never from production code paths.
+
+**Do not add an oracle inventory here.** The authoritative record of which oracles
+exist and what they verify lives in the code:
+- Each oracle is documented at its definition site in `crates/ffwd-kani/src/`
+- Each oracle's proof is in the same file, co-located with the oracle
+- Production linkages are documented in `dev-docs/VERIFICATION.md` per-module status,
+  which is already kept up to date as part of PR review
+
+When adding an oracle, document at the definition site:
+- What it computes
+- What production function it verifies (if any)
+- Any known limitations (e.g., golden-copy limitation)
 
 ## Repo Pointers
 
@@ -221,7 +336,9 @@ never from production code paths.
 - Crate constraints: `dev-docs/CRATE_RULES.md`
 - Boundary contract source: `dev-docs/verification/kani-boundary-contract.toml`
 - Boundary validator: `scripts/verify_kani_boundary_contract.py`
+- Oracle proof audit guide: `dev-docs/VERIFICATION.md` → per-module table
 
 ## Upstream
 
 - https://model-checking.github.io/kani/
+- Firecracker Kani patterns: `kani::any_where`, `#[kani::unwind(0)]`, stubbing at boundaries


### PR DESCRIPTION
## Summary

Two fixes merged into one PR:

### Fix #2584: Reject negative `RetryConfig.max_attempts`
- Change `RetryConfig.max_attempts` from `Option<i32>` to `Option<u32>` in `shared.rs`
- Add 3 validation tests confirming negative values are rejected, zero and positive are accepted

### Fix #2631: Add tests to `ffwd-otap-proto` and `ffwd-config-wasm`
- **ffwd-otap-proto** (5 new tests): Roundtrip prost encode/decode tests for all proto message types (`BatchArrowRecords`, `ArrowPayload`, `BatchStatus`) and all enum variants (`ArrowPayloadType`, `StatusCode`).
- **ffwd-config-wasm** (6 new tests): Template lookup tests that verify all registered input/output template IDs return `Some`, invalid IDs return `None`, and known templates have non-empty snippets.

## Testing

```bash
cargo test -p ffwd-otap-proto   # 5 tests
cargo test -p ffwd-config-wasm  # 6 tests
cargo test -p ffwd-config       # 3 new #2584 tests
```

All crates previously returned 0 tests. Both fixes now pass `just ci`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject negative `RetryConfig.max_attempts` values by changing its type to `u32`
> - Changes `max_attempts` in [`RetryConfig`](https://github.com/strawgate/fastforward/pull/2682/files#diff-ae33b990c0b4f0f73c8cd98eec648027f1ffc24afa380182a180aa18d3301f62) from `Option<i32>` to `Option<u32>`, so negative values now fail deserialization instead of being silently accepted.
> - Adds integration tests in [`validation_gaps.rs`](https://github.com/strawgate/fastforward/pull/2682/files#diff-73ebf3fef05701db66e2b97c10eeffd3bd0e0cba5e330bf2d7671602d749a89d) confirming that negative values are rejected and that `0` and positive values parse correctly.
> - Also introduces `#![deny(clippy::indexing_slicing)]` at the crate root of `ffwd-core`, `ffwd-arrow`, and `ffwd-io`, with targeted `#[allow(...)]` annotations or safe accessor refactors across the codebase to comply.
> - Several small panic-to-error or panic-to-skip fixes were made while resolving the lint (e.g. `materialize_all`, `begin_batch`, `scatter_values`, `load_block`).
> - Behavioral Change: any existing config with a negative `max_attempts` will now fail to load.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 628a326.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->