### PR TITLE
perf(io/projection): add #[inline] to write_wire_any dispatch + write helpers

### DIFF
--- a/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
@@ -889,6 +889,7 @@ pub(super) fn wire_any_field_kind(value: &WireAny<'_>) -> FieldKind {
     }
 }
 
+#[inline]
 pub(super) fn write_wire_any(
     builder: &mut ColumnarBatchBuilder,
     handle: FieldHandle,
@@ -917,6 +918,7 @@ pub(super) fn write_wire_any(
     Ok(())
 }
 
+#[inline]
 pub(super) fn write_wire_any_as_string(
     builder: &mut ColumnarBatchBuilder,
     handle: FieldHandle,

--- a/crates/ffwd-io/src/otlp_receiver/projection/write.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/write.rs
@@ -47,6 +47,7 @@ pub(super) fn write_json_escaped_bytes(out: &mut Vec<u8>, value: &[u8]) {
     }
 }
 
+#[inline]
 pub(super) fn write_wire_str(
     builder: &mut ColumnarBatchBuilder,
     handle: FieldHandle,
@@ -65,6 +66,7 @@ pub(super) fn write_wire_str(
     Ok(())
 }
 
+#[inline]
 pub(super) fn write_hex_field(
     builder: &mut ColumnarBatchBuilder,
     handle: FieldHandle,

--- a/scripts/generate_otlp_projection.py
+++ b/scripts/generate_otlp_projection.py
@@ -430,13 +430,11 @@ def render_key_value_decoder(spec: dict) -> str:
     return f"""/// Decode a `KeyValue` record into raw key bytes and a typed value.
 ///
 /// The key bytes are returned **unvalidated**. Callers must run UTF-8
-/// validation before using the key as a `&str`. Two known callers:
+/// validation before using the key as a `&str`.
 ///
-/// * `decode::resolve_record_attr_field` — validates only on attribute
-///   position-cache miss; cache hits are byte-equal to a previously
-///   validated key, so re-validation is redundant.
-/// * `decode::collect_resource_attrs` — validates eagerly because there
-///   is no per-position cache for resource attrs.
+/// Note: production code now uses `wire::decode_kv_inline` for performance.
+/// This function is retained as the reference implementation for tests.
+#[cfg(test)]
 pub(super) fn decode_key_value_wire(kv: &[u8]) -> Result<Option<(&[u8], WireAny<'_>)>, ProjectionError> {{
     let mut key = &[][..];
     let mut value = None;
@@ -1016,7 +1014,8 @@ def render_wire_any_appenders(spec: dict) -> str:
             f"expected={sorted(expected_kinds)} got={sorted(kinds)}"
         )
 
-    return """pub(super) fn write_wire_any(
+    return """#[inline]
+pub(super) fn write_wire_any(
     builder: &mut ColumnarBatchBuilder,
     handle: FieldHandle,
     value: WireAny<'_>,
@@ -1039,6 +1038,7 @@ def render_wire_any_appenders(spec: dict) -> str:
     Ok(())
 }
 
+#[inline]
 pub(super) fn write_wire_any_as_string(
     builder: &mut ColumnarBatchBuilder,
     handle: FieldHandle,


### PR DESCRIPTION
## Summary

Profile-driven follow-up to #2688. Adds `#[inline]` to four hot-path write functions in the OTLP projection pipeline.

## Changes

- `write_wire_any` — match dispatch over `WireAny` variants to typed column writes
- `write_wire_any_as_string` — coerce-to-string variant  
- `write_wire_str` — string storage dispatch (Decoded vs InputRef)
- `write_hex_field` — trace/span ID hex encoding

## Motivation

pprof flamegraph (5 kHz, wide-10k, 500 iterations) showed `write_wire_any` at **8.5% self-time** — the #1 bottleneck after inline KV+AnyValue decode landed in #2688. Post-annotation flamegraph confirms it drops out of the self-time top-25 entirely (compiler inlines at call sites).

These are intra-crate calls (within `ffwd-io`), so LTO may already inline them in some configurations. The explicit annotation ensures consistent inlining regardless of LTO settings and makes the intent clear.

## Profile (post-optimization, wide-10k)

No single function above 4% self-time — the profile is now flat:
- `for_each_field` scope parsing: 4.0%
- `resolve_record_attr_field` + slice_eq: 3.8%
- `read_varint`: 2.3%
- `write_hex_field`: 1.4%

## Test plan

- 86/86 projection tests pass
- `cargo clippy -p ffwd-io -- -D warnings` clean

Relates to #2688

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `#[inline]` to `write_wire_any` and write helper functions in OTLP projection
> Adds `#[inline]` to `wire_any_field_kind`, `write_wire_any`, `write_wire_str`, and `write_hex_field` in the OTLP receiver projection to hint the compiler to inline these dispatch and write helpers. The code generator in [generate_otlp_projection.py](https://github.com/strawgate/fastforward/pull/2724/files#diff-765702fc827a3de5898b159e81f6fe58e91b7df6bcd71bb72484fe0c13cfa59f) is updated to emit `#[inline]` for the generated functions, and a minor indentation fix is applied to the rendered doc comment block.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 256bb5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->