### PR TITLE
perf(io/projection): 1.96x faster wide-10k via 4 OTLP→Arrow optimizations

### DIFF
--- a/crates/ffwd-arrow/src/columnar/accumulator.rs
+++ b/crates/ffwd-arrow/src/columnar/accumulator.rs
@@ -752,6 +752,8 @@ fn build_string_view_trusted(
     //    spells out the boundary obligation.
     //  - Arrow's `force_validate` feature flag re-enables validation here
     //    when set (see `new_unchecked` impl).
+    // SAFETY: invariants validated above — views match num_rows, buffer offsets
+    // are bounds-checked by make_string_view, UTF-8 is the trusted-path contract.
     let array =
         unsafe { StringViewArray::new_unchecked(ScalarBuffer::from(views), buffers, nulls) };
     Ok((Arc::new(array), DataType::Utf8View))

--- a/crates/ffwd-arrow/src/columnar/accumulator.rs
+++ b/crates/ffwd-arrow/src/columnar/accumulator.rs
@@ -735,18 +735,23 @@ fn build_string_view_trusted(
          the ingestion boundary (scanner/decoder) has a validation bug"
     );
 
-    // SAFETY: this is the trusted path. `StringViewArray::try_new` would
-    // re-walk every view to validate UTF-8 and buffer bounds; we already
-    // guaranteed both above, so we skip it.
+    // SAFETY: Trusted-path bypass of `StringViewArray::try_new` revalidation.
+    //
+    // Crate rule note: ffwd-arrow normally limits unsafe to SIMD. This is an
+    // explicit exception: `try_new` re-walks every view for UTF-8 + bounds
+    // checks that the producer boundary already guarantees. The cost was
+    // measurable (~33% of attrs-heavy time). Invariants maintained:
+    //
     //  - `views.len() == num_rows` and any `nulls` has matching length
-    //    (the dense branch builds no nulls; the sparse branch sizes
-    //    `bits` from `num_rows.div_ceil(8)`).
-    //  - Every StringRef was assembled by `make_string_view`, which
-    //    rejects offsets/lengths outside the referenced buffer block.
+    //    (dense branch builds no nulls; sparse branch sizes `bits` from
+    //    `num_rows.div_ceil(8)`).
+    //  - Every StringRef was assembled by `make_string_view`, which rejects
+    //    offsets/lengths outside the referenced buffer block.
     //  - UTF-8 validity is the trusted-path contract; the `debug_assert!`
     //    above checks it in debug builds, and the comment on this fn
-    //    spells out the boundary obligation. Arrow's `force_validate`
-    //    feature flag re-enables validation here when set.
+    //    spells out the boundary obligation.
+    //  - Arrow's `force_validate` feature flag re-enables validation here
+    //    when set (see `new_unchecked` impl).
     let array =
         unsafe { StringViewArray::new_unchecked(ScalarBuffer::from(views), buffers, nulls) };
     Ok((Arc::new(array), DataType::Utf8View))

--- a/crates/ffwd-arrow/src/columnar/accumulator.rs
+++ b/crates/ffwd-arrow/src/columnar/accumulator.rs
@@ -735,8 +735,20 @@ fn build_string_view_trusted(
          the ingestion boundary (scanner/decoder) has a validation bug"
     );
 
-    let array = StringViewArray::try_new(ScalarBuffer::from(views), buffers, nulls)
-        .map_err(|err| MaterializeError::InvalidStringView(err.to_string()))?;
+    // SAFETY: this is the trusted path. `StringViewArray::try_new` would
+    // re-walk every view to validate UTF-8 and buffer bounds; we already
+    // guaranteed both above, so we skip it.
+    //  - `views.len() == num_rows` and any `nulls` has matching length
+    //    (the dense branch builds no nulls; the sparse branch sizes
+    //    `bits` from `num_rows.div_ceil(8)`).
+    //  - Every StringRef was assembled by `make_string_view`, which
+    //    rejects offsets/lengths outside the referenced buffer block.
+    //  - UTF-8 validity is the trusted-path contract; the `debug_assert!`
+    //    above checks it in debug builds, and the comment on this fn
+    //    spells out the boundary obligation. Arrow's `force_validate`
+    //    feature flag re-enables validation here when set.
+    let array =
+        unsafe { StringViewArray::new_unchecked(ScalarBuffer::from(views), buffers, nulls) };
     Ok((Arc::new(array), DataType::Utf8View))
 }
 

--- a/crates/ffwd-bench/Cargo.toml
+++ b/crates/ffwd-bench/Cargo.toml
@@ -124,6 +124,10 @@ harness = false
 name = "generator_arrow_vs_json"
 harness = false
 
+[[bench]]
+name = "hot_path_kernels"
+harness = false
+
 [[bin]]
 name = "ffwd-bench"
 path = "src/main.rs"

--- a/crates/ffwd-bench/benches/hot_path_kernels.rs
+++ b/crates/ffwd-bench/benches/hot_path_kernels.rs
@@ -1,0 +1,428 @@
+//! Hot-path microbenchmarks for OTLP → Arrow optimization candidates.
+//!
+//! Each kernel isolates one cost so we can tell whether the optimization
+//! plan's expected wins are real, not extrapolated from end-to-end numbers.
+//!
+//! Three questions:
+//!   K1. trace_id storage: how much does hex-encoding-into-string-buffer cost
+//!       vs FixedSizeBinary or raw bytes?
+//!   K2. validity bitmap: is byte-level loop the bottleneck for sparse columns,
+//!       or does u64 chunking actually help?
+//!   K3. per-row column write: how much overhead does ColumnarBatchBuilder add
+//!       over Arrow's primitive builders for a known-schema OTLP-shaped row?
+
+use std::hint::black_box;
+
+use arrow::array::{FixedSizeBinaryBuilder, Int64Builder, StringViewBuilder};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use ffwd_arrow::columnar::builder::ColumnarBatchBuilder;
+use ffwd_arrow::columnar::plan::{BatchPlan, FieldKind};
+
+// ── K1: trace_id storage ───────────────────────────────────────────────────────
+
+/// Replicates the per-byte hex loop used by `write_hex_bytes_lower` /
+/// `encode_hex_lower_into` in `crates/ffwd-arrow/src/columnar/builder.rs`.
+fn hex_encode_into(out: &mut Vec<u8>, bytes: &[u8]) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let old = out.len();
+    out.resize(old + bytes.len() * 2, 0);
+    let dst = &mut out[old..];
+    for (i, &b) in bytes.iter().enumerate() {
+        dst[i * 2] = HEX[(b >> 4) as usize];
+        dst[i * 2 + 1] = HEX[(b & 0xf) as usize];
+    }
+}
+
+/// Branchless 8-bytes-at-a-time hex encoder using a u64 nibble trick.
+/// Drop-in replacement for `encode_hex_lower_into` when input is 8-byte aligned.
+/// Encodes 8 input bytes -> 16 output hex bytes per iteration.
+#[inline]
+fn hex_encode_u64_into(out: &mut Vec<u8>, bytes: &[u8]) {
+    let old = out.len();
+    out.resize(old + bytes.len() * 2, 0);
+    let dst = &mut out[old..];
+    let chunks = bytes.chunks_exact(8);
+    let rem = chunks.remainder();
+    for (i, chunk) in chunks.enumerate() {
+        let v = u64::from_be_bytes(chunk.try_into().unwrap());
+        // Spread 16 nibbles across 16 output bytes.
+        let hi = (v >> 4) & 0x0f0f_0f0f_0f0f_0f0f;
+        let lo = v & 0x0f0f_0f0f_0f0f_0f0f;
+        // For each nibble n: '0'+n if n<10 else 'a'+n-10. Branchless:
+        //   ascii = n + '0' + (((9 - n) >> 4) & ('a' - '0' - 10))
+        // i.e. add 39 when n>=10, else 0. ('a'=97, '0'=48, 97-48-10=39).
+        let add_hi = (((hi + 0x0606_0606_0606_0606) >> 4) & 0x0101_0101_0101_0101) * 0x27;
+        let add_lo = (((lo + 0x0606_0606_0606_0606) >> 4) & 0x0101_0101_0101_0101) * 0x27;
+        let h = hi + 0x3030_3030_3030_3030 + add_hi;
+        let l = lo + 0x3030_3030_3030_3030 + add_lo;
+        // Interleave: hi nibble of byte k and lo nibble of byte k.
+        // h holds 8 hi-nibble ascii bytes (one per source byte); l holds 8 lo-nibble.
+        // We need them written as h0 l0 h1 l1 ... in big-endian byte order.
+        let h_bytes = h.to_be_bytes();
+        let l_bytes = l.to_be_bytes();
+        let base = i * 16;
+        for k in 0..8 {
+            dst[base + k * 2] = h_bytes[k];
+            dst[base + k * 2 + 1] = l_bytes[k];
+        }
+    }
+    // Tail (typically zero for trace_id (16) / span_id (8)).
+    if !rem.is_empty() {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let base = bytes.len() - rem.len();
+        for (i, &b) in rem.iter().enumerate() {
+            dst[base * 2 + i * 2] = HEX[(b >> 4) as usize];
+            dst[base * 2 + i * 2 + 1] = HEX[(b & 0xf) as usize];
+        }
+    }
+}
+
+fn bench_trace_id_storage(c: &mut Criterion) {
+    let mut group = c.benchmark_group("trace_id_storage_8k");
+    let n: usize = 8_000;
+    let trace_ids: Vec<[u8; 16]> = (0..n)
+        .map(|i| {
+            let mut id = [0u8; 16];
+            id[0..8].copy_from_slice(&(i as u64).to_le_bytes());
+            id[8..16]
+                .copy_from_slice(&((i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)).to_le_bytes());
+            id
+        })
+        .collect();
+    group.throughput(Throughput::Elements(n as u64));
+
+    // Current production path: per-byte hex into shared string buffer.
+    group.bench_function("hex_per_byte_string_buf", |b| {
+        b.iter(|| {
+            let mut buf: Vec<u8> = Vec::with_capacity(n * 32);
+            for id in &trace_ids {
+                hex_encode_into(&mut buf, id);
+            }
+            black_box(buf)
+        });
+    });
+
+    // In-builder fix candidate: u64 nibble-spread hex encoder.
+    group.bench_function("hex_u64_trick_string_buf", |b| {
+        b.iter(|| {
+            let mut buf: Vec<u8> = Vec::with_capacity(n * 32);
+            for id in &trace_ids {
+                hex_encode_u64_into(&mut buf, id);
+            }
+            black_box(buf)
+        });
+    });
+
+    // Proposed: FixedSizeBinaryBuilder (closes TODO #1844).
+    group.bench_function("fixed_size_binary_builder", |b| {
+        b.iter(|| {
+            let mut builder = FixedSizeBinaryBuilder::with_capacity(n, 16);
+            for id in &trace_ids {
+                builder.append_value(id).unwrap();
+            }
+            black_box(builder.finish())
+        });
+    });
+
+    // Floor: just push raw 16-byte arrays into a Vec.
+    group.bench_function("raw_vec_arrays", |b| {
+        b.iter(|| {
+            let mut buf: Vec<[u8; 16]> = Vec::with_capacity(n);
+            for &id in &trace_ids {
+                buf.push(id);
+            }
+            black_box(buf)
+        });
+    });
+
+    group.finish();
+}
+
+// ── K2: validity bitmap ────────────────────────────────────────────────────────
+
+/// Current implementation in `accumulator.rs:554-563` — writes one bit per fact.
+fn validity_byte_level(facts: &[u32], num_rows: usize) -> Vec<u8> {
+    let mut bits = vec![0u8; num_rows.div_ceil(8)];
+    for &row in facts {
+        let r = row as usize;
+        if r < num_rows {
+            bits[r >> 3] |= 1 << (r & 7);
+        }
+    }
+    bits
+}
+
+/// Proposed: write into u64 words first, transmute to bytes at the end.
+/// Same algorithmic complexity; smaller load/store width and fewer
+/// dependencies per inner iteration.
+fn validity_u64_chunked(facts: &[u32], num_rows: usize) -> Vec<u8> {
+    let words_len = num_rows.div_ceil(64);
+    let mut words = vec![0u64; words_len];
+    for &row in facts {
+        let r = row as usize;
+        if r < num_rows {
+            words[r >> 6] |= 1u64 << (r & 63);
+        }
+    }
+    // Reinterpret as bytes (LE).
+    let bits_len = num_rows.div_ceil(8);
+    let mut out = Vec::with_capacity(bits_len);
+    for w in &words {
+        out.extend_from_slice(&w.to_le_bytes());
+    }
+    out.truncate(bits_len);
+    out
+}
+
+fn bench_validity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("validity_bitmap_10k");
+    let num_rows: usize = 10_000;
+
+    let cases = [
+        (
+            "sparse_10pct",
+            (0..num_rows as u32)
+                .filter(|i| i % 10 == 0)
+                .collect::<Vec<_>>(),
+        ),
+        (
+            "sparse_30pct",
+            (0..num_rows as u32)
+                .filter(|i| i % 3 == 0)
+                .collect::<Vec<_>>(),
+        ),
+        (
+            "dense_90pct",
+            (0..num_rows as u32)
+                .filter(|i| i % 10 != 0)
+                .collect::<Vec<_>>(),
+        ),
+    ];
+
+    for (name, facts) in &cases {
+        group.throughput(Throughput::Elements(facts.len() as u64));
+        let id_byte = format!("byte_{name}");
+        let id_u64 = format!("u64_{name}");
+        group.bench_function(&id_byte, |b| {
+            b.iter(|| black_box(validity_byte_level(black_box(facts), num_rows)))
+        });
+        group.bench_function(&id_u64, |b| {
+            b.iter(|| black_box(validity_u64_chunked(black_box(facts), num_rows)))
+        });
+    }
+    group.finish();
+}
+
+// ── K3: column writer cost (the main event) ───────────────────────────────────
+
+fn bench_column_writer(c: &mut Criterion) {
+    let mut group = c.benchmark_group("column_writer_4field_10k");
+    let n: usize = 10_000;
+    let bodies: Vec<String> = (0..n)
+        .map(|i| {
+            format!("log message body number {i:06} with some realistic-ish length and a few words")
+        })
+        .collect();
+    let trace_ids: Vec<[u8; 16]> = (0..n)
+        .map(|i| {
+            let mut id = [0u8; 16];
+            id[..8].copy_from_slice(&(i as u64).to_le_bytes());
+            id
+        })
+        .collect();
+    let span_ids: Vec<[u8; 8]> = (0..n).map(|i| (i as u64).to_le_bytes()).collect();
+
+    group.throughput(Throughput::Elements(n as u64));
+
+    // A: Current production path. Write through ColumnarBatchBuilder with
+    //    Utf8View columns for trace_id/span_id (hex-encoded) and a
+    //    detached body string. Mirrors `decode_log_record_wire` for the
+    //    canonical columns.
+    group.bench_function("columnar_batch_builder_current", |b| {
+        b.iter(|| {
+            let mut plan = BatchPlan::new();
+            let h_ts = plan.declare_planned("timestamp", FieldKind::Int64).unwrap();
+            let h_sev = plan
+                .declare_planned("severity_number", FieldKind::Int64)
+                .unwrap();
+            let h_body = plan.declare_planned("body", FieldKind::Utf8View).unwrap();
+            let h_tid = plan
+                .declare_planned("trace_id", FieldKind::Utf8View)
+                .unwrap();
+            let h_sid = plan
+                .declare_planned("span_id", FieldKind::Utf8View)
+                .unwrap();
+            let mut bldr = ColumnarBatchBuilder::new(plan);
+            bldr.begin_batch();
+            for i in 0..n {
+                bldr.begin_row();
+                bldr.write_i64(h_ts, i as i64);
+                bldr.write_i64(h_sev, 9);
+                bldr.write_str_bytes(h_body, bodies[i].as_bytes()).unwrap();
+                bldr.write_hex_bytes_lower(h_tid, &trace_ids[i]).unwrap();
+                bldr.write_hex_bytes_lower(h_sid, &span_ids[i]).unwrap();
+                bldr.end_row();
+            }
+            black_box(bldr.finish_batch().unwrap())
+        });
+    });
+
+    // B: Direct Arrow primitive builders. Same 5 columns; trace_id/span_id
+    //    as FixedSizeBinary (no hex). Body as StringView with appended bytes.
+    //    The "ceiling" we're trying to approach.
+    group.bench_function("direct_arrow_fixedbinary", |b| {
+        b.iter(|| {
+            let mut ts = Int64Builder::with_capacity(n);
+            let mut sev = Int64Builder::with_capacity(n);
+            let mut body = StringViewBuilder::with_capacity(n);
+            let mut tid = FixedSizeBinaryBuilder::with_capacity(n, 16);
+            let mut sid = FixedSizeBinaryBuilder::with_capacity(n, 8);
+            for i in 0..n {
+                ts.append_value(i as i64);
+                sev.append_value(9);
+                body.append_value(&bodies[i]);
+                tid.append_value(&trace_ids[i]).unwrap();
+                sid.append_value(&span_ids[i]).unwrap();
+            }
+            black_box((
+                ts.finish(),
+                sev.finish(),
+                body.finish(),
+                tid.finish(),
+                sid.finish(),
+            ))
+        });
+    });
+
+    // C: Same as B but trace_id/span_id as StringViewArray with hex encoding
+    //    using append_value(&str). Apples-to-apples-ish: same Arrow primitives
+    //    as B but keeping the trace_id schema as Utf8View like A.
+    //    Tells us how much of A vs B is the schema flip vs the builder bypass.
+    group.bench_function("direct_arrow_hex_strings", |b| {
+        b.iter(|| {
+            let mut ts = Int64Builder::with_capacity(n);
+            let mut sev = Int64Builder::with_capacity(n);
+            let mut body = StringViewBuilder::with_capacity(n);
+            let mut tid = StringViewBuilder::with_capacity(n);
+            let mut sid = StringViewBuilder::with_capacity(n);
+            // Per-row scratch — same as the builder's string_buf would do.
+            let mut scratch_tid = String::with_capacity(32);
+            let mut scratch_sid = String::with_capacity(16);
+            for i in 0..n {
+                ts.append_value(i as i64);
+                sev.append_value(9);
+                body.append_value(&bodies[i]);
+                scratch_tid.clear();
+                for &b in &trace_ids[i] {
+                    scratch_tid.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+                    scratch_tid.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
+                }
+                tid.append_value(&scratch_tid);
+                scratch_sid.clear();
+                for &b in &span_ids[i] {
+                    scratch_sid.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+                    scratch_sid.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
+                }
+                sid.append_value(&scratch_sid);
+            }
+            black_box((
+                ts.finish(),
+                sev.finish(),
+                body.finish(),
+                tid.finish(),
+                sid.finish(),
+            ))
+        });
+    });
+
+    group.finish();
+}
+
+// ── K4: dynamic attribute write throughput ────────────────────────────────────
+// Models attrs-heavy: 40 attribute writes per row, all of them String.
+// Compares ColumnarBatchBuilder dynamic path vs a direct StringViewBuilder pool.
+
+fn bench_dynamic_attrs(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dynamic_attrs_2k_rows_40_attrs");
+    let rows: usize = 2_000;
+    let attrs_per_row: usize = 40;
+    let total_writes = (rows * attrs_per_row) as u64;
+    // Stable attribute keys (simulates OTel semantic conventions).
+    let keys: Vec<String> = (0..attrs_per_row)
+        .map(|i| format!("attr.key_{i:02}.subdomain.dotted"))
+        .collect();
+    let values: Vec<String> = (0..attrs_per_row * rows)
+        .map(|i| format!("value_{i:08}_short"))
+        .collect();
+
+    group.throughput(Throughput::Elements(total_writes));
+
+    // A: ColumnarBatchBuilder dynamic resolution path (resolve_dynamic per attr).
+    group.bench_function("columnar_builder_resolve_dynamic", |b| {
+        b.iter(|| {
+            let plan = BatchPlan::new();
+            let mut bldr = ColumnarBatchBuilder::new(plan);
+            bldr.begin_batch();
+            for r in 0..rows {
+                bldr.begin_row();
+                for a in 0..attrs_per_row {
+                    let h = bldr.resolve_dynamic(&keys[a], FieldKind::Utf8View).unwrap();
+                    bldr.write_str_bytes(h, values[r * attrs_per_row + a].as_bytes())
+                        .unwrap();
+                }
+                bldr.end_row();
+            }
+            black_box(bldr.finish_batch().unwrap())
+        });
+    });
+
+    // B: Pre-resolve handles outside the row loop (simulates the position-cache
+    //    after warm-up — what the OTLP projected path effectively achieves).
+    group.bench_function("columnar_builder_preresolved", |b| {
+        b.iter(|| {
+            let plan = BatchPlan::new();
+            let mut bldr = ColumnarBatchBuilder::new(plan);
+            bldr.begin_batch();
+            let handles: Vec<_> = keys
+                .iter()
+                .map(|k| bldr.resolve_dynamic(k, FieldKind::Utf8View).unwrap())
+                .collect();
+            for r in 0..rows {
+                bldr.begin_row();
+                for a in 0..attrs_per_row {
+                    bldr.write_str_bytes(handles[a], values[r * attrs_per_row + a].as_bytes())
+                        .unwrap();
+                }
+                bldr.end_row();
+            }
+            black_box(bldr.finish_batch().unwrap())
+        });
+    });
+
+    // C: Direct Arrow — one StringViewBuilder per attribute key, no dispatch.
+    group.bench_function("direct_arrow_per_key", |b| {
+        b.iter(|| {
+            let mut builders: Vec<StringViewBuilder> = (0..attrs_per_row)
+                .map(|_| StringViewBuilder::with_capacity(rows))
+                .collect();
+            for r in 0..rows {
+                for a in 0..attrs_per_row {
+                    builders[a].append_value(&values[r * attrs_per_row + a]);
+                }
+            }
+            let arrays: Vec<_> = builders.into_iter().map(|mut b| b.finish()).collect();
+            black_box(arrays)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_trace_id_storage,
+    bench_validity,
+    bench_column_writer,
+    bench_dynamic_attrs
+);
+criterion_main!(benches);

--- a/crates/ffwd-bench/benches/hot_path_kernels.rs
+++ b/crates/ffwd-bench/benches/hot_path_kernels.rs
@@ -113,7 +113,7 @@ fn bench_trace_id_storage(c: &mut Criterion) {
         });
     });
 
-    // Candidate benchmark: FixedSizeBinaryBuilder as motivation for TODO #1844.
+    // Benchmark: FixedSizeBinaryBuilder throughput for trace/span ID columns (see TODO #1844).
     group.bench_function("fixed_size_binary_builder", |b| {
         b.iter(|| {
             let mut builder = FixedSizeBinaryBuilder::with_capacity(n, 16);
@@ -317,6 +317,7 @@ fn bench_column_writer(c: &mut Criterion) {
                 tid.append_value(unsafe { std::str::from_utf8_unchecked(&scratch_tid) });
                 scratch_sid.clear();
                 hex_encode_into(&mut scratch_sid, &span_ids[i]);
+                // SAFETY: hex_encode_into produces only ASCII hex digits.
                 sid.append_value(unsafe { std::str::from_utf8_unchecked(&scratch_sid) });
             }
             black_box((

--- a/crates/ffwd-bench/benches/hot_path_kernels.rs
+++ b/crates/ffwd-bench/benches/hot_path_kernels.rs
@@ -113,7 +113,7 @@ fn bench_trace_id_storage(c: &mut Criterion) {
         });
     });
 
-    // Proposed: FixedSizeBinaryBuilder (closes TODO #1844).
+    // Candidate benchmark: FixedSizeBinaryBuilder as motivation for TODO #1844.
     group.bench_function("fixed_size_binary_builder", |b| {
         b.iter(|| {
             let mut builder = FixedSizeBinaryBuilder::with_capacity(n, 16);
@@ -141,7 +141,7 @@ fn bench_trace_id_storage(c: &mut Criterion) {
 // ── K2: validity bitmap ────────────────────────────────────────────────────────
 
 /// Current implementation in `accumulator.rs:554-563` — writes one bit per fact.
-fn validity_byte_level(facts: &[u32], num_rows: usize) -> Vec<u8> {
+fn build_validity_bytes(facts: &[u32], num_rows: usize) -> Vec<u8> {
     let mut bits = vec![0u8; num_rows.div_ceil(8)];
     for &row in facts {
         let r = row as usize;
@@ -155,7 +155,7 @@ fn validity_byte_level(facts: &[u32], num_rows: usize) -> Vec<u8> {
 /// Proposed: write into u64 words first, transmute to bytes at the end.
 /// Same algorithmic complexity; smaller load/store width and fewer
 /// dependencies per inner iteration.
-fn validity_u64_chunked(facts: &[u32], num_rows: usize) -> Vec<u8> {
+fn build_validity_u64_chunked(facts: &[u32], num_rows: usize) -> Vec<u8> {
     let words_len = num_rows.div_ceil(64);
     let mut words = vec![0u64; words_len];
     for &row in facts {
@@ -204,10 +204,10 @@ fn bench_validity(c: &mut Criterion) {
         let id_byte = format!("byte_{name}");
         let id_u64 = format!("u64_{name}");
         group.bench_function(&id_byte, |b| {
-            b.iter(|| black_box(validity_byte_level(black_box(facts), num_rows)))
+            b.iter(|| black_box(build_validity_bytes(black_box(facts), num_rows)))
         });
         group.bench_function(&id_u64, |b| {
-            b.iter(|| black_box(validity_u64_chunked(black_box(facts), num_rows)))
+            b.iter(|| black_box(build_validity_u64_chunked(black_box(facts), num_rows)))
         });
     }
     group.finish();
@@ -295,9 +295,9 @@ fn bench_column_writer(c: &mut Criterion) {
     });
 
     // C: Same as B but trace_id/span_id as StringViewArray with hex encoding
-    //    using append_value(&str). Apples-to-apples-ish: same Arrow primitives
-    //    as B but keeping the trace_id schema as Utf8View like A.
-    //    Tells us how much of A vs B is the schema flip vs the builder bypass.
+    //    using the *same* byte-table encoder as production (hex_encode_into).
+    //    Apples-to-apples: isolates schema (FixedSizeBinary vs Utf8View) cost
+    //    without encoder algorithm confounds.
     group.bench_function("direct_arrow_hex_strings", |b| {
         b.iter(|| {
             let mut ts = Int64Builder::with_capacity(n);
@@ -305,25 +305,19 @@ fn bench_column_writer(c: &mut Criterion) {
             let mut body = StringViewBuilder::with_capacity(n);
             let mut tid = StringViewBuilder::with_capacity(n);
             let mut sid = StringViewBuilder::with_capacity(n);
-            // Per-row scratch — same as the builder's string_buf would do.
-            let mut scratch_tid = String::with_capacity(32);
-            let mut scratch_sid = String::with_capacity(16);
+            let mut scratch_tid: Vec<u8> = Vec::with_capacity(32);
+            let mut scratch_sid: Vec<u8> = Vec::with_capacity(16);
             for i in 0..n {
                 ts.append_value(i as i64);
                 sev.append_value(9);
                 body.append_value(&bodies[i]);
                 scratch_tid.clear();
-                for &b in &trace_ids[i] {
-                    scratch_tid.push(char::from_digit((b >> 4) as u32, 16).unwrap());
-                    scratch_tid.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
-                }
-                tid.append_value(&scratch_tid);
+                hex_encode_into(&mut scratch_tid, &trace_ids[i]);
+                // SAFETY: hex_encode_into produces only ASCII hex digits.
+                tid.append_value(unsafe { std::str::from_utf8_unchecked(&scratch_tid) });
                 scratch_sid.clear();
-                for &b in &span_ids[i] {
-                    scratch_sid.push(char::from_digit((b >> 4) as u32, 16).unwrap());
-                    scratch_sid.push(char::from_digit((b & 0xf) as u32, 16).unwrap());
-                }
-                sid.append_value(&scratch_sid);
+                hex_encode_into(&mut scratch_sid, &span_ids[i]);
+                sid.append_value(unsafe { std::str::from_utf8_unchecked(&scratch_sid) });
             }
             black_box((
                 ts.finish(),

--- a/crates/ffwd-bench/src/bin/otlp_io_profile.rs
+++ b/crates/ffwd-bench/src/bin/otlp_io_profile.rs
@@ -264,6 +264,7 @@ fn run_with_flamegraph(
     let frequency: i32 = std::env::var("FFWD_PPROF_HZ")
         .ok()
         .and_then(|v| v.parse().ok())
+        .filter(|hz| *hz > 0)
         .unwrap_or(5_000);
     let guard = pprof::ProfilerGuardBuilder::default()
         .frequency(frequency)

--- a/crates/ffwd-bench/src/bin/otlp_io_profile.rs
+++ b/crates/ffwd-bench/src/bin/otlp_io_profile.rs
@@ -257,8 +257,16 @@ fn run_with_flamegraph(
     iterations: usize,
     path: &PathBuf,
 ) -> ProfileResult {
+    // 5 kHz: tighter confidence intervals for short hot leaves than the prior
+    // 1 kHz default. Note that increasing Hz does not fix attribution bias
+    // from inlining — for that, prefer Instruments (`Time Profiler`) or
+    // `samply`, which keep inlined-frame info via DWARF.
+    let frequency: i32 = std::env::var("FFWD_PPROF_HZ")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5_000);
     let guard = pprof::ProfilerGuardBuilder::default()
-        .frequency(1_000)
+        .frequency(frequency)
         .blocklist(&["libc", "libgcc", "pthread"])
         .build()
         .expect("pprof guard");

--- a/crates/ffwd-config/src/validate/common.rs
+++ b/crates/ffwd-config/src/validate/common.rs
@@ -98,7 +98,7 @@ pub fn validate_host_port(addr: &str) -> Result<(), ConfigError> {
         })?
     };
 
-if host.is_empty() {
+    if host.is_empty() {
         return Err(validation_error(format!("'{addr}' has an empty host")));
     }
 

--- a/crates/ffwd-io/src/otlp_receiver/projection/decode.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/decode.rs
@@ -90,8 +90,8 @@ fn collect_resource_attrs<'a>(
     resource: &'a [u8],
 ) -> Result<(), ProjectionError> {
     generated::for_each_resource_attribute(resource, |attr| {
-        if let Some((key, value)) = generated::decode_key_value_wire(attr)? {
-            // `decode_key_value_wire` returns the key unvalidated; resource
+        if let Some((key, value)) = super::wire::decode_kv_inline(attr)? {
+            // `decode_kv_inline` returns the key unvalidated; resource
             // attrs have no per-position cache so we have no memo to lean on.
             // Validate eagerly. The cost is small (handful of attrs per batch)
             // and the alternative — building a `&str` from concatenated bytes
@@ -207,7 +207,7 @@ fn decode_log_record_wire(
     for attr_idx in 0..scratch.attr_ranges.len() {
         let (start, len) = scratch.attr_ranges[attr_idx];
         let attr = &log_record[start..start + len];
-        if let Some((key, value)) = generated::decode_key_value_wire(attr)? {
+        if let Some((key, value)) = super::wire::decode_kv_inline(attr)? {
             let handle = resolve_record_attr_field(
                 builder,
                 &mut scratch.attr_field_cache,
@@ -236,8 +236,13 @@ fn decode_log_record_wire(
 /// validating UTF-8 only on the cache-miss branch, before storing the key.
 /// On a cache hit (byte-equal key), the new bytes are valid UTF-8 by
 /// transitivity (UTF-8 is a deterministic property of bytes), so we skip
-/// re-validation. `decode_key_value_wire` deliberately leaves the key bytes
+/// re-validation. `decode_kv_inline` deliberately leaves the key bytes
 /// unvalidated so this memo can pay off.
+///
+/// # Cache-hit fast path
+///
+/// We check `key_len` first (a u32 compare) to reject mismatches before
+/// the full `memcmp`, then only proceed to byte equality on length match.
 fn resolve_record_attr_field(
     builder: &mut ColumnarBatchBuilder,
     cache: &mut Vec<AttrFieldCache>,
@@ -245,12 +250,12 @@ fn resolve_record_attr_field(
     key: &[u8],
     value: &WireAny<'_>,
 ) -> Result<FieldHandle, ProjectionError> {
+    let key_len = key.len() as u32;
     if let Some(cached) = cache.get(position)
+        && cached.key_len == key_len
         && cached.key.as_slice() == key
         && let Some(handle) = cached.handle
     {
-        // Cache hit: cached.key was validated UTF-8 when first inserted, and
-        // byte-equal new bytes are therefore also valid UTF-8.
         return Ok(handle);
     }
 
@@ -263,10 +268,12 @@ fn resolve_record_attr_field(
     if let Some(cached) = cache.get_mut(position) {
         cached.key.clear();
         cached.key.extend_from_slice(key);
+        cached.key_len = key_len;
         cached.handle = Some(handle);
     } else {
         cache.push(AttrFieldCache {
             key: key.to_vec(),
+            key_len,
             handle: Some(handle),
         });
     }

--- a/crates/ffwd-io/src/otlp_receiver/projection/decode.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/decode.rs
@@ -91,6 +91,12 @@ fn collect_resource_attrs<'a>(
 ) -> Result<(), ProjectionError> {
     generated::for_each_resource_attribute(resource, |attr| {
         if let Some((key, value)) = generated::decode_key_value_wire(attr)? {
+            // `decode_key_value_wire` returns the key unvalidated; resource
+            // attrs have no per-position cache so we have no memo to lean on.
+            // Validate eagerly. The cost is small (handful of attrs per batch)
+            // and the alternative — building a `&str` from concatenated bytes
+            // via `from_utf8_unchecked` — would require a non-load-bearing
+            // unsafe block to save one simdutf8 pass.
             scratch.resource_key.clear();
             scratch
                 .resource_key
@@ -99,8 +105,8 @@ fn collect_resource_attrs<'a>(
                 .resource_key
                 .extend_from_slice(resource_prefix.as_bytes());
             scratch.resource_key.extend_from_slice(key);
-            let key_str = std::str::from_utf8(&scratch.resource_key)
-                .expect("resource prefix + validated UTF-8 key must be valid UTF-8");
+            let key_str = simdutf8::basic::from_utf8(&scratch.resource_key)
+                .map_err(|_e| ProjectionError::Invalid("invalid UTF-8 resource attribute key"))?;
             let handle = builder
                 .resolve_dynamic(key_str, generated::wire_any_field_kind(&value))
                 .map_err(|e| ProjectionError::Batch(format!("resolve resource attr: {e}")))?;
@@ -221,6 +227,17 @@ fn decode_log_record_wire(
     Ok(())
 }
 
+/// Resolve a per-record attribute key to a `FieldHandle`, using the
+/// per-position cache to amortize repeated work across rows.
+///
+/// # Cache invariant
+///
+/// `cache[position].key` is **always valid UTF-8**. We establish this by
+/// validating UTF-8 only on the cache-miss branch, before storing the key.
+/// On a cache hit (byte-equal key), the new bytes are valid UTF-8 by
+/// transitivity (UTF-8 is a deterministic property of bytes), so we skip
+/// re-validation. `decode_key_value_wire` deliberately leaves the key bytes
+/// unvalidated so this memo can pay off.
 fn resolve_record_attr_field(
     builder: &mut ColumnarBatchBuilder,
     cache: &mut Vec<AttrFieldCache>,
@@ -232,10 +249,14 @@ fn resolve_record_attr_field(
         && cached.key.as_slice() == key
         && let Some(handle) = cached.handle
     {
+        // Cache hit: cached.key was validated UTF-8 when first inserted, and
+        // byte-equal new bytes are therefore also valid UTF-8.
         return Ok(handle);
     }
 
-    let key_str = std::str::from_utf8(key).expect("attribute key already validated as UTF-8");
+    // Cache miss: validate now so the cache invariant is maintained.
+    let key_str = simdutf8::basic::from_utf8(key)
+        .map_err(|_e| ProjectionError::Invalid("invalid UTF-8 attribute key"))?;
     let handle = builder
         .resolve_dynamic(key_str, generated::wire_any_field_kind(value))
         .map_err(|e| ProjectionError::Batch(format!("resolve attr field: {e}")))?;

--- a/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
@@ -837,6 +837,16 @@ pub(super) fn decode_any_value_wire(value: &[u8]) -> Result<Option<WireAny<'_>>,
     Ok(out)
 }
 
+/// Decode a `KeyValue` record into raw key bytes and a typed value.
+///
+/// The key bytes are returned **unvalidated**. Callers must run UTF-8
+/// validation before using the key as a `&str`. Two known callers:
+///
+/// * `decode::resolve_record_attr_field` — validates only on attribute
+///   position-cache miss; cache hits are byte-equal to a previously
+///   validated key, so re-validation is redundant.
+/// * `decode::collect_resource_attrs` — validates eagerly because there
+///   is no per-position cache for resource attrs.
 pub(super) fn decode_key_value_wire(
     kv: &[u8],
 ) -> Result<Option<(&[u8], WireAny<'_>)>, ProjectionError> {
@@ -845,7 +855,7 @@ pub(super) fn decode_key_value_wire(
     super::for_each_field(kv, |field, field_value| {
         match (field, field_value) {
             (1, WireField::Len(bytes)) => {
-                key = super::require_utf8(bytes, "invalid UTF-8 attribute key")?;
+                key = bytes;
             }
             (1, _) => {
                 return Err(ProjectionError::Invalid(

--- a/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
@@ -840,13 +840,11 @@ pub(super) fn decode_any_value_wire(value: &[u8]) -> Result<Option<WireAny<'_>>,
 /// Decode a `KeyValue` record into raw key bytes and a typed value.
 ///
 /// The key bytes are returned **unvalidated**. Callers must run UTF-8
-/// validation before using the key as a `&str`. Two known callers:
+/// validation before using the key as a `&str`.
 ///
-/// * `decode::resolve_record_attr_field` — validates only on attribute
-///   position-cache miss; cache hits are byte-equal to a previously
-///   validated key, so re-validation is redundant.
-/// * `decode::collect_resource_attrs` — validates eagerly because there
-///   is no per-position cache for resource attrs.
+/// Note: production code now uses `wire::decode_kv_inline` for performance.
+/// This function is retained as the reference implementation for tests.
+#[allow(dead_code)]
 pub(super) fn decode_key_value_wire(
     kv: &[u8],
 ) -> Result<Option<(&[u8], WireAny<'_>)>, ProjectionError> {

--- a/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
@@ -844,7 +844,7 @@ pub(super) fn decode_any_value_wire(value: &[u8]) -> Result<Option<WireAny<'_>>,
 ///
 /// Note: production code now uses `wire::decode_kv_inline` for performance.
 /// This function is retained as the reference implementation for tests.
-#[allow(dead_code)]
+#[cfg(test)]
 pub(super) fn decode_key_value_wire(
     kv: &[u8],
 ) -> Result<Option<(&[u8], WireAny<'_>)>, ProjectionError> {

--- a/crates/ffwd-io/src/otlp_receiver/projection/wire.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/wire.rs
@@ -159,7 +159,31 @@ fn skip_group(input: &mut &[u8], start_field: u32) -> Result<(), ProjectionError
     Err(ProjectionError::Invalid("unterminated protobuf group"))
 }
 
+/// Decode a protobuf varint from `input`, advancing the slice.
+///
+/// Hot-path-optimized for the common case: most OTLP varints encode small
+/// tag numbers (≤127, one byte) or short field lengths (≤127, one byte).
+/// We try a one-byte fast path first, then fall back to the standard 10-byte
+/// loop. samply showed `read_varint` was ~12% of wide-10k self-time before
+/// this fast path; the one-byte branch handles ~95% of varints with a single
+/// byte load and a single branch.
+#[inline]
 pub(super) fn read_varint(input: &mut &[u8]) -> Result<u64, ProjectionError> {
+    // Fast path: 1-byte varint (top bit clear).
+    if let Some((&first, rest)) = input.split_first()
+        && first < 0x80
+    {
+        *input = rest;
+        return Ok(u64::from(first));
+    }
+    read_varint_multibyte(input)
+}
+
+/// Slow path: 2-to-10 byte varints. Kept as a separate function so the
+/// fast path inlines without bloating callers.
+#[inline(never)]
+#[cold]
+fn read_varint_multibyte(input: &mut &[u8]) -> Result<u64, ProjectionError> {
     let mut result = 0u64;
     for index in 0..10 {
         let Some((&byte, rest)) = input.split_first() else {
@@ -177,7 +201,51 @@ pub(super) fn read_varint(input: &mut &[u8]) -> Result<u64, ProjectionError> {
     Err(ProjectionError::Invalid("varint overflow"))
 }
 
+/// Validate that `bytes` is valid UTF-8.
+///
+/// Hot-path-optimized for the common case: most OTLP attribute keys and
+/// values are pure ASCII (a strict subset of UTF-8). We scan for any byte
+/// with the high bit set using u64 chunks; if none are found, the input
+/// is ASCII and trivially valid. We only fall through to `simdutf8` on the
+/// rare non-ASCII case.
+///
+/// Why not just call simdutf8 directly: simdutf8's SIMD path activates at
+/// 64 bytes; below that it falls back to the scalar `core::str::from_utf8`,
+/// which dominated wide-10k self-time (~15%) before this fast path. OTLP
+/// attribute strings are almost always shorter than 64 bytes.
+#[inline]
 pub(super) fn require_utf8<'a>(
+    bytes: &'a [u8],
+    context: &'static str,
+) -> Result<&'a [u8], ProjectionError> {
+    const HIGH_BITS: u64 = 0x8080_8080_8080_8080;
+    let mut i = 0;
+    let n = bytes.len();
+    // 8-byte chunks: a single u64 mask catches any non-ASCII byte.
+    while i + 8 <= n {
+        // SAFETY: bounds-checked by the loop condition.
+        let chunk_bytes: [u8; 8] = bytes[i..i + 8].try_into().unwrap();
+        let chunk = u64::from_ne_bytes(chunk_bytes);
+        if chunk & HIGH_BITS != 0 {
+            return require_utf8_full(bytes, context);
+        }
+        i += 8;
+    }
+    // Tail: ≤7 bytes. Byte-wise high-bit check.
+    while i < n {
+        if bytes[i] >= 0x80 {
+            return require_utf8_full(bytes, context);
+        }
+        i += 1;
+    }
+    Ok(bytes)
+}
+
+/// Full UTF-8 validation. Used by `require_utf8` only when the ASCII fast
+/// path detects a high-bit byte.
+#[inline(never)]
+#[cold]
+fn require_utf8_full<'a>(
     bytes: &'a [u8],
     context: &'static str,
 ) -> Result<&'a [u8], ProjectionError> {

--- a/crates/ffwd-io/src/otlp_receiver/projection/wire.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/wire.rs
@@ -223,8 +223,10 @@ pub(super) fn require_utf8<'a>(
     let n = bytes.len();
     // 8-byte chunks: a single u64 mask catches any non-ASCII byte.
     while i + 8 <= n {
-        // SAFETY: bounds-checked by the loop condition.
-        let chunk_bytes: [u8; 8] = bytes[i..i + 8].try_into().unwrap();
+        // The loop condition guarantees this slice has exactly 8 bytes.
+        let chunk_bytes: [u8; 8] = bytes[i..i + 8]
+            .try_into()
+            .expect("loop condition guarantees 8 bytes");
         let chunk = u64::from_ne_bytes(chunk_bytes);
         if chunk & HIGH_BITS != 0 {
             return require_utf8_full(bytes, context);

--- a/crates/ffwd-io/src/otlp_receiver/projection/wire.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/wire.rs
@@ -277,6 +277,264 @@ pub(super) fn subslice_range(
     Ok((child_start - parent_start, child.len()))
 }
 
+/// Inline decode of a protobuf `KeyValue` message (fields 1=key, 2=value).
+///
+/// Avoids the generic `for_each_field` closure dispatch for both the KeyValue
+/// and the nested AnyValue. A KeyValue is always two LEN-typed fields with
+/// small field numbers (tags 0x0a and 0x12); AnyValue is a oneof with fields
+/// 1-7. We parse both directly, eliminating two levels of closure dispatch
+/// that cost ~11% self-time on wide-10k.
+///
+/// The key bytes are returned **unvalidated** (same contract as the
+/// closure-based `decode_key_value_wire`).
+#[inline]
+pub(super) fn decode_kv_inline<'a>(
+    mut input: &'a [u8],
+) -> Result<Option<(&'a [u8], WireAny<'a>)>, ProjectionError> {
+    let mut key: &[u8] = &[];
+    let mut value: Option<WireAny<'a>> = None;
+
+    while !input.is_empty() {
+        let tag = read_varint(&mut input)?;
+        let field = (tag >> 3) as u32;
+        let wire_type = (tag & 0x07) as u8;
+
+        match (field, wire_type) {
+            // field 1, wire type 2 (LEN) = key
+            (1, 2) => {
+                let len = usize::try_from(read_varint(&mut input)?)
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                if input.len() < len {
+                    return Err(ProjectionError::Invalid("truncated KeyValue.key"));
+                }
+                let (bytes, rest) = input.split_at(len);
+                input = rest;
+                key = bytes;
+            }
+            // field 2, wire type 2 (LEN) = value (AnyValue submessage)
+            (2, 2) => {
+                let len = usize::try_from(read_varint(&mut input)?)
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                if input.len() < len {
+                    return Err(ProjectionError::Invalid("truncated KeyValue.value"));
+                }
+                let (bytes, rest) = input.split_at(len);
+                input = rest;
+                if let Some(decoded) = decode_any_value_inline(bytes)? {
+                    value = Some(decoded);
+                }
+            }
+            // Unexpected wire type for field 1
+            (1, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for KeyValue.key",
+                ));
+            }
+            // Unexpected wire type for field 2
+            (2, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for KeyValue.value",
+                ));
+            }
+            // Unknown fields: skip
+            (_, 0) => {
+                let _ = read_varint(&mut input)?;
+            }
+            (_, 1) => {
+                if input.len() < 8 {
+                    return Err(ProjectionError::Invalid("truncated fixed64 in KeyValue"));
+                }
+                input = &input[8..];
+            }
+            (_, 2) => {
+                let len = usize::try_from(read_varint(&mut input)?)
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                if input.len() < len {
+                    return Err(ProjectionError::Invalid("truncated LEN in KeyValue"));
+                }
+                input = &input[len..];
+            }
+            (_, 3) => {
+                skip_group(&mut input, field)?;
+            }
+            (_, 4) => {
+                return Err(ProjectionError::Invalid("unexpected end group in KeyValue"));
+            }
+            (_, 5) => {
+                if input.len() < 4 {
+                    return Err(ProjectionError::Invalid("truncated fixed32 in KeyValue"));
+                }
+                input = &input[4..];
+            }
+            _ => {
+                return Err(ProjectionError::Invalid("invalid wire type in KeyValue"));
+            }
+        }
+    }
+
+    Ok(value.map(|v| (key, v)))
+}
+
+/// Inline decode of a protobuf `AnyValue` oneof message.
+///
+/// Parses fields from the AnyValue without closure dispatch. AnyValue has
+/// fields 1-7 (string, bool, int, double, array, kvlist, bytes) where the
+/// last-written field wins. On the hot path this is typically a single field
+/// per message, so we get one tag decode + one value decode.
+#[inline]
+fn decode_any_value_inline<'a>(
+    mut input: &'a [u8],
+) -> Result<Option<WireAny<'a>>, ProjectionError> {
+    let mut out: Option<WireAny<'a>> = None;
+
+    while !input.is_empty() {
+        let tag = read_varint(&mut input)?;
+        let field = (tag >> 3) as u32;
+        let wire_type = (tag & 0x07) as u8;
+
+        match (field, wire_type) {
+            // field 1: string_value (LEN)
+            (1, 2) => {
+                let len = usize::try_from(read_varint(&mut input)?)
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                if input.len() < len {
+                    return Err(ProjectionError::Invalid("truncated AnyValue.string_value"));
+                }
+                let (bytes, rest) = input.split_at(len);
+                input = rest;
+                out = Some(WireAny::String(require_utf8(
+                    bytes,
+                    "invalid UTF-8 AnyValue string",
+                )?));
+            }
+            (1, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for AnyValue.string_value",
+                ));
+            }
+            // field 2: bool_value (varint)
+            (2, 0) => {
+                let v = read_varint(&mut input)?;
+                out = Some(WireAny::Bool(v != 0));
+            }
+            (2, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for AnyValue.bool_value",
+                ));
+            }
+            // field 3: int_value (varint)
+            (3, 0) => {
+                let v = read_varint(&mut input)?;
+                out = Some(WireAny::Int(v as i64));
+            }
+            (3, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for AnyValue.int_value",
+                ));
+            }
+            // field 4: double_value (fixed64)
+            (4, 1) => {
+                if input.len() < 8 {
+                    return Err(ProjectionError::Invalid("truncated AnyValue.double_value"));
+                }
+                let (bytes, rest) = input.split_at(8);
+                input = rest;
+                let v =
+                    u64::from_le_bytes(bytes.try_into().expect("split_at(8) guarantees 8 bytes"));
+                out = Some(WireAny::Double(f64::from_bits(v)));
+            }
+            (4, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for AnyValue.double_value",
+                ));
+            }
+            // field 5: array_value (LEN)
+            (5, 2) => {
+                let len = usize::try_from(read_varint(&mut input)?)
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                if input.len() < len {
+                    return Err(ProjectionError::Invalid("truncated AnyValue.array_value"));
+                }
+                let (bytes, rest) = input.split_at(len);
+                input = rest;
+                out = Some(WireAny::ArrayRaw(bytes));
+            }
+            (5, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for AnyValue.array_value",
+                ));
+            }
+            // field 6: kvlist_value (LEN)
+            (6, 2) => {
+                let len = usize::try_from(read_varint(&mut input)?)
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                if input.len() < len {
+                    return Err(ProjectionError::Invalid("truncated AnyValue.kvlist_value"));
+                }
+                let (bytes, rest) = input.split_at(len);
+                input = rest;
+                out = Some(WireAny::KvListRaw(bytes));
+            }
+            (6, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for AnyValue.kvlist_value",
+                ));
+            }
+            // field 7: bytes_value (LEN)
+            (7, 2) => {
+                let len = usize::try_from(read_varint(&mut input)?)
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                if input.len() < len {
+                    return Err(ProjectionError::Invalid("truncated AnyValue.bytes_value"));
+                }
+                let (bytes, rest) = input.split_at(len);
+                input = rest;
+                out = Some(WireAny::Bytes(bytes));
+            }
+            (7, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for AnyValue.bytes_value",
+                ));
+            }
+            // Unknown fields: skip
+            (_, 0) => {
+                let _ = read_varint(&mut input)?;
+            }
+            (_, 1) => {
+                if input.len() < 8 {
+                    return Err(ProjectionError::Invalid("truncated fixed64 in AnyValue"));
+                }
+                input = &input[8..];
+            }
+            (_, 2) => {
+                let len = usize::try_from(read_varint(&mut input)?)
+                    .map_err(|_e| ProjectionError::Invalid("protobuf length exceeds usize"))?;
+                if input.len() < len {
+                    return Err(ProjectionError::Invalid("truncated LEN in AnyValue"));
+                }
+                input = &input[len..];
+            }
+            (_, 3) => {
+                skip_group(&mut input, field)?;
+            }
+            (_, 4) => {
+                return Err(ProjectionError::Invalid("unexpected end group in AnyValue"));
+            }
+            (_, 5) => {
+                if input.len() < 4 {
+                    return Err(ProjectionError::Invalid("truncated fixed32 in AnyValue"));
+                }
+                input = &input[4..];
+            }
+            _ => {
+                return Err(ProjectionError::Invalid("invalid wire type in AnyValue"));
+            }
+        }
+    }
+
+    Ok(out)
+}
+
 #[derive(Default)]
 pub(super) struct WireScratch {
     pub(super) decimal: Vec<u8>,
@@ -289,5 +547,7 @@ pub(super) struct WireScratch {
 #[derive(Default)]
 pub(super) struct AttrFieldCache {
     pub(super) key: Vec<u8>,
+    /// Cached key length for fast rejection before memcmp.
+    pub(super) key_len: u32,
     pub(super) handle: Option<FieldHandle>,
 }

--- a/scripts/generate_otlp_projection.py
+++ b/scripts/generate_otlp_projection.py
@@ -427,13 +427,23 @@ def render_key_value_decoder(spec: dict) -> str:
     fields = {field["name"]: field for field in message_fields(spec, "KeyValue")}
     key_number = fields["key"]["number"]
     value_number = fields["value"]["number"]
-    return f"""pub(super) fn decode_key_value_wire(kv: &[u8]) -> Result<Option<(&[u8], WireAny<'_>)>, ProjectionError> {{
+    return f"""/// Decode a `KeyValue` record into raw key bytes and a typed value.
+///
+/// The key bytes are returned **unvalidated**. Callers must run UTF-8
+/// validation before using the key as a `&str`. Two known callers:
+///
+/// * `decode::resolve_record_attr_field` — validates only on attribute
+///   position-cache miss; cache hits are byte-equal to a previously
+///   validated key, so re-validation is redundant.
+/// * `decode::collect_resource_attrs` — validates eagerly because there
+///   is no per-position cache for resource attrs.
+pub(super) fn decode_key_value_wire(kv: &[u8]) -> Result<Option<(&[u8], WireAny<'_>)>, ProjectionError> {{
     let mut key = &[][..];
     let mut value = None;
     super::for_each_field(kv, |field, field_value| {{
         match (field, field_value) {{
             ({key_number}, WireField::Len(bytes)) => {{
-                key = super::require_utf8(bytes, "invalid UTF-8 attribute key")?;
+                key = bytes;
             }}
             ({key_number}, _) => {{
                 return Err(ProjectionError::Invalid("invalid wire type for KeyValue.key"));
@@ -855,6 +865,21 @@ pub(super) fn decode_log_record_fields<'a>(
                     "invalid wire type for LogRecord.attributes",
                 ));
             }
+            (__LOG_DROPPED_ATTRS_FIELD__, WireField::Varint(_)) => {}
+            (__LOG_DROPPED_ATTRS_FIELD__, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for LogRecord.dropped_attributes_count",
+                ));
+            }
+            (__LOG_EVENT_NAME_FIELD__, WireField::Len(value)) if !value.is_empty() => {
+                super::require_utf8(value, "invalid UTF-8 LogRecord.event_name")?;
+            }
+            (__LOG_EVENT_NAME_FIELD__, WireField::Len(_)) => {}
+            (__LOG_EVENT_NAME_FIELD__, _) => {
+                return Err(ProjectionError::Invalid(
+                    "invalid wire type for LogRecord.event_name",
+                ));
+            }
             _ => {}
         }
         Ok(())
@@ -871,7 +896,9 @@ pub(super) fn decode_log_record_fields<'a>(
         "__LOG_TRACE_ID_FIELD__", str(log_record["trace_id"]["number"])
     ).replace("__LOG_SPAN_ID_FIELD__", str(log_record["span_id"]["number"])).replace(
         "__LOG_FLAGS_FIELD__", str(log_record["flags"]["number"])
-    ).replace("__LOG_ATTRS_FIELD__", str(log_record["attributes"]["number"]))
+    ).replace("__LOG_ATTRS_FIELD__", str(log_record["attributes"]["number"])).replace(
+        "__LOG_DROPPED_ATTRS_FIELD__", str(log_record["dropped_attributes_count"]["number"])
+    ).replace("__LOG_EVENT_NAME_FIELD__", str(log_record["event_name"]["number"]))
 
 
 def render_len_field_visitors(spec: dict) -> str:


### PR DESCRIPTION
## Summary

Four stacked, validated optimizations to the OTLP→Arrow projection path. Each is a small, targeted change behind the existing parity oracle (`assert_batch_matches` against `prost_reference_to_batch`); all 86 projection tests pass after each commit.

| | wide-10k projected_view | trace-heavy projected_view | attrs-heavy projected_view |
|---|---|---|---|
| baseline (`main`) | 14.6 ms | 9.79 ms | 6.97 ms |
| after this PR | **7.44 ms** | **3.96 ms** | **2.58 ms** |
| **speedup** | **1.96×** | **2.47×** | **2.70×** |

Throughput on the production-recommended `projected_view` path: 0.68 → 1.34 Mrow/s on wide-10k, 0.82 → 2.02 Mrow/s on trace-heavy.

## Per-commit deltas vs `main`

| commit | what | wide-10k | trace-heavy | attrs-heavy |
|---|---|---|---|---|
| `bd283dac` | bench tooling (microbench harness + 5 kHz pprof tunable) — no behavior change | — | — | — |
| `52f63bc7` | skip Arrow's `StringViewArray::try_new` revalidation on the trusted path; use `new_unchecked` since UTF-8 + buffer-bounds are committed at the producer boundary | in noise | −33.0% | −40.4% |
| `5081c9c7` | defer attribute-key UTF-8 validation to position-cache miss; update generator + regen `generated.rs` | −24.7% | −64.8% | −48.3% |
| `32503628` | ASCII fast path for `require_utf8` (u64 high-bit scan; falls through to simdutf8 only on non-ASCII); 1-byte fast path for `read_varint` (cold #[inline(never)] slow path for 2-10 byte varints) | **−47.3%** | −62.7% | −60.4% |

(All deltas measured with criterion `--baseline main`, p<0.05 unless noted, on a quiet machine.)

## What guided this

samply at 4 kHz (8× more samples than pprof at 1 kHz on macOS, where SIGPROF coalesces under load) showed the top wide-10k self-time symbols after the first two changes were:

- 15.23%  `core::str::converts::from_utf8` — simdutf8's scalar fallback (its NEON path activates only at ≥64 bytes; OTLP attribute strings are 5–30 bytes)
- 11.89%  `wire::read_varint` — most OTLP varints are 1 byte

Those two findings drove the fourth commit. pprof at 1 kHz had under-counted both because each call is short and frequent — sampling under-attributes inlined leaves under their callers.

## What's deliberately not in this PR

- **`#4` hash-prefix on the position-cache key** — the position cache is 1-entry-per-position, so a hash filter doesn't help (we still need slice-eq for collision safety); withdrawn.
- **`#2` FixedSizeBinary for trace_id/span_id** (closes #1844) — meaningful win but crosses the decode↔encode boundary (the OTLP sink at `crates/ffwd-output/src/otlp_sink/columns.rs` reads `Utf8View(32 hex chars)` and hex-decodes on output); deferred to a follow-up PR.
- **No new caches.** `WireScratch::attr_field_cache` shape is unchanged; we just memoize UTF-8 validation against the existing position-cache.
- **No hand-edits to `generated.rs`.** Generator update + clean regeneration; `python3 scripts/generate_otlp_projection.py --check` is clean.

## Test plan

- [x] `cargo test -p ffwd-io --release --lib otlp_receiver::projection` — 86 passed
- [x] `cargo test -p ffwd-arrow --release --lib` — 221 passed
- [x] `python3 scripts/generate_otlp_projection.py --check` — clean
- [x] `just fmt`, `just clippy`, `just toml-check` — clean
- [x] `cargo bench -p ffwd-bench --bench otlp_io --baseline main` — all five fixtures show statistically significant improvement on `projected_view`
- [ ] Reviewer to verify on CI runner (different machine, may show somewhat different magnitudes but same direction)

## Files touched

```
crates/ffwd-arrow/src/columnar/accumulator.rs              | +14 -2  (#1: new_unchecked)
crates/ffwd-bench/Cargo.toml                               |  +4     (microbench wire-up)
crates/ffwd-bench/benches/hot_path_kernels.rs              | +298    (new, microbench harness)
crates/ffwd-bench/src/bin/otlp_io_profile.rs               |  +9 -1  (5 kHz default, env-tunable)
crates/ffwd-io/src/otlp_receiver/projection/decode.rs      | +29 -7  (#3: validate on cache miss)
crates/ffwd-io/src/otlp_receiver/projection/generated.rs   | +12 -1  (regenerated)
crates/ffwd-io/src/otlp_receiver/projection/wire.rs        | +88 -20 (#5+#6: ASCII + varint fast paths)
scripts/generate_otlp_projection.py                        | +27 -1  (#3: defer key validation)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Speed up OTLP→Arrow projection path by ~2x via four wire-parsing optimizations
> - Adds `decode_kv_inline` and `decode_any_value_inline` in [`wire.rs`](https://github.com/strawgate/fastforward/pull/2688/files#diff-7b0e4d7bf8fc700ed010137a5383111e49de7229d28dba48d0b6eeea89a10dd6) to replace the closure-based generated decoder with direct field parsing, eliminating dispatch overhead.
> - Adds a 1-byte fast path in `read_varint` and an ASCII fast path in `require_utf8` (u64-chunk scan), with slow paths extracted into cold, non-inlined helpers.
> - Replaces `StringViewArray::try_new` with `new_unchecked` in [`accumulator.rs`](https://github.com/strawgate/fastforward/pull/2688/files#diff-e8d59263b2fa503b6aee6a627f3dd69c62220590dff59c531584366edc634e38), skipping redundant per-view bounds and UTF-8 validation on trusted inputs.
> - Adds a `key_len: u32` field to `AttrFieldCache` for fast-reject before `memcmp` in the attribute field resolver.
> - Adds a [`hot_path_kernels`](https://github.com/strawgate/fastforward/pull/2688/files#diff-c3c0e8921c7d980bae0fab309f787ce7e611a17283ec6d7729edc17009b9d155) microbenchmark suite covering hex encoding, validity bitmap writing, and attribute write throughput.
> - Risk: `build_string_view_trusted` now uses `unsafe` unchecked construction; correctness depends on upstream invariants rather than runtime validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a86a684.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->