### PR TITLE
fix: copy xtask in Dockerfile.e2e

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -14,6 +14,7 @@ WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
 COPY .cargo/ .cargo/
 COPY crates/ crates/
+COPY xtask/ xtask/
 RUN --mount=type=cache,target=/src/target \
     --mount=type=cache,target=/usr/local/cargo/registry \
     CARGO_BUILD_RUSTC_WRAPPER="" \


### PR DESCRIPTION
## Summary
- Add missing COPY xtask/ xtask/ to Dockerfile.e2e to fix E2E image build failure
- The workspace includes xtask/ as a member but the Dockerfile only copied crates/

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `xtask/` directory missing from `Dockerfile.e2e` build context
> Adds a `COPY xtask/ xtask/` instruction to [Dockerfile.e2e](https://github.com/strawgate/fastforward/pull/2683/files#diff-6a44760ef8623aacfb197f34a33a30d7d86ba096e84be607869ee2ea8f20cafc) so the `xtask` directory is present during the e2e image build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c77e4f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->