### PR TITLE
feat: add UDF fuzz target and backpressure benchmarks (Phase 7d, 8)

### DIFF
--- a/crates/ffwd-bench/Cargo.toml
+++ b/crates/ffwd-bench/Cargo.toml
@@ -128,6 +128,10 @@ harness = false
 name = "hot_path_kernels"
 harness = false
 
+[[bench]]
+name = "backpressure"
+harness = false
+
 [[bin]]
 name = "ffwd-bench"
 path = "src/main.rs"

--- a/crates/ffwd-bench/benches/backpressure.rs
+++ b/crates/ffwd-bench/benches/backpressure.rs
@@ -1,0 +1,245 @@
+//! Backpressure behavior benchmarks: measures how pipeline throughput degrades
+//! as output latency increases.
+//!
+//! Uses a producer-consumer model to simulate the pipeline's bounded channel
+//! behavior. A producer adds realistic CPU work (scanning) and sends raw bytes
+//! through a bounded mpsc channel while a consumer simulates slow output with
+//! configurable delays.
+//!
+//! **Design note:** We scan to add CPU work but send raw bytes (not RecordBatch)
+//! through the channel. RecordBatch is not Sync, so it cannot be sent through
+//! std::sync::mpsc::sync_channel. This design measures channel backpressure
+//! dynamics, not scanner throughput.
+//!
+//! **Metrics captured:**
+//! - Throughput degradation curve (lines/sec vs output delay)
+//! - Producer stall frequency (how often the producer blocks on a full channel)
+//! - Stall rate (stalls per batch sent)
+//!
+//! **Delays tested:** 0ms, 10ms, 50ms, 200ms per batch
+//!
+//! Run with: `cargo bench -p ffwd-bench --bench backpressure`
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use ffwd_arrow::scanner::Scanner;
+use ffwd_bench::generators;
+use ffwd_core::scan_config::ScanConfig;
+
+const CHANNEL_CAPACITY: usize = 16;
+
+/// Approximate bytes per line for the production_mixed generator output.
+/// Used only for throughput estimation (lines/sec) since production_mixed varies.
+const ESTIMATED_BYTES_PER_LINE: f64 = 250.0;
+
+const DELAYS_MS: &[u64] = &[0, 10, 50, 200];
+
+struct SlowConsumer {
+    delay: Duration,
+}
+
+impl SlowConsumer {
+    fn new(delay_ms: u64) -> Self {
+        Self {
+            delay: Duration::from_millis(delay_ms),
+        }
+    }
+
+    fn consume(&self) {
+        if self.delay > Duration::ZERO {
+            std::thread::sleep(self.delay);
+        }
+    }
+}
+
+struct ProducerStats {
+    batches_sent: std::sync::atomic::AtomicUsize,
+    stalls: std::sync::atomic::AtomicUsize,
+    total_bytes: std::sync::atomic::AtomicU64,
+}
+
+impl ProducerStats {
+    fn new() -> Self {
+        Self {
+            batches_sent: std::sync::atomic::AtomicUsize::new(0),
+            stalls: std::sync::atomic::AtomicUsize::new(0),
+            total_bytes: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+}
+
+fn run_backpressure_benchmark(
+    delay_ms: u64,
+    data_bytes: &Bytes,
+    runtime_secs: f64,
+) -> (f64, usize, usize, f64) {
+    let consumer = SlowConsumer::new(delay_ms);
+    let stats = Arc::new(ProducerStats::new());
+
+    // std::sync::mpsc::sync_channel is bounded (like the pipeline's mpsc channel)
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Bytes>(CHANNEL_CAPACITY);
+
+    let stats_clone = Arc::clone(&stats);
+    // Clone once so the thread owns its copy (Bytes clone is cheap — refcount bump)
+    let data_for_thread = data_bytes.clone();
+
+    let start = Instant::now();
+    let deadline = start + Duration::from_secs_f64(runtime_secs);
+
+    // Producer thread: sends batches until deadline
+    let producer_handle = std::thread::spawn(move || {
+        let mut batches_sent = 0usize;
+        let mut stalls = 0usize;
+        let mut total_bytes = 0u64;
+
+        while Instant::now() < deadline {
+            // Scan to add realistic CPU work (simulates scanner in the pipeline).
+            // RecordBatch is not Sync so we cannot send it through std::sync::mpsc.
+            // We send raw bytes instead — this measures channel backpressure behavior,
+            // not scanner throughput. The scan call above is the CPU work simulation.
+            let mut scanner = Scanner::new(ScanConfig::default());
+            // Panic on scan failure to avoid misleading partial results
+            scanner
+                .scan_detached(data_for_thread.clone())
+                .expect("benchmark data should scan successfully");
+            let batch_bytes = data_for_thread.len() as u64;
+
+            // Try non-blocking send first to count stalls, then blocking send if needed
+            match tx.try_send(data_for_thread.clone()) {
+                Ok(()) => {
+                    // Sent immediately — no stall
+                }
+                Err(std::sync::mpsc::TrySendError::Full(_)) => {
+                    // Channel full — this is a stall; block until sent
+                    stalls += 1;
+                    if tx.send(data_for_thread.clone()).is_err() {
+                        break; // channel closed (consumer done)
+                    }
+                }
+                Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {
+                    // Consumer exited — producer is done
+                    break;
+                }
+            }
+
+            batches_sent += 1;
+            total_bytes += batch_bytes;
+        }
+
+        stats_clone
+            .batches_sent
+            .store(batches_sent, std::sync::atomic::Ordering::Relaxed);
+        stats_clone
+            .stalls
+            .store(stalls, std::sync::atomic::Ordering::Relaxed);
+        stats_clone
+            .total_bytes
+            .store(total_bytes, std::sync::atomic::Ordering::Relaxed);
+    });
+
+    // Consumer thread: receives and "processes" (sleeps) until producer done
+    let consumer_handle = std::thread::spawn(move || {
+        while rx.recv().is_ok() {
+            // Simulate slow output
+            consumer.consume();
+        }
+    });
+
+    // Wait for producer to finish (it closes tx by dropping when done)
+    producer_handle.join().unwrap();
+    // Consumer will exit when tx is dropped
+    consumer_handle.join().unwrap();
+
+    let elapsed = start.elapsed();
+    let batches_sent = stats
+        .batches_sent
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let stalls = stats.stalls.load(std::sync::atomic::Ordering::Relaxed);
+    let total_bytes = stats.total_bytes.load(std::sync::atomic::Ordering::Relaxed);
+
+    // Throughput in bytes/sec and lines/sec
+    let bytes_per_sec = total_bytes as f64 / elapsed.as_secs_f64();
+    let lines_per_sec = bytes_per_sec / ESTIMATED_BYTES_PER_LINE;
+
+    // Stall rate
+    let stall_rate = if batches_sent > 0 {
+        stalls as f64 / batches_sent as f64
+    } else {
+        0.0
+    };
+
+    (lines_per_sec, stalls, batches_sent, stall_rate)
+}
+
+fn bench_backpressure(c: &mut Criterion) {
+    let mut group = c.benchmark_group("backpressure");
+
+    // Fixed dataset: 10K rows of production_mixed data
+    let n = 10_000;
+    let data = generators::gen_production_mixed(n, 42);
+    // Pre-construct Bytes once to avoid repeated allocation inside b.iter
+    let data_bytes = Bytes::from(data.clone());
+    let runtime_secs = 2.0; // Short runs for benchmarking
+
+    group.throughput(Throughput::Bytes(data_bytes.len() as u64));
+    group.sample_size(10);
+
+    for &delay_ms in DELAYS_MS {
+        group.bench_with_input(
+            BenchmarkId::new("delay_ms", delay_ms),
+            &delay_ms,
+            |b, &delay| {
+                // Clone Bytes cheaply (ref count bump) inside the timed iteration
+                let bytes = data_bytes.clone();
+                // Use iter_custom so Criterion times the actual function call.
+                // The function self-times for runtime_secs and returns metrics;
+                // we return the wall-clock elapsed time so Criterion reports accurately.
+                // Loop iters times and return total elapsed so Criterion computes
+                // per-iteration time correctly (divides total by iteration count).
+                b.iter_custom(|iters| {
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        let result = run_backpressure_benchmark(delay, &bytes, runtime_secs);
+                        std::hint::black_box(result);
+                    }
+                    start.elapsed()
+                });
+            },
+        );
+    }
+
+    // Summary table: printed to stderr so it shows up in benchmark output.
+    // Re-running the benchmarks is intentional — criterion's measured times include
+    // all thread coordination overhead, while this summary shows aggregate behavior.
+    // Gate behind BACKPRESSURE_SUMMARY=1 for CI environments where extra runtime matters.
+    if std::env::var("BACKPRESSURE_SUMMARY").is_ok() {
+        eprintln!(
+            "\n=== Backpressure Summary (runtime: {}s per config) ===",
+            runtime_secs
+        );
+        eprintln!(
+            "{:<12} {:>15} {:>12} {:>12} {:>12}",
+            "Delay", "Lines/sec", "Stalls", "Batches", "Stall Rate"
+        );
+
+        for &delay_ms in DELAYS_MS {
+            let (lines_per_sec, stalls, batches_sent, stall_rate) =
+                run_backpressure_benchmark(delay_ms, &data_bytes, runtime_secs);
+
+            eprintln!(
+                "{:<12} {:>15.0} {:>12} {:>12} {:>12.3}",
+                format!("{}ms", delay_ms),
+                lines_per_sec,
+                stalls,
+                batches_sent,
+                stall_rate
+            );
+        }
+    }
+}
+
+criterion_group!(benches, bench_backpressure);
+criterion_main!(benches);

--- a/crates/ffwd-core/fuzz/Cargo.toml
+++ b/crates/ffwd-core/fuzz/Cargo.toml
@@ -59,3 +59,8 @@ doc = false
 name = "fuzz_cri"
 path = "fuzz_targets/cri.rs"
 doc = false
+
+[[bin]]
+name = "fuzz_udf"
+path = "fuzz_targets/fuzz_udf.rs"
+doc = false

--- a/crates/ffwd-core/fuzz/fuzz_targets/fuzz_udf.rs
+++ b/crates/ffwd-core/fuzz/fuzz_targets/fuzz_udf.rs
@@ -1,0 +1,77 @@
+//! Fuzz the UDF implementations (json, json_int, json_float, hash,
+//! regexp_extract, grok) against arbitrary scanner-produced RecordBatches.
+//!
+//! The goal is to verify that no combination of SQL expression + input data
+//! can cause a panic inside a UDF. Errors returned by `TransformError` are
+//! expected and acceptable — only panics are failures.
+//!
+//! The scanner is configured with `line_field_name = "body"` so all queries
+//! referencing the `body` column are valid and UDF code paths are exercised.
+//!
+//! Run with:
+//! ```
+//! cargo +nightly fuzz run fuzz_udf -- -max_total_time=600
+//! ```
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use ffwd_arrow::scanner::Scanner;
+use ffwd_core::scan_config::ScanConfig;
+use ffwd_transform::SqlTransform;
+
+const UDF_QUERIES: &[&str] = &[
+    // json() — extract field as string
+    "SELECT json(body, 'status') AS status FROM logs",
+    "SELECT json(body, 'level') AS lvl FROM logs",
+    "SELECT json(body, 'msg') AS msg FROM logs",
+    "SELECT json(body, 'nested') AS nested FROM logs",
+    // json_int() — extract field as int
+    "SELECT json_int(body, 'status') AS status FROM logs",
+    "SELECT json_int(body, 'count') AS cnt FROM logs",
+    "SELECT json_int(body, 'duration_ms') AS dur FROM logs",
+    // json_float() — extract field as float
+    "SELECT json_float(body, 'latency') AS lat FROM logs",
+    "SELECT json_float(body, 'rate') AS rate FROM logs",
+    // hash() — deterministic FNV-1a
+    "SELECT hash(body) AS h FROM logs",
+    "SELECT hash(body), hash(msg) FROM logs",
+    // regexp_extract()
+    "SELECT regexp_extract(body, '(GET|POST) (\\S+)', 1) AS method FROM logs",
+    "SELECT regexp_extract(body, 'status=([0-9]+)', 1) AS code FROM logs",
+    // grok()
+    "SELECT grok(body, '%{WORD:method} %{URIPATH:path}') AS parsed FROM logs",
+    // Multiple UDFs in one query
+    "SELECT json(body, 'status') AS s, hash(body) AS h FROM logs",
+    "SELECT json_int(body, 'status') + 1 AS s1, json_float(body, 'rate') * 2 AS r2 FROM logs",
+    // Edge cases
+    "SELECT json(body, 'nonexistent') AS missing FROM logs",
+    "SELECT json(body, '') AS empty_key FROM logs",
+    "SELECT json_int(body, 'not_a_number') AS nan FROM logs",
+    "SELECT json_float(body, 'also_not_num') AS nnn FROM logs",
+];
+
+fn run_udf(data: &[u8]) {
+    let mut scanner = Scanner::new(ScanConfig {
+        wanted_fields: vec![],
+        extract_all: true,
+        line_field_name: Some("body".to_string()),
+        validate_utf8: false,
+        row_predicate: None,
+    });
+
+    let Ok(batch) = scanner.scan_detached(bytes::Bytes::copy_from_slice(data)) else {
+        return;
+    };
+
+    for sql in UDF_QUERIES {
+        let mut transform =
+            SqlTransform::new(sql).expect("UDF fuzz query list must stay SQL-valid");
+        let _ = transform.execute_blocking(batch.clone());
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    run_udf(data);
+});

--- a/crates/ffwd-core/fuzz/fuzz_targets/scanner_transform.rs
+++ b/crates/ffwd-core/fuzz/fuzz_targets/scanner_transform.rs
@@ -7,7 +7,7 @@
 //! panic inside DataFusion. Errors (returned as `Err(String)`) are expected
 //! and acceptable — only panics are failures.
 //!
-//! Note: `SqlTransform::execute` creates a single-threaded tokio runtime
+//! Note: `SqlTransform::execute_blocking` creates a temporary tokio runtime
 //! internally, making this target slower than the pure scanner targets.
 //! Run it with a reduced corpus or a time limit, e.g.:
 //!
@@ -16,10 +16,10 @@
 //! ```
 
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use ffwd_core::scan_config::ScanConfig;
 use ffwd_arrow::scanner::Scanner;
+use ffwd_core::scan_config::ScanConfig;
 use ffwd_transform::SqlTransform;
+use libfuzzer_sys::fuzz_target;
 
 fn run_transform(data: &[u8], validate_utf8: bool) {
     let mut scanner = Scanner::new(ScanConfig {
@@ -27,13 +27,17 @@ fn run_transform(data: &[u8], validate_utf8: bool) {
         extract_all: true,
         line_field_name: None,
         validate_utf8,
+        row_predicate: None,
     });
-    let Ok(batch) = scanner.scan_detached(bytes::Bytes::copy_from_slice(data)) else { return; };
+    let Ok(batch) = scanner.scan_detached(bytes::Bytes::copy_from_slice(data)) else {
+        return;
+    };
 
     // SELECT * passes every column through DataFusion unchanged.
     if let Ok(mut transform) = SqlTransform::new("SELECT * FROM logs") {
+        // `execute_blocking` creates a temporary tokio runtime if needed.
         // Errors are fine; panics are not.
-        let _ = transform.execute(batch);
+        let _ = transform.execute_blocking(batch);
     }
 }
 

--- a/dev-docs/verification/fuzz-manifest.toml
+++ b/dev-docs/verification/fuzz-manifest.toml
@@ -17,6 +17,7 @@ targets = [
     "fuzz_scanner_sink",
     "fuzz_scanner_transform",
     "fuzz_cri",
+    "fuzz_udf",
 ]
 
 [crates.ffwd_io_fuzz]


### PR DESCRIPTION
## Summary

Implements Phase 7d (UDF fuzz target) and Phase 8 (backpressure benchmarks) from the reliability stabilization plan.

### Phase 7d — UDF fuzz target

New `fuzz_udf` cargo-fuzz target exercises all 6 UDF implementations against arbitrary scanner-produced RecordBatches:

- **json(), json_int(), json_float()**: field extraction from JSON body
- **hash()**: deterministic FNV-1a hashing
- **regexp_extract()**: regex-based field extraction
- **grok()**: grok pattern matching

20 SQL query variants including edge cases (missing keys, empty keys, non-numeric strings). Errors from `TransformError` are expected and acceptable — only panics are bugs.

**Bug fix**: `scanner_transform.rs` was calling `execute(batch)` (async) without `.await` — the Future was created and immediately dropped, meaning SQL was **never actually executed**. Changed to `execute_blocking()`.

### Phase 8 — Backpressure benchmarks

New `backpressure` Criterion benchmark measures pipeline throughput degradation as output latency increases. Uses `std::sync::mpsc::sync_channel` (capacity=16) to simulate pipeline backpressure.

- **Delays tested**: 0ms, 10ms, 50ms, 200ms per batch
- **Metrics**: lines/sec throughput, stall count, stall rate
- **Key question**: Is the degradation curve smooth or does it cliff?

## Testing

```bash
# Run backpressure benchmark
cargo bench -p ffwd-bench --bench backpressure

# Run UDF fuzz target (requires nightly)
cargo +nightly fuzz run fuzz_udf -- -max_total_time=600
```

## Files changed

| File | Change |
|------|--------|
| `crates/ffwd-core/fuzz/fuzz_targets/fuzz_udf.rs` | New — UDF fuzz target |
| `crates/ffwd-core/fuzz/fuzz_targets/scanner_transform.rs` | Fix `execute()` → `execute_blocking()`, add `row_predicate: None` |
| `crates/ffwd-core/fuzz/Cargo.toml` | Add `fuzz_udf` binary |
| `crates/ffwd-bench/benches/backpressure.rs` | New — backpressure benchmark |
| `crates/ffwd-bench/Cargo.toml` | Add `backpressure` bench |
| `dev-docs/verification/fuzz-manifest.toml` | Register `fuzz_udf` target |

## Pre-existing issues found

- **scanner_transform.rs**: Original `execute(batch)` call was async but never awaited — SQL never ran
- **scanner_transform.rs**: Missing `row_predicate` field in `ScanConfig` (also fixed in `fuzz_udf.rs`)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add UDF fuzz target and backpressure benchmarks to ffwd-core and ffwd-bench
> - Adds a new fuzz target [`fuzz_udf`](https://github.com/strawgate/fastforward/pull/2705/files#diff-b44f6bdbef5782ca9d21e48eb816df1454882439e79e4d5fd129d49a39508024) that runs multiple UDF-focused SQL queries against scanner-produced `RecordBatch` outputs, surfacing panics on arbitrary input while ignoring errors.
> - Updates [`scanner_transform.rs`](https://github.com/strawgate/fastforward/pull/2705/files#diff-e417c93c1a5d0e4d9ab4bc07f48b8db65269d46080ea9b88d9ae752a5aa6d24a) to use `execute_blocking` instead of `execute` for synchronous query execution.
> - Adds a [`backpressure` Criterion benchmark](https://github.com/strawgate/fastforward/pull/2705/files#diff-c82ee382db6e284542b93f4e4106ab1f88fb1ceb9b0d014cb17f345148faf5b9) that runs a bounded producer-consumer simulation with configurable consumer delays (0, 10, 50, 200ms), reporting throughput (bytes/sec, lines/sec) and stall metrics.
> - Setting `BACKPRESSURE_SUMMARY` env var prints an aggregate metrics table to stderr after benchmarking.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2e3e8cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->