### PR TITLE
fix: upgrade actions/setup-node from v4 to v6

### DIFF
--- a/.github/actions/build-dashboard/action.yml
+++ b/.github/actions/build-dashboard/action.yml
@@ -4,7 +4,7 @@ description: Build the Preact/TypeScript dashboard into a single HTML file
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
         node-version: "22"
         cache: npm


### PR DESCRIPTION
## Summary
- Upgrades  from v4 to v6 in 
- Resolves Node.js 20 deprecation warning in CI lint check (affects main and all PRs)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade `actions/setup-node` from v4 to v6 in build-dashboard action
> Updates the `actions/setup-node` version in [action.yml](https://github.com/strawgate/fastforward/pull/2692/files#diff-45a0924478e59959fd950b7bef4af066810997ea570c78c1b908db606847a783) to keep the CI workflow on a supported release.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71ca04f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->