### PR TITLE
fix: remove duplicate write_hex16 and use saturating_add in generator

### DIFF
--- a/crates/ffwd-io/src/generator/arrow.rs
+++ b/crates/ffwd-io/src/generator/arrow.rs
@@ -41,7 +41,7 @@ pub fn generate_arrow_batch(
     let mut msg_buf = Vec::with_capacity(64);
 
     for i in 0..n {
-        let counter = start_counter.wrapping_add(i as u64);
+        let counter = start_counter.saturating_add(i as u64);
         let Some(fields) =
             compute_log_fields(counter, timestamp_config, GeneratorComplexity::Simple, None)
         else {
@@ -67,7 +67,7 @@ pub fn generate_arrow_batch(
         duration_builder.append_value(fields.duration_ms as i64);
 
         // request_id: stack-based hex formatting
-        write_hex16_into(&mut hex_buf, fields.request_id);
+        write_hex16(&mut hex_buf, fields.request_id);
         append_utf8_or_null(&mut rid_builder, &hex_buf);
 
         service_builder.append_value(fields.service);
@@ -104,17 +104,5 @@ fn append_utf8_or_null(builder: &mut StringBuilder, bytes: &[u8]) {
     match std::str::from_utf8(bytes) {
         Ok(value) => builder.append_value(value),
         Err(_) => builder.append_null(),
-    }
-}
-
-/// Write a u64 as 16 zero-padded lowercase hex digits into a fixed buffer.
-fn write_hex16_into(out: &mut [u8; 16], val: u64) {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut v = val;
-    let mut i = 15_i32;
-    while i >= 0 {
-        out[i as usize] = HEX[(v & 0xf) as usize];
-        v >>= 4;
-        i -= 1;
     }
 }


### PR DESCRIPTION
## Summary

Fixes two code quality issues in the generator module introduced during PR #2607 (generator Arrow batch support).

## Changes

### Remove duplicate `write_hex16_into` (arrow.rs)

### Replace `wrapping_add` with `saturating_add` (arrow.rs:44)
The counter arithmetic in `generate_arrow_batch` used `wrapping_add`, which could silently wrap around near `u64::MAX` and produce duplicate counter values (generating duplicate events). Using `saturating_add` instead ensures the counter clamps at `u64::MAX`, which then causes `compute_log_fields` to return `None` (triggering the early break), consistent with how `input.rs` uses `checked_add` for its counter.

## Test Plan

```bash
cargo clippy -p ffwd-io -- -D warnings  # ✅ clean
cargo test -p ffwd-io --lib generator    # ✅ 36 tests pass
```

The existing `arrow_matches_json_path` equivalence test confirms the arrow batch path still produces identical output to the JSON serialization path.

Closes #2718

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate `write_hex16` and use `saturating_add` for counter in arrow generator
> - Replaces the local `write_hex16_into` helper in [arrow.rs](https://github.com/strawgate/fastforward/pull/2723/files#diff-71bef03e5f8f63baf096a23de69796cabcb0efbe4996d98cdd671f6356a36e2f) with a call to the shared `write_hex16` function, removing the duplicate.
> - Changes the per-row counter calculation in `generate_arrow_batch` from `wrapping_add` to `saturating_add`, so the counter saturates at `u64::MAX` instead of wrapping around on overflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2757bfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->