### PR TITLE
fix: reject negative RetryConfig.max_attempts

### DIFF
--- a/crates/ffwd-config/src/shared.rs
+++ b/crates/ffwd-config/src/shared.rs
@@ -60,7 +60,7 @@ pub struct TlsServerConfig {
 #[serde(deny_unknown_fields)]
 pub struct RetryConfig {
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_attempts: Option<i32>,
+    pub max_attempts: Option<u32>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub initial_backoff_secs: Option<PositiveSecs>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]

--- a/crates/ffwd-config/src/shared.rs
+++ b/crates/ffwd-config/src/shared.rs
@@ -59,6 +59,9 @@ pub struct TlsServerConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RetryConfig {
+    /// Maximum retry attempts for the sink.
+    /// `None` uses the sink default.
+    /// `Some(0)` means no retry limit.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub max_attempts: Option<u32>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1,4 +1,4 @@
-use ffwd_config::Config;
+use ffwd_config::{Config, OutputConfigV2};
 use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
@@ -1467,11 +1467,19 @@ pipelines:
         retry:
           max_attempts: 3
 "#;
-    let result = Config::load_str(yaml);
-    assert!(
-        result.is_ok(),
-        "elasticsearch with max_attempts=3 should be accepted, but got: {:?}",
-        result
+    let config = Config::load_str(yaml)
+        .expect("elasticsearch with max_attempts=3 should be accepted");
+    let output = config.pipelines.get("test")
+        .expect("pipeline 'test' should exist")
+        .outputs.first()
+        .expect("output #0 should exist");
+    let OutputConfigV2::Elasticsearch(es) = output else {
+        panic!("output #0 should be Elasticsearch");
+    };
+    assert_eq!(
+        es.retry.as_ref().and_then(|r| r.max_attempts),
+        Some(3),
+        "elasticsearch retry.max_attempts should be Some(3)"
     );
 }
 
@@ -1490,10 +1498,18 @@ pipelines:
         retry:
           max_attempts: 0
 "#;
-    let result = Config::load_str(yaml);
-    assert!(
-        result.is_ok(),
-        "elasticsearch with max_attempts=0 should be accepted (zero means no retry limit), but got: {:?}",
-        result
+    let config = Config::load_str(yaml)
+        .expect("elasticsearch with max_attempts=0 should be accepted");
+    let output = config.pipelines.get("test")
+        .expect("pipeline 'test' should exist")
+        .outputs.first()
+        .expect("output #0 should exist");
+    let OutputConfigV2::Elasticsearch(es) = output else {
+        panic!("output #0 should be Elasticsearch");
+    };
+    assert_eq!(
+        es.retry.as_ref().and_then(|r| r.max_attempts),
+        Some(0),
+        "elasticsearch retry.max_attempts should be Some(0)"
     );
 }

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1425,3 +1425,75 @@ pipelines:
     Config::load_str(yaml)
         .expect("push path with trailing slash should be accepted (normalized by output)");
 }
+
+#[test]
+fn issue_2584_retry_max_attempts_rejects_negative_values() {
+    for max_attempts in [-1, -100] {
+        let yaml = format!(
+            r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: {max_attempts}
+"#,
+        );
+        let result = Config::load_str(&yaml);
+        assert!(
+            result.is_err(),
+            "elasticsearch with max_attempts={max_attempts} should be rejected, but got Ok"
+        );
+    }
+}
+
+#[test]
+fn issue_2584_retry_max_attempts_accepts_positive_values() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: 3
+"#;
+    let result = Config::load_str(yaml);
+    assert!(
+        result.is_ok(),
+        "elasticsearch with max_attempts=3 should be accepted, but got: {:?}",
+        result
+    );
+}
+
+#[test]
+fn issue_2584_retry_max_attempts_accepts_zero() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: 0
+"#;
+    let result = Config::load_str(yaml);
+    assert!(
+        result.is_ok(),
+        "elasticsearch with max_attempts=0 should be accepted (zero means no retry limit), but got: {:?}",
+        result
+    );
+}

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1428,8 +1428,9 @@ pipelines:
 
 #[test]
 fn issue_2584_retry_max_attempts_rejects_negative_values() {
-    for max_attempts in [-1, -100] {
-        let yaml = format!(
+    let configs: &[(&str, &str)] = &[
+        (
+            "elasticsearch",
             r#"
 pipelines:
   test:
@@ -1441,13 +1442,37 @@ pipelines:
       - type: elasticsearch
         endpoint: http://localhost:9200
         retry:
-          max_attempts: {max_attempts}
+          max_attempts: -1
 "#,
-        );
-        let result = Config::load_str(&yaml);
+        ),
+        (
+            "loki",
+            r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: loki
+        endpoint: http://localhost:3100
+        retry:
+          max_attempts: -100
+"#,
+        ),
+    ];
+
+    for (sink_name, yaml) in configs {
+        let result = Config::load_str(yaml);
         assert!(
             result.is_err(),
-            "elasticsearch with max_attempts={max_attempts} should be rejected, but got Ok"
+            "{sink_name} with negative max_attempts should be rejected, but got Ok"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("invalid value") || err_msg.contains("max_attempts"),
+            "{sink_name} error should indicate invalid value for max_attempts, got: {err_msg}"
         );
     }
 }
@@ -1467,11 +1492,14 @@ pipelines:
         retry:
           max_attempts: 3
 "#;
-    let config = Config::load_str(yaml)
-        .expect("elasticsearch with max_attempts=3 should be accepted");
-    let output = config.pipelines.get("test")
+    let config =
+        Config::load_str(yaml).expect("elasticsearch with max_attempts=3 should be accepted");
+    let output = config
+        .pipelines
+        .get("test")
         .expect("pipeline 'test' should exist")
-        .outputs.first()
+        .outputs
+        .first()
         .expect("output #0 should exist");
     let OutputConfigV2::Elasticsearch(es) = output else {
         panic!("output #0 should be Elasticsearch");
@@ -1498,11 +1526,14 @@ pipelines:
         retry:
           max_attempts: 0
 "#;
-    let config = Config::load_str(yaml)
-        .expect("elasticsearch with max_attempts=0 should be accepted");
-    let output = config.pipelines.get("test")
+    let config =
+        Config::load_str(yaml).expect("elasticsearch with max_attempts=0 should be accepted");
+    let output = config
+        .pipelines
+        .get("test")
         .expect("pipeline 'test' should exist")
-        .outputs.first()
+        .outputs
+        .first()
         .expect("output #0 should exist");
     let OutputConfigV2::Elasticsearch(es) = output else {
         panic!("output #0 should be Elasticsearch");


### PR DESCRIPTION
## Summary

Fixes #2584: `RetryConfig.max_attempts` was declared as `Option<i32>`, allowing negative values to pass YAML deserialization. Changed to `Option<u32>` to reject negative values at parse time.

## Changes

- `crates/ffwd-config/src/shared.rs`: `max_attempts: Option<i32>` → `max_attempts: Option<u32>` + doc comment
- `crates/ffwd-config/tests/validation_gaps.rs`: 3 new validation tests

## Tests

```
test issue_2584_retry_max_attempts_rejects_negative_values ... ok
test issue_2584_retry_max_attempts_accepts_zero ... ok
test issue_2584_retry_max_attempts_accepts_positive_values ... ok
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject negative values for `RetryConfig.max_attempts`
> Changes the `max_attempts` field in `RetryConfig` from `Option<i32>` to `Option<u32>` in [shared.rs](https://github.com/strawgate/fastforward/pull/2684/files#diff-ae33b990c0b4f0f73c8cd98eec648027f1ffc24afa380182a180aa18d3301f62), so negative values are rejected at deserialization. `None` uses the default behavior; `Some(0)` means no retry limit. Tests cover rejection of negative values and acceptance of zero and positive values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d7626e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->