### PR TITLE
fix(output): add Content-Encoding header for ES gzip + retry connect failures

### DIFF
--- a/crates/ffwd-output/src/elasticsearch/tests/bulk_retry.rs
+++ b/crates/ffwd-output/src/elasticsearch/tests/bulk_retry.rs
@@ -302,3 +302,59 @@ fn bulk_all_permanent_returns_rejected() {
         "error should report count: {err}"
     );
 }
+
+#[tokio::test]
+async fn bulk_send_with_gzip_sets_content_encoding_header() {
+    use crate::sink::Sink;
+
+    let mut server = mockito::Server::new_async().await;
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new("msg", DataType::Utf8, false)])),
+        vec![Arc::new(StringArray::from(vec!["hello"]))],
+    )
+    .expect("test batch should be valid");
+    let metadata = zero_metadata();
+
+    // Create a config with compress: true
+    let escaped_index = serde_json::to_string("logs").expect("test index");
+    let config = Arc::new(ElasticsearchConfig {
+        endpoint: server.url(),
+        headers: Vec::new(),
+        compress: true,
+        request_mode: ElasticsearchRequestMode::Buffered,
+        max_bulk_bytes: usize::MAX,
+        stream_chunk_bytes: 64 * 1024,
+        bulk_url: format!(
+            "{}/_bulk?filter_path=errors,took,items.*.error,items.*.status",
+            server.url()
+        ),
+        action_bytes: format!("{{\"index\":{{\"_index\":{escaped_index}}}}}\n")
+            .into_bytes()
+            .into_boxed_slice(),
+    });
+
+    let mock = server
+        .mock("POST", "/_bulk")
+        .match_query(mockito::Matcher::Any)
+        .match_header("Content-Encoding", "gzip")
+        .with_status(200)
+        .with_body(r#"{"took":1,"errors":false,"items":[{"index":{"status":201}}]}"#)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mut sink = ElasticsearchSink::new(
+        "test".to_string(),
+        config,
+        reqwest::Client::new(),
+        Arc::new(ComponentStats::default()),
+    );
+
+    let result = sink.send_batch(&batch, &metadata).await;
+    assert!(
+        matches!(result, crate::sink::SendResult::Ok),
+        "gzip send should succeed, got {result:?}"
+    );
+
+    mock.assert_async().await;
+}

--- a/crates/ffwd-output/src/elasticsearch/transport.rs
+++ b/crates/ffwd-output/src/elasticsearch/transport.rs
@@ -57,6 +57,9 @@ impl ElasticsearchSink {
             .client
             .post(&self.config.bulk_url)
             .header("Content-Type", "application/x-ndjson");
+        if self.config.compress {
+            req = req.header("Content-Encoding", "gzip");
+        }
         for (k, v) in &self.config.headers {
             req = req.header(k.clone(), v.clone());
         }

--- a/crates/ffwd-output/src/retry_writer.rs
+++ b/crates/ffwd-output/src/retry_writer.rs
@@ -108,11 +108,26 @@ where
             let deadline = Instant::now() + timeout;
 
             if self.inner.is_none() {
-                let writer = tokio::time::timeout_at(deadline, (self.connect)())
-                    .await
-                    .map_err(|_elapsed| {
-                        io::Error::new(io::ErrorKind::TimedOut, "connect deadline exceeded")
-                    })??;
+                let writer = match tokio::time::timeout_at(deadline, (self.connect)()).await {
+                    Ok(Ok(w)) => w,
+                    Ok(Err(e)) => {
+                        last_error = Some(e);
+                        if attempt == 1 {
+                            break;
+                        }
+                        continue;
+                    }
+                    Err(_elapsed) => {
+                        last_error = Some(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "connect deadline exceeded",
+                        ));
+                        if attempt == 1 {
+                            break;
+                        }
+                        continue;
+                    }
+                };
                 self.inner = Some(writer);
             }
 
@@ -447,5 +462,41 @@ mod tests {
             .await
             .expect_err("should fail when retry connect fails");
         assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
+    }
+
+    #[tokio::test]
+    async fn retry_writer_retries_transient_connect_failure() {
+        // First connect fails, second succeeds. Write should succeed.
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let writer = ScriptedWriter::new(vec![ScriptStep::Write(5)], Arc::clone(&received));
+
+        let connect_calls = Arc::new(Mutex::new(0u32));
+        let connect_calls_clone = Arc::clone(&connect_calls);
+        let writer = Arc::new(Mutex::new(Some(writer)));
+
+        let mut retry: RetryWriter<ScriptedWriter, _> = RetryWriter::new(move || {
+            let mut calls = connect_calls_clone.lock().unwrap();
+            *calls += 1;
+            let call = *calls;
+            let writer = Arc::clone(&writer);
+            async move {
+                if call == 1 {
+                    Err(io::Error::new(
+                        io::ErrorKind::ConnectionRefused,
+                        "transient failure",
+                    ))
+                } else {
+                    Ok(writer.lock().unwrap().take().unwrap())
+                }
+            }
+        });
+
+        retry
+            .write_all_with_retry(b"hello")
+            .await
+            .expect("should succeed after transient connect failure");
+
+        assert_eq!(&*received.lock().unwrap(), &b"hello"[..5]);
+        assert_eq!(*connect_calls.lock().unwrap(), 2, "should have tried twice");
     }
 }


### PR DESCRIPTION
## Summary

Fixes three issues found during codebase audit of recent PRs:

1. **ES gzip Content-Encoding header** — `do_send()` was compressing the body but never setting `Content-Encoding: gzip`. ES would reject the payload.
2. **RetryWriter connect retry** — The `??` operator on connect error early-returned from the retry loop. Transient connect failures now trigger a retry.
3. **Test coverage** — Added `bulk_send_with_gzip_sets_content_encoding_header` and `retry_writer_retries_transient_connect_failure`.

## Changes
- `crates/ffwd-output/src/elasticsearch/transport.rs` — conditionally add `Content-Encoding: gzip`
- `crates/ffwd-output/src/retry_writer.rs` — handle connect errors within the retry loop
- `crates/ffwd-output/src/elasticsearch/tests/bulk_retry.rs` — new gzip header test

## Verification
- `cargo test -p ffwd-output` — all 320 tests pass
- `cargo clippy -p ffwd-output -- -D warnings` — clean

Closes #2714

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing `Content-Encoding: gzip` header in ES bulk requests and retry connect failures
> - Adds the `Content-Encoding: gzip` header to bulk HTTP requests in [`transport.rs`](https://github.com/strawgate/fastforward/pull/2720/files#diff-a445b022d9bf36d8467c8327cfc6d7f30282e981ea6856e37f0956fce1fbb5d3) when `config.compress` is true; previously the header was omitted, causing Elasticsearch to reject compressed payloads.
> - Reworks connection error handling in [`retry_writer.rs`](https://github.com/strawgate/fastforward/pull/2720/files#diff-95708bdf1c61b67907e3084694f1ca373966bee3e2b707484b2cf4bcc631ad35) so that a failed initial connect attempt is retried once before returning an error, matching existing retry behavior for write failures.
> - Behavioral Change: connect errors that previously caused an immediate failure will now trigger one additional connect attempt, adding latency on transient failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef763da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->