### PR TITLE
fix(runtime): remove DrainIngress channel drain suppression + add trait dispatch test

### DIFF
--- a/crates/ffwd-runtime/src/pipeline/mod.rs
+++ b/crates/ffwd-runtime/src/pipeline/mod.rs
@@ -175,13 +175,13 @@ pub enum ControlMessage {
     /// Graceful shutdown: stop accepting new data, cancel workers, drain processors.
     Shutdown,
     /// Intended to stop new ingress while allowing in-flight data to finish.
-    /// Current status: staged placeholder (logs only).
+    /// Current status: staged placeholder — broadcasts to workers but takes no pipeline action.
     DrainIngress,
     /// Trigger checkpoint persistence via the pipeline's [`flush_checkpoints()`][Pipeline::flush_checkpoints] method.
     /// Current status: flushes checkpoint store only; does not evacuate I/O or worker buffers.
     Flush,
     /// Intended hot-reload hook.
-    /// Current status: staged placeholder (logs only).
+    /// Current status: staged placeholder — broadcasts to workers but takes no pipeline action.
     Reconfigure,
 }
 

--- a/crates/ffwd-runtime/src/pipeline/run.rs
+++ b/crates/ffwd-runtime/src/pipeline/run.rs
@@ -168,7 +168,9 @@ impl Pipeline {
                             tracing::debug!("received drain ingress control message");
                             let _ = self.worker_control_tx.send(ControlMessage::DrainIngress);
                             // TODO(#233): stop accepting new input but finish in-flight batches.
-                            should_drain_input_channel = false;
+                            // Note: do NOT set should_drain_input_channel = false here.
+                            // DrainIngress means "stop new input but drain what's buffered" —
+                            // disabling drain would discard pending batches on shutdown.
                         }
                         Some(ControlMessage::Flush) => {
                             tracing::debug!("received flush control message");

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -336,4 +336,32 @@ mod tests {
             assert!(transform.validate_plan().is_ok());
         }
     }
+
+    /// Test that `create_transform` returns a `Box<dyn Transform>` and that
+    /// calling trait methods through the vtable works correctly.
+    #[test]
+    fn create_transform_returns_usable_trait_object() {
+        use arrow::array::Int32Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use std::sync::Arc;
+
+        let transform: Box<dyn Transform> =
+            create_transform("SELECT * FROM logs").expect("create_transform should succeed");
+
+        // Verify trait methods are callable through the vtable.
+        let _config = transform.scan_config();
+
+        // Verify execute_blocking works through dynamic dispatch.
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = arrow::record_batch::RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .expect("valid test batch");
+
+        let mut transform = create_transform("SELECT * FROM logs").expect("create_transform");
+        let result = transform.execute_blocking(batch);
+        assert!(result.is_ok(), "execute_blocking through dyn Transform should work");
+        assert_eq!(result.unwrap().num_rows(), 3);
+    }
 }

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -361,7 +361,10 @@ mod tests {
 
         let mut transform = create_transform("SELECT * FROM logs").expect("create_transform");
         let result = transform.execute_blocking(batch);
-        assert!(result.is_ok(), "execute_blocking through dyn Transform should work");
+        assert!(
+            result.is_ok(),
+            "execute_blocking through dyn Transform should work"
+        );
         assert_eq!(result.unwrap().num_rows(), 3);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a data-loss bug and adds missing test coverage found during codebase audit.

### 1. 🔴 DrainIngress data loss bug (from PR #2689)

**File:** `crates/ffwd-runtime/src/pipeline/run.rs:171`

The `DrainIngress` handler was setting `should_drain_input_channel = false`. This caused a subsequent shutdown to skip the channel drain loop (line 241), dropping any in-flight batches still in the bounded channel. This is the opposite of the stated semantics ("stop new ingress while allowing in-flight data to finish").

**Fix:** Remove the flag mutation. DrainIngress is a staged placeholder — it should not affect drain behavior until #233 is properly implemented.

### 2. Doc comment accuracy (from PR #2689)

Updated `ControlMessage` variant doc comments to reflect actual behavior (broadcasts to workers) rather than the inaccurate "logs only" claim.

### 3. Transform trait dispatch test (from PR #2667)

Added `create_transform_returns_usable_trait_object` that exercises `Box<dyn Transform>` dispatch through the vtable, covering the dynamic dispatch path that was previously untested.

## Verification
- `cargo test -p ffwd-runtime --lib transform` — 10 tests pass
- `cargo clippy -p ffwd-runtime -- -D warnings` — clean

Closes #2716

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `DrainIngress` to keep input channel draining enabled in pipeline run loop
> - Removes an erroneous assignment in the `ControlMessage::DrainIngress` match arm in [`run.rs`](https://github.com/strawgate/fastforward/pull/2721/files#diff-0ca8afafe7514fb7d1a1efed81c5082ddcd5f721e415101399a50805d3419dd8) that was setting `should_drain_input_channel = false`, which caused buffered batches to be discarded instead of processed.
> - Adds a test in [`transform.rs`](https://github.com/strawgate/fastforward/pull/2721/files#diff-82fa3bfc4e6200ef08023428759d2794a7c92ef67b4c202edcb2b52a30de1bdf) verifying that `create_transform` produces a usable trait object and that dynamic dispatch through `scan_config` and `execute_blocking` works correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c858ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->