### PR TITLE
docs: fix factual errors in CLI reference and dev-docs

### DIFF
--- a/book/src/content/docs/cli/reference.mdx
+++ b/book/src/content/docs/cli/reference.mdx
@@ -96,13 +96,14 @@ In non-interactive mode `--destination` is required. In an interactive terminal,
 
 | Option | Description |
 |--------|-------------|
-| `--destination` | Sink type (required in non-interactive mode, prompted otherwise): `otlp`, `elasticsearch` (aliases: `elasticsearch_otlp`, `elasticsearch_bulk`), `loki`, `arrow_ipc`, `udp`, `tcp`, `null` |
+| `--destination` | Sink type (required in non-interactive mode, prompted otherwise): `otlp` (alias: `elasticsearch_otlp`), `elasticsearch` (alias: `elasticsearch_bulk`), `loki`, `arrow_ipc`, `udp`, `tcp`, `null` |
 | `--endpoint` | Destination URL/address (required for all destinations except `null`) |
 | `--workers` | Worker threads (default: `2`) |
 | `--batch-lines` | Lines per batch (default: `5000`) |
 | `--duration-secs` | Stop automatically after N seconds (default: run until stopped) |
 | `--auth-bearer-token` | Bearer token auth header |
 | `--auth-header` | Extra header, repeatable: `--auth-header 'Authorization=ApiKey xyz'` |
+| `--diagnostics-addr` | Diagnostics server bind address (default: `127.0.0.1:0`) |
 
 ## ff devour
 
@@ -121,6 +122,7 @@ Unlike `blast`, `devour` does **not** require `--destination` — it accepts mul
 | `--mode` | Receiver type: `otlp` (default), `http`, `elasticsearch_bulk`, `tcp`, `udp` |
 | `--listen` | Bind address (default depends on mode: OTLP → `127.0.0.1:4318`) |
 | `--duration-secs` | Stop automatically after N seconds (default: run until stopped) |
+| `--diagnostics-addr` | Diagnostics server bind address (default: `127.0.0.1:0`) |
 
 ## ff blackhole
 
@@ -169,6 +171,7 @@ Print shell completion scripts.
 ff completions bash
 ff completions zsh
 ff completions fish
+ff completions elvish
 ff completions powershell
 ff completions nushell
 ```

--- a/dev-docs/ADAPTER_CONTRACT.md
+++ b/dev-docs/ADAPTER_CONTRACT.md
@@ -19,7 +19,7 @@ responsibilities. Current code still uses implementation names such as
 In-scope:
 
 - OTLP HTTP input (`crates/ffwd-io/src/otlp_receiver.rs`)
-- OTLP output (`crates/ffwd-output/src/otlp_sink.rs`)
+- OTLP output (`crates/ffwd-output/src/otlp_sink/`)
 - File input + framing + checkpointed delivery
 - diagnostics/readiness/status surfaces
 - pipeline checkpoint and output retry semantics

--- a/dev-docs/ARCHITECTURE.md
+++ b/dev-docs/ARCHITECTURE.md
@@ -264,7 +264,7 @@ RecordBatch → OutputSink::send_batch() → HTTP/stdout/file
 - **JsonLinesSink**: Converts RecordBatch → newline-delimited JSON,
   sends via HTTP with zstd compression.
 - **StdoutSink**: Renders to terminal (JSON, console, or text format).
-- **FanoutSink**: Sends to multiple sinks.
+- **AsyncFanoutSink**: Sends to multiple sinks.
 
 ## Crate boundaries
 

--- a/dev-docs/CRATE_RULES.md
+++ b/dev-docs/CRATE_RULES.md
@@ -72,7 +72,7 @@ Rules and constraints for each crate. Enforced by CI, not just convention.
 | Rule | Enforcement |
 |------|-------------|
 | Owns diagnostics server, telemetry shaping, and stderr/span buffering | Architecture |
-| Allowed deps: `ffwd-types`, `tiny_http`, `tracing`, `serde(_yaml_ng/_json)`, `opentelemetry(_sdk)`, `url`, `libc` | Cargo.toml + review |
+| Allowed deps: `ffwd-types`, `axum`, `tokio`, `tracing`, `serde(_yaml_ng/_json)`, `opentelemetry(_sdk)`, `url`, `libc` | Cargo.toml + review |
 | Owns diagnostics dashboard asset `crates/ffwd-diagnostics/src/dashboard.html` (generated from `dashboard/`) | Dashboard build + code review |
 | Must not depend on runtime orchestration crates (`ffwd-runtime`, `ffwd-output`) | Cargo dependency graph + review |
 | Kani seams for readiness policy and stderr escaping stay tracked in `dev-docs/verification/kani-boundary-contract.toml` | CI script: `python3 scripts/verify_kani_boundary_contract.py` |

--- a/dev-docs/CRATE_RULES.md
+++ b/dev-docs/CRATE_RULES.md
@@ -8,7 +8,7 @@ Rules and constraints for each crate. Enforced by CI, not just convention.
 |------|-------------|
 | `#![no_std]` + alloc | Compiler. CI: `cargo build --target thumbv6m-none-eabi` |
 | `#![forbid(unsafe_code)]` | Compiler. Cannot be overridden with `#[allow]`. |
-| Only deps: memchr + wide + ffwd-kani | CI dependency allowlist check |
+| Only deps: memchr + wide + ffwd-kani + ffwd-lint-attrs | CI dependency allowlist check |
 | No panics | `clippy::unwrap_used`, `clippy::panic`, `clippy::indexing_slicing` = deny |
 | Every public item documented | `#![warn(missing_docs)]` at crate root |
 | No stdout/stderr writes | `clippy::print_stdout`, `clippy::print_stderr` = warn workspace-wide; no `#![allow]` opt-out |


### PR DESCRIPTION
## Summary

Fixes several factual errors and omissions in documentation introduced or missed during the recent rename and restructuring PRs.

## Changes

### CLI Reference (book/src/content/docs/cli/reference.mdx)
- **Fix `--destination` alias grouping**: `elasticsearch_otlp` is an alias for `otlp`, not for `elasticsearch`. `elasticsearch_bulk` is the alias for `elasticsearch`.
- **Add `--diagnostics-addr`** to both `blast` and `devour` option tables (flag exists in CLI but was undocumented).
- **Add `elvish`** to shell completions list (supported in code via `CompletionShell::Elvish`).

### Dev-docs
- **CRATE_RULES.md**: `ffwd-diagnostics` allowed deps listed `tiny_http` but the crate actually uses `axum` + `tokio`.
- **ADAPTER_CONTRACT.md**: Referenced `otlp_sink.rs` (a file) but it's actually `otlp_sink/` (a directory/module).
- **ARCHITECTURE.md**: Referenced `FanoutSink` but the actual struct is `AsyncFanoutSink`.

## Test Plan

Documentation-only changes. Verified all referenced items exist:
- `CompletionShell::Elvish` variant in `crates/ffwd/src/cli.rs`
- `--diagnostics-addr` flag on both blast and devour subcommands
- `axum` in `crates/ffwd-diagnostics/Cargo.toml`
- `crates/ffwd-output/src/otlp_sink/` is a directory
- `AsyncFanoutSink` struct in `crates/ffwd-output/src/sink.rs`

Closes #2717

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix factual errors in CLI reference and dev-docs
> - Updates `--destination` option descriptions in [reference.mdx](https://github.com/strawgate/fastforward/pull/2722/files#diff-c03092700868e06036dd075389e65503c425087d81a2c29b84f3934b03da0bb0) to correctly pair aliases with primary types (e.g. `otlp (alias: elasticsearch_otlp)`).
> - Adds missing `--diagnostics-addr` option rows for `ff blast` and `ff devour` commands, and adds `ff completions elvish` to the completions examples.
> - Corrects OTLP sink path in [ADAPTER_CONTRACT.md](https://github.com/strawgate/fastforward/pull/2722/files#diff-a8fd95c1bdb4125a19cebace3395d30eac66de7eee3f4721796e01d26f06ffbc) from a single file to the directory `crates/ffwd-output/src/otlp_sink/`.
> - Renames `FanoutSink` to `AsyncFanoutSink` in [ARCHITECTURE.md](https://github.com/strawgate/fastforward/pull/2722/files#diff-f109635269f2efa455c79859387e178d4dbe865572738500d977bf02709278a0) and updates allowed dependencies in [CRATE_RULES.md](https://github.com/strawgate/fastforward/pull/2722/files#diff-958a311e311cbbb8f5cd2468d12a90f0c4532cbdbd684c51633fa6fabb0333a3) to reflect `axum`/`tokio` replacing `tiny_http` and adding `ffwd-lint-attrs`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24182c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->