### PR TITLE
Pipelined file sink separating serialization from I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,6 +2200,7 @@ dependencies = [
  "httpdate",
  "insta",
  "itoa",
+ "libc",
  "memchr",
  "mockito",
  "opentelemetry-proto",

--- a/crates/ffwd-bench/Cargo.toml
+++ b/crates/ffwd-bench/Cargo.toml
@@ -12,7 +12,9 @@ autobins = false
 # Enables helper/profiling binaries and their non-benchmark dependency graph.
 bench-tools = ["dep:parquet"]
 dhat-heap = ["dep:dhat"]
+io-bench = ["dep:ffwd-io", "ffwd-io/otlp-research"]
 otlp-profile-alloc = []
+s3-bench = ["io-bench", "ffwd-io/s3"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libc = "0.2"
@@ -26,10 +28,7 @@ dhat = { version = "0.3", optional = true }
 fastrand = "2"
 ffwd-arrow = { version = "0.1.0", path = "../ffwd-arrow" }
 ffwd-core = { version = "0.1.0", path = "../ffwd-core" }
-ffwd-io = { version = "0.1.0", path = "../ffwd-io", features = [
-    "otlp-research",
-    "s3",
-] }
+ffwd-io = { version = "0.1.0", path = "../ffwd-io", optional = true }
 ffwd-output = { version = "0.1.0", path = "../ffwd-output" }
 ffwd-transform = { version = "0.1.0", path = "../ffwd-transform" }
 ffwd-types = { version = "0.1.0", path = "../ffwd-types" }
@@ -47,7 +46,7 @@ serde_json = "1"
 stats_alloc = { workspace = true }
 tempfile = "3"
 tiny_http = "0.12"
-tokio = { version = "1", features = ["rt-multi-thread"] }
+tokio = { version = "1", features = ["rt-multi-thread", "fs", "io-util"] }
 
 # Research: library evaluation candidates
 async-compression = { version = "0.4", features = ["tokio", "zstd", "gzip"] }
@@ -71,6 +70,7 @@ harness = false
 [[bench]]
 name = "pipeline"
 harness = false
+required-features = ["io-bench"]
 
 [[bench]]
 name = "elasticsearch_arrow"
@@ -83,6 +83,7 @@ harness = false
 [[bench]]
 name = "output_encode"
 harness = false
+required-features = ["io-bench"]
 
 [[bench]]
 name = "otap_proto"
@@ -91,6 +92,7 @@ harness = false
 [[bench]]
 name = "otlp_io"
 harness = false
+required-features = ["io-bench"]
 
 [[bench]]
 name = "full_chain"
@@ -115,6 +117,7 @@ harness = false
 [[bench]]
 name = "s3_input"
 harness = false
+required-features = ["s3-bench"]
 
 [[bench]]
 name = "source_metadata"
@@ -123,6 +126,7 @@ harness = false
 [[bench]]
 name = "generator_arrow_vs_json"
 harness = false
+required-features = ["io-bench"]
 
 [[bench]]
 name = "hot_path_kernels"
@@ -161,11 +165,18 @@ test = false
 required-features = ["bench-tools"]
 
 [[bin]]
+name = "file_sink_compare"
+path = "src/bin/file_sink_compare.rs"
+bench = false
+test = false
+required-features = ["bench-tools"]
+
+[[bin]]
 name = "framed_input_profile"
 path = "src/bin/framed_input_profile.rs"
 bench = false
 test = false
-required-features = ["bench-tools"]
+required-features = ["bench-tools", "io-bench"]
 
 [[bin]]
 name = "generator_profile"
@@ -200,7 +211,7 @@ name = "otlp_e2e_profile"
 path = "src/bin/otlp_e2e_profile.rs"
 bench = false
 test = false
-required-features = ["bench-tools"]
+required-features = ["bench-tools", "io-bench"]
 
 [[bin]]
 name = "otlp_encode_profile"
@@ -214,7 +225,7 @@ name = "otlp_io_profile"
 path = "src/bin/otlp_io_profile.rs"
 bench = false
 test = false
-required-features = ["bench-tools"]
+required-features = ["bench-tools", "io-bench"]
 
 [[bin]]
 name = "source_metadata_profile"
@@ -228,7 +239,7 @@ name = "e2e_profile"
 path = "src/e2e_profile.rs"
 bench = false
 test = false
-required-features = ["bench-tools"]
+required-features = ["bench-tools", "io-bench"]
 
 [[bin]]
 name = "explore"

--- a/crates/ffwd-bench/src/bin/file_sink_compare.rs
+++ b/crates/ffwd-bench/src/bin/file_sink_compare.rs
@@ -1,0 +1,850 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+//! Comprehensive file output strategy comparison.
+//!
+//! Tests three key dimensions:
+//! 1. Serialization+I/O threading strategies (serial vs threaded pipeline)
+//! 2. Durability modes (no-sync, periodic sync, every-batch sync)
+//! 3. Sustained load (enough volume to exhaust page cache benefit)
+//!
+//! Run with: cargo run --release -p ffwd-bench --bin file_sink_compare -- [OPTIONS]
+//!   --schema narrow|wide|mixed   Data schema (default: wide)
+//!   --batches N                  Number of batches (default: 200)
+//!   --batch-size N               Rows per batch (default: 10000)
+//!   --sync-interval N            Fsync every N batches, 0=never (default: 0)
+//!   --scenario all|basic|sync|sustained  Which test set (default: all)
+
+use std::io::{self, Write};
+use std::sync::Arc;
+use std::sync::mpsc::{SyncSender, sync_channel};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use arrow::record_batch::RecordBatch;
+use ffwd_bench::generators;
+use ffwd_output::{BatchMetadata, FileSinkFactory, SinkFactory, StdoutFormat, StdoutSink};
+use ffwd_types::diagnostics::ComponentStats;
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncWriteExt, BufWriter};
+use tokio::runtime::Runtime;
+use tokio::sync::Mutex;
+
+const TOKIO_BUF_CAPACITY: usize = 16 * 1024 * 1024;
+const STD_BUF_CAPACITY: usize = 16 * 1024 * 1024;
+
+struct StrategyResult {
+    name: &'static str,
+    elapsed: Duration,
+}
+
+fn parse_flag(args: &[String], flag: &str, default: &str) -> String {
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1))
+        .map_or_else(|| default.to_string(), String::clone)
+}
+
+fn parse_usize_flag(args: &[String], flag: &str, default: usize) -> usize {
+    parse_flag(args, flag, &default.to_string())
+        .parse()
+        .unwrap_or(default)
+}
+
+fn fmt_throughput(total_rows: u64, total_bytes: u64, elapsed: Duration) -> String {
+    let secs = elapsed.as_secs_f64();
+    if secs == 0.0 {
+        return "N/A".to_owned();
+    }
+    let lines_per_sec = total_rows as f64 / secs;
+    let mb_per_sec = total_bytes as f64 / 1_048_576.0 / secs;
+    format!("{lines_per_sec:.0} lines/sec ({mb_per_sec:.1} MB/sec)")
+}
+
+fn fmt_bytes(bytes: u64) -> String {
+    if bytes >= 1_073_741_824 {
+        format!("{:.1} GB", bytes as f64 / 1_073_741_824.0)
+    } else if bytes >= 1_048_576 {
+        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
+    } else if bytes >= 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn generate_batch(schema: &str, batch_size: usize) -> (RecordBatch, BatchMetadata, &'static str) {
+    match schema {
+        "wide" => (
+            generators::gen_wide_batch(batch_size, 42),
+            generators::make_metadata(),
+            "wide",
+        ),
+        "mixed" => (
+            generators::gen_production_mixed_batch(batch_size, 42),
+            generators::make_metadata(),
+            "mixed",
+        ),
+        _ => (
+            generators::gen_narrow_batch(batch_size, 42),
+            generators::make_metadata(),
+            "narrow",
+        ),
+    }
+}
+
+fn serialize_batch(batch: &RecordBatch, meta: &BatchMetadata) -> io::Result<Vec<u8>> {
+    let stats = Arc::new(ComponentStats::new());
+    let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+    let mut out = Vec::with_capacity(batch.num_rows() * 300);
+    sink.write_batch_to(batch, meta, &mut out)?;
+    Ok(out)
+}
+
+fn run_serialize_only(
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let stats = Arc::new(ComponentStats::new());
+    let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+    let mut out = Vec::with_capacity(batch.num_rows() * 300);
+    let start = Instant::now();
+    for _ in 0..num_batches {
+        out.clear();
+        sink.write_batch_to(batch, meta, &mut out)?;
+        std::hint::black_box(&out);
+    }
+    Ok(StrategyResult {
+        name: "serialize_only",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_serialize_std_nosync(
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let stats = Arc::new(ComponentStats::new());
+    let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+    let mut out = Vec::with_capacity(batch.num_rows() * 300);
+    let tmp = NamedTempFile::new()?;
+    let mut file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let start = Instant::now();
+    for _ in 0..num_batches {
+        out.clear();
+        sink.write_batch_to(batch, meta, &mut out)?;
+        file.write_all(&out)?;
+    }
+    Ok(StrategyResult {
+        name: "serialize_std_nosync",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_serialize_tokio_nosync(
+    rt: &Runtime,
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let stats = Arc::new(ComponentStats::new());
+    let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+    let mut out = Vec::with_capacity(batch.num_rows() * 300);
+    let tmp = NamedTempFile::new()?;
+    let std_file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let mut file = tokio::fs::File::from_std(std_file);
+    let start = Instant::now();
+    rt.block_on(async {
+        for _ in 0..num_batches {
+            out.clear();
+            sink.write_batch_to(batch, meta, &mut out)?;
+            file.write_all(&out).await?;
+        }
+        Ok::<(), io::Error>(())
+    })?;
+    Ok(StrategyResult {
+        name: "serialize_tokio_nosync",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_serialize_tokio_mutex_nosync(
+    rt: &Runtime,
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let stats = Arc::new(ComponentStats::new());
+    let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+    let mut out = Vec::with_capacity(batch.num_rows() * 300);
+    let tmp = NamedTempFile::new()?;
+    let std_file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let file = Arc::new(Mutex::new(tokio::fs::File::from_std(std_file)));
+    let start = Instant::now();
+    rt.block_on(async {
+        for _ in 0..num_batches {
+            out.clear();
+            sink.write_batch_to(batch, meta, &mut out)?;
+            let mut guard = file.lock().await;
+            guard.write_all(&out).await?;
+        }
+        Ok::<(), io::Error>(())
+    })?;
+    Ok(StrategyResult {
+        name: "serialize_tokio_mutex",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_std_direct(payload: &[u8], num_batches: usize) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let mut file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let start = Instant::now();
+    for _ in 0..num_batches {
+        file.write_all(payload)?;
+    }
+    file.flush()?;
+    file.sync_data()?;
+    Ok(StrategyResult {
+        name: "std_direct",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_std_direct_nosync(payload: &[u8], num_batches: usize) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let mut file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let start = Instant::now();
+    for _ in 0..num_batches {
+        file.write_all(payload)?;
+    }
+    Ok(StrategyResult {
+        name: "std_direct_nosync",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_std_bufwriter(payload: &[u8], num_batches: usize) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let mut file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let start = Instant::now();
+    {
+        let mut writer = io::BufWriter::with_capacity(STD_BUF_CAPACITY, &mut file);
+        for _ in 0..num_batches {
+            writer.write_all(payload)?;
+        }
+        writer.flush()?;
+    }
+    file.sync_data()?;
+    Ok(StrategyResult {
+        name: "std_bufwriter_16m",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_tokio_direct(
+    rt: &Runtime,
+    payload: &[u8],
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let std_file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let mut file = tokio::fs::File::from_std(std_file);
+    let start = Instant::now();
+    rt.block_on(async {
+        for _ in 0..num_batches {
+            file.write_all(payload).await?;
+        }
+        file.flush().await?;
+        file.sync_data().await
+    })?;
+    Ok(StrategyResult {
+        name: "tokio_direct",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_tokio_direct_nosync(
+    rt: &Runtime,
+    payload: &[u8],
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let std_file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let mut file = tokio::fs::File::from_std(std_file);
+    let start = Instant::now();
+    rt.block_on(async {
+        for _ in 0..num_batches {
+            file.write_all(payload).await?;
+        }
+        Ok::<(), io::Error>(())
+    })?;
+    Ok(StrategyResult {
+        name: "tokio_direct_nosync",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_tokio_bufwriter(
+    rt: &Runtime,
+    payload: &[u8],
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let std_file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let file = tokio::fs::File::from_std(std_file);
+    let mut writer = BufWriter::with_capacity(TOKIO_BUF_CAPACITY, file);
+    let start = Instant::now();
+    rt.block_on(async {
+        for _ in 0..num_batches {
+            writer.write_all(payload).await?;
+        }
+        writer.flush().await?;
+        writer.get_mut().sync_data().await
+    })?;
+    Ok(StrategyResult {
+        name: "tokio_bufwriter_16m",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_file_sink(
+    rt: &Runtime,
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let stats = Arc::new(ComponentStats::new());
+    let factory = FileSinkFactory::new(
+        "bench".into(),
+        tmp.path().to_string_lossy().into_owned(),
+        StdoutFormat::Json,
+        stats,
+    )?;
+    let mut sink = factory.create()?;
+    let start = Instant::now();
+    rt.block_on(async {
+        for _ in 0..num_batches {
+            match sink.send_batch(batch, meta).await {
+                ffwd_output::SendResult::Ok => {}
+                other => {
+                    return Err(io::Error::other(format!(
+                        "file sink send_batch failed: {other:?}"
+                    )));
+                }
+            }
+        }
+        sink.flush().await
+    })?;
+    Ok(StrategyResult {
+        name: "file_sink_full",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn run_file_sink_send_only(
+    rt: &Runtime,
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let stats = Arc::new(ComponentStats::new());
+    let factory = FileSinkFactory::new(
+        "bench".into(),
+        tmp.path().to_string_lossy().into_owned(),
+        StdoutFormat::Json,
+        stats,
+    )?;
+    let mut sink = factory.create()?;
+    let start = Instant::now();
+    rt.block_on(async {
+        for _ in 0..num_batches {
+            match sink.send_batch(batch, meta).await {
+                ffwd_output::SendResult::Ok => {}
+                other => {
+                    return Err(io::Error::other(format!(
+                        "file sink send_batch failed: {other:?}"
+                    )));
+                }
+            }
+        }
+        Ok::<(), io::Error>(())
+    })?;
+    Ok(StrategyResult {
+        name: "file_sink_send_only",
+        elapsed: start.elapsed(),
+    })
+}
+
+fn return_buffer(tx: &SyncSender<Vec<u8>>, mut buf: Vec<u8>) -> io::Result<()> {
+    buf.clear();
+    tx.send(buf)
+        .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "buffer return channel closed"))
+}
+
+/// Threaded pipeline: serialization on caller, I/O on dedicated OS thread.
+/// Double-buffered with sync_channel.
+fn run_threaded_pipeline(
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+    sync_interval: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let path = tmp.path().to_path_buf();
+    let payload_capacity = batch.num_rows() * 300;
+
+    // Use 3 buffers for triple-buffering: writer can drain while serializer fills next
+    let (filled_tx, filled_rx) = sync_channel::<Vec<u8>>(3);
+    let (empty_tx, empty_rx) = sync_channel::<Vec<u8>>(3);
+    for _ in 0..3 {
+        empty_tx
+            .send(Vec::with_capacity(payload_capacity))
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "failed to seed empty buffer")
+            })?;
+    }
+
+    let sync_iv = sync_interval;
+    let writer_empty_tx = empty_tx.clone();
+    let writer = thread::spawn(move || -> io::Result<()> {
+        let mut file = std::fs::OpenOptions::new().append(true).open(&path)?;
+        let mut count = 0usize;
+        while let Ok(buf) = filled_rx.recv() {
+            file.write_all(&buf)?;
+            return_buffer(&writer_empty_tx, buf)?;
+            count += 1;
+            if sync_iv > 0 && count % sync_iv == 0 {
+                file.sync_data()?;
+            }
+        }
+        file.flush()?;
+        file.sync_data()?;
+        Ok(())
+    });
+
+    let stats = Arc::new(ComponentStats::new());
+    let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+    let start = Instant::now();
+    for _ in 0..num_batches {
+        let mut buf = empty_rx.recv().map_err(|_| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "empty buffer channel closed")
+        })?;
+        sink.write_batch_to(batch, meta, &mut buf)?;
+        filled_tx.send(buf).map_err(|_| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "filled buffer channel closed")
+        })?;
+    }
+    drop(filled_tx);
+    drop(empty_tx);
+    writer
+        .join()
+        .map_err(|_| io::Error::other("writer thread panicked"))??;
+
+    let name = if sync_interval > 0 {
+        "threaded_sync"
+    } else {
+        "threaded_nosync"
+    };
+    Ok(StrategyResult {
+        name,
+        elapsed: start.elapsed(),
+    })
+}
+
+/// Serial pipeline with periodic sync: serialize then write sequentially, fsync every N.
+fn run_serial_periodic_sync(
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+    sync_interval: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let mut file = std::fs::OpenOptions::new().append(true).open(tmp.path())?;
+    let stats = Arc::new(ComponentStats::new());
+    let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+    let mut out = Vec::with_capacity(batch.num_rows() * 300);
+
+    let start = Instant::now();
+    for i in 0..num_batches {
+        out.clear();
+        sink.write_batch_to(batch, meta, &mut out)?;
+        file.write_all(&out)?;
+        if sync_interval > 0 && (i + 1) % sync_interval == 0 {
+            file.sync_data()?;
+        }
+    }
+    file.flush()?;
+    file.sync_data()?;
+
+    let name = if sync_interval > 0 {
+        "serial_sync"
+    } else {
+        "serial_nosync"
+    };
+    Ok(StrategyResult {
+        name,
+        elapsed: start.elapsed(),
+    })
+}
+
+/// Multi-producer threaded pipeline: N serializer threads feed one writer thread.
+/// Simulates real pipeline with multiple workers.
+fn run_multi_producer_threaded(
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+    num_producers: usize,
+    sync_interval: usize,
+) -> io::Result<StrategyResult> {
+    use std::sync::Mutex as StdMutex;
+
+    let tmp = NamedTempFile::new()?;
+    let path = tmp.path().to_path_buf();
+    let payload_capacity = batch.num_rows() * 300;
+
+    // Shared channels: all producers write filled buffers, shared empty pool
+    let (filled_tx, filled_rx) = sync_channel::<Vec<u8>>(num_producers * 2);
+    let (empty_tx, empty_rx) = sync_channel::<Vec<u8>>(num_producers * 2);
+    for _ in 0..(num_producers * 2) {
+        empty_tx
+            .send(Vec::with_capacity(payload_capacity))
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "failed to seed empty buffer")
+            })?;
+    }
+
+    // Wrap receiver in Arc<Mutex> for sharing among producers
+    let empty_rx = Arc::new(StdMutex::new(empty_rx));
+
+    let sync_iv = sync_interval;
+    let writer_empty_tx = empty_tx.clone();
+    let writer = thread::spawn(move || -> io::Result<()> {
+        let mut file = std::fs::OpenOptions::new().append(true).open(&path)?;
+        let mut count = 0usize;
+        while let Ok(buf) = filled_rx.recv() {
+            file.write_all(&buf)?;
+            return_buffer(&writer_empty_tx, buf)?;
+            count += 1;
+            if sync_iv > 0 && count % sync_iv == 0 {
+                file.sync_data()?;
+            }
+        }
+        file.flush()?;
+        file.sync_data()?;
+        Ok(())
+    });
+
+    let batches_per_producer = num_batches / num_producers;
+    let start = Instant::now();
+
+    // Spawn producer threads
+    let producers: Vec<_> = (0..num_producers)
+        .map(|_| {
+            let batch = batch.clone();
+            let meta = meta.clone();
+            let filled_tx = filled_tx.clone();
+            let empty_rx = Arc::clone(&empty_rx);
+            thread::spawn(move || -> io::Result<()> {
+                let stats = Arc::new(ComponentStats::new());
+                let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+                for _ in 0..batches_per_producer {
+                    let mut buf = empty_rx
+                        .lock()
+                        .map_err(|_| io::Error::other("mutex poisoned"))?
+                        .recv()
+                        .map_err(|_| {
+                            io::Error::new(
+                                io::ErrorKind::BrokenPipe,
+                                "empty buffer channel closed",
+                            )
+                        })?;
+                    sink.write_batch_to(&batch, &meta, &mut buf)?;
+                    filled_tx.send(buf).map_err(|_| {
+                        io::Error::new(io::ErrorKind::BrokenPipe, "filled buffer channel closed")
+                    })?;
+                }
+                Ok(())
+            })
+        })
+        .collect();
+
+    // Drop our copies so the writer sees EOF when all producers finish
+    drop(filled_tx);
+    drop(empty_tx);
+
+    for p in producers {
+        p.join()
+            .map_err(|_| io::Error::other("producer thread panicked"))??;
+    }
+    writer
+        .join()
+        .map_err(|_| io::Error::other("writer thread panicked"))??;
+
+    Ok(StrategyResult {
+        name: "multi_producer",
+        elapsed: start.elapsed(),
+    })
+}
+
+/// Threaded pipeline with BufWriter on the writer thread.
+/// Reduces syscall count by coalescing small writes.
+fn run_threaded_bufwriter(
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+    sync_interval: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let path = tmp.path().to_path_buf();
+    let payload_capacity = batch.num_rows() * 300;
+
+    let (filled_tx, filled_rx) = sync_channel::<Vec<u8>>(3);
+    let (empty_tx, empty_rx) = sync_channel::<Vec<u8>>(3);
+    for _ in 0..3 {
+        empty_tx
+            .send(Vec::with_capacity(payload_capacity))
+            .map_err(|_| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "failed to seed empty buffer")
+            })?;
+    }
+
+    let sync_iv = sync_interval;
+    let writer_empty_tx = empty_tx.clone();
+    let writer = thread::spawn(move || -> io::Result<()> {
+        let file = std::fs::OpenOptions::new().append(true).open(&path)?;
+        let mut writer = io::BufWriter::with_capacity(STD_BUF_CAPACITY, file);
+        let mut count = 0usize;
+        while let Ok(buf) = filled_rx.recv() {
+            writer.write_all(&buf)?;
+            return_buffer(&writer_empty_tx, buf)?;
+            count += 1;
+            if sync_iv > 0 && count % sync_iv == 0 {
+                writer.flush()?;
+                writer.get_mut().sync_data()?;
+            }
+        }
+        writer.flush()?;
+        writer.get_mut().sync_data()?;
+        Ok(())
+    });
+
+    let stats = Arc::new(ComponentStats::new());
+    let mut sink = StdoutSink::new("bench".into(), StdoutFormat::Json, stats);
+    let start = Instant::now();
+    for _ in 0..num_batches {
+        let mut buf = empty_rx.recv().map_err(|_| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "empty buffer channel closed")
+        })?;
+        sink.write_batch_to(batch, meta, &mut buf)?;
+        filled_tx.send(buf).map_err(|_| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "filled buffer channel closed")
+        })?;
+    }
+    drop(filled_tx);
+    drop(empty_tx);
+    writer
+        .join()
+        .map_err(|_| io::Error::other("writer thread panicked"))??;
+
+    let name = if sync_interval > 0 {
+        "threaded_buf_sync"
+    } else {
+        "threaded_buf_nosync"
+    };
+    Ok(StrategyResult {
+        name,
+        elapsed: start.elapsed(),
+    })
+}
+
+/// FileSink with periodic flush (simulates real-world durability).
+fn run_file_sink_periodic_sync(
+    rt: &Runtime,
+    batch: &RecordBatch,
+    meta: &BatchMetadata,
+    num_batches: usize,
+    sync_interval: usize,
+) -> io::Result<StrategyResult> {
+    let tmp = NamedTempFile::new()?;
+    let stats = Arc::new(ComponentStats::new());
+    let factory = FileSinkFactory::new(
+        "bench".into(),
+        tmp.path().to_string_lossy().into_owned(),
+        StdoutFormat::Json,
+        stats,
+    )?;
+    let mut sink = factory.create()?;
+    let start = Instant::now();
+    rt.block_on(async {
+        for i in 0..num_batches {
+            match sink.send_batch(batch, meta).await {
+                ffwd_output::SendResult::Ok => {}
+                other => {
+                    return Err(io::Error::other(format!(
+                        "file sink send_batch failed: {other:?}"
+                    )));
+                }
+            }
+            if sync_interval > 0 && (i + 1) % sync_interval == 0 {
+                sink.flush().await?;
+            }
+        }
+        sink.flush().await
+    })?;
+
+    let name = if sync_interval > 0 {
+        "filesink_sync"
+    } else {
+        "filesink_nosync"
+    };
+    Ok(StrategyResult {
+        name,
+        elapsed: start.elapsed(),
+    })
+}
+
+fn main() -> io::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        eprintln!("Usage: file_sink_compare [OPTIONS]");
+        eprintln!("  --schema narrow|wide|mixed  Data schema (default: wide)");
+        eprintln!("  --batches N                 Number of batches (default: 200)");
+        eprintln!("  --batch-size N              Rows per batch (default: 10000)");
+        eprintln!("  --sync-interval N           Fsync every N batches, 0=never (default: 0)");
+        eprintln!("  --scenario all|basic|sync|sustained|threaded");
+        eprintln!("                              Which test set (default: all)");
+        return Ok(());
+    }
+
+    let schema = parse_flag(&args, "--schema", "wide");
+    let num_batches = parse_usize_flag(&args, "--batches", 200);
+    let batch_size = parse_usize_flag(&args, "--batch-size", 10_000);
+    let sync_interval = parse_usize_flag(&args, "--sync-interval", 0);
+    let scenario = parse_flag(&args, "--scenario", "all");
+
+    let (batch, meta, schema_name) = generate_batch(&schema, batch_size);
+    let payload = serialize_batch(&batch, &meta)?;
+    let total_rows = (num_batches * batch.num_rows()) as u64;
+    let total_bytes = payload.len() as u64 * num_batches as u64;
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    println!("=== File Sink Compare ===");
+    println!("Schema:        {schema_name}");
+    println!("Batch rows:    {}", batch.num_rows());
+    println!("Batches:       {num_batches}");
+    println!(
+        "Payload/batch: {} ({:.0} bytes/row)",
+        fmt_bytes(payload.len() as u64),
+        payload.len() as f64 / batch.num_rows() as f64
+    );
+    println!("Total output:  {}", fmt_bytes(total_bytes));
+    if sync_interval > 0 {
+        println!("Sync interval: every {sync_interval} batches");
+    }
+    println!();
+
+    let mut results: Vec<StrategyResult> = Vec::new();
+
+    // === Basic strategies (original set) ===
+    if scenario == "all" || scenario == "basic" {
+        println!("--- Basic Strategies ---");
+        results.push(run_serialize_only(&batch, &meta, num_batches)?);
+        results.push(run_serialize_std_nosync(&batch, &meta, num_batches)?);
+        results.push(run_serialize_tokio_nosync(&rt, &batch, &meta, num_batches)?);
+        results.push(run_serialize_tokio_mutex_nosync(&rt, &batch, &meta, num_batches)?);
+        results.push(run_std_direct_nosync(&payload, num_batches)?);
+        results.push(run_std_direct(&payload, num_batches)?);
+        results.push(run_std_bufwriter(&payload, num_batches)?);
+        results.push(run_tokio_direct_nosync(&rt, &payload, num_batches)?);
+        results.push(run_tokio_direct(&rt, &payload, num_batches)?);
+        results.push(run_tokio_bufwriter(&rt, &payload, num_batches)?);
+        results.push(run_file_sink_send_only(&rt, &batch, &meta, num_batches)?);
+        results.push(run_file_sink(&rt, &batch, &meta, num_batches)?);
+    }
+
+    // === Threaded pipeline comparison ===
+    if scenario == "all" || scenario == "threaded" {
+        println!("--- Threaded Pipeline Strategies ---");
+        // No sync
+        results.push(run_serial_periodic_sync(&batch, &meta, num_batches, 0)?);
+        results.push(run_threaded_pipeline(&batch, &meta, num_batches, 0)?);
+        results.push(run_threaded_bufwriter(&batch, &meta, num_batches, 0)?);
+        results.push(run_file_sink_periodic_sync(
+            &rt, &batch, &meta, num_batches, 0,
+        )?);
+    }
+
+    // === Sync-interval comparison (the money test) ===
+    if scenario == "all" || scenario == "sync" {
+        let intervals = if sync_interval > 0 {
+            vec![sync_interval]
+        } else {
+            vec![10, 50]
+        };
+        for iv in &intervals {
+            println!("--- Sync Every {iv} Batches ---");
+            results.push(run_serial_periodic_sync(&batch, &meta, num_batches, *iv)?);
+            results.push(run_threaded_pipeline(&batch, &meta, num_batches, *iv)?);
+            results.push(run_threaded_bufwriter(&batch, &meta, num_batches, *iv)?);
+            results.push(run_file_sink_periodic_sync(
+                &rt, &batch, &meta, num_batches, *iv,
+            )?);
+        }
+    }
+
+    // === Sustained high-volume test ===
+    if scenario == "all" || scenario == "sustained" {
+        // Use 2000 batches (20M rows) to exhaust page cache benefit
+        let sustained_batches = 2000;
+        let sustained_total_rows = (sustained_batches * batch.num_rows()) as u64;
+        let sustained_total_bytes = payload.len() as u64 * sustained_batches as u64;
+        println!(
+            "--- Sustained Volume ({} / {} rows) ---",
+            fmt_bytes(sustained_total_bytes),
+            sustained_total_rows
+        );
+        let s1 = run_serial_periodic_sync(&batch, &meta, sustained_batches, 50)?;
+        let s2 = run_threaded_pipeline(&batch, &meta, sustained_batches, 50)?;
+        let s3 = run_threaded_bufwriter(&batch, &meta, sustained_batches, 50)?;
+        let s4 = run_multi_producer_threaded(&batch, &meta, sustained_batches, 2, 50)?;
+        let s5 = run_multi_producer_threaded(&batch, &meta, sustained_batches, 4, 50)?;
+
+        println!("| Strategy | Elapsed | Per Batch | Throughput |");
+        println!("|----------|---------|-----------|------------|");
+        for result in [&s1, &s2, &s3, &s4, &s5] {
+            let per_batch = result.elapsed / sustained_batches as u32;
+            println!(
+                "| {} | {:>7.1?} | {:>9.1?} | {} |",
+                result.name,
+                result.elapsed,
+                per_batch,
+                fmt_throughput(sustained_total_rows, sustained_total_bytes, result.elapsed),
+            );
+        }
+        println!();
+    }
+
+    // Print main results table
+    if !results.is_empty() {
+        println!("| Strategy | Elapsed | Per Batch | Throughput |");
+        println!("|----------|---------|-----------|------------|");
+        for result in &results {
+            let per_batch = result.elapsed / num_batches as u32;
+            println!(
+                "| {} | {:>7.1?} | {:>9.1?} | {} |",
+                result.name,
+                result.elapsed,
+                per_batch,
+                fmt_throughput(total_rows, total_bytes, result.elapsed),
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/ffwd-bench/src/bin/file_sink_compare.rs
+++ b/crates/ffwd-bench/src/bin/file_sink_compare.rs
@@ -557,10 +557,7 @@ fn run_multi_producer_threaded(
                         .map_err(|_| io::Error::other("mutex poisoned"))?
                         .recv()
                         .map_err(|_| {
-                            io::Error::new(
-                                io::ErrorKind::BrokenPipe,
-                                "empty buffer channel closed",
-                            )
+                            io::Error::new(io::ErrorKind::BrokenPipe, "empty buffer channel closed")
                         })?;
                     sink.write_batch_to(&batch, &meta, &mut buf)?;
                     filled_tx.send(buf).map_err(|_| {
@@ -757,7 +754,12 @@ fn main() -> io::Result<()> {
         results.push(run_serialize_only(&batch, &meta, num_batches)?);
         results.push(run_serialize_std_nosync(&batch, &meta, num_batches)?);
         results.push(run_serialize_tokio_nosync(&rt, &batch, &meta, num_batches)?);
-        results.push(run_serialize_tokio_mutex_nosync(&rt, &batch, &meta, num_batches)?);
+        results.push(run_serialize_tokio_mutex_nosync(
+            &rt,
+            &batch,
+            &meta,
+            num_batches,
+        )?);
         results.push(run_std_direct_nosync(&payload, num_batches)?);
         results.push(run_std_direct(&payload, num_batches)?);
         results.push(run_std_bufwriter(&payload, num_batches)?);
@@ -776,7 +778,11 @@ fn main() -> io::Result<()> {
         results.push(run_threaded_pipeline(&batch, &meta, num_batches, 0)?);
         results.push(run_threaded_bufwriter(&batch, &meta, num_batches, 0)?);
         results.push(run_file_sink_periodic_sync(
-            &rt, &batch, &meta, num_batches, 0,
+            &rt,
+            &batch,
+            &meta,
+            num_batches,
+            0,
         )?);
     }
 
@@ -793,7 +799,11 @@ fn main() -> io::Result<()> {
             results.push(run_threaded_pipeline(&batch, &meta, num_batches, *iv)?);
             results.push(run_threaded_bufwriter(&batch, &meta, num_batches, *iv)?);
             results.push(run_file_sink_periodic_sync(
-                &rt, &batch, &meta, num_batches, *iv,
+                &rt,
+                &batch,
+                &meta,
+                num_batches,
+                *iv,
             )?);
         }
     }

--- a/crates/ffwd-bench/src/file_output_profile.rs
+++ b/crates/ffwd-bench/src/file_output_profile.rs
@@ -1,8 +1,19 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 //! CPU and memory profiler for the file output hot path.
 //!
-//! Isolates the JSON serialization + file I/O cost of `FileSink` / `StdoutSink`
-//! so we can identify where cycles and allocations go.
+//! Isolates JSON serialization plus a **FileSink-like std::fs write path** so we
+//! can identify where cycles and allocations go.
+//!
+//! Important: this tool does **not** exercise the actual async `FileSink`
+//! implementation. Its "FULL" path models:
+//! - `StdoutSink::write_batch_to`
+//! - line counting with `memchr`
+//! - `std::fs::File::write_all`
+//! - a final `sync_data()` at the end of the run
+//!
+//! That makes it useful for splitting serialization vs write cost, but its
+//! "FULL" number is durability-sensitive and can diverge from steady-state
+//! `FileSink::send_batch` throughput.
 //!
 //! Modes:
 //!   - **cpu**: pprof flamegraph of `write_batch_to` + file I/O
@@ -166,7 +177,15 @@ fn run_breakdown(
     }
     let build_col_elapsed = start.elapsed();
 
-    // 2. write_row_json_resolved loop timing (with pre-built col_infos + resolve)
+    // 2. resolve_col_infos timing
+    let cols = build_col_infos(batch);
+    let start = Instant::now();
+    for _ in 0..num_batches {
+        let _resolved = std::hint::black_box(resolve_col_infos(batch, &cols));
+    }
+    let resolve_col_elapsed = start.elapsed();
+
+    // 3. write_row_json_resolved loop timing (with pre-built col_infos + resolve)
     let cols = build_col_infos(batch);
     let resolved = resolve_col_infos(batch, &cols);
     let start = Instant::now();
@@ -179,7 +198,7 @@ fn run_breakdown(
     }
     let json_elapsed = start.elapsed();
 
-    // 3. write_batch_to timing (includes build_col_infos + write_row_json)
+    // 4. write_batch_to timing (includes build_col_infos + resolve_col_infos + write_row_json)
     let start = Instant::now();
     for _ in 0..num_batches {
         buf.clear();
@@ -189,7 +208,7 @@ fn run_breakdown(
     }
     let batch_elapsed = start.elapsed();
 
-    // 4. memchr line counting timing
+    // 5. memchr line counting timing
     let start = Instant::now();
     for _ in 0..num_batches {
         // Re-serialize to have realistic data in buf
@@ -202,7 +221,7 @@ fn run_breakdown(
     // Subtract the batch_elapsed to isolate memchr cost
     let memchr_only = count_elapsed.saturating_sub(batch_elapsed);
 
-    // 5. File I/O timing (write_all to tmpfile)
+    // 6. File I/O timing (write_all to tmpfile)
     let tmp = tempfile::NamedTempFile::new().expect("tmpfile failed");
     let mut file = std::fs::OpenOptions::new()
         .append(true)
@@ -219,7 +238,7 @@ fn run_breakdown(
     file.sync_data().expect("sync_data failed");
     let io_elapsed = start.elapsed();
 
-    // 6. Full file output timing (serialize + write_all + line count)
+    // 7. Full std::fs write path timing (serialize + line count + write_all)
     let mut file2 = std::fs::OpenOptions::new()
         .append(true)
         .open(tmp.path())
@@ -243,11 +262,12 @@ fn run_breakdown(
     println!("|-------|-------|-----------|-----------|------------|");
     let stages: Vec<(&str, Duration)> = vec![
         ("build_col_infos", build_col_elapsed),
+        ("resolve_col_infos", resolve_col_elapsed),
         ("write_row_json_resolved (loop)", json_elapsed),
         ("write_batch_to (end-to-end)", batch_elapsed),
         ("memchr line count", memchr_only),
         ("file write_all + sync", io_elapsed),
-        ("FULL (serialize+count+IO)", full_elapsed),
+        ("FULL (serialize+count+std::fs IO)", full_elapsed),
     ];
     for (name, dur) in &stages {
         let pct = if full_elapsed.as_nanos() > 0 {
@@ -279,6 +299,10 @@ fn run_breakdown(
     println!(
         "  Serialization:     {:.1}% of total",
         batch_elapsed.as_nanos() as f64 / full_elapsed.as_nanos() as f64 * 100.0
+    );
+    println!(
+        "  resolve_col_infos: {:.1}% of serialization",
+        resolve_col_elapsed.as_nanos() as f64 / batch_elapsed.as_nanos() as f64 * 100.0
     );
     println!(
         "  File I/O:          {:.1}% of total",
@@ -335,7 +359,15 @@ fn run_alloc(
     }
     let col_stats = reg.change();
 
-    // 2. write_row_json_resolved with pre-built cols (buffer reuse)
+    // 2. resolve_col_infos allocations
+    let cols = build_col_infos(batch);
+    let reg = Region::new(&INSTRUMENTED_SYSTEM);
+    for _ in 0..num_batches {
+        let _resolved = std::hint::black_box(resolve_col_infos(batch, &cols));
+    }
+    let resolve_stats = reg.change();
+
+    // 3. write_row_json_resolved with pre-built cols (buffer reuse)
     let cols = build_col_infos(batch);
     let resolved = resolve_col_infos(batch, &cols);
     buf.clear();
@@ -349,7 +381,7 @@ fn run_alloc(
     }
     let json_stats = reg.change();
 
-    // 3. write_batch_to end-to-end
+    // 4. write_batch_to end-to-end
     let reg = Region::new(&INSTRUMENTED_SYSTEM);
     for _ in 0..num_batches {
         buf.clear();
@@ -358,7 +390,7 @@ fn run_alloc(
     }
     let batch_stats = reg.change();
 
-    // 4. Full FileSink-like path (serialize + line count + file write)
+    // 5. Full FileSink-like path (serialize + line count + file write)
     let tmp = tempfile::NamedTempFile::new().expect("tmpfile failed");
     let mut file = std::fs::OpenOptions::new()
         .append(true)
@@ -382,6 +414,7 @@ fn run_alloc(
 
     let stages = vec![
         ("build_col_infos", &col_stats),
+        ("resolve_col_infos", &resolve_stats),
         ("write_row_json_resolved (reuse buf)", &json_stats),
         ("write_batch_to", &batch_stats),
         ("FULL (ser+count+IO)", &full_stats),
@@ -540,6 +573,10 @@ fn main() {
         );
         eprintln!();
         eprintln!("Note: --mode alloc requires --features otlp-profile-alloc");
+        eprintln!(
+            "Note: FULL timing uses a std::fs write path with end-of-run sync_data(); \
+steady-state FileSink send_batch throughput can differ."
+        );
         return;
     }
 

--- a/crates/ffwd-output/Cargo.toml
+++ b/crates/ffwd-output/Cargo.toml
@@ -16,6 +16,7 @@ ffwd-core = { version = "0.1.0", path = "../ffwd-core" }
 ffwd-otap-proto = { version = "0.1.0", path = "../ffwd-otap-proto" }
 ffwd-types = { version = "0.1.0", path = "../ffwd-types" }
 flate2 = "1"
+libc = { workspace = true }
 httpdate = "1"
 itoa = "1"
 memchr = "2"

--- a/crates/ffwd-output/src/file_sink.rs
+++ b/crates/ffwd-output/src/file_sink.rs
@@ -17,8 +17,8 @@ use ffwd_types::field_names;
 /// Append-only file sink with pipelined serialization and I/O.
 ///
 /// Serialization (JSON/text) runs on the tokio worker thread while a dedicated
-/// OS writer thread handles file I/O. This overlaps CPU and I/O for ~40% higher
-/// sustained throughput at volume.
+/// OS writer thread handles file I/O. This overlaps CPU and I/O for ~21% higher
+/// sustained throughput at volume (benchmarked on Apple M4).
 ///
 /// Uses the same row serialization logic as `StdoutSink` so `stdout` and
 /// `file` stay behaviorally aligned.

--- a/crates/ffwd-output/src/file_sink.rs
+++ b/crates/ffwd-output/src/file_sink.rs
@@ -32,7 +32,7 @@ impl FileSink {
         format: StdoutFormat,
         file: std::fs::File,
         stats: Arc<ComponentStats>,
-    ) -> Self {
+    ) -> io::Result<Self> {
         Self::with_message_field(name, format, field_names::BODY.to_string(), file, stats)
     }
 
@@ -43,7 +43,7 @@ impl FileSink {
         message_field: String,
         file: std::fs::File,
         stats: Arc<ComponentStats>,
-    ) -> Self {
+    ) -> io::Result<Self> {
         let serializer = JsonBatchSerializer::with_message_field(
             name,
             format,
@@ -52,9 +52,9 @@ impl FileSink {
         );
         let writer = FileWriter::new(file);
         let config = PipelineConfig::default();
-        Self {
-            inner: PipelinedSink::new(serializer, writer, stats, config),
-        }
+        Ok(Self {
+            inner: PipelinedSink::new(serializer, writer, stats, config)?,
+        })
     }
 }
 
@@ -133,7 +133,7 @@ impl SinkFactory for FileSinkFactory {
             self.message_field.clone(),
             file,
             Arc::clone(&self.stats),
-        )))
+        )?))
     }
 
     fn name(&self) -> &str {

--- a/crates/ffwd-output/src/file_sink.rs
+++ b/crates/ffwd-output/src/file_sink.rs
@@ -4,59 +4,56 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use arrow::record_batch::RecordBatch;
-use tokio::io::AsyncWriteExt;
-use tokio::sync::Mutex;
 
 use ffwd_types::diagnostics::ComponentStats;
 
 use crate::BatchMetadata;
+use crate::pipelined::{FileWriter, JsonBatchSerializer, PipelineConfig, PipelinedSink};
 use crate::sink::{SendResult, Sink, SinkFactory};
 
-use super::stdout::{StdoutFormat, StdoutSink};
+use super::stdout::StdoutFormat;
 use ffwd_types::field_names;
 
-/// Append-only file sink.
+/// Append-only file sink with pipelined serialization and I/O.
+///
+/// Serialization (JSON/text) runs on the tokio worker thread while a dedicated
+/// OS writer thread handles file I/O. This overlaps CPU and I/O for ~40% higher
+/// sustained throughput at volume.
 ///
 /// Uses the same row serialization logic as `StdoutSink` so `stdout` and
 /// `file` stay behaviorally aligned.
 pub struct FileSink {
-    serializer: StdoutSink,
-    file: Arc<Mutex<tokio::fs::File>>,
-    output_buf: Vec<u8>,
-    stats: Arc<ComponentStats>,
+    inner: PipelinedSink<JsonBatchSerializer>,
 }
 
 impl FileSink {
     pub fn new(
         name: String,
         format: StdoutFormat,
-        file: Arc<Mutex<tokio::fs::File>>,
+        file: std::fs::File,
         stats: Arc<ComponentStats>,
     ) -> Self {
         Self::with_message_field(name, format, field_names::BODY.to_string(), file, stats)
     }
 
     /// Create a file sink with a custom text/console message field fallback.
-    ///
-    /// The serializer prefers canonical `body` when present, then this
-    /// configured field, then legacy aliases.
     pub fn with_message_field(
         name: String,
         format: StdoutFormat,
         message_field: String,
-        file: Arc<Mutex<tokio::fs::File>>,
+        file: std::fs::File,
         stats: Arc<ComponentStats>,
     ) -> Self {
+        let serializer = JsonBatchSerializer::with_message_field(
+            name,
+            format,
+            message_field,
+            Arc::clone(&stats),
+        );
+        let writer = FileWriter::new(file);
+        let config = PipelineConfig::default();
         Self {
-            serializer: StdoutSink::with_message_field(
-                name,
-                format,
-                message_field,
-                Arc::clone(&stats),
-            ),
-            file,
-            output_buf: Vec::with_capacity(64 * 1024),
-            stats,
+            inner: PipelinedSink::new(serializer, writer, stats, config),
         }
     }
 }
@@ -67,47 +64,19 @@ impl Sink for FileSink {
         batch: &'a RecordBatch,
         metadata: &'a BatchMetadata,
     ) -> Pin<Box<dyn Future<Output = SendResult> + Send + 'a>> {
-        Box::pin(async move {
-            self.output_buf.clear();
-            let lines_written =
-                match self
-                    .serializer
-                    .write_batch_to(batch, metadata, &mut self.output_buf)
-                {
-                    Ok(n) => n as u64,
-                    Err(e) => return SendResult::from_io_error(e),
-                };
-
-            let bytes_written = self.output_buf.len() as u64;
-            let mut file = self.file.lock().await;
-            if let Err(e) = file.write_all(&self.output_buf).await {
-                return SendResult::from_io_error(e);
-            }
-
-            self.stats.inc_lines(lines_written);
-            self.stats.inc_bytes(bytes_written);
-            SendResult::Ok
-        })
+        self.inner.send_batch(batch, metadata)
     }
 
     fn flush(&mut self) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + '_>> {
-        Box::pin(async move {
-            let mut file = self.file.lock().await;
-            file.flush().await?;
-            file.sync_data().await
-        })
+        self.inner.flush()
     }
 
     fn name(&self) -> &str {
-        self.serializer.name()
+        self.inner.name()
     }
 
     fn shutdown(&mut self) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + '_>> {
-        Box::pin(async move {
-            let mut file = self.file.lock().await;
-            file.flush().await?;
-            file.sync_data().await
-        })
+        self.inner.shutdown()
     }
 }
 
@@ -115,7 +84,7 @@ pub struct FileSinkFactory {
     name: String,
     format: StdoutFormat,
     message_field: String,
-    file: Arc<Mutex<tokio::fs::File>>,
+    path: String,
     stats: Arc<ComponentStats>,
 }
 
@@ -137,16 +106,16 @@ impl FileSinkFactory {
         message_field: String,
         stats: Arc<ComponentStats>,
     ) -> io::Result<Self> {
-        let std_file = std::fs::OpenOptions::new()
+        // Verify we can open the file (fail-fast on permission errors).
+        let _file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(path)?;
-        let file = tokio::fs::File::from_std(std_file);
+            .open(&path)?;
         Ok(Self {
             name,
             format,
             message_field,
-            file: Arc::new(Mutex::new(file)),
+            path,
             stats,
         })
     }
@@ -154,11 +123,15 @@ impl FileSinkFactory {
 
 impl SinkFactory for FileSinkFactory {
     fn create(&self) -> io::Result<Box<dyn Sink>> {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
         Ok(Box::new(FileSink::with_message_field(
             self.name.clone(),
             self.format,
             self.message_field.clone(),
-            Arc::clone(&self.file),
+            file,
             Arc::clone(&self.stats),
         )))
     }
@@ -168,6 +141,10 @@ impl SinkFactory for FileSinkFactory {
     }
 
     fn is_single_use(&self) -> bool {
+        // A single file can only safely have one writer — multiple fds in
+        // append mode risk interleaving partial writes for large buffers.
+        // The pipelined sink already overlaps serialize+I/O on one worker,
+        // which is the optimal architecture for single-file output.
         true
     }
 }

--- a/crates/ffwd-output/src/lib.rs
+++ b/crates/ffwd-output/src/lib.rs
@@ -10,6 +10,7 @@ mod json_lines;
 mod null;
 mod otap_sink;
 mod otlp_sink;
+pub mod pipelined;
 pub(crate) mod retry_writer;
 pub mod sink;
 mod stdout;
@@ -46,6 +47,9 @@ pub use otap_sink::{
     encode_batch_arrow_records_generated_fast,
 };
 pub use otlp_sink::{OtlpSink, OtlpSinkFactory};
+pub use pipelined::{
+    BatchSerializer, BatchWriter, FileWriter, JsonBatchSerializer, PipelineConfig, PipelinedSink,
+};
 pub use sink::{
     AsyncFanoutFactory, AsyncFanoutSink, OnceAsyncFactory, SendResult, Sink, SinkFactory,
 };

--- a/crates/ffwd-output/src/lib.rs
+++ b/crates/ffwd-output/src/lib.rs
@@ -10,7 +10,7 @@ mod json_lines;
 mod null;
 mod otap_sink;
 mod otlp_sink;
-pub mod pipelined;
+pub(crate) mod pipelined;
 pub(crate) mod retry_writer;
 pub mod sink;
 mod stdout;
@@ -47,9 +47,6 @@ pub use otap_sink::{
     encode_batch_arrow_records_generated_fast,
 };
 pub use otlp_sink::{OtlpSink, OtlpSinkFactory};
-pub use pipelined::{
-    BatchSerializer, BatchWriter, FileWriter, JsonBatchSerializer, PipelineConfig, PipelinedSink,
-};
 pub use sink::{
     AsyncFanoutFactory, AsyncFanoutSink, OnceAsyncFactory, SendResult, Sink, SinkFactory,
 };

--- a/crates/ffwd-output/src/pipelined.rs
+++ b/crates/ffwd-output/src/pipelined.rs
@@ -115,6 +115,9 @@ enum WriterMsg {
     Shutdown(SyncSender<io::Result<()>>),
 }
 
+/// Sent from writer thread to signal a write failure.
+struct WriteError(io::Error);
+
 // ---------------------------------------------------------------------------
 // PipelinedSink
 // ---------------------------------------------------------------------------
@@ -131,6 +134,10 @@ pub struct PipelinedSink<S: BatchSerializer> {
     /// Channel to receive empty (recycled) buffers back from the writer.
     empty_rx: mpsc::Receiver<Vec<u8>>,
 
+    /// Channel to receive write errors from the writer thread.
+    /// Non-blocking: checked before each send_batch to surface I/O failures.
+    error_rx: mpsc::Receiver<WriteError>,
+
     /// Handle to the writer thread (for join on shutdown).
     writer_handle: Option<JoinHandle<()>>,
 }
@@ -139,14 +146,16 @@ impl<S: BatchSerializer> PipelinedSink<S> {
     /// Create a new pipelined sink.
     ///
     /// Spawns a dedicated OS thread for the writer immediately.
+    /// Returns an error if the thread cannot be spawned.
     pub fn new(
         serializer: S,
         writer: impl BatchWriter,
         stats: Arc<ComponentStats>,
         config: PipelineConfig,
-    ) -> Self {
+    ) -> io::Result<Self> {
         let (filled_tx, filled_rx) = mpsc::sync_channel::<WriterMsg>(config.num_buffers);
         let (empty_tx, empty_rx) = mpsc::sync_channel::<Vec<u8>>(config.num_buffers);
+        let (error_tx, error_rx) = mpsc::sync_channel::<WriteError>(config.num_buffers);
 
         // Seed the empty buffer pool.
         for _ in 0..config.num_buffers {
@@ -156,16 +165,29 @@ impl<S: BatchSerializer> PipelinedSink<S> {
         let writer_handle = thread::Builder::new()
             .name(format!("ffwd-writer-{}", serializer.name()))
             .spawn(move || {
-                writer_thread_loop(writer, filled_rx, empty_tx);
+                writer_thread_loop(writer, filled_rx, empty_tx, error_tx);
             })
-            .expect("failed to spawn writer thread");
+            .map_err(io::Error::other)?;
 
-        Self {
+        Ok(Self {
             serializer,
             stats,
             filled_tx: Some(filled_tx),
             empty_rx,
+            error_rx,
             writer_handle: Some(writer_handle),
+        })
+    }
+
+    /// Check for write errors from the writer thread (non-blocking).
+    ///
+    /// Returns the first queued error, if any. This surfaces I/O failures
+    /// from previous batches — a write error on batch N is reported during
+    /// `send_batch` for batch N+1.
+    fn check_writer_error(&self) -> io::Result<()> {
+        match self.error_rx.try_recv() {
+            Ok(WriteError(e)) => Err(e),
+            Err(_) => Ok(()),
         }
     }
 
@@ -228,6 +250,11 @@ impl<S: BatchSerializer> Sink for PipelinedSink<S> {
         metadata: &'a BatchMetadata,
     ) -> Pin<Box<dyn Future<Output = SendResult> + Send + 'a>> {
         Box::pin(async move {
+            // Check for write errors from previous batches before accepting new work.
+            if let Err(e) = self.check_writer_error() {
+                return SendResult::from_io_error(e);
+            }
+
             // Acquire an empty buffer from the pool (blocks if writer is behind).
             let mut buf = match self.acquire_buffer() {
                 Ok(b) => b,
@@ -305,13 +332,15 @@ fn writer_thread_loop(
     mut writer: impl BatchWriter,
     filled_rx: mpsc::Receiver<WriterMsg>,
     empty_tx: SyncSender<Vec<u8>>,
+    error_tx: SyncSender<WriteError>,
 ) {
     while let Ok(msg) = filled_rx.recv() {
         match msg {
             WriterMsg::Data(buf) => {
                 if let Err(e) = writer.write(&buf) {
                     tracing::error!(error = %e, "pipelined writer: write failed");
-                    // Return the buffer anyway to avoid deadlock.
+                    // Notify the caller about the write failure.
+                    let _ = error_tx.try_send(WriteError(e));
                 }
                 // Recycle the buffer back to the pool.
                 let mut recycled = buf;
@@ -505,13 +534,6 @@ pub struct JsonBatchSerializer {
 }
 
 impl JsonBatchSerializer {
-    /// Create a new JSON batch serializer.
-    pub fn new(name: String, format: StdoutFormat, stats: Arc<ComponentStats>) -> Self {
-        Self {
-            inner: StdoutSink::new(name, format, stats),
-        }
-    }
-
     /// Create with a custom message field name.
     pub fn with_message_field(
         name: String,

--- a/crates/ffwd-output/src/pipelined.rs
+++ b/crates/ffwd-output/src/pipelined.rs
@@ -84,8 +84,10 @@ pub trait BatchWriter: Send + 'static {
 
 /// Configuration for the pipelined sink.
 pub struct PipelineConfig {
-    /// Number of buffers in the pool (channel depth + 1 in-flight).
-    /// Default: 3 (triple-buffered).
+    /// Number of buffers in the pool. These are cycled between the serializer
+    /// and writer threads for zero-allocation steady-state operation.
+    /// Default: 3 (triple-buffered: one being serialized, one in flight, one
+    /// being written).
     pub num_buffers: usize,
 
     /// Initial capacity for each buffer in bytes.

--- a/crates/ffwd-output/src/pipelined.rs
+++ b/crates/ffwd-output/src/pipelined.rs
@@ -338,22 +338,144 @@ fn writer_thread_loop(
 // FileWriter
 // ---------------------------------------------------------------------------
 
+/// Pre-allocation chunk size: 64 MB.
+///
+/// When the file is opened (or needs more space), we ask the OS to reserve
+/// this much contiguous space.  This avoids per-write metadata updates on
+/// ext4/xfs/APFS that slow down sequential extending writes.
+const PREALLOC_BYTES: i64 = 64 * 1024 * 1024;
+
 /// A [`BatchWriter`] that writes to a file using blocking std::fs I/O.
+///
+/// Applies platform-specific optimizations on construction:
+///
+/// | Platform | Optimization |
+/// |----------|-------------|
+/// | Linux | `fallocate` pre-allocation, `POSIX_FADV_DONTNEED` after writes |
+/// | macOS | `F_PREALLOCATE`, `F_NOCACHE` (bypass UBC for written pages) |
+/// | Windows | (standard `write_all` — no extra APIs yet) |
 pub struct FileWriter {
     file: std::fs::File,
+    /// Cumulative bytes written — used for `FADV_DONTNEED` offset tracking.
+    #[cfg(target_os = "linux")]
+    bytes_written: u64,
 }
 
 impl FileWriter {
-    /// Create a new file writer from a std::fs::File.
+    /// Create a new file writer, applying platform-specific hints.
     pub fn new(file: std::fs::File) -> Self {
-        Self { file }
+        Self::apply_platform_hints(&file);
+        Self {
+            file,
+            #[cfg(target_os = "linux")]
+            bytes_written: 0,
+        }
+    }
+
+    /// Apply one-time platform-specific optimizations to the file descriptor.
+    fn apply_platform_hints(file: &std::fs::File) {
+        #[cfg(target_os = "linux")]
+        Self::apply_linux_hints(file);
+        #[cfg(target_os = "macos")]
+        Self::apply_macos_hints(file);
+    }
+
+    /// Linux: pre-allocate space with `fallocate` and set sequential advice.
+    #[cfg(target_os = "linux")]
+    fn apply_linux_hints(file: &std::fs::File) {
+        use std::os::unix::io::AsRawFd;
+        let fd = file.as_raw_fd();
+
+        // Pre-allocate disk space to avoid metadata updates on every
+        // extending write.  KEEP_SIZE means the visible file size is not
+        // changed — only the underlying blocks are reserved.
+        // SAFETY: fd is valid (owned by `file`), flags and offsets are correct.
+        // fallocate failure is benign (returns -1, we ignore).
+        unsafe {
+            let _ = libc::fallocate(fd, libc::FALLOC_FL_KEEP_SIZE, 0, PREALLOC_BYTES);
+        }
+
+        // Tell the kernel we're doing sequential writes so it can optimize
+        // read-ahead and page cache management.
+        // SAFETY: fd is valid (owned by `file`), POSIX_FADV_SEQUENTIAL is an
+        // advisory hint that cannot cause UB regardless of return value.
+        unsafe {
+            let _ = libc::posix_fadvise(fd, 0, 0, libc::POSIX_FADV_SEQUENTIAL);
+        }
+    }
+
+    /// macOS: set `F_NOCACHE` and pre-allocate with `F_PREALLOCATE`.
+    #[cfg(target_os = "macos")]
+    fn apply_macos_hints(file: &std::fs::File) {
+        use std::os::unix::io::AsRawFd;
+        let fd = file.as_raw_fd();
+
+        // F_NOCACHE: bypass the Unified Buffer Cache for this fd.
+        // Written pages won't linger in memory — good for a forwarder that
+        // produces write-only data consumers won't re-read via this fd.
+        // SAFETY: fd is valid (owned by `file`), F_NOCACHE with arg=1 is a
+        // hint that cannot cause UB regardless of return value.
+        unsafe {
+            let _ = libc::fcntl(fd, libc::F_NOCACHE, 1i32);
+        }
+
+        // F_PREALLOCATE: reserve contiguous disk space.
+        // This is macOS's equivalent of Linux fallocate — it avoids
+        // fragmentation and repeated metadata updates during sequential
+        // extending writes.
+        // SAFETY: fd is valid (owned by `file`), fstore_t is zero-initialized
+        // then fully populated.  fcntl(F_PREALLOCATE) reads the struct by
+        // pointer and never writes through it.
+        unsafe {
+            let mut store: libc::fstore_t = std::mem::zeroed();
+            store.fst_flags = libc::F_ALLOCATECONTIG;
+            store.fst_posmode = libc::F_PEOFPOSMODE;
+            store.fst_offset = 0;
+            store.fst_length = PREALLOC_BYTES;
+            let ret = libc::fcntl(fd, libc::F_PREALLOCATE, &store);
+            if ret == -1 {
+                // Contiguous allocation failed — retry allowing fragments.
+                store.fst_flags = libc::F_ALLOCATEALL;
+                let _ = libc::fcntl(fd, libc::F_PREALLOCATE, &store);
+            }
+        }
+    }
+
+    /// Linux: advise the kernel to drop page cache for already-written data.
+    ///
+    /// This prevents the forwarder from bloating the host's page cache with
+    /// write-only log data that will never be re-read by this process.
+    #[cfg(target_os = "linux")]
+    fn advise_dontneed(&self, offset: u64, len: u64) {
+        use std::os::unix::io::AsRawFd;
+        let fd = self.file.as_raw_fd();
+        // SAFETY: fd is valid (owned by `self.file`), offset and len describe
+        // already-written data, POSIX_FADV_DONTNEED is an advisory hint.
+        unsafe {
+            let _ = libc::posix_fadvise(
+                fd,
+                offset as libc::off_t,
+                len as libc::off_t,
+                libc::POSIX_FADV_DONTNEED,
+            );
+        }
     }
 }
 
 impl BatchWriter for FileWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<()> {
         use std::io::Write;
-        self.file.write_all(buf)
+        self.file.write_all(buf)?;
+
+        // Tell the OS to drop the pages we just wrote — we won't re-read them.
+        #[cfg(target_os = "linux")]
+        {
+            let offset = self.bytes_written;
+            self.bytes_written += buf.len() as u64;
+            self.advise_dontneed(offset, buf.len() as u64);
+        }
+
+        Ok(())
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/crates/ffwd-output/src/pipelined.rs
+++ b/crates/ffwd-output/src/pipelined.rs
@@ -1,0 +1,421 @@
+//! Pipelined sink: separates serialization (CPU) from transport (I/O).
+//!
+//! The pipeline uses a dedicated OS thread for I/O, overlapping serialization
+//! of batch N+1 with writing of batch N. A triple-buffered pool avoids
+//! allocation churn.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────┐     sync_channel      ┌──────────────────┐
+//! │  Caller thread   │ ──── filled buf ────▶ │  Writer thread    │
+//! │  (tokio worker)  │ ◀─── empty buf ───── │  (OS thread)      │
+//! │                  │                       │                   │
+//! │  serialize(batch)│                       │  writer.write(buf)│
+//! └─────────────────┘                       └──────────────────┘
+//! ```
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! let sink = PipelinedSink::new(serializer, writer, PipelineConfig::default());
+//! // sink implements Sink trait — use it in the worker pool as normal
+//! ```
+
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::mpsc::{self, SyncSender};
+use std::thread::{self, JoinHandle};
+
+use arrow::record_batch::RecordBatch;
+use ffwd_types::diagnostics::ComponentStats;
+
+use crate::BatchMetadata;
+use crate::sink::{SendResult, Sink};
+
+// ---------------------------------------------------------------------------
+// BatchSerializer trait
+// ---------------------------------------------------------------------------
+
+/// Pure CPU serialization: converts a `RecordBatch` into bytes.
+///
+/// Implementors MUST NOT perform any I/O. This trait is intentionally
+/// synchronous to enforce that constraint at the type level.
+pub trait BatchSerializer: Send {
+    /// Serialize `batch` into `buf`, appending bytes.
+    ///
+    /// Returns the number of logical rows written (may differ from
+    /// `batch.num_rows()` if some rows are filtered/skipped).
+    fn serialize(
+        &mut self,
+        batch: &RecordBatch,
+        metadata: &BatchMetadata,
+        buf: &mut Vec<u8>,
+    ) -> io::Result<u64>;
+
+    /// Human-readable name for logging and diagnostics.
+    fn name(&self) -> &str;
+}
+
+// ---------------------------------------------------------------------------
+// BatchWriter trait
+// ---------------------------------------------------------------------------
+
+/// I/O transport: takes serialized bytes and delivers them to a destination.
+///
+/// Runs on a dedicated OS thread. Implementations own the file descriptor,
+/// socket, or HTTP client and perform blocking I/O.
+pub trait BatchWriter: Send + 'static {
+    /// Write the serialized payload to the destination.
+    fn write(&mut self, buf: &[u8]) -> io::Result<()>;
+
+    /// Flush internal buffers (if any) to the OS.
+    fn flush(&mut self) -> io::Result<()>;
+
+    /// Graceful shutdown: flush + fsync / close connection.
+    fn shutdown(&mut self) -> io::Result<()>;
+}
+
+// ---------------------------------------------------------------------------
+// PipelineConfig
+// ---------------------------------------------------------------------------
+
+/// Configuration for the pipelined sink.
+pub struct PipelineConfig {
+    /// Number of buffers in the pool (channel depth + 1 in-flight).
+    /// Default: 3 (triple-buffered).
+    pub num_buffers: usize,
+
+    /// Initial capacity for each buffer in bytes.
+    /// Default: 2 MB.
+    pub buf_capacity: usize,
+}
+
+impl Default for PipelineConfig {
+    fn default() -> Self {
+        Self {
+            num_buffers: 3,
+            buf_capacity: 2 * 1024 * 1024,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writer thread messages
+// ---------------------------------------------------------------------------
+
+enum WriterMsg {
+    /// A filled buffer ready to be written.
+    Data(Vec<u8>),
+    /// Flush request with a one-shot ack channel.
+    Flush(SyncSender<io::Result<()>>),
+    /// Shutdown request — writer should flush, sync, then exit.
+    Shutdown(SyncSender<io::Result<()>>),
+}
+
+// ---------------------------------------------------------------------------
+// PipelinedSink
+// ---------------------------------------------------------------------------
+
+/// A `Sink` implementation that pipelines serialization and I/O on separate
+/// threads for maximum throughput.
+pub struct PipelinedSink<S: BatchSerializer> {
+    serializer: S,
+    stats: Arc<ComponentStats>,
+
+    /// Channel to send filled buffers (and control messages) to the writer.
+    filled_tx: Option<SyncSender<WriterMsg>>,
+
+    /// Channel to receive empty (recycled) buffers back from the writer.
+    empty_rx: mpsc::Receiver<Vec<u8>>,
+
+    /// Handle to the writer thread (for join on shutdown).
+    writer_handle: Option<JoinHandle<()>>,
+}
+
+impl<S: BatchSerializer> PipelinedSink<S> {
+    /// Create a new pipelined sink.
+    ///
+    /// Spawns a dedicated OS thread for the writer immediately.
+    pub fn new(
+        serializer: S,
+        writer: impl BatchWriter,
+        stats: Arc<ComponentStats>,
+        config: PipelineConfig,
+    ) -> Self {
+        let (filled_tx, filled_rx) = mpsc::sync_channel::<WriterMsg>(config.num_buffers);
+        let (empty_tx, empty_rx) = mpsc::sync_channel::<Vec<u8>>(config.num_buffers);
+
+        // Seed the empty buffer pool.
+        for _ in 0..config.num_buffers {
+            let _ = empty_tx.send(Vec::with_capacity(config.buf_capacity));
+        }
+
+        let writer_handle = thread::Builder::new()
+            .name(format!("ffwd-writer-{}", serializer.name()))
+            .spawn(move || {
+                writer_thread_loop(writer, filled_rx, empty_tx);
+            })
+            .expect("failed to spawn writer thread");
+
+        Self {
+            serializer,
+            stats,
+            filled_tx: Some(filled_tx),
+            empty_rx,
+            writer_handle: Some(writer_handle),
+        }
+    }
+
+    /// Get an empty buffer from the pool, blocking until one is available.
+    fn acquire_buffer(&self) -> io::Result<Vec<u8>> {
+        self.empty_rx.recv().map_err(|_recv| {
+            io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "writer thread exited unexpectedly",
+            )
+        })
+    }
+
+    /// Send a filled buffer to the writer thread.
+    fn send_filled(&self, buf: Vec<u8>) -> io::Result<()> {
+        if let Some(ref tx) = self.filled_tx {
+            tx.send(WriterMsg::Data(buf)).map_err(|_send| {
+                io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "writer thread exited unexpectedly",
+                )
+            })
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "sink already shut down",
+            ))
+        }
+    }
+
+    /// Send a control message and wait for the ack.
+    fn send_control<F>(&self, make_msg: F) -> io::Result<()>
+    where
+        F: FnOnce(SyncSender<io::Result<()>>) -> WriterMsg,
+    {
+        let (ack_tx, ack_rx) = mpsc::sync_channel(1);
+        if let Some(ref tx) = self.filled_tx {
+            tx.send(make_msg(ack_tx)).map_err(|_send| {
+                io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "writer thread exited unexpectedly",
+                )
+            })?;
+            ack_rx.recv().map_err(|_recv| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "writer thread exited before ack")
+            })?
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "sink already shut down",
+            ))
+        }
+    }
+}
+
+impl<S: BatchSerializer> Sink for PipelinedSink<S> {
+    fn send_batch<'a>(
+        &'a mut self,
+        batch: &'a RecordBatch,
+        metadata: &'a BatchMetadata,
+    ) -> Pin<Box<dyn Future<Output = SendResult> + Send + 'a>> {
+        Box::pin(async move {
+            // Acquire an empty buffer from the pool (blocks if writer is behind).
+            let mut buf = match self.acquire_buffer() {
+                Ok(b) => b,
+                Err(e) => return SendResult::from_io_error(e),
+            };
+            buf.clear();
+
+            // Serialize on the caller thread (CPU work).
+            let rows = match self.serializer.serialize(batch, metadata, &mut buf) {
+                Ok(n) => n,
+                Err(e) => {
+                    // Return buffer to pool to avoid exhaustion on repeated errors.
+                    // Send it through the writer thread as empty data — the writer
+                    // will write zero bytes (no-op) and recycle the buffer.
+                    buf.clear();
+                    let _ = self.send_filled(buf);
+                    return SendResult::from_io_error(e);
+                }
+            };
+
+            let bytes = buf.len() as u64;
+
+            // Hand off the filled buffer to the writer thread.
+            if let Err(e) = self.send_filled(buf) {
+                return SendResult::from_io_error(e);
+            }
+
+            self.stats.inc_lines(rows);
+            self.stats.inc_bytes(bytes);
+            SendResult::Ok
+        })
+    }
+
+    fn flush(&mut self) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + '_>> {
+        Box::pin(async move { self.send_control(WriterMsg::Flush) })
+    }
+
+    fn name(&self) -> &str {
+        self.serializer.name()
+    }
+
+    fn shutdown(&mut self) -> Pin<Box<dyn Future<Output = io::Result<()>> + Send + '_>> {
+        Box::pin(async move {
+            // Send shutdown message and wait for ack.
+            let result = self.send_control(WriterMsg::Shutdown);
+
+            // Drop the sender so the writer thread exits its loop.
+            self.filled_tx.take();
+
+            // Join the writer thread.
+            if let Some(handle) = self.writer_handle.take() {
+                let _ = handle.join();
+            }
+
+            result
+        })
+    }
+}
+
+impl<S: BatchSerializer> Drop for PipelinedSink<S> {
+    fn drop(&mut self) {
+        // Best-effort shutdown if not already done.
+        self.filled_tx.take();
+        if let Some(handle) = self.writer_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writer thread loop
+// ---------------------------------------------------------------------------
+
+fn writer_thread_loop(
+    mut writer: impl BatchWriter,
+    filled_rx: mpsc::Receiver<WriterMsg>,
+    empty_tx: SyncSender<Vec<u8>>,
+) {
+    while let Ok(msg) = filled_rx.recv() {
+        match msg {
+            WriterMsg::Data(buf) => {
+                if let Err(e) = writer.write(&buf) {
+                    tracing::error!(error = %e, "pipelined writer: write failed");
+                    // Return the buffer anyway to avoid deadlock.
+                }
+                // Recycle the buffer back to the pool.
+                let mut recycled = buf;
+                recycled.clear();
+                // If send fails, the sink is being dropped — just let the buffer go.
+                let _ = empty_tx.try_send(recycled);
+            }
+            WriterMsg::Flush(ack) => {
+                let result = writer.flush();
+                let _ = ack.send(result);
+            }
+            WriterMsg::Shutdown(ack) => {
+                let result = writer.shutdown();
+                let _ = ack.send(result);
+                return;
+            }
+        }
+    }
+    // Channel closed without Shutdown — best-effort shutdown.
+    let _ = writer.shutdown();
+}
+
+// ---------------------------------------------------------------------------
+// FileWriter
+// ---------------------------------------------------------------------------
+
+/// A [`BatchWriter`] that writes to a file using blocking std::fs I/O.
+pub struct FileWriter {
+    file: std::fs::File,
+}
+
+impl FileWriter {
+    /// Create a new file writer from a std::fs::File.
+    pub fn new(file: std::fs::File) -> Self {
+        Self { file }
+    }
+}
+
+impl BatchWriter for FileWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<()> {
+        use std::io::Write;
+        self.file.write_all(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        use std::io::Write;
+        self.file.flush()?;
+        self.file.sync_data()
+    }
+
+    fn shutdown(&mut self) -> io::Result<()> {
+        use std::io::Write;
+        self.file.flush()?;
+        self.file.sync_data()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JsonBatchSerializer
+// ---------------------------------------------------------------------------
+
+use crate::stdout::{StdoutFormat, StdoutSink};
+
+/// A [`BatchSerializer`] that produces JSON-lines or text output.
+///
+/// Wraps the same serialization logic as `StdoutSink::write_batch_to`.
+pub struct JsonBatchSerializer {
+    inner: StdoutSink,
+}
+
+impl JsonBatchSerializer {
+    /// Create a new JSON batch serializer.
+    pub fn new(name: String, format: StdoutFormat, stats: Arc<ComponentStats>) -> Self {
+        Self {
+            inner: StdoutSink::new(name, format, stats),
+        }
+    }
+
+    /// Create with a custom message field name.
+    pub fn with_message_field(
+        name: String,
+        format: StdoutFormat,
+        message_field: String,
+        stats: Arc<ComponentStats>,
+    ) -> Self {
+        Self {
+            inner: StdoutSink::with_message_field(name, format, message_field, stats),
+        }
+    }
+}
+
+impl BatchSerializer for JsonBatchSerializer {
+    fn serialize(
+        &mut self,
+        batch: &RecordBatch,
+        metadata: &BatchMetadata,
+        buf: &mut Vec<u8>,
+    ) -> io::Result<u64> {
+        self.inner
+            .write_batch_to(batch, metadata, buf)
+            .map(|n| n as u64)
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+}

--- a/crates/ffwd-output/src/pipelined.rs
+++ b/crates/ffwd-output/src/pipelined.rs
@@ -18,7 +18,7 @@
 //! # Usage
 //!
 //! ```rust,ignore
-//! let sink = PipelinedSink::new(serializer, writer, PipelineConfig::default());
+//! let sink = PipelinedSink::new(serializer, writer, stats, PipelineConfig::default())?;
 //! // sink implements Sink trait — use it in the worker pool as normal
 //! ```
 
@@ -148,13 +148,20 @@ impl<S: BatchSerializer> PipelinedSink<S> {
     /// Create a new pipelined sink.
     ///
     /// Spawns a dedicated OS thread for the writer immediately.
-    /// Returns an error if the thread cannot be spawned.
+    /// Returns an error if the thread cannot be spawned or config is invalid.
     pub fn new(
         serializer: S,
         writer: impl BatchWriter,
         stats: Arc<ComponentStats>,
         config: PipelineConfig,
     ) -> io::Result<Self> {
+        if config.num_buffers == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "PipelineConfig::num_buffers must be >= 1",
+            ));
+        }
+
         let (filled_tx, filled_rx) = mpsc::sync_channel::<WriterMsg>(config.num_buffers);
         let (empty_tx, empty_rx) = mpsc::sync_channel::<Vec<u8>>(config.num_buffers);
         let (error_tx, error_rx) = mpsc::sync_channel::<WriteError>(config.num_buffers);
@@ -396,10 +403,16 @@ impl FileWriter {
     /// Create a new file writer, applying platform-specific hints.
     pub fn new(file: std::fs::File) -> Self {
         Self::apply_platform_hints(&file);
+
+        // Initialize bytes_written to the current file position so that
+        // FADV_DONTNEED offsets are correct when appending to existing files.
+        #[cfg(target_os = "linux")]
+        let bytes_written = file.metadata().map(|m| m.len()).unwrap_or(0);
+
         Self {
             file,
             #[cfg(target_os = "linux")]
-            bytes_written: 0,
+            bytes_written,
         }
     }
 

--- a/crates/ffwd-output/src/pipelined.rs
+++ b/crates/ffwd-output/src/pipelined.rs
@@ -407,7 +407,7 @@ impl FileWriter {
         // Initialize bytes_written to the current file position so that
         // FADV_DONTNEED offsets are correct when appending to existing files.
         #[cfg(target_os = "linux")]
-        let bytes_written = file.metadata().map(|m| m.len()).unwrap_or(0);
+        let bytes_written = file.metadata().map_or(0, |m| m.len());
 
         Self {
             file,

--- a/crates/ffwd-output/src/row_json.rs
+++ b/crates/ffwd-output/src/row_json.rs
@@ -1,5 +1,5 @@
 // xtask-verify: allow(pub_module_needs_tests) reason: integration coverage lives in otlp_sink/arrow sink tests; dedicated unit tests tracked separately
-use std::io;
+use std::{io, ptr};
 
 use arrow::array::{
     Array, AsArray, BinaryArray, FixedSizeBinaryArray, LargeBinaryArray, LargeStringArray,
@@ -121,6 +121,34 @@ fn first_escape_pos(bytes: &[u8]) -> usize {
     len
 }
 
+#[inline]
+fn append_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
+    let len = out.len();
+    let new_len = len + bytes.len();
+    if new_len > out.capacity() {
+        out.reserve(new_len - len);
+    }
+    // SAFETY: we reserved sufficient tail capacity, then initialize exactly
+    // `bytes.len()` bytes before extending the vector length.
+    unsafe {
+        ptr::copy_nonoverlapping(bytes.as_ptr(), out.as_mut_ptr().add(len), bytes.len());
+        out.set_len(new_len);
+    }
+}
+
+#[inline]
+fn append_byte(out: &mut Vec<u8>, byte: u8) {
+    let len = out.len();
+    if len == out.capacity() {
+        out.reserve(1);
+    }
+    // SAFETY: reserve above guarantees one writable byte of spare capacity.
+    unsafe {
+        *out.as_mut_ptr().add(len) = byte;
+        out.set_len(len + 1);
+    }
+}
+
 /// Write a JSON string value with RFC 8259 escaping.
 ///
 /// **Hot path optimization**: most log field values (timestamps, service names,
@@ -139,22 +167,22 @@ pub(crate) fn write_json_string(out: &mut Vec<u8>, v: &str) -> io::Result<()> {
 
     if first_esc == bytes.len() {
         // Fast path: no escaping needed (vast majority of log field values).
-        // Single reserve + two extend_from_slice calls.
+        // Single reserve + two append operations.
         out.reserve(bytes.len() + 2);
-        out.push(b'"');
-        out.extend_from_slice(bytes);
-        out.push(b'"');
+        append_byte(out, b'"');
+        append_bytes(out, bytes);
+        append_byte(out, b'"');
         return Ok(());
     }
 
     // Slow path: has at least one byte needing escaping.
     // Reserve a reasonable estimate (original length + some overhead for escapes).
     out.reserve(bytes.len() + 8);
-    out.push(b'"');
+    append_byte(out, b'"');
 
     // Write the safe prefix before the first escape.
     if first_esc > 0 {
-        out.extend_from_slice(&bytes[..first_esc]);
+        append_bytes(out, &bytes[..first_esc]);
     }
 
     // Process from the first escape byte onward.
@@ -162,22 +190,25 @@ pub(crate) fn write_json_string(out: &mut Vec<u8>, v: &str) -> io::Result<()> {
     loop {
         // Emit the escape sequence for the current byte.
         match bytes[start] {
-            b'"' => out.extend_from_slice(b"\\\""),
-            b'\\' => out.extend_from_slice(b"\\\\"),
-            b'\n' => out.extend_from_slice(b"\\n"),
-            b'\r' => out.extend_from_slice(b"\\r"),
-            b'\t' => out.extend_from_slice(b"\\t"),
+            b'"' => append_bytes(out, b"\\\""),
+            b'\\' => append_bytes(out, b"\\\\"),
+            b'\n' => append_bytes(out, b"\\n"),
+            b'\r' => append_bytes(out, b"\\r"),
+            b'\t' => append_bytes(out, b"\\t"),
             b => {
                 // Control char → \u00XX. Avoid format_args! allocation.
                 const HEX: &[u8; 16] = b"0123456789abcdef";
-                out.extend_from_slice(&[
-                    b'\\',
-                    b'u',
-                    b'0',
-                    b'0',
-                    HEX[(b >> 4) as usize],
-                    HEX[(b & 0x0f) as usize],
-                ]);
+                append_bytes(
+                    out,
+                    &[
+                        b'\\',
+                        b'u',
+                        b'0',
+                        b'0',
+                        HEX[(b >> 4) as usize],
+                        HEX[(b & 0x0f) as usize],
+                    ],
+                );
             }
         }
         start += 1;
@@ -190,7 +221,7 @@ pub(crate) fn write_json_string(out: &mut Vec<u8>, v: &str) -> io::Result<()> {
         let remaining = &bytes[start..];
         let next_esc = first_escape_pos(remaining);
         if next_esc > 0 {
-            out.extend_from_slice(&remaining[..next_esc]);
+            append_bytes(out, &remaining[..next_esc]);
         }
         if next_esc == remaining.len() {
             break;
@@ -198,7 +229,7 @@ pub(crate) fn write_json_string(out: &mut Vec<u8>, v: &str) -> io::Result<()> {
         start += next_esc;
     }
 
-    out.push(b'"');
+    append_byte(out, b'"');
     Ok(())
 }
 
@@ -207,13 +238,13 @@ fn write_json_hex_bytes(out: &mut Vec<u8>, bytes: &[u8]) {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     // Reserve for surrounding quotes + "0x" prefix + 2 hex chars per byte.
     out.reserve(4 + bytes.len().saturating_mul(2));
-    out.push(b'"');
-    out.extend_from_slice(b"0x");
+    append_byte(out, b'"');
+    append_bytes(out, b"0x");
     for &b in bytes {
-        out.push(HEX[(b >> 4) as usize]);
-        out.push(HEX[(b & 0x0f) as usize]);
+        append_byte(out, HEX[(b >> 4) as usize]);
+        append_byte(out, HEX[(b & 0x0f) as usize]);
     }
-    out.push(b'"');
+    append_byte(out, b'"');
 }
 
 /// Write a single Arrow value as JSON, dispatching on the actual Arrow DataType.
@@ -449,71 +480,71 @@ pub(crate) fn write_typed_json_value(
 ) -> io::Result<()> {
     match typed {
         TypedArrayRef::Null => {
-            out.extend_from_slice(b"null");
+            append_bytes(out, b"null");
         }
         // SAFETY for all typed arms below: row < a.len() is guaranteed by the caller
         TypedArrayRef::Int8(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(itoa::Buffer::new().format(v).as_bytes());
+            append_bytes(out, itoa::Buffer::new().format(v).as_bytes());
         }
         TypedArrayRef::Int16(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(itoa::Buffer::new().format(v).as_bytes());
+            append_bytes(out, itoa::Buffer::new().format(v).as_bytes());
         }
         TypedArrayRef::Int32(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(itoa::Buffer::new().format(v).as_bytes());
+            append_bytes(out, itoa::Buffer::new().format(v).as_bytes());
         }
         TypedArrayRef::Int64(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(itoa::Buffer::new().format(v).as_bytes());
+            append_bytes(out, itoa::Buffer::new().format(v).as_bytes());
         }
         TypedArrayRef::UInt8(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(itoa::Buffer::new().format(v).as_bytes());
+            append_bytes(out, itoa::Buffer::new().format(v).as_bytes());
         }
         TypedArrayRef::UInt16(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(itoa::Buffer::new().format(v).as_bytes());
+            append_bytes(out, itoa::Buffer::new().format(v).as_bytes());
         }
         TypedArrayRef::UInt32(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(itoa::Buffer::new().format(v).as_bytes());
+            append_bytes(out, itoa::Buffer::new().format(v).as_bytes());
         }
         TypedArrayRef::UInt64(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(itoa::Buffer::new().format(v).as_bytes());
+            append_bytes(out, itoa::Buffer::new().format(v).as_bytes());
         }
         TypedArrayRef::Float32(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
             if v.is_finite() {
-                out.extend_from_slice(ryu::Buffer::new().format_finite(v).as_bytes());
+                append_bytes(out, ryu::Buffer::new().format_finite(v).as_bytes());
             } else {
-                out.extend_from_slice(b"null");
+                append_bytes(out, b"null");
             }
         }
         TypedArrayRef::Float64(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
             if v.is_finite() {
-                out.extend_from_slice(ryu::Buffer::new().format_finite(v).as_bytes());
+                append_bytes(out, ryu::Buffer::new().format_finite(v).as_bytes());
             } else {
-                out.extend_from_slice(b"null");
+                append_bytes(out, b"null");
             }
         }
         TypedArrayRef::Boolean(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
             let v = unsafe { a.value_unchecked(row) };
-            out.extend_from_slice(if v { b"true" } else { b"false" });
+            append_bytes(out, if v { b"true" } else { b"false" });
         }
         TypedArrayRef::Utf8(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
@@ -528,24 +559,24 @@ pub(crate) fn write_typed_json_value(
             write_json_string(out, unsafe { a.value_unchecked(row) })?;
         }
         TypedArrayRef::Struct(a) => {
-            out.push(b'{');
+            append_byte(out, b'{');
             let fields = a.fields();
             let mut first = true;
             for field_idx in 0..a.num_columns() {
                 if !first {
-                    out.push(b',');
+                    append_byte(out, b',');
                 }
                 first = false;
                 write_json_string(out, fields[field_idx].name())?;
-                out.push(b':');
+                append_byte(out, b':');
                 let child = a.column(field_idx);
                 if child.is_null(row) {
-                    out.extend_from_slice(b"null");
+                    append_bytes(out, b"null");
                 } else {
                     write_json_value(child.as_ref(), row, out)?;
                 }
             }
-            out.push(b'}');
+            append_byte(out, b'}');
         }
         TypedArrayRef::Binary(a) => {
             // SAFETY: row < a.len() is guaranteed by the caller (see block comment above)
@@ -580,7 +611,7 @@ pub fn write_row_json_resolved(
     out: &mut Vec<u8>,
     newline: bool,
 ) -> io::Result<()> {
-    out.push(b'{');
+    append_byte(out, b'{');
     // key_json is `b',"fieldname":'`.  For the first non-null field we skip
     // the leading comma (offset 1); for subsequent fields we include it (offset 0).
     // This replaces N separate `push(b',')` calls with one extend_from_slice.
@@ -590,14 +621,14 @@ pub fn write_row_json_resolved(
             continue;
         };
 
-        out.extend_from_slice(&key_json[sep_skip..]);
+        append_bytes(out, &key_json[sep_skip..]);
         write_typed_json_value(typed, row, out)?;
         sep_skip = 0;
     }
     if newline {
-        out.extend_from_slice(b"}\n");
+        append_bytes(out, b"}\n");
     } else {
-        out.push(b'}');
+        append_byte(out, b'}');
     }
     Ok(())
 }

--- a/crates/ffwd-output/src/stdout.rs
+++ b/crates/ffwd-output/src/stdout.rs
@@ -78,6 +78,11 @@ impl StdoutSink {
         }
     }
 
+    /// Human-readable sink name (from config).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// Write a batch into a `Vec<u8>` destination.
     ///
     /// All production callers (FileSink, StdoutSink::serialize_batch) pass

--- a/justfile
+++ b/justfile
@@ -513,7 +513,7 @@ bench-pipelines seconds="10":
 
 # Run Tier 1 criterion benchmarks (fast, ~30s — composed functions, no heavy I/O)
 bench:
-    cargo bench -p ffwd-bench --bench pipeline --bench output_encode --bench full_chain
+    cargo bench -p ffwd-bench --features io-bench --bench pipeline --bench output_encode --bench full_chain
 
 # Run throughput ceiling benchmark (generator → scan → null, no transform)
 bench-ceiling:
@@ -522,7 +522,7 @@ bench-ceiling:
 # Run all criterion benchmarks (Tier 1 + Tier 2 — includes I/O and batch scaling, ~2-5min)
 # Excludes elasticsearch_arrow which requires a running ES instance.
 bench-full:
-    cargo bench -p ffwd-bench --bench pipeline --bench output_encode --bench full_chain --bench builder_compare --bench batch_formation --bench file_io --bench throughput_ceiling
+    cargo bench -p ffwd-bench --features io-bench --bench pipeline --bench output_encode --bench full_chain --bench builder_compare --bench batch_formation --bench file_io --bench throughput_ceiling
 
 # Backpressure benchmarks: measures pipeline throughput degradation under output latency.
 # See backpressure.rs for baseline workflow (save/compare).
@@ -673,11 +673,11 @@ profile-otlp-local lines="500000" seconds="6":
 
 # Run OTLP I/O Criterion benchmarks (stage-separated: parser, decode, encode, compression, e2e).
 bench-otlp-io *ARGS:
-    cargo bench -p ffwd-bench --bench otlp_io -- {{ARGS}}
+    cargo bench -p ffwd-bench --features io-bench --bench otlp_io -- {{ARGS}}
 
 # Run OTLP I/O benchmarks with fast local iteration settings.
 bench-otlp-io-fast *ARGS:
-    cargo bench -p ffwd-bench --bench otlp_io -- --warm-up-time 1 --measurement-time 2 --sample-size 10 {{ARGS}}
+    cargo bench -p ffwd-bench --features io-bench --bench otlp_io -- --warm-up-time 1 --measurement-time 2 --sample-size 10 {{ARGS}}
 
 # Run source metadata attachment benchmarks.
 bench-source-metadata *ARGS:


### PR DESCRIPTION
## Summary

Introduces a **Serializer + Writer trait split** that separates CPU-bound JSON serialization from I/O-bound file writes using a dedicated OS writer thread with triple-buffered channels, plus platform-specific file I/O optimizations.

This mirrors the input-side architecture (`io_worker_loop` → channel → `cpu_worker_loop`) and delivers **21% higher sustained throughput** for file output at production volumes.

## Changes

### New: `pipelined.rs` — reusable output pipeline infrastructure

- `BatchSerializer` trait — pure CPU, no I/O allowed (enforced at type level)
- `BatchWriter` trait — blocking I/O transport
- `PipelinedSink<S: BatchSerializer>` — generic sink that spawns a dedicated OS writer thread
- `FileWriter` — `std::fs::File` blocking I/O with platform-specific hints
- `JsonBatchSerializer` — wraps existing `StdoutSink::write_batch_to` logic

### Platform-specific I/O optimizations in `FileWriter`

| Platform | Optimization | Purpose |
|----------|-------------|---------|
| Linux | `fallocate(FALLOC_FL_KEEP_SIZE)` 64MB pre-alloc | Avoids per-write metadata updates on ext4/xfs |
| Linux | `posix_fadvise(POSIX_FADV_SEQUENTIAL)` | Hints sequential access pattern |
| Linux | `posix_fadvise(POSIX_FADV_DONTNEED)` after each write | Drops page cache for written data (write-only workload) |
| macOS | `fcntl(F_NOCACHE)` | Bypasses Unified Buffer Cache |
| macOS | `fcntl(F_PREALLOCATE)` 64MB | Pre-allocates disk space (contiguous, fragmented fallback) |

All hints are best-effort (failures silently ignored) — no correctness impact.

### Rewritten: `file_sink.rs`

- `FileSink` now wraps `PipelinedSink<JsonBatchSerializer>`
- `FileSinkFactory` keeps `is_single_use() = true` (single file, single writer — correctness)
- Removed `Arc<Mutex<tokio::fs::File>>` — simpler, faster

### Performance: `row_json.rs`

- `append_bytes`/`append_byte` helpers using `ptr::copy_nonoverlapping`
- ~25% faster JSON string writing in hot path (avoids Vec bounds checks in inner loop)

### Bench harness: `file_sink_compare`

- 15+ write strategies for systematic comparison
- Supports `--scenario`, `--sync-interval`, `--batches`, `--batch-size` flags

## Architecture

```
┌──────────────────┐     sync_channel(3)     ┌────────────────────┐
│  Caller thread   │ ──── filled bufs ─────▶ │  Writer OS thread  │
│  (tokio worker)  │ ◀─── empty bufs ─────── │  (std::fs::File)   │
│                  │                          │                    │
│  serialize(batch)│                          │  write_all(buf)    │
│  into buffer     │                          │  flush() on demand │
└──────────────────┘                          └────────────────────┘
```

Triple-buffered: serialize(N+1) overlaps with write(N), third buffer in flight.

## Benchmarks (Apple M4, wide/10k, 200 batches, 1.3GB, no sync)

| Strategy | Throughput | vs Serial |
|----------|-----------|-----------|
| Serialize only (no I/O) | 2.31M lines/sec | ceiling |
| Serial write (old pattern) | 1.97M lines/sec | baseline |
| **PipelinedSink + platform hints** | **2.38M lines/sec** | **+21%** |
| Threaded (manual, no hints) | 2.30M lines/sec | +17% |

The new FileSink **exceeds** the manual threaded pipeline because platform hints reduce filesystem metadata overhead.

## Competitive Analysis

No major log forwarder separates serialization from I/O:
- **Vector** (Rust/tokio): per-event write_all, single task, BufWriter
- **Fluent Bit** (C): fclose after each batch, single thread, libc stdio
- **OTel Collector** (Go): bufio.Flush on timer, no thread separation
- **rsyslog** (C): has async writer thread (closest to our pattern), but no platform hints
- **syslog-ng** (C): flush-lines batching, no thread separation

Our pipelined approach with platform hints is novel.

### Dragons identified from research (not in scope for this PR):
- logrotate interaction (inode-based reopen detection needed)
- Disk full mid-write (ENOSPC → RetryAfter mapping)
- NFS atomicity not guaranteed for O_APPEND
- Template paths need LRU fd cache + idle timeout
- Compressed files can't be appended after close

## Test Plan

- All 323 ffwd-output tests pass (including 3 file_sink-specific tests)
- `cargo clippy -p ffwd-output -- -D warnings` clean
- `cargo check -p ffwd-runtime` clean (downstream compiles)
- `file_sink_compare --scenario threaded` validates E2E throughput
- Buffer pool exhaustion fix: on serialize error, buffer recycled through writer thread

## Future Work

- Convert OTLP, Elasticsearch, Loki, TCP, UDP sinks to same pattern
- File rotation (size-based, logrotate compatibility)
- Make flush sync configurable (sync vs no-sync vs periodic)
- `create_dirs` for auto-creating parent directories
- Better error handling: ENOSPC → RetryAfter, EACCES → Rejected

## Review Feedback Addressed

All 38 review threads resolved. Key fixes:

- **Writer error propagation**: Write failures now surface to callers via dedicated error channel (non-blocking `check_writer_error()` on each `send_batch`)
- **`PipelinedSink::new()` → `io::Result`**: No more panics on thread spawn failure
- **`FileSink` constructors → `io::Result`**: Proper error propagation through factory
- **`pub(crate)` visibility**: Pipeline types are internal (no semver commitment)
- **`num_buffers` validation**: Rejects zero-buffer configs that would deadlock
- **Linux DONTNEED offset**: Initialized from file metadata (correct for appends to existing files)
- **Bench feature gates**: `just bench`/`bench-full`/`bench-otlp-io` now pass `--features io-bench`
- **Doc accuracy**: Fixed throughput claim (~40% → ~21%), fixed stale rustdoc example

### Acknowledged (by design, not changing):
- **Blocking `recv()` in async future**: Deliberate design matching the input-side pattern (`io_worker_loop` ↔ `cpu_worker_loop`). Output sinks run on dedicated worker tasks with bounded buffer pools (3 buffers = bounded blocking).
- **`append_bytes`/`append_byte` unsafe helpers**: Benchmarked ~25% faster than `extend_from_slice` in the hot JSON serialization loop. Soundness argument: reserve guard ensures capacity, `ptr::copy_nonoverlapping` between non-overlapping allocations, `set_len` follows initialization.
- **Proptests for pipeline state machine**: Good suggestion, separate PR scope.

Relates to #2733

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add pipelined file sink separating serialization from I/O on a dedicated writer thread
> - Introduces [`PipelinedSink`](https://github.com/strawgate/fastforward/pull/2736/files#diff-3df1575950dc67f5ab409fbbb264647880cab1cb4533cd73fd8055d2f7f82098) in a new `pipelined` module that overlaps CPU serialization (on the caller thread) with blocking file I/O (on a dedicated OS thread) using a triple-buffer channel.
> - Refactors [`FileSink`](https://github.com/strawgate/fastforward/pull/2736/files#diff-1e0617b0acebee6a5d0ff358b30c1e07f680cc1cb896b6dd0407f2452c571434) to use `PipelinedSink<JsonBatchSerializer>` backed by a `std::fs::File`; constructors now return `io::Result<Self>` and accept a standard file instead of a tokio async file.
> - Adds platform-specific I/O hints in `FileWriter`: `fallocate` + `posix_fadvise(SEQUENTIAL/DONTNEED)` on Linux; `F_NOCACHE` + `F_PREALLOCATE` on macOS.
> - Adds a new [`file_sink_compare`](https://github.com/strawgate/fastforward/pull/2736/files#diff-b3457a571ac22853b69080d9b4e2e9874f415859780fc198979d0db82fe4f8fb) CLI binary (behind `bench-tools` feature) for runtime comparison of file output strategies across serialization and I/O scenarios.
> - Risk: `FileSink::new` and `FileSink::with_message_field` now return `Result` — callers that previously assumed infallible construction will need updating.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f473ce6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->