### PR TITLE
fix: correct indentation in validate_host_port

### DIFF
--- a/crates/ffwd-config/src/validate/common.rs
+++ b/crates/ffwd-config/src/validate/common.rs
@@ -98,7 +98,7 @@ pub fn validate_host_port(addr: &str) -> Result<(), ConfigError> {
         })?
     };
 
-if host.is_empty() {
+    if host.is_empty() {
         return Err(validation_error(format!("'{addr}' has an empty host")));
     }
 


### PR DESCRIPTION
## Summary

Fix formatting issue in `ffwd-config/src/validate/common.rs` where the `if host.is_empty()` check had incorrect indentation.

This was causing Lint failures on PRs that include changes to ffwd-config.

## Changes

- Correct indentation for `if host.is_empty()` check (line 101)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix indentation in `validate_host_port` in common.rs
> Corrects the indentation of the `if host.is_empty()` block in [common.rs](https://github.com/strawgate/fastforward/pull/2691/files#diff-bd8f6c7cf0dc064e84a9e80074cda0393b8b20de7bc2566b24186dd56755afd1) to align with surrounding code. No logic or behavior changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d81e8a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->