### PR TITLE
docs: audit and fix CLI command documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,8 @@ Component labels use `component:` prefix (e.g., `component:processor/scanner`). 
 - **Find what SQL UDFs exist:** `crates/ffwd-transform/src/udf/` for `json()`, `json_int()`, `json_float()`, `regexp_extract()`, `grok()`, `geo_lookup()`, `hash()` (internal), and `crates/ffwd-transform/src/cast_udf.rs` for `int()` / `float()` — all are custom `ScalarUDFImpl` implementations registered on the DataFusion context.
 - **Find config schema:** `book/src/content/docs/configuration/reference.mdx` — all YAML fields, input/output types.
 - **Find example configs:** `examples/use-cases/` — 20 common patterns.
+- **Review active work/priorities:** open GitHub issues and PRs (`gh issue list --state open`, `gh pr list --state open`).
+- **Find library-specific patterns:** `dev-docs/references/` — Arrow, DataFusion, Tokio, OTLP, Kani.
 - **Find CLI reference:** `book/src/content/docs/cli/reference.mdx` — all `ff` subcommands with options.
 - **Start quickly:** `ff init` creates a starter `ffwd.yaml`; `ff wizard` is an interactive alternative.
 - **Find verification status:** `dev-docs/VERIFICATION.md` — per-module proof status.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,7 @@ Component labels use `component:` prefix (e.g., `component:processor/scanner`). 
 - **Find what SQL UDFs exist:** `crates/ffwd-transform/src/udf/` for `json()`, `json_int()`, `json_float()`, `regexp_extract()`, `grok()`, `geo_lookup()`, `hash()` (internal), and `crates/ffwd-transform/src/cast_udf.rs` for `int()` / `float()` — all are custom `ScalarUDFImpl` implementations registered on the DataFusion context.
 - **Find config schema:** `book/src/content/docs/configuration/reference.mdx` — all YAML fields, input/output types.
 - **Find example configs:** `examples/use-cases/` — 20 common patterns.
-- **Review active work/priorities:** open GitHub issues and PRs (`gh issue list --state open`, `gh pr list --state open`).
-- **Find library-specific patterns:** `dev-docs/references/` — Arrow, DataFusion, Tokio, OTLP, Kani.
+- **Find CLI reference:** `book/src/content/docs/cli/reference.mdx` — all `ff` subcommands with options.
+- **Start quickly:** `ff init` creates a starter `ffwd.yaml`; `ff wizard` is an interactive alternative.
 - **Find verification status:** `dev-docs/VERIFICATION.md` — per-module proof status.
 - **Find what breaks together:** `dev-docs/CHANGE_MAP.md` — co-change requirements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,8 @@ just lint         # Fast lint gate
 just lint-all     # Full lint gate
 just clippy       # Clippy with -D warnings (same as CI default tier)
 just fmt          # Format code
-just bench        # Criterion benchmarks
+just bench        # Tier 1 Criterion benchmarks (~30s: pipeline, output_encode, full_chain)
+just bench-full  # Full criterion suite (~2–5min, excludes elasticsearch_arrow)
 just kani         # Run Kani proofs (requires: cargo install --locked kani-verifier && cargo kani setup)
 cargo test -p ffwd-core  # Fast single-crate iteration
 ```

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -31,8 +31,8 @@ Optional but recommended:
 |------|---------|---------|
 | [taplo](https://taplo.tamasfe.dev) | TOML linting (`just toml-check`) | `cargo install taplo-cli` |
 | [cargo-deny](https://embarkstudios.github.io/cargo-deny/) | License/advisory audit (`just deny`) | `cargo install cargo-deny` |
-| [Node.js](https://nodejs.org) 22+ | Dashboard build (`just dashboard`) | via nvm or nodejs.org |
-| [Docker](https://www.docker.com) | Local services (`docker-compose.dev.yml`) | docker.com |
+| [Node.js](https://nodejs.org) 22+ | Dashboard build (`just dashboard`) | via mise, nvm, or nodejs.org |
+| [Docker](https://www.docker.com) | Local Elasticsearch for `just bench-es` | docker.com |
 | [sccache](https://github.com/mozilla/sccache) | Compile caching | `cargo install sccache --locked` |
 | [OpenJDK](https://openjdk.org) | Run TLC model checks (`just tlc-tail`) | `brew install openjdk` (macOS) |
 | Miri nightly components | Local UB checks (`just miri`) | `just miri-setup` |
@@ -52,17 +52,23 @@ just ci        # fast lint + test (~30s)
 
 ### Local services (optional)
 
-Some benchmarks and examples need Elasticsearch or an OTLP receiver:
+Some benchmarks and examples need Elasticsearch:
 
 ```bash
-docker compose -f docker-compose.dev.yml up -d   # start services
-docker compose -f docker-compose.dev.yml down     # stop
+docker compose -f examples/elasticsearch/docker-compose.yml up -d   # start
+docker compose -f examples/elasticsearch/docker-compose.yml down     # stop
+```
+
+For OTLP end-to-end testing, start the built-in blackhole receiver yourself:
+
+```bash
+ff devour   # listens on 127.0.0.1:4318
 ```
 
 | Service | URL | Used by |
 |---------|-----|---------|
 | Elasticsearch | `http://localhost:9200` | `just bench-es`, `examples/elasticsearch/` |
-| OTLP blackhole | `http://localhost:4318` | OTLP end-to-end tests |
+| OTLP blackhole | `http://localhost:4318` | `just bench-otlp`, `just profile-otlp-local` |
 
 ## Workspace layout
 

--- a/book/src/content/docs/cli/reference.mdx
+++ b/book/src/content/docs/cli/reference.mdx
@@ -96,7 +96,7 @@ In non-interactive mode `--destination` is required. In an interactive terminal,
 
 | Option | Description |
 |--------|-------------|
-| `--destination` | **Required.** Sink type: `otlp`, `elasticsearch`, `loki`, `arrow_ipc`, `udp`, `tcp`, `null` |
+| `--destination` | Sink type (required in non-interactive mode, prompted otherwise): `otlp`, `elasticsearch` (aliases: `elasticsearch_otlp`, `elasticsearch_bulk`), `loki`, `arrow_ipc`, `udp`, `tcp`, `null` |
 | `--endpoint` | Destination URL/address (required for all destinations except `null`) |
 | `--workers` | Worker threads (default: `2`) |
 | `--batch-lines` | Lines per batch (default: `5000`) |
@@ -111,7 +111,7 @@ Runs a built-in receiver that accepts incoming log traffic and drops it. Use thi
 ```bash
 ff devour                          # defaults to OTLP mode on 127.0.0.1:4318
 ff devour --mode tcp --listen 127.0.0.1:15140
-ff devour --mode elasticsearch --listen 127.0.0.1:9200
+ff devour --mode elasticsearch_bulk --listen 127.0.0.1:9200
 ```
 
 Unlike `blast`, `devour` does **not** require `--destination` — it accepts multiple built-in receiver modes.

--- a/book/src/content/docs/cli/reference.mdx
+++ b/book/src/content/docs/cli/reference.mdx
@@ -20,36 +20,6 @@ The `--config` flag is optional. FastForward will automatically discover configu
 4. `~/.config/ffwd/config.yaml`
 5. `/etc/ffwd/config.yaml`
 
-## ff blast
-
-Blasts generated synthetic log data into a destination sink to test throughput and network performance. This command uses the same core pipeline runtime but bypasses reading from disk or the network.
-
-```bash
-ff blast --destination otlp --endpoint http://127.0.0.1:4318/v1/logs
-```
-
-| Option | Description |
-|--------|-------------|
-| `--destination` | The sink type (e.g., `otlp`, `elasticsearch_otlp`, `arrow_ipc`, `null`) |
-| `--endpoint` | Destination endpoint URL (required for network destinations) |
-| `--workers` | Number of worker threads (default: 2) |
-| `--batch-lines` | Lines generated per batch (default: 5000) |
-| `--duration-secs` | Optional duration in seconds before stopping automatically |
-
-## ff devour
-
-Starts a built-in 'blackhole' receiver that accepts incoming log traffic and drops it. Used for isolating sender performance issues and testing upstream clients.
-
-```bash
-ff devour --mode otlp --listen 127.0.0.1:4318
-```
-
-| Option | Description |
-|--------|-------------|
-| `--mode` | The receiver type (e.g., `otlp`, `elasticsearch`) (default: `otlp`) |
-| `--listen` | Bind address (default: `127.0.0.1:4318` for OTLP) |
-| `--duration-secs` | Optional duration in seconds before stopping automatically |
-
 ## ff validate
 
 Parses and validates the YAML configuration file and its schema without starting any pipeline components.
@@ -58,12 +28,26 @@ Parses and validates the YAML configuration file and its schema without starting
 ff validate --config pipeline.yaml
 ```
 
+On success, `validate` exits with code `0` and prints:
+
+```
+  ready: default
+config ok: 1 pipeline(s)
+```
+
 ## ff dry-run
 
-Builds all pipeline objects (inputs, SQL transforms, and outputs) without starting active IO workers. This is stricter than `validate` because it compiles SQL queries against the Arrow schema, catching column name typos or type mismatches.
+Builds all pipeline objects (inputs, SQL transforms, and outputs) without starting active IO workers. `dry-run` runs the same validation path as `validate` — both build full pipelines and compile SQL queries against the Arrow schema to catch column name typos or type mismatches. The only difference is the success label: `dry run ok` instead of `config ok`.
 
 ```bash
 ff dry-run --config pipeline.yaml
+```
+
+On success, prints:
+
+```
+  ready: default
+dry run ok: 1 pipeline(s)
 ```
 
 ## ff send
@@ -76,5 +60,154 @@ cat app.log | ff send --config destination.yaml --format json
 
 | Option | Description |
 |--------|-------------|
-| `--format` | The log format (e.g., json, cri) |
-| `--service` | The service name to attach to logs |
+| `--config` | Destination YAML config file |
+| `--format` | Input format: `auto`, `cri`, `json`, `raw` (default: `auto`) |
+| `--service` | Set `service.name` on emitted records |
+| `--resource` | Add or override a resource attribute, repeatable: `--resource key=value` |
+
+See [Inputs](/configuration/inputs/) for stdin and piping patterns.
+
+## ff generate-json
+
+Generates synthetic JSON log lines for testing. Creates a file with stable, parseable records that exercise all column types.
+
+```bash
+ff generate-json 10000 logs.json
+```
+
+This creates 10,000 JSON log lines with fields: `timestamp`, `level`, `message`, `duration_ms`, `request_id`, `service`, `status`.
+
+| Option | Description |
+|--------|-------------|
+| `NUM_LINES` | Number of log lines to generate |
+| `OUTPUT_FILE` | Path to write the generated file |
+
+## ff blast
+
+Blasts generated synthetic log data into a destination sink to test throughput and network performance. This command uses the same core pipeline runtime but bypasses reading from disk or the network.
+
+```bash
+ff blast --destination otlp --endpoint http://127.0.0.1:4318/v1/logs
+```
+
+:::note
+In non-interactive mode `--destination` is required. In an interactive terminal, `blast` prompts for the destination if omitted.
+:::
+
+| Option | Description |
+|--------|-------------|
+| `--destination` | **Required.** Sink type: `otlp`, `elasticsearch`, `loki`, `arrow_ipc`, `udp`, `tcp`, `null` |
+| `--endpoint` | Destination URL/address (required for all destinations except `null`) |
+| `--workers` | Worker threads (default: `2`) |
+| `--batch-lines` | Lines per batch (default: `5000`) |
+| `--duration-secs` | Stop automatically after N seconds (default: run until stopped) |
+| `--auth-bearer-token` | Bearer token auth header |
+| `--auth-header` | Extra header, repeatable: `--auth-header 'Authorization=ApiKey xyz'` |
+
+## ff devour
+
+Runs a built-in receiver that accepts incoming log traffic and drops it. Use this to isolate sender performance or test upstream clients in isolation.
+
+```bash
+ff devour                          # defaults to OTLP mode on 127.0.0.1:4318
+ff devour --mode tcp --listen 127.0.0.1:15140
+ff devour --mode elasticsearch --listen 127.0.0.1:9200
+```
+
+Unlike `blast`, `devour` does **not** require `--destination` — it accepts multiple built-in receiver modes.
+
+| Option | Description |
+|--------|-------------|
+| `--mode` | Receiver type: `otlp` (default), `http`, `elasticsearch_bulk`, `tcp`, `udp` |
+| `--listen` | Bind address (default depends on mode: OTLP → `127.0.0.1:4318`) |
+| `--duration-secs` | Stop automatically after N seconds (default: run until stopped) |
+
+## ff blackhole
+
+A convenience alias for `devour --mode otlp` with no other arguments.
+
+```bash
+ff blackhole                      # listens on 127.0.0.1:4318
+ff blackhole 0.0.0.0:14318       # custom bind address
+```
+
+`blackhole` and `devour` both accept the same OTLP mode defaults. Use whichever reads more naturally in your workflow.
+
+## ff effective-config
+
+Validates the config, expands environment variable placeholders, redacts secrets, and prints the final YAML. Use this to inspect how your config looks after expansion before deploying.
+
+```bash
+ff effective-config --config pipeline.yaml
+```
+
+## ff init
+
+Creates a starter `ffwd.yaml` in the current directory with a basic file → stdout pipeline.
+
+```bash
+ff init
+```
+
+The generated config includes comments pointing to the next steps. Refuses to overwrite an existing file.
+
+## ff wizard
+
+Interactive step-by-step config builder. Choose a use-case preset or assemble your own input and output.
+
+```bash
+ff wizard
+```
+
+`wizard` requires an interactive terminal (stdin and stdout must both be TTYs). It validates the generated config before writing, so bad column names or type mismatches are caught before you run.
+
+## ff completions
+
+Print shell completion scripts.
+
+```bash
+ff completions bash
+ff completions zsh
+ff completions fish
+ff completions powershell
+ff completions nushell
+```
+
+Redirect output into the appropriate location for your shell, e.g.:
+
+```bash
+ff completions bash >> ~/.bashrc
+```
+
+## Config file format
+
+All pipeline commands (`run`, `validate`, `dry-run`, `effective-config`) accept the same YAML config format:
+
+```yaml
+pipelines:
+  default:
+    inputs:
+      - type: file
+        path: ./logs.json
+        format: json
+    transform: |
+      SELECT * FROM logs WHERE level = 'ERROR'
+    outputs:
+      - type: stdout
+        format: console
+
+server:
+  diagnostics: 127.0.0.1:9090
+  log_level: info
+```
+
+See the [YAML configuration reference](/configuration/reference/) for all available input, transform, and output options.
+
+## Global options
+
+```bash
+ff --version     # Print version and exit
+ff --help        # Show top-level help and exit
+```
+
+Run `ff <command> --help` for subcommand-specific options.

--- a/book/src/content/docs/quick-start.mdx
+++ b/book/src/content/docs/quick-start.mdx
@@ -53,6 +53,13 @@ ff --version
 ff --help
 ```
 
+Or start from a generated config:
+
+```bash
+ff init              # creates ffwd.yaml with a basic file → stdout pipeline
+ff wizard            # interactive: choose a use-case preset or build your own
+```
+
 ---
 
 ## Stage 1: See log output

--- a/book/src/content/docs/troubleshooting.md
+++ b/book/src/content/docs/troubleshooting.md
@@ -95,8 +95,15 @@ curl -s http://localhost:9090/admin/v1/status | jq '.pipelines[0].transform'
 ### Checks
 
 ```bash
-# HTTP OTLP health check (4318)
-curl -v http://otel-collector:4318/v1/logs
+# HTTP OTLP health check (local)
+curl -X POST http://localhost:4318/v1/logs \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+
+# HTTP OTLP health check (Kubernetes — replace otel-collector with your namespace/service)
+curl -X POST http://otel-collector:4318/v1/logs \
+  -H 'Content-Type: application/json' \
+  -d '{}'
 
 # Kubernetes DNS resolution check
 POD=$(kubectl -n collectors get pods -l app=ffwd -o jsonpath='{.items[0].metadata.name}')
@@ -132,7 +139,12 @@ ff validate --config config.yaml
 
 ### Expected
 
-Validation succeeds and prints `config ok: <n> pipeline(s)`.
+```
+  ready: default
+config ok: 1 pipeline(s)
+```
+
+Exit code `0` on success, `1` on configuration error.
 
 ### Common causes and fixes
 

--- a/crates/ffwd-config/src/shared.rs
+++ b/crates/ffwd-config/src/shared.rs
@@ -59,8 +59,11 @@ pub struct TlsServerConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct RetryConfig {
+    /// Maximum retry attempts for the sink.
+    /// `None` uses the sink default.
+    /// `Some(0)` means no retry limit.
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
-    pub max_attempts: Option<i32>,
+    pub max_attempts: Option<u32>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]
     pub initial_backoff_secs: Option<PositiveSecs>,
     #[serde(default, deserialize_with = "deserialize_option_from_string_or_value")]

--- a/crates/ffwd-config/tests/validation_gaps.rs
+++ b/crates/ffwd-config/tests/validation_gaps.rs
@@ -1,4 +1,4 @@
-use ffwd_config::Config;
+use ffwd_config::{Config, OutputConfigV2};
 use std::ffi::OsString;
 use std::fs;
 #[cfg(unix)]
@@ -1424,4 +1424,123 @@ pipelines:
 ";
     Config::load_str(yaml)
         .expect("push path with trailing slash should be accepted (normalized by output)");
+}
+
+#[test]
+fn issue_2584_retry_max_attempts_rejects_negative_values() {
+    let configs: &[(&str, &str)] = &[
+        (
+            "elasticsearch",
+            r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: -1
+"#,
+        ),
+        (
+            "loki",
+            r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: loki
+        endpoint: http://localhost:3100
+        retry:
+          max_attempts: -100
+"#,
+        ),
+    ];
+
+    for (sink_name, yaml) in configs {
+        let result = Config::load_str(yaml);
+        assert!(
+            result.is_err(),
+            "{sink_name} with negative max_attempts should be rejected, but got Ok"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("invalid value") || err_msg.contains("max_attempts"),
+            "{sink_name} error should indicate invalid value for max_attempts, got: {err_msg}"
+        );
+    }
+}
+
+#[test]
+fn issue_2584_retry_max_attempts_accepts_positive_values() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: 3
+"#;
+    let config =
+        Config::load_str(yaml).expect("elasticsearch with max_attempts=3 should be accepted");
+    let output = config
+        .pipelines
+        .get("test")
+        .expect("pipeline 'test' should exist")
+        .outputs
+        .first()
+        .expect("output #0 should exist");
+    let OutputConfigV2::Elasticsearch(es) = output else {
+        panic!("output #0 should be Elasticsearch");
+    };
+    assert_eq!(
+        es.retry.as_ref().and_then(|r| r.max_attempts),
+        Some(3),
+        "elasticsearch retry.max_attempts should be Some(3)"
+    );
+}
+
+#[test]
+fn issue_2584_retry_max_attempts_accepts_zero() {
+    let yaml = r#"
+pipelines:
+  test:
+    inputs:
+      - type: generator
+        generator:
+          profile: record
+    outputs:
+      - type: elasticsearch
+        endpoint: http://localhost:9200
+        retry:
+          max_attempts: 0
+"#;
+    let config =
+        Config::load_str(yaml).expect("elasticsearch with max_attempts=0 should be accepted");
+    let output = config
+        .pipelines
+        .get("test")
+        .expect("pipeline 'test' should exist")
+        .outputs
+        .first()
+        .expect("output #0 should exist");
+    let OutputConfigV2::Elasticsearch(es) = output else {
+        panic!("output #0 should be Elasticsearch");
+    };
+    assert_eq!(
+        es.retry.as_ref().and_then(|r| r.max_attempts),
+        Some(0),
+        "elasticsearch retry.max_attempts should be Some(0)"
+    );
 }

--- a/crates/ffwd/src/commands.rs
+++ b/crates/ffwd/src/commands.rs
@@ -346,9 +346,9 @@ fn cmd_init() -> Result<(), CliError> {
 # Docs: https://github.com/strawgate/fastforward
 
 # ── Quick start ─────────────────────────────────────────────
-# 1. Generate sample data:  ff generate-json 10000 sample.json
-# 2. Validate this config:  ff validate --config ffwd.yaml
-# 3. Run the pipeline:      ff run --config ffwd.yaml
+# 1. Generate test data:   ff generate-json 10000 logs.json
+# 2. Validate this config: ff validate --config ffwd.yaml
+# 3. Run the pipeline:     ff run --config ffwd.yaml
 #
 # For production, change the input path and output to your real
 # source/destination — see the examples at https://github.com/strawgate/fastforward/tree/main/examples/use-cases/
@@ -359,7 +359,7 @@ pipelines:
     # Tail a JSON log file and stream new lines as they appear.
     inputs:
       - type: file
-        path: ./sample.json
+        path: ./logs.json
         format: json
 
     # SQL transform (optional) — filter, reshape, or enrich logs.
@@ -396,12 +396,12 @@ pipelines:
     eprintln!();
     eprintln!("{}Try it now:{}", bold(), reset());
     eprintln!(
-        "  ff generate-json 10000 sample.json   {}# create sample data{}",
+        "  ff generate-json 10000 logs.json    {}# create sample data{}",
         dim(),
         reset()
     );
     eprintln!(
-        "  ff run --config ffwd.yaml           {}# run the pipeline{}",
+        "  ff run --config ffwd.yaml          {}# run the pipeline{}",
         dim(),
         reset()
     );

--- a/crates/ffwd/src/main.rs
+++ b/crates/ffwd/src/main.rs
@@ -48,7 +48,7 @@ const CLI_AFTER_HELP: &str = r"Examples:
   ff blackhole
   ff blast --destination otlp --endpoint http://127.0.0.1:4318/v1/logs
   ff devour --mode otlp --listen 127.0.0.1:4318
-  ff generate-json 10000 test.json
+  ff generate-json 10000 logs.json
   ff wizard
   ff completions bash
 

--- a/tla/README.md
+++ b/tla/README.md
@@ -13,7 +13,7 @@ just tlc-tail                              # TailLifecycle (fast CI)
 just tla-setup                             # download jar without running a model
 ```
 
-For all other specs, the general form is `just tlc <model_file> <config_file>`:
+For all other specs, the general form is `just tlc <model_file> <config_file>` (run from the repo root):
 
 ```bash
 # PipelineMachine

--- a/tla/README.md
+++ b/tla/README.md
@@ -4,24 +4,31 @@ Formal models for the ffwd pipeline design. These specs capture
 properties that Kani (bounded model checker) cannot express — temporal
 logic, liveness, and protocol-level design invariants.
 
-## Contributor Quickstart (CI parity)
+## Contributor Quickstart
 
-Run these TLC commands locally for parity with CI coverage:
+Run `just tlc-tail` for the TailLifecycle model (fast CI gate). The `just tlc` recipe auto-downloads `tla2tools.jar` to `.tools/`, finds your Java runtime, and runs from the `tla/` directory.
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.liveness.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCShutdownProtocol.tla -config tla/ShutdownProtocol.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCShutdownProtocol.tla -config tla/ShutdownProtocol.liveness.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineBatch.tla -config tla/PipelineBatch.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineBatch.tla -config tla/PipelineBatch.liveness.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCDeliveryRetry.tla -config tla/DeliveryRetry.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCDeliveryRetry.tla -config tla/DeliveryRetry.liveness.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCWorkerPoolDispatch.tla -config tla/WorkerPoolDispatch.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCWorkerPoolDispatch.tla -config tla/WorkerPoolDispatch.liveness.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCFanoutSink.tla -config tla/FanoutSink.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCFanoutSink.tla -config tla/FanoutSink.liveness.cfg
+just tlc-tail                              # TailLifecycle (fast CI)
+just tla-setup                             # download jar without running a model
 ```
+
+For all other specs, the general form is `just tlc <model_file> <config_file>`:
+
+```bash
+# PipelineMachine
+just tlc MCPipelineMachine.tla PipelineMachine.cfg
+just tlc MCPipelineMachine.tla PipelineMachine.liveness.cfg
+
+# All other specs use the same pattern (model MC file + config):
+just tlc MCShutdownProtocol.tla ShutdownProtocol.cfg
+just tlc MCPipelineBatch.tla PipelineBatch.cfg
+just tlc MCDeliveryRetry.tla DeliveryRetry.cfg
+just tlc MCWorkerPoolDispatch.tla WorkerPoolDispatch.cfg
+just tlc MCFanoutSink.tla FanoutSink.cfg
+```
+
+See individual spec sections below for the complete list of model/config combinations.
 
 ## PipelineMachine.tla
 
@@ -130,7 +137,7 @@ tla/
 **Model 1 — Safety (normal + ForceStop paths):**
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.cfg
+just tlc MCPipelineMachine.tla PipelineMachine.cfg
 # Sources={"s1","s2"}, MaxBatchesPerSource=3, MaxNonTerminalHolds=1
 # ~10.8M distinct states locally with one TLC worker, < 10 min. Checks all
 # INVARIANTS + temporal action properties.
@@ -139,7 +146,7 @@ java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/P
 **Model 2 — Liveness (smaller constants, no SYMMETRY):**
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.liveness.cfg
+just tlc MCPipelineMachine.tla PipelineMachine.liveness.cfg
 # Sources={"s1","s2"}, MaxBatchesPerSource=2, MaxNonTerminalHolds=1
 # ~77K distinct states locally with one TLC worker, < 5 min. Checks drain,
 # terminalization, held-release, and stopped-stability liveness.
@@ -156,7 +163,7 @@ java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/P
 **Model 3 — Coverage / reachability (vacuity guards):**
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.coverage.cfg
+just tlc MCPipelineMachine.tla PipelineMachine.coverage.cfg
 # TLC will report INVARIANT VIOLATIONS for BeginDrainReachable, StopReachable,
 # AckOccurs, RejectOccurs, HoldOccurs, RetryOccurs, PanicHoldOccurs,
 # CheckpointAdvances, ForcedReachable, AbandonOccurs, HeldAbandonOccurs —
@@ -176,7 +183,7 @@ impossible.
 **Model 4 — Thorough safety sweep (optional, slower):**
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.thorough.cfg
+just tlc MCPipelineMachine.tla PipelineMachine.thorough.cfg
 # Local thorough depth: Sources={"s1","s2","s3"}, MaxBatchesPerSource=3
 # PR CI intentionally skips thorough configs; nightly owns scheduled deep runs.
 ```
@@ -184,7 +191,7 @@ java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/P
 **Model 5 — Nightly deep safety sweep (slowest):**
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.nightly.thorough.cfg
+just tlc MCPipelineMachine.tla PipelineMachine.nightly.thorough.cfg
 # Nightly CI depth: Sources={"s1","s2","s3"}, MaxBatchesPerSource=4
 ```
 
@@ -195,19 +202,27 @@ and the invariant was trivially satisfied.
 
 ### Running TLC
 
+The `just tlc` recipe handles Java detection and `.tools/tla2tools.jar`
+auto-download. Run from the repo root:
+
 ```bash
-# CLI (requires tla2tools.jar)
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.cfg
-
-# With coverage stats (verify every action fires):
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineMachine.tla -config tla/PipelineMachine.cfg -coverage 1
-
-# Via TLA+ Toolbox:
-# File -> Open Spec -> MCPipelineMachine.tla
-# TLC Model Checker -> New Model -> Load from PipelineMachine.cfg
+just tlc-tail                              # TailLifecycle shortcut
+just tlc <model_file> <config_file>        # General form (from tla/ directory)
+just tla-setup                            # download jar without running a model
 ```
 
----
+Raw form (for Toolbox or CI script usage):
+
+```bash
+cd tla
+java -cp ../.tools/tla2tools.jar tlc2.TLC <model_file> -config <config_file>
+```
+
+Coverage (run from repo root, paths are relative to repo root):
+
+```bash
+python3 scripts/verify_tla_coverage.py --jar .tools/tla2tools.jar --tla-file tla/<model_file> --config tla/<config_file>
+```
 
 ## ShutdownProtocol.tla
 
@@ -292,12 +307,11 @@ ack/reject handling at the batching seam.
 Run:
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineBatch.tla -config tla/PipelineBatch.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineBatch.tla -config tla/PipelineBatch.liveness.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCPipelineBatch.tla -config tla/PipelineBatch.coverage.cfg
+just tlc MCPipelineBatch.tla PipelineBatch.cfg
+just tlc MCPipelineBatch.tla PipelineBatch.liveness.cfg
+just tlc MCPipelineBatch.tla PipelineBatch.coverage.cfg
 ```
 
----
 
 ## DeliveryRetry.tla
 
@@ -352,9 +366,9 @@ or Cancel (shutdown). Liveness depends on sink recovery OR shutdown cancellation
 ### Run
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCDeliveryRetry.tla -config tla/DeliveryRetry.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCDeliveryRetry.tla -config tla/DeliveryRetry.liveness.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCDeliveryRetry.tla -config tla/DeliveryRetry.coverage.cfg
+just tlc MCDeliveryRetry.tla DeliveryRetry.cfg
+just tlc MCDeliveryRetry.tla DeliveryRetry.liveness.cfg
+just tlc MCDeliveryRetry.tla DeliveryRetry.coverage.cfg
 ```
 
 ### Key design: retry forever, terminate on cancel
@@ -458,9 +472,9 @@ algorithm is worker-count-independent so small values suffice.
 ### Run
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCWorkerPoolDispatch.tla -config tla/WorkerPoolDispatch.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCWorkerPoolDispatch.tla -config tla/WorkerPoolDispatch.liveness.cfg
-python3 scripts/verify_tla_coverage.py --jar /path/to/tla2tools.jar --tla-file tla/MCWorkerPoolDispatch.tla --config tla/WorkerPoolDispatch.coverage.cfg
+just tlc MCWorkerPoolDispatch.tla WorkerPoolDispatch.cfg
+just tlc MCWorkerPoolDispatch.tla WorkerPoolDispatch.liveness.cfg
+python3 scripts/verify_tla_coverage.py --jar .tools/tla2tools.jar --tla-file tla/MCWorkerPoolDispatch.tla --config tla/WorkerPoolDispatch.coverage.cfg
 ```
 
 ### Key design: MRU dispatch with spawn-or-wait
@@ -527,9 +541,9 @@ when a retry re-sent data to children that had already accepted it.
 ### Run
 
 ```bash
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCFanoutSink.tla -config tla/FanoutSink.cfg
-java -cp /path/to/tla2tools.jar tlc2.TLC tla/MCFanoutSink.tla -config tla/FanoutSink.liveness.cfg
-python3 scripts/verify_tla_coverage.py --jar /path/to/tla2tools.jar --tla-file tla/MCFanoutSink.tla --config tla/FanoutSink.coverage.cfg
+just tlc MCFanoutSink.tla FanoutSink.cfg
+just tlc MCFanoutSink.tla FanoutSink.liveness.cfg
+python3 scripts/verify_tla_coverage.py --jar .tools/tla2tools.jar --tla-file tla/MCFanoutSink.tla --config tla/FanoutSink.coverage.cfg
 ```
 
 ### Key design: per-child state tracking across retries


### PR DESCRIPTION
See original PR #2693

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix and expand CLI command documentation across reference, quick-start, and troubleshooting pages
> - Expands [cli/reference.mdx](https://github.com/strawgate/fastforward/pull/2696/files#diff-c03092700868e06036dd075389e65503c425087d81a2c29b84f3934b03da0bb0) with detailed sections for `ff validate`, `ff dry-run`, `ff send`, `ff blast`, `ff devour`, `ff init`, `ff wizard`, `ff completions`, and global options.
> - Updates [troubleshooting.md](https://github.com/strawgate/fastforward/pull/2696/files#diff-3c0ddab98a9fb429c092e4b80f07a103632e3cf87d806da2c416a1f1b022d215) with correct OTLP health check curl commands (HTTP POST with JSON body) and explicit expected output for `ff validate`.
> - Changes `retry.max_attempts` in `RetryConfig` from `Option<i32>` to `Option<u32>`, rejecting negative values at deserialization time; adds tests covering negative, zero, and positive values.
> - Updates `ff init` template and CLI help text to reference `logs.json` instead of `sample.json`.
> - Risk: configs with a negative `retry.max_attempts` will now fail to deserialize instead of being accepted.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 25926d8. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->