### PR TITLE
Redesign benchmark dashboard with teal design system

### DIFF
--- a/bench/dashboard/competitive.html
+++ b/bench/dashboard/competitive.html
@@ -338,7 +338,5 @@ async function main() {
 
 main();
 </script>
-</main>
-</div>
 </body>
 </html>

--- a/bench/dashboard/competitive.html
+++ b/bench/dashboard/competitive.html
@@ -3,57 +3,66 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#10243a">
-  <title>Competitive Analysis - Benchmark Dashboard</title>
+  <title>Competitive Analysis - FastForward Benchmarks</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
 </head>
 <body>
-<div class="container">
-  <div class="breadcrumb">
-    <a href="index.html">Dashboard</a><span class="sep">/</span>Competitive
-  </div>
-
-  <header class="hero">
-    <p class="eyebrow">competitive lane</p>
-    <h1>Competitive Analysis</h1>
-    <p class="lede">Compare collector throughput by scenario, inspect trend movement over recent runs, and spot stability gaps quickly.</p>
-    <div class="hero-tags">
-      <span>collector shootout</span><span>trend-aware</span><span>benchkit adapters</span>
-    </div>
+<div class="site-wrapper">
+  <header class="top-bar">
+    <a class="top-bar-brand" href="https://strawgate.github.io/fastforward/">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+        <path d="M2 17l10 5 10-5"/>
+        <path d="M2 12l10 5 10-5"/>
+      </svg>
+      <span>FastForward</span>
+    </a>
+    <div class="top-bar-divider"></div>
+    <span class="top-bar-section">Benchmarks</span>
+    <nav class="top-bar-links">
+      <a href="index.html">Overview</a>
+      <a href="competitive.html" class="active">Competitive</a>
+      <a href="development.html">Development</a>
+      <a href="project-health.html">Project Health</a>
+    </nav>
   </header>
 
-  <nav class="nav-pills">
-    <a href="index.html">Overview</a>
-    <a href="competitive.html" class="active">Competitive</a>
-    <a href="development.html">Development</a>
-    <a href="project-health.html">Project Health</a>
-  </nav>
+  <main class="main-content">
+
+    <header class="hero">
+      <p class="hero-eyebrow">Competitive</p>
+      <h1>Competitive Analysis</h1>
+      <p class="hero-lede">Compare collector throughput by scenario and inspect trend movement over recent runs.</p>
+    </header>
 
   <div id="loading" class="loading">Loading competitive data...</div>
   <div id="content" style="display:none">
-    <div class="tracking-cards" id="competitive-kpis"></div>
+    <div id="competitive-kpis" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem;margin-bottom:1.5rem;"></div>
 
     <div id="charts-section" class="section">
       <h2>Per-Scenario Throughput</h2>
-      <div class="chart-grid" id="scenario-charts"></div>
+      <div class="card" id="scenario-charts"></div>
     </div>
 
     <div id="trends-section" class="section">
       <h2>Throughput Trends</h2>
-      <div class="chart-grid" id="trend-charts"></div>
+      <div class="card" id="trend-charts"></div>
     </div>
 
     <div id="table-section" class="section">
       <h2>Full Results</h2>
-      <div class="card table-card">
-        <table id="results-table">
-          <thead id="results-thead"></thead>
-          <tbody id="results-tbody"></tbody>
-        </table>
+      <div class="card">
+        <div class="card-body" style="overflow-x:auto;">
+          <table id="results-table">
+            <thead id="results-thead"></thead>
+            <tbody id="results-tbody"></tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>
+</main>
 </div>
 
 <script type="module">
@@ -329,5 +338,7 @@ async function main() {
 
 main();
 </script>
+</main>
+</div>
 </body>
 </html>

--- a/bench/dashboard/development.html
+++ b/bench/dashboard/development.html
@@ -3,32 +3,38 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#10243a">
-  <title>Development Metrics - Benchmark Dashboard</title>
+  <title>Development Metrics - FastForward Benchmarks</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
 </head>
 <body>
-<div class="container">
-  <div class="breadcrumb">
-    <a href="index.html">Dashboard</a><span class="sep">/</span>Development
-  </div>
-
-  <header class="hero">
-    <p class="eyebrow">development lane</p>
-    <h1>Development Metrics</h1>
-    <p class="lede">Watch resource curves and criterion drift so we can defend scanner and pipeline performance with real trend evidence.</p>
-    <div class="hero-tags">
-      <span>criterion drift</span><span>rate pressure</span><span>perf confidence</span>
-    </div>
+<div class="site-wrapper">
+  <header class="top-bar">
+    <a class="top-bar-brand" href="https://strawgate.github.io/fastforward/">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+        <path d="M2 17l10 5 10-5"/>
+        <path d="M2 12l10 5 10-5"/>
+      </svg>
+      <span>FastForward</span>
+    </a>
+    <div class="top-bar-divider"></div>
+    <span class="top-bar-section">Benchmarks</span>
+    <nav class="top-bar-links">
+      <a href="index.html">Overview</a>
+      <a href="competitive.html">Competitive</a>
+      <a href="development.html" class="active">Development</a>
+      <a href="project-health.html">Project Health</a>
+    </nav>
   </header>
 
-  <nav class="nav-pills">
-    <a href="index.html">Overview</a>
-    <a href="competitive.html">Competitive</a>
-    <a href="development.html" class="active">Development</a>
-    <a href="project-health.html">Project Health</a>
-  </nav>
+  <main class="main-content">
+
+    <header class="hero">
+      <p class="hero-eyebrow">Development</p>
+      <h1>Development Metrics</h1>
+      <p class="hero-lede">Resource curves and criterion drift for scanner and pipeline performance.</p>
+    </header>
 
   <div id="loading" class="loading">Loading development data...</div>
   <div id="content" style="display:none">
@@ -384,5 +390,7 @@ async function main() {
 
 main();
 </script>
+</main>
+</div>
 </body>
 </html>

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -153,7 +153,7 @@ async function main() {
   if (runs.length === 0) {
     heroEl.innerHTML = '<p class="hero-pending">No benchmark runs recorded yet.</p>';
   } else {
-    // latest run is the last one (runs are newest-first in index)
+    // latest run is the last one (runs are oldest-first in index)
     const latest = runs[runs.length - 1];
     const count = runs.length;
     heroEl.innerHTML = `

--- a/bench/dashboard/index.html
+++ b/bench/dashboard/index.html
@@ -3,362 +3,254 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#10243a">
-  <title>Benchmark Dashboard</title>
+  <title>FastForward Benchmark Dashboard</title>
   <link rel="stylesheet" href="style.css">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
 </head>
 <body>
-<div class="container">
-  <header class="hero">
-    <p class="eyebrow">ff benchmark suite</p>
-    <h1>Benchmark Control Room</h1>
-    <p class="lede">Track competitive throughput, development resource curves, and run-level details from nightly data in one view.</p>
-    <div class="hero-tags">
-      <span>benchkit powered</span><span>nightly telemetry</span><span>main branch signal</span>
-    </div>
+<div class="site-wrapper">
+
+  <header class="top-bar">
+    <a class="top-bar-brand" href="https://strawgate.github.io/fastforward/">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+        <path d="M2 17l10 5 10-5"/>
+        <path d="M2 12l10 5 10-5"/>
+      </svg>
+      <span>FastForward</span>
+    </a>
+    <div class="top-bar-divider"></div>
+    <span class="top-bar-section">Benchmarks</span>
+    <nav class="top-bar-links">
+      <a href="index.html" class="active">Overview</a>
+      <a href="competitive.html">Competitive</a>
+      <a href="development.html">Development</a>
+      <a href="project-health.html">Project Health</a>
+    </nav>
   </header>
 
-  <nav class="nav-pills">
-    <a href="index.html" class="active">Overview</a>
-    <a href="competitive.html">Competitive</a>
-    <a href="development.html">Development</a>
-    <a href="project-health.html">Project Health</a>
-  </nav>
+  <main class="main-content">
 
-  <div id="loading" class="loading">Loading data...</div>
-  <div id="content" style="display:none">
+    <div class="hero">
+      <p class="hero-eyebrow">Benchmark Suite</p>
+      <h1>FastForward Benchmarks</h1>
+      <p class="hero-lede">Competitive throughput vs. other log collectors, plus development rate and criterion benchmarks from CI runs.</p>
 
-    <!-- Headline Cards -->
-    <div class="tracking-cards" id="headline-cards"></div>
-
-    <!-- Recent Competitive Results -->
-    <div class="section" id="competitive-section" style="display:none">
-      <h2>Recent Competitive Results</h2>
-      <div class="card">
-        <table id="competitive-table">
-          <thead><tr><th>Scenario</th></tr></thead>
-          <tbody></tbody>
-        </table>
+      <div id="hero-stats">
+        <p class="hero-pending">Loading…</p>
       </div>
     </div>
 
-    <!-- Recent Development Metrics -->
-    <div class="section" id="dev-section" style="display:none">
-      <h2>Recent Development Metrics</h2>
-      <div class="card">
-        <table id="dev-table">
-          <thead><tr><th>Benchmark</th><th class="numeric">Mean</th><th class="numeric">Throughput</th></tr></thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
+    <div id="loading" class="loading">Fetching benchmark data…</div>
+    <div id="content" style="display:none">
 
-    <!-- All Runs -->
-    <div class="section" id="runs-section" style="display:none">
-      <h2>All Runs</h2>
-      <div class="card">
-        <table id="runs-table">
-          <thead><tr><th>ID</th><th>Type</th></tr></thead>
-          <tbody></tbody>
-        </table>
+      <!-- Competitive results -->
+      <div id="competitive-section" class="section" style="display:none">
+        <div class="section-header">
+          <h2>Competitive Results</h2>
+          <p>Throughput vs. open-source log collectors</p>
+        </div>
+        <div class="card">
+          <div class="card-header">
+            <span class="card-title">Latest Run</span>
+            <code id="latest-run-id"></code>
+          </div>
+          <div class="card-body" style="overflow-x:auto;">
+            <table id="competitive-table">
+              <thead><tr><th>Scenario</th></tr></thead>
+              <tbody></tbody>
+            </table>
+          </div>
+        </div>
       </div>
+
+      <!-- All runs -->
+      <div id="runs-section" class="section">
+        <div class="section-header">
+          <h2>All Runs</h2>
+          <p id="runs-count"></p>
+        </div>
+        <div class="card">
+          <div class="card-body" style="overflow-x:auto;">
+            <table>
+              <thead>
+                <tr>
+                  <th>Run</th>
+                  <th>Branch / Ref</th>
+                  <th>Commit</th>
+                  <th>Type</th>
+                </tr>
+              </thead>
+              <tbody id="runs-table-body"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
     </div>
-  </div>
+  </main>
+
 </div>
 
 <script type="module">
-import { fetchBenchIndex, fetchBenchJson, fetchBenchRun } from "./o11y-client.js";
+import { fetchBenchIndex, fetchBenchJson } from "./o11y-client.js";
 
 const SCENARIO_NAMES = {
-  'passthrough': { title: 'Passthrough (No Transforms)', config: 'transform: "SELECT * FROM logs"' },
-  'json_parse': { title: 'JSON Parsing & Extraction', config: 'transform: "SELECT timestamp_str, level_str, message_str, duration_ms_int AS latency_ms, request_id_str, service_str FROM logs"' },
-  'filter': { title: 'Filtering (ERROR/WARN only)', config: 'transform: "SELECT * FROM logs WHERE level_str IN (\'WARN\', \'ERROR\')"' }
-};
-function getScenarioTitle(sn) {
-  return SCENARIO_NAMES[sn] ? SCENARIO_NAMES[sn].title : sn;
-}
-
-const AGENT_COLORS = {
-  'ff': '#2563eb', 'ffwd': '#2563eb', 'vector': '#7c3aed', 'fluent-bit': '#059669',
-  'filebeat': '#d97706', 'otelcol': '#dc2626', 'vlagent': '#64748b'
+  'passthrough': { title: 'Passthrough', config: 'transform: "SELECT * FROM logs"' },
+  'json_parse': { title: 'JSON Parsing', config: 'SELECT timestamp, level, message…' },
+  'filter': { title: 'Filtering (WARN/ERROR)', config: 'WHERE level IN (\'WARN\', \'ERROR\')' },
 };
 
-function formatLPS(n) {
-  if (n >= 1e6) return (n / 1e6).toFixed(2) + 'M';
-  if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
-  return Math.round(n).toString();
+function fmt(ts) {
+  if (!ts) return '—';
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short', day: 'numeric', year: 'numeric',
+      hour: '2-digit', minute: '2-digit'
+    }).format(new Date(ts));
+  } catch { return ts; }
 }
 
-function formatNs(ns) {
-  if (ns >= 1e9) return (ns / 1e9).toFixed(2) + 's';
-  if (ns >= 1e6) return (ns / 1e6).toFixed(2) + 'ms';
-  if (ns >= 1e3) return (ns / 1e3).toFixed(1) + 'us';
-  return Math.round(ns) + 'ns';
+function shortId(id) {
+  const s = String(id || '');
+  // fastforward-bench format: "24767474344-1--compose-bench-smoke-otlp-t1m-multi-logfwd"
+  // extract workflow run id (first segment)
+  const first = s.split('-')[0];
+  return first.length > 8 ? '#' + first.slice(-8) : '#' + first;
 }
 
-function averageLps(entry) {
-  if (!entry || typeof entry !== 'object') return null;
-  if (Number.isFinite(entry.avg_lps)) return Math.max(0, entry.avg_lps);
-  if (Array.isArray(entry.lps)) {
-    const values = entry.lps.filter((v) => Number.isFinite(v));
-    if (values.length > 0) return values.reduce((sum, v) => sum + v, 0) / values.length;
-  }
-  return null;
+function shortCommit(c) {
+  return String(c || '').slice(0, 7);
 }
 
-function normalizeRateMap(rateRun) {
-  if (!rateRun || typeof rateRun !== 'object') return {};
-  if (rateRun.rates && typeof rateRun.rates === 'object') return rateRun.rates;
-  const out = {};
-  if (Array.isArray(rateRun.results)) {
-    for (const row of rateRun.results) {
-      const eps = Number(row?.eps);
-      if (!Number.isFinite(eps)) continue;
-      out[String(Math.trunc(eps))] = {
-        rss_mb: Number.isFinite(row?.rss_mb) ? row.rss_mb : (Number.isFinite(row?.rss_kb) ? row.rss_kb / 1024 : null),
-        cpu_pct: Number.isFinite(row?.cpu_pct) ? row.cpu_pct : (Number.isFinite(row?.cpu_percent) ? row.cpu_percent : null),
-        actual_eps: Number.isFinite(row?.actual_eps) ? row.actual_eps : null,
-      };
-    }
-  }
-  return out;
-}
-
-function formatCriterionThroughput(entry) {
-  if (!entry || typeof entry !== 'object') return '--';
-  if (Number.isFinite(entry.thrpt_mib_s)) return entry.thrpt_mib_s.toFixed(1) + ' MiB/s';
-  if (Number.isFinite(entry.thrpt_melem_s)) return entry.thrpt_melem_s.toFixed(1) + ' Melem/s';
-  const meanNs = Number(entry.mean_ns);
-  const bytes = Number(entry.throughput?.Bytes);
-  const elems = Number(entry.throughput?.Elements);
-  if (Number.isFinite(meanNs) && meanNs > 0 && Number.isFinite(bytes)) {
-    const mibPerSec = (bytes / (meanNs / 1e9)) / (1024 * 1024);
-    return mibPerSec.toFixed(1) + ' MiB/s';
-  }
-  if (Number.isFinite(meanNs) && meanNs > 0 && Number.isFinite(elems)) {
-    const melemPerSec = (elems / (meanNs / 1e9)) / 1e6;
-    return melemPerSec.toFixed(1) + ' Melem/s';
-  }
-  return '--';
-}
-
-function isDark() {
-  return window.matchMedia('(prefers-color-scheme: dark)').matches;
-}
-
-function chartDefaults() {
-  const dark = isDark();
-  Chart.defaults.color = dark ? '#8b949e' : '#656d76';
-  Chart.defaults.borderColor = dark ? '#30363d' : '#d0d7de';
-}
-
-function drawSparkline(canvas, data, color) {
-  if (!canvas || !data || data.length === 0) return;
-  new Chart(canvas, {
-    type: 'line',
-    data: {
-      labels: data.map((_, i) => i),
-      datasets: [{ data, borderColor: color || '#2563eb', borderWidth: 1.5, pointRadius: 0, fill: false, tension: 0.3 }]
-    },
-    options: {
-      responsive: false, maintainAspectRatio: false,
-      plugins: { legend: { display: false }, tooltip: { enabled: false } },
-      scales: { x: { display: false }, y: { display: false } },
-      animation: false
-    }
-  });
-}
-
-function runId(entry) {
-  if (entry && typeof entry === 'object') return entry.id;
-  return entry;
+function runTypeFromId(id) {
+  const s = String(id || '');
+  if (s.includes('compose-bench')) return 'compose';
+  if (s.includes('kind-bench')) return 'kind';
+  return 'unknown';
 }
 
 async function main() {
-  chartDefaults();
   const index = await fetchBenchIndex();
+  const el = document.getElementById('loading');
+
   if (!index) {
-    document.getElementById('loading').textContent = 'No data available.';
+    el.className = 'empty-state';
+    el.textContent = 'No benchmark data available. Run a benchmark to populate results.';
     return;
   }
 
-  const runEntries = index.competitive_runs || index.runs || [];
-  // bench-data index is newest-first; normalize to oldest->newest for downstream logic
-  const runs = runEntries.map(runId).filter(Boolean).map(String).reverse();
-  const rateRuns = (index.rate_runs || []).map(runId).filter(Boolean).map(String);
-  const criterionRuns = (index.criterion_runs || []).map(runId).filter(Boolean).map(String);
-
-  // Load latest of each type
-  const latestRun = runs.length ? await fetchBenchRun(runs[runs.length - 1]) : null;
-  const latestRate = rateRuns.length ? await fetchBenchJson('rate-runs/' + rateRuns[rateRuns.length - 1] + '.json') : null;
-  const latestCriterion = criterionRuns.length ? await fetchBenchJson('criterion-runs/' + criterionRuns[criterionRuns.length - 1] + '.json') : null;
-
-  // Load a few recent runs for sparklines
-  const recentRunIds = runs.slice(-10);
-  const recentRuns = (await Promise.all(recentRunIds.map(id => fetchBenchRun(id)))).filter(Boolean);
-
-  document.getElementById('loading').style.display = 'none';
+  el.style.display = 'none';
   document.getElementById('content').style.display = '';
 
-  // Headline cards
-  const cardsEl = document.getElementById('headline-cards');
+  // Normalize fastforward-bench format: runs is an array of objects with {id, timestamp, commit, ref, benchmarks, metrics}
+  const rawRuns = index.runs || [];
+  const runs = rawRuns
+    .map(r => typeof r === 'string' ? { id: r } : r)
+    .filter(r => r.id);
 
-  // Card 1: Latest primary-scenario winner
-  let primaryWinner = null;
-  let primarySparkData = [];
-  if (latestRun && latestRun.scenarios) {
-    const firstScenario = latestRun.scenario_names?.[0] || Object.keys(latestRun.scenarios)[0];
-    const firstScenarioData = firstScenario ? latestRun.scenarios[firstScenario] : null;
-    if (firstScenarioData) {
-      let bestAgent = null;
-      let bestLps = 0;
-      for (const [agent, stats] of Object.entries(firstScenarioData)) {
-        const avg = averageLps(stats) || 0;
-        if (avg > bestLps) {
-          bestLps = avg;
-          bestAgent = agent;
+  // Hero stats
+  const heroEl = document.getElementById('hero-stats');
+  if (runs.length === 0) {
+    heroEl.innerHTML = '<p class="hero-pending">No benchmark runs recorded yet.</p>';
+  } else {
+    // latest run is the last one (runs are newest-first in index)
+    const latest = runs[runs.length - 1];
+    const count = runs.length;
+    heroEl.innerHTML = `
+      <div class="hero-stat-row">
+        <div class="hero-stat">
+          <span class="hero-stat-value">${count}</span>
+          <span class="hero-stat-label">Total runs</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-value mono">${shortId(latest.id)}</span>
+          <span class="hero-stat-label">Latest run</span>
+        </div>
+        <div class="hero-stat">
+          <span class="hero-stat-value mono" style="font-size:clamp(0.9rem,1.5vw,1.1rem);">${fmt(latest.timestamp)}</span>
+          <span class="hero-stat-label">Last updated</span>
+        </div>
+      </div>`;
+  }
+
+  // Runs table
+  const tbody = document.getElementById('runs-table-body');
+  document.getElementById('runs-count').textContent = `${runs.length} runs on bench-data`;
+  let rows = '';
+  for (const run of [...runs].reverse().slice(0, 100)) {
+    const rt = runTypeFromId(run.id);
+    const badgeClass = rt === 'compose' ? 'badge-competitive' : rt === 'kind' ? 'badge-rate' : '';
+    const refLabel = (run.ref || '').replace('refs/heads/', '');
+    rows += `<tr>
+      <td><a href="run.html?id=${encodeURIComponent(run.id)}">${shortId(run.id)}</a></td>
+      <td>${refLabel}</td>
+      <td><code>${shortCommit(run.commit)}</code></td>
+      <td><span class="badge ${badgeClass}">${rt}</span></td>
+    </tr>`;
+  }
+  tbody.innerHTML = rows || '<tr><td colspan="4" style="text-align:center;color:var(--ff-ink-muted);padding:1rem;">No runs recorded.</td></tr>';
+
+  // Competitive section — only if runs have scenarios/agents data
+  const latestRunId = runs.length ? runs[runs.length - 1].id : null;
+  if (latestRunId) {
+    const runData = await fetchBenchJson(`runs/${latestRunId}.json`);
+    if (runData && runData.scenarios && runData.agents) {
+      document.getElementById('latest-run-id').textContent = shortId(latestRunId);
+      renderCompetitive(runData);
+      document.getElementById('competitive-section').style.display = '';
+    }
+  }
+}
+
+function renderCompetitive(runData) {
+  const table = document.getElementById('competitive-table');
+  const thead = table.querySelector('thead tr');
+  const tbody = table.querySelector('tbody');
+
+  (runData.agents || []).forEach(a => {
+    thead.innerHTML += `<th class="numeric">${a}</th>`;
+  });
+
+  let rows = '';
+  for (const sn of (runData.scenario_names || Object.keys(runData.scenarios))) {
+    const sc = runData.scenarios[sn];
+    let bestAgent = null, bestLps = 0;
+    (runData.agents || []).forEach(a => {
+      const entry = sc?.[a];
+      let lps = null;
+      if (entry && typeof entry === 'object') {
+        if (Number.isFinite(entry.avg_lps)) lps = entry.avg_lps;
+        else if (Array.isArray(entry.lps)) {
+          const vals = entry.lps.filter(v => Number.isFinite(v));
+          if (vals.length) lps = vals.reduce((s, v) => s + v, 0) / vals.length;
         }
       }
-      if (bestAgent && bestLps > 0) {
-        primaryWinner = { agent: bestAgent, lps: bestLps, scenario: firstScenario };
-      }
-    }
-    // Sparkline from recent runs (winner of primary scenario per run)
-    for (const r of recentRuns) {
-      const sc = r.scenario_names?.[0] || Object.keys(r.scenarios || {})[0];
-      const scenarioData = sc ? r.scenarios?.[sc] : null;
-      if (!scenarioData) continue;
-      let bestLps = 0;
-      for (const stats of Object.values(scenarioData)) {
-        const avg = averageLps(stats) || 0;
-        if (avg > bestLps) bestLps = avg;
-      }
-      if (bestLps > 0) primarySparkData.push(bestLps);
-    }
-  }
-  cardsEl.innerHTML += `
-    <div class="tracking-card">
-      <span class="label">Primary Scenario Winner</span>
-      <span class="value">${primaryWinner ? formatLPS(primaryWinner.lps) : '--'}</span>
-      <span class="subtitle">${primaryWinner ? primaryWinner.agent + ' (' + getScenarioTitle(primaryWinner.scenario) + ')' : 'no recent competitive data'}</span>
-      <canvas class="sparkline" id="spark-lps" width="120" height="36"></canvas>
-    </div>`;
+      if (lps !== null && lps > bestLps) { bestLps = lps; bestAgent = a; }
+    });
 
-  // Card 2: Best ffwd ratio where available
-  let bestRatio = null;
-  if (latestRun && latestRun.scenarios) {
-    for (const sn of (latestRun.scenario_names || Object.keys(latestRun.scenarios))) {
-      const sc = latestRun.scenarios[sn];
-      const ffLps = averageLps(sc?.ff);
-      const ffwdLps = averageLps(sc?.ffwd);
-      const scenarioFfLps = ffLps > 0 ? ffLps : ffwdLps;
-      if (!(scenarioFfLps > 0)) continue;
-      for (const agent of Object.keys(sc)) {
-        if (agent === 'ff' || agent === 'ffwd') continue;
-        const competitorLps = averageLps(sc[agent]) || 0;
-        if (!(competitorLps > 0)) continue;
-        const ratio = scenarioFfLps / competitorLps;
-        if (!bestRatio || ratio > bestRatio.value) bestRatio = { value: ratio, vs: agent, scenario: sn };
-      }
-    }
-  }
-  cardsEl.innerHTML += `
-    <div class="tracking-card">
-      <span class="label">Best Competitive Ratio</span>
-      <span class="value">${bestRatio ? bestRatio.value.toFixed(1) + 'x' : '--'}</span>
-      <span class="subtitle">${bestRatio ? 'vs ' + bestRatio.vs + ' (' + getScenarioTitle(bestRatio.scenario) + ')' : 'no data'}</span>
-    </div>`;
-
-  // Card 3: RSS at 100K eps
-  let rss100k = null;
-  const rateMap = normalizeRateMap(latestRate);
-  if (rateMap["100000"]) {
-    rss100k = rateMap["100000"].rss_mb;
-  }
-  cardsEl.innerHTML += `
-    <div class="tracking-card">
-      <span class="label">RSS @ 100K eps</span>
-      <span class="value">${rss100k != null ? rss100k.toFixed(1) + ' MB' : '--'}</span>
-      <span class="subtitle">Memory usage at 100K events/sec</span>
-    </div>`;
-
-  // Draw sparklines after DOM update
-  if (primarySparkData.length > 1) drawSparkline(document.getElementById('spark-lps'), primarySparkData, '#2563eb');
-
-  // Recent competitive results table
-  if (latestRun && latestRun.scenarios) {
-    const section = document.getElementById('competitive-section');
-    section.style.display = '';
-    const table = document.getElementById('competitive-table');
-    const agents = latestRun.agents || [];
-    const thead = table.querySelector('thead tr');
-    agents.forEach(a => { thead.innerHTML += `<th class="numeric">${a}</th>`; });
-
-    const tbody = table.querySelector('tbody');
-    let rowsHtml = '';
-    for (const sn of (latestRun.scenario_names || Object.keys(latestRun.scenarios))) {
-      const sc = latestRun.scenarios[sn];
-      let bestAgent = null, bestLps = 0;
-      agents.forEach(a => {
-        const lps = averageLps(sc?.[a]) || 0;
-        if (lps > bestLps) {
-          bestLps = lps;
-          bestAgent = a;
+    let cells = `<td>${SCENARIO_NAMES[sn]?.title || sn}</td>`;
+    (runData.agents || []).forEach(a => {
+      const entry = sc?.[a];
+      let lps = null;
+      if (entry && typeof entry === 'object') {
+        if (Number.isFinite(entry.avg_lps)) lps = entry.avg_lps;
+        else if (Array.isArray(entry.lps)) {
+          const vals = entry.lps.filter(v => Number.isFinite(v));
+          if (vals.length) lps = vals.reduce((s, v) => s + v, 0) / vals.length;
         }
-      });
-
-      let row = `<td><a href="competitive.html">${getScenarioTitle(sn)}</a></td>`;
-      agents.forEach(a => {
-        const lps = averageLps(sc?.[a]);
-        const cls = a === bestAgent ? 'numeric winner' : 'numeric';
-        row += `<td class="${cls}">${lps != null ? formatLPS(lps) : '--'}</td>`;
-      });
-      rowsHtml += `<tr>${row}</tr>`;
-    }
-    tbody.innerHTML = rowsHtml;
+      }
+      const cls = a === bestAgent ? 'numeric winner' : 'numeric';
+      cells += `<td class="${cls}">${lps !== null ? fmtLPS(lps) : '—'}</td>`;
+    });
+    rows += `<tr>${cells}</tr>`;
   }
+  tbody.innerHTML = rows;
+}
 
-  // Recent development metrics
-  if (latestCriterion && latestCriterion.benchmarks) {
-    const section = document.getElementById('dev-section');
-    section.style.display = '';
-    const tbody = document.querySelector('#dev-table tbody');
-    const benchmarks = latestCriterion.benchmarks;
-    let rowsHtml = '';
-    for (const [name, data] of Object.entries(benchmarks).slice(0, 10)) {
-      const thrpt = formatCriterionThroughput(data);
-      rowsHtml += `<tr>
-        <td><a href="development.html">${name}</a></td>
-        <td class="numeric">${formatNs(data.mean_ns)}</td>
-        <td class="numeric">${thrpt}</td>
-      </tr>`;
-    }
-    tbody.innerHTML = rowsHtml;
-  }
-
-  // All runs list
-  const allRunIds = [...new Set([...runs, ...rateRuns, ...criterionRuns])];
-  if (allRunIds.length > 0) {
-    const section = document.getElementById('runs-section');
-    section.style.display = '';
-    const tbody = document.querySelector('#runs-table tbody');
-
-    // Show runs in reverse order (newest first)
-    let rowsHtml = '';
-    for (const id of [...allRunIds].reverse().slice(0, 50)) {
-      const types = [];
-      if (runs.includes(id)) types.push('competitive');
-      if (rateRuns.includes(id)) types.push('rate');
-      if (criterionRuns.includes(id)) types.push('criterion');
-
-      rowsHtml += `<tr>
-        <td><a href="run.html?id=${id}">#${id}</a></td>
-        <td>${types.map(t => '<span class="badge">' + t + '</span> ').join('')}</td>
-      </tr>`;
-    }
-    tbody.innerHTML = rowsHtml;
-  }
+function fmtLPS(n) {
+  if (n >= 1e6) return (n / 1e6).toFixed(2) + 'M';
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
+  return Math.round(n).toString();
 }
 
 main();

--- a/bench/dashboard/o11y-client.js
+++ b/bench/dashboard/o11y-client.js
@@ -8,7 +8,7 @@ import { trendChartDataset } from "https://cdn.jsdelivr.net/npm/@benchkit/adapte
 
 export const benchDataSource = {
   owner: "strawgate",
-  repo: "fastforward",
+  repo: "fastforward-bench",
   branch: "bench-data",
 };
 

--- a/bench/dashboard/project-health.html
+++ b/bench/dashboard/project-health.html
@@ -3,32 +3,38 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#10243a">
-  <title>Project Health - FastForward</title>
+  <title>Project Health - FastForward Benchmarks</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
 </head>
 <body>
-<div class="container">
-  <div class="breadcrumb">
-    <a href="index.html">Dashboard</a><span class="sep">/</span>Project Health
-  </div>
-
-  <header class="hero">
-    <p class="eyebrow">repository health</p>
-    <h1>Project Health</h1>
-    <p class="lede">Track FastForward’s repository signal over time: community adoption, backlog shape, delivery speed, CI stability, and codebase growth.</p>
-    <div class="hero-tags">
-      <span>octo11y metrics</span><span>bench-data history</span><span>repo trendlines</span>
-    </div>
+<div class="site-wrapper">
+  <header class="top-bar">
+    <a class="top-bar-brand" href="https://strawgate.github.io/fastforward/">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+        <path d="M2 17l10 5 10-5"/>
+        <path d="M2 12l10 5 10-5"/>
+      </svg>
+      <span>FastForward</span>
+    </a>
+    <div class="top-bar-divider"></div>
+    <span class="top-bar-section">Benchmarks</span>
+    <nav class="top-bar-links">
+      <a href="index.html">Overview</a>
+      <a href="competitive.html">Competitive</a>
+      <a href="development.html">Development</a>
+      <a href="project-health.html" class="active">Project Health</a>
+    </nav>
   </header>
 
-  <nav class="nav-pills">
-    <a href="index.html">Overview</a>
-    <a href="competitive.html">Competitive</a>
-    <a href="development.html">Development</a>
-    <a href="project-health.html" class="active">Project Health</a>
-  </nav>
+  <main class="main-content">
+
+    <header class="hero">
+      <p class="hero-eyebrow">Project Health</p>
+      <h1>Project Health</h1>
+      <p class="hero-lede">Track FastForward's repository signal over time.</p>
+    </header>
 
   <div id="loading" class="loading">Loading project health data...</div>
   <div id="empty" class="empty-state" style="display:none">
@@ -480,5 +486,7 @@ async function main() {
 
 main();
 </script>
+</main>
+</div>
 </body>
 </html>

--- a/bench/dashboard/run.html
+++ b/bench/dashboard/run.html
@@ -355,7 +355,5 @@ async function main() {
 
 main();
 </script>
-</main>
-</div>
 </body>
 </html>

--- a/bench/dashboard/run.html
+++ b/bench/dashboard/run.html
@@ -3,32 +3,38 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="theme-color" content="#10243a">
-  <title>Run Detail - Benchmark Dashboard</title>
+  <title>Run Detail - FastForward Benchmarks</title>
   <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7"></script>
 </head>
 <body>
-<div class="container">
-  <div class="breadcrumb">
-    <a href="index.html">Dashboard</a><span class="sep">/</span><span id="breadcrumb-title">Run</span>
-  </div>
-
-  <header class="hero">
-    <p class="eyebrow">run inspector</p>
-    <h1>Run Detail</h1>
-    <p class="lede">Deep-dive one benchmark run to compare per-scenario throughput and resource peaks across all configured collectors.</p>
-    <div class="hero-tags">
-      <span>single run forensics</span><span>scenario deltas</span><span>resource peaks</span>
-    </div>
+<div class="site-wrapper">
+  <header class="top-bar">
+    <a class="top-bar-brand" href="https://strawgate.github.io/fastforward/">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+        <path d="M2 17l10 5 10-5"/>
+        <path d="M2 12l10 5 10-5"/>
+      </svg>
+      <span>FastForward</span>
+    </a>
+    <div class="top-bar-divider"></div>
+    <span class="top-bar-section">Benchmarks</span>
+    <nav class="top-bar-links">
+      <a href="index.html">Overview</a>
+      <a href="competitive.html">Competitive</a>
+      <a href="development.html">Development</a>
+      <a href="project-health.html">Project Health</a>
+    </nav>
   </header>
 
-  <nav class="nav-pills">
-    <a href="index.html">Overview</a>
-    <a href="competitive.html">Competitive</a>
-    <a href="development.html">Development</a>
-    <a href="project-health.html">Project Health</a>
-  </nav>
+  <main class="main-content">
+
+    <header class="hero">
+      <p class="hero-eyebrow">Run Inspector</p>
+      <h1>Run Detail</h1>
+      <p class="hero-lede">Deep-dive one benchmark run to compare per-scenario throughput and resource peaks across all configured collectors.</p>
+    </header>
 
   <div id="loading" class="loading">Loading run data...</div>
   <div id="content" style="display:none">
@@ -60,14 +66,17 @@
 
     <div class="section">
       <h2>Full Results</h2>
-      <div class="card table-card">
-        <table id="results-table">
-          <thead id="results-thead"></thead>
-          <tbody id="results-tbody"></tbody>
-        </table>
+      <div class="card">
+        <div class="card-body" style="overflow-x:auto;">
+          <table id="results-table">
+            <thead id="results-thead"></thead>
+            <tbody id="results-tbody"></tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>
+</main>
 </div>
 
 <script type="module">
@@ -346,5 +355,7 @@ async function main() {
 
 main();
 </script>
+</main>
+</div>
 </body>
 </html>

--- a/bench/dashboard/style.css
+++ b/bench/dashboard/style.css
@@ -1,525 +1,466 @@
-@import "https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap";
+/* fastforward benchmark dashboard — matches Starlight teal design system */
 
 :root {
-  --bg: #f4f8ff;
-  --bg-elevated: #ffffff;
-  --bg-panel: rgba(255, 255, 255, 0.88);
-  --ink: #0f172a;
-  --ink-soft: #1e293b;
-  --ink-muted: #475569;
-  --border: rgba(15, 23, 42, 0.12);
-  --glow-a: #12b981;
-  --glow-b: #2563eb;
-  --glow-c: #f97316;
-  --good: #0f9d58;
-  --bad: #ef4444;
-  --warning: #f59e0b;
-  --mono: "IBM Plex Mono", "SFMono-Regular", "Menlo", "Monaco", "Consolas", monospace;
-  --sans: "Sora", "Avenir Next", "Segoe UI", sans-serif;
-  --radius-lg: 18px;
-  --radius-md: 12px;
-  --shadow-lg: 0 22px 50px -26px rgba(15, 23, 42, 0.55);
-  --shadow-sm: 0 10px 25px -20px rgba(15, 23, 42, 0.55);
+  /* Teal accent — mirrors Starlight custom.css */
+  --ff-accent-low: #1a3a4a;
+  --ff-accent: #2d8ca8;
+  --ff-accent-high: #b8e4f0;
+
+  /* Typography — mirrors Starlight custom.css */
+  --ff-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --ff-mono: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo,
+    Consolas, "DejaVu Sans Mono", monospace;
+
+  /* Light mode (default) */
+  --ff-bg: #ffffff;
+  --ff-bg-nav: #f7f8f9;
+  --ff-bg-card: #f7f8f9;
+  --ff-ink: #0f172a;
+  --ff-ink-muted: #475569;
+  --ff-border: #e2e8f0;
+  --ff-shadow: 0 1px 3px rgba(0,0,0,0.08);
+
+  color-scheme: light dark;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #081023;
-    --bg-elevated: rgba(9, 18, 38, 0.92);
-    --bg-panel: rgba(8, 16, 35, 0.82);
-    --ink: #f8fafc;
-    --ink-soft: #dbeafe;
-    --ink-muted: #94a3b8;
-    --border: rgba(148, 163, 184, 0.25);
-    --good: #22c55e;
-    --bad: #f87171;
-    --warning: #fbbf24;
-    --shadow-lg: 0 22px 50px -26px rgba(0, 0, 0, 0.8);
-    --shadow-sm: 0 10px 25px -20px rgba(0, 0, 0, 0.75);
+    --ff-bg: #0f172a;
+    --ff-bg-nav: #1e293b;
+    --ff-bg-card: #1e293b;
+    --ff-ink: #f1f5f9;
+    --ff-ink-muted: #94a3b8;
+    --ff-border: #334155;
+    --ff-shadow: 0 1px 3px rgba(0,0,0,0.4);
   }
 }
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
+*, *::before, *::after { box-sizing: border-box; }
+
+html {
+  scroll-behavior: smooth;
 }
 
-html,
 body {
   margin: 0;
   padding: 0;
+  font-family: var(--ff-sans);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ff-ink);
+  background: var(--ff-bg);
+  -webkit-font-smoothing: antialiased;
 }
 
-body {
-  font-family: var(--sans);
-  color: var(--ink);
-  background:
-    radial-gradient(1200px 600px at -10% -10%, rgba(37, 99, 235, 0.2), transparent 70%),
-    radial-gradient(1000px 520px at 110% 0%, rgba(249, 115, 22, 0.18), transparent 72%),
-    linear-gradient(180deg, var(--bg) 0%, color-mix(in srgb, var(--bg) 88%, #dbeafe 12%) 100%);
+/* ── Layout ─────────────────────────────────────────── */
+
+.site-wrapper {
+  display: grid;
+  grid-template-rows: auto 1fr;
   min-height: 100vh;
-  line-height: 1.5;
 }
 
-body::before,
-body::after {
-  content: "";
-  position: fixed;
-  z-index: -1;
-  width: 360px;
-  height: 360px;
-  border-radius: 999px;
-  filter: blur(48px);
-  pointer-events: none;
+.top-bar {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.75rem 2rem;
+  background: var(--ff-bg-nav);
+  border-bottom: 1px solid var(--ff-border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
-body::before {
-  top: 22%;
-  left: -110px;
-  background: rgba(18, 185, 129, 0.18);
-  animation: drift-a 22s ease-in-out infinite;
-}
-
-body::after {
-  right: -120px;
-  bottom: 8%;
-  background: rgba(37, 99, 235, 0.2);
-  animation: drift-b 26s ease-in-out infinite;
-}
-
-@keyframes drift-a {
-  0%, 100% { transform: translateY(0) scale(1); }
-  50% { transform: translateY(-16px) scale(1.06); }
-}
-
-@keyframes drift-b {
-  0%, 100% { transform: translateX(0) scale(1); }
-  50% { transform: translateX(-18px) scale(1.08); }
-}
-
-a {
-  color: color-mix(in srgb, var(--glow-b) 76%, var(--ink) 24%);
+.top-bar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   text-decoration: none;
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--ff-ink);
+  letter-spacing: -0.01em;
 }
 
-a:hover {
-  color: color-mix(in srgb, var(--glow-b) 88%, var(--ink) 12%);
+.top-bar-brand svg {
+  width: 22px;
+  height: 22px;
+  color: var(--ff-accent);
+  flex-shrink: 0;
 }
 
-.container {
-  width: min(1280px, 100% - 34px);
-  margin: 24px auto 44px;
+.top-bar-brand span {
+  color: var(--ff-accent);
 }
+
+.top-bar-divider {
+  width: 1px;
+  height: 1.25rem;
+  background: var(--ff-border);
+  flex-shrink: 0;
+}
+
+.top-bar-section {
+  font-size: 0.8rem;
+  font-family: var(--ff-mono);
+  color: var(--ff-ink-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.top-bar-links {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+.top-bar-links a {
+  padding: 0.3rem 0.65rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-family: var(--ff-mono);
+  text-decoration: none;
+  color: var(--ff-ink-muted);
+  transition: background 0.15s, color 0.15s;
+  letter-spacing: 0.02em;
+}
+
+.top-bar-links a:hover {
+  background: var(--ff-border);
+  color: var(--ff-ink);
+}
+
+.top-bar-links a.active {
+  background: color-mix(in srgb, var(--ff-accent) 12%, transparent);
+  color: var(--ff-accent);
+  font-weight: 600;
+}
+
+.main-content {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 2.5rem 2rem;
+  width: 100%;
+}
+
+/* ── Hero ───────────────────────────────────────────── */
 
 .hero {
-  position: relative;
-  background: linear-gradient(
-    132deg,
-    color-mix(in srgb, var(--bg-elevated) 90%, var(--glow-b) 10%) 0%,
-    color-mix(in srgb, var(--bg-elevated) 92%, var(--glow-c) 8%) 48%,
-    color-mix(in srgb, var(--bg-elevated) 91%, var(--glow-a) 9%) 100%
-  );
-  border: 1px solid var(--border);
-  border-radius: 24px;
-  box-shadow: var(--shadow-lg);
-  padding: 26px 28px 22px;
-  overflow: hidden;
-  margin-bottom: 18px;
+  padding: 2.5rem 2.75rem;
+  background: var(--ff-bg-card);
+  border: 1px solid var(--ff-border);
+  border-radius: 12px;
+  box-shadow: var(--ff-shadow);
+  margin-bottom: 2rem;
 }
 
-.hero::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background:
-    linear-gradient(120deg, transparent 0 48%, rgba(255, 255, 255, 0.18) 51%, transparent 54%),
-    radial-gradient(380px 180px at 82% 18%, rgba(255, 255, 255, 0.15), transparent 70%);
-  pointer-events: none;
-}
-
-.eyebrow {
-  margin: 0 0 10px;
-  font: 600 11px/1 var(--mono);
+.hero-eyebrow {
+  margin: 0 0 0.5rem;
+  font-family: var(--ff-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: color-mix(in srgb, var(--ink) 56%, white 44%);
+  color: var(--ff-accent);
 }
 
-h1 {
-  margin: 0;
-  font-size: clamp(1.9rem, 3.6vw, 2.7rem);
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  color: var(--ink);
+.hero h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 750;
+  letter-spacing: -0.025em;
+  color: var(--ff-ink);
+  line-height: 1.15;
 }
 
-.lede {
-  margin: 12px 0 0;
-  max-width: 78ch;
-  font-size: 0.98rem;
-  color: var(--ink-muted);
+.hero-lede {
+  margin: 0 0 1.25rem;
+  font-size: 0.9rem;
+  color: var(--ff-ink-muted);
+  max-width: 56ch;
+  line-height: 1.55;
 }
 
-.hero-tags {
+.hero-stat-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 14px;
+  gap: 1.5rem;
+  align-items: baseline;
 }
 
-.hero-tags span {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid color-mix(in srgb, var(--glow-b) 34%, var(--border) 66%);
-  background: color-mix(in srgb, var(--bg-elevated) 86%, var(--glow-b) 14%);
-  border-radius: 999px;
-  padding: 4px 10px;
-  font: 500 11px/1.2 var(--mono);
-  letter-spacing: 0.04em;
-  color: color-mix(in srgb, var(--ink-soft) 88%, var(--glow-b) 12%);
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
 }
 
-h2 {
-  margin: 0 0 14px;
-  font-size: 1.2rem;
-  letter-spacing: -0.015em;
+.hero-stat-value {
+  font-family: var(--ff-mono);
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  font-weight: 750;
+  letter-spacing: -0.03em;
+  color: var(--ff-ink);
+  line-height: 1;
 }
 
-h3 {
-  margin: 0 0 10px;
-  font-size: 0.98rem;
+.hero-stat-value.mono {
+  font-family: var(--ff-mono);
+  font-size: clamp(1rem, 2vw, 1.3rem);
   font-weight: 600;
-  color: var(--ink-soft);
+  letter-spacing: -0.01em;
 }
 
-.scenario-title {
-  display: block;
-  font-weight: 700;
-  color: var(--ink);
-}
-
-.scenario-code {
-  display: block;
-  margin-top: 7px;
-  padding: 7px 9px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--bg-panel) 86%, var(--glow-b) 14%);
-  font: 500 11px/1.35 var(--mono);
-  color: var(--ink-muted);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  word-break: normal;
-}
-
-.breadcrumb {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  margin-bottom: 10px;
-  padding: 6px 10px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg-panel) 94%, var(--glow-a) 6%);
-  font: 500 12px/1 var(--mono);
-  color: var(--ink-muted);
-}
-
-.breadcrumb .sep {
-  opacity: 0.45;
-}
-
-.nav-pills {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 20px;
-  padding: 7px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg-panel) 88%, var(--glow-b) 12%);
-  box-shadow: var(--shadow-sm);
-}
-
-.nav-pills a {
-  padding: 8px 14px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  font: 600 12px/1 var(--mono);
-  letter-spacing: 0.05em;
+.hero-stat-label {
+  font-size: 0.75rem;
+  font-family: var(--ff-mono);
+  color: var(--ff-ink-muted);
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--ink-muted);
 }
 
-.nav-pills a:hover {
-  color: var(--ink);
-  border-color: color-mix(in srgb, var(--glow-b) 28%, var(--border) 72%);
+.hero-stat + .hero-stat {
+  padding-left: 1.5rem;
+  border-left: 1px solid var(--ff-border);
 }
 
-.nav-pills a.active {
-  color: #fff;
-  background: linear-gradient(
-    118deg,
-    color-mix(in srgb, var(--glow-b) 78%, #0f172a 22%) 0%,
-    color-mix(in srgb, var(--glow-a) 74%, #0f172a 26%) 100%
-  );
-  box-shadow: 0 8px 20px -12px rgba(37, 99, 235, 0.8);
+.hero-pending {
+  font-family: var(--ff-mono);
+  font-size: 0.85rem;
+  color: var(--ff-ink-muted);
+  padding: 0.5rem 0;
 }
 
-.section {
-  margin: 22px 0 30px;
-  animation: rise 0.42s ease;
-}
-
-@keyframes rise {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
-}
+/* ── Cards ──────────────────────────────────────────── */
 
 .card {
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: var(--bg-panel);
-  box-shadow: var(--shadow-sm);
-  padding: 20px;
-  backdrop-filter: blur(8px);
-  overflow-x: auto;
-}
-
-.table-card {
-  padding: 14px;
-}
-
-.tracking-cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(245px, 1fr));
-  gap: 14px;
-  margin-bottom: 22px;
-}
-
-.tracking-card {
-  position: relative;
-  border-radius: 16px;
-  border: 1px solid var(--border);
-  background: color-mix(in srgb, var(--bg-panel) 88%, white 12%);
-  box-shadow: var(--shadow-sm);
-  padding: 16px 16px 14px;
+  background: var(--ff-bg-card);
+  border: 1px solid var(--ff-border);
+  border-radius: 10px;
+  box-shadow: var(--ff-shadow);
   overflow: hidden;
+  margin-bottom: 1.5rem;
 }
 
-.tracking-card::before {
-  content: "";
-  position: absolute;
-  inset: 0 auto auto 0;
-  width: 100%;
-  height: 3px;
-  background: linear-gradient(90deg, var(--glow-a), var(--glow-b), var(--glow-c));
-  opacity: 0.85;
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1.1rem;
+  border-bottom: 1px solid var(--ff-border);
+  background: color-mix(in srgb, var(--ff-accent) 5%, var(--ff-bg-card));
 }
 
-.tracking-card .label {
-  display: block;
-  margin-top: 2px;
-  font: 600 10px/1 var(--mono);
-  text-transform: uppercase;
-  letter-spacing: 0.13em;
-  color: var(--ink-muted);
-}
-
-.tracking-card .value {
-  display: block;
-  margin-top: 9px;
-  font-size: clamp(1.4rem, 3.1vw, 2rem);
-  font-weight: 750;
-  letter-spacing: -0.028em;
-  color: var(--ink);
-}
-
-.tracking-card .subtitle {
-  display: block;
-  margin-top: 6px;
+.card-title {
+  margin: 0;
   font-size: 0.82rem;
-  color: var(--ink-muted);
+  font-weight: 700;
+  font-family: var(--ff-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ff-ink-muted);
 }
 
-.sparkline {
-  width: 100%;
-  height: 48px;
-  margin-top: 8px;
+.card-body {
+  padding: 0.75rem 1.1rem;
 }
 
-.chart-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
-  gap: 16px;
-}
-
-.chart-grid .card canvas {
-  margin-top: 12px;
-}
+/* ── Tables ─────────────────────────────────────────── */
 
 table {
   width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  min-width: 780px;
-  font-size: 13.5px;
-}
-
-th,
-td {
-  padding: 10px 12px;
-  border-bottom: 1px solid color-mix(in srgb, var(--border) 80%, transparent 20%);
+  border-collapse: collapse;
+  font-size: 0.875rem;
 }
 
 th {
+  text-align: left;
+  padding: 0.55rem 1rem;
+  font-family: var(--ff-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font: 600 10px/1.1 var(--mono);
-  color: var(--ink-muted);
+  color: var(--ff-ink-muted);
+  border-bottom: 1px solid var(--ff-border);
+  white-space: nowrap;
 }
 
 td {
-  color: var(--ink-soft);
+  padding: 0.65rem 1rem;
+  border-bottom: 1px solid var(--ff-border);
+  color: var(--ff-ink);
+  vertical-align: middle;
 }
 
-tr:last-child td {
-  border-bottom: none;
-}
+tr:last-child td { border-bottom: none; }
 
-tr:hover td {
-  background: color-mix(in srgb, var(--bg-panel) 84%, var(--glow-b) 16%);
-}
+tr:hover td { background: color-mix(in srgb, var(--ff-accent) 4%, transparent); }
 
-td.numeric,
-th.numeric {
+td.numeric, th.numeric {
   text-align: right;
   font-variant-numeric: tabular-nums;
+  font-family: var(--ff-mono);
 }
 
-.winner {
-  color: var(--good);
-  font-weight: 700;
+a { color: var(--ff-accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+code {
+  font-family: var(--ff-mono);
+  font-size: 0.8em;
+  background: color-mix(in srgb, var(--ff-accent) 8%, transparent);
+  color: var(--ff-ink);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+  border: 1px solid color-mix(in srgb, var(--ff-accent) 20%, transparent);
 }
+
+/* ── Badges ─────────────────────────────────────────── */
 
 .badge {
   display: inline-flex;
   align-items: center;
-  margin-right: 6px;
-  margin-bottom: 4px;
-  padding: 4px 9px;
+  padding: 0.15rem 0.5rem;
   border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--glow-a) 35%, var(--border) 65%);
-  background: color-mix(in srgb, var(--bg-panel) 88%, var(--glow-a) 12%);
-  font: 600 10px/1 var(--mono);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--ink-soft) 88%, var(--glow-a) 12%);
-}
-
-.delta-good {
-  color: var(--good);
-  font-weight: 700;
-}
-
-.delta-bad {
-  color: var(--bad);
-  font-weight: 700;
-}
-
-.delta-flat {
-  color: var(--ink-muted);
+  font-family: var(--ff-mono);
+  font-size: 0.7rem;
   font-weight: 600;
-}
-
-.run-header {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-bottom: 10px;
-}
-
-.run-header h1 {
-  font-size: clamp(1.5rem, 2.6vw, 2rem);
-}
-
-.run-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 18px;
-  margin-bottom: 16px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--bg-panel) 92%, var(--glow-c) 8%);
-  padding: 10px 12px;
-  font-size: 13px;
-  color: var(--ink-muted);
-}
-
-.run-meta code {
-  font-family: var(--mono);
-  font-size: 11px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--bg-elevated) 88%, var(--glow-b) 12%);
-  padding: 2px 6px;
-  color: var(--ink-soft);
-}
-
-.info-note {
-  margin: 10px 0 2px;
-  border-left: 3px solid var(--warning);
-  background: color-mix(in srgb, var(--bg-panel) 80%, var(--warning) 20%);
-  border-radius: 7px;
-  padding: 7px 9px;
-  font-size: 12px;
-  color: color-mix(in srgb, var(--ink-soft) 75%, var(--warning) 25%);
-}
-
-.loading,
-.empty-state {
-  border: 1px dashed var(--border);
-  border-radius: 14px;
-  background: color-mix(in srgb, var(--bg-panel) 86%, var(--glow-c) 14%);
-  padding: 28px 18px;
-  text-align: center;
-  color: var(--ink-muted);
-  font: 500 13px/1.4 var(--mono);
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  border: 1px solid transparent;
 }
 
-@media (max-width: 920px) {
-  .container {
-    width: min(1280px, 100% - 20px);
-    margin-top: 14px;
-  }
-
-  .hero {
-    padding: 18px 16px 16px;
-    border-radius: 18px;
-  }
-
-  .nav-pills {
-    width: 100%;
-  }
-
-  .chart-grid {
-    grid-template-columns: 1fr;
-  }
-
-  table {
-    min-width: 680px;
-  }
+.badge-competitive {
+  background: color-mix(in srgb, var(--ff-accent) 12%, transparent);
+  color: var(--ff-accent);
+  border-color: color-mix(in srgb, var(--ff-accent) 25%, transparent);
 }
+
+.badge-rate {
+  background: color-mix(in srgb, #f59e0b 12%, transparent);
+  color: #b45309;
+  border-color: color-mix(in srgb, #f59e0b 25%, transparent);
+}
+
+.badge-criterion {
+  background: color-mix(in srgb, #8b5cf6 12%, transparent);
+  color: #6d28d9;
+  border-color: color-mix(in srgb, #8b5cf6 25%, transparent);
+}
+
+@media (prefers-color-scheme: dark) {
+  .badge-rate { color: #fbbf24; }
+  .badge-criterion { color: #c4b5fd; }
+}
+
+/* ── States ─────────────────────────────────────────── */
+
+.loading, .empty-state {
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  font-family: var(--ff-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ff-ink-muted);
+  border: 1px dashed var(--ff-border);
+  border-radius: 8px;
+}
+
+.empty-state {
+  border-color: color-mix(in srgb, var(--ff-accent) 20%, transparent);
+  color: var(--ff-ink-muted);
+}
+
+/* ── Section headers ─────────────────────────────────── */
+
+.section-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  margin: 0 0 0.85rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ff-ink);
+}
+
+.section-header p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--ff-ink-muted);
+}
+
+/* ── Chart grid ─────────────────────────────────────── */
+
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.chart-grid .card {
+  margin-bottom: 0;
+}
+
+/* ── Tracking cards (for KPI grids) ──────────────────── */
+
+.tracking-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.tracking-card {
+  background: var(--ff-bg-card);
+  border: 1px solid var(--ff-border);
+  border-radius: 10px;
+  box-shadow: var(--ff-shadow);
+  padding: 1rem 1.1rem;
+}
+
+.tracking-card .label {
+  display: block;
+  font-family: var(--ff-mono);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ff-ink-muted);
+}
+
+.tracking-card .value {
+  display: block;
+  margin-top: 0.4rem;
+  font-family: var(--ff-mono);
+  font-size: 1.6rem;
+  font-weight: 750;
+  letter-spacing: -0.025em;
+  color: var(--ff-ink);
+}
+
+.tracking-card .subtitle {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.78rem;
+  color: var(--ff-ink-muted);
+}
+
+/* ── Responsive ─────────────────────────────────────── */
 
 @media (max-width: 640px) {
-  .tracking-cards {
-    grid-template-columns: 1fr;
-  }
-
-  .hero-tags span {
-    font-size: 10px;
-  }
+  .top-bar { padding: 0.6rem 1rem; }
+  .top-bar-section { display: none; }
+  .main-content { padding: 1.5rem 1rem; }
+  .hero { padding: 1.5rem 1.25rem; }
+  .hero-stat-row { gap: 1rem; }
+  .hero-stat + .hero-stat { padding-left: 1rem; }
 }

--- a/book/astro.config.mjs
+++ b/book/astro.config.mjs
@@ -73,6 +73,10 @@ export default defineConfig({
           label: "Troubleshooting",
           slug: "troubleshooting",
         },
+        {
+          label: "Benchmarks",
+          link: "/bench/",
+        },
       ],
     }),
   ],

--- a/book/src/content/docs/index.mdx
+++ b/book/src/content/docs/index.mdx
@@ -208,30 +208,27 @@ export const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   }
 `}</style>
 
-<script is:inline>
-(async function () {
-  const el = document.getElementById('bench-hero-stat');
+<Fragment set:html={`<script>(async function () {
+  var el = document.getElementById('bench-hero-stat');
   if (!el) return;
   try {
-    const res = await fetch(
+    var res = await fetch(
       'https://raw.githubusercontent.com/strawgate/fastforward-bench/bench-data/data/index.json'
     );
     if (!res.ok) throw new Error('not ok');
-    const index = await res.json();
-    const runs = index.runs || [];
+    var index = await res.json();
+    var runs = index.runs || [];
     if (!runs.length) {
       el.textContent = 'No benchmark runs recorded yet';
       return;
     }
-    // runs are newest-first
-    const latest = runs[runs.length - 1];
-    const count = runs.length;
-    const date = latest.timestamp
+    var latest = runs[runs.length - 1];
+    var count = runs.length;
+    var date = latest.timestamp
       ? new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(latest.timestamp))
       : '';
-    el.textContent = count + ' runs recorded · last updated ' + date;
-  } catch {
+    el.textContent = count + ' runs recorded \\u00b7 last updated ' + date;
+  } catch (e) {
     if (el) el.textContent = 'Benchmark data unavailable';
   }
-})();
-</script>
+})();</script>`} />

--- a/book/src/content/docs/index.mdx
+++ b/book/src/content/docs/index.mdx
@@ -23,6 +23,11 @@ export const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
     <h2 class="home-col-title">Use It</h2>
 
+    <a class="home-link-card home-link-card--bench" href={`${base}/bench/`}>
+      <span class="home-link-label">Benchmarks</span>
+      <span class="home-link-desc" id="bench-hero-stat">Loading benchmark data…</span>
+    </a>
+
     <a class="home-link-card" href={`${base}/quick-start/`}>
       <span class="home-link-label">Quick Start</span>
       <span class="home-link-desc">Install, run your first pipeline, and ship logs in 15 minutes</span>
@@ -163,6 +168,12 @@ export const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     line-height: 1.4;
   }
 
+  .home-link-card--bench {
+    background: color-mix(in srgb, var(--sl-color-accent) 8%, var(--sl-color-bg-sidebar));
+    border-color: color-mix(in srgb, var(--sl-color-accent) 30%, var(--sl-color-hairline));
+    margin-bottom: 0.5rem;
+  }
+
   .home-preview-card {
     display: flex;
     flex-direction: column;
@@ -196,3 +207,31 @@ export const base = import.meta.env.BASE_URL.replace(/\/$/, '');
     padding: 0.55rem 0.75rem 0.65rem;
   }
 `}</style>
+
+<script is:inline>
+(async function () {
+  const el = document.getElementById('bench-hero-stat');
+  if (!el) return;
+  try {
+    const res = await fetch(
+      'https://raw.githubusercontent.com/strawgate/fastforward-bench/bench-data/data/index.json'
+    );
+    if (!res.ok) throw new Error('not ok');
+    const index = await res.json();
+    const runs = index.runs || [];
+    if (!runs.length) {
+      el.textContent = 'No benchmark runs recorded yet';
+      return;
+    }
+    // runs are newest-first
+    const latest = runs[runs.length - 1];
+    const count = runs.length;
+    const date = latest.timestamp
+      ? new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(latest.timestamp))
+      : '';
+    el.textContent = count + ' runs recorded · last updated ' + date;
+  } catch {
+    if (el) el.textContent = 'Benchmark data unavailable';
+  }
+})();
+</script>


### PR DESCRIPTION
The benchmark dashboard was redesigned to align with FastForward's Starlight teal design system and integrated into the site navigation.

- Rewrites `style.css` to use system fonts and `#2d8ca8` accent, replacing SaaS gradients and custom fonts
- Adds a sticky top-bar with brand logo and nav links to all 5 benchmark pages
- Simplifies the Overview page to show run count and last-updated date fetched from `fastforward-bench`
- Wires "Benchmarks" into the Starlight sidebar and adds a live-updating hero card on the docs homepage
- Switches data source from `fastforward` to `fastforward-bench` repo on the `bench-data` branch

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redesign benchmark dashboard with a teal design system and updated index page
> - Replaces the old breadcrumb/nav-pills layout across all dashboard pages with a sticky top-bar navigation, hero sections, and card-based content wrappers in [style.css](https://github.com/strawgate/fastforward/pull/2737/files#diff-3b238610a37e6d3acc73f6a55eab64b317c08fa3bec18235e767457a212fac25).
> - Rewrites [index.html](https://github.com/strawgate/fastforward/pull/2737/files#diff-4966c221d2dcf0d441633340bea8e27c6fc5c3d0af479777fdeebcc70117278f) to show hero stats (total runs, latest run ID, last updated), a competitive results table with per-scenario winner highlighting, and a runs table with type badges; removes previous KPI cards, sparklines, and Chart.js.
> - Changes `benchDataSource.repo` in [o11y-client.js](https://github.com/strawgate/fastforward/pull/2737/files#diff-47bc58b3d1668a5904bf40c36f20f300e430b6d188f536b896f9d48d523ef019) from `fastforward` to `fastforward-bench`, redirecting all data fetches.
> - Adds a Benchmarks link card to the docs homepage ([index.mdx](https://github.com/strawgate/fastforward/pull/2737/files#diff-636692e35d15d7919bd1de78dd72a4142aaf0c915d2375e980098637a2d0d0b6)) with a live run count and last-updated stat fetched from the `fastforward-bench` repo.
> - Adds a Benchmarks entry to the docs sidebar in [astro.config.mjs](https://github.com/strawgate/fastforward/pull/2737/files#diff-806b4b49726ba8ffdf700b2a4923be7a361db2c11273c3b889a550c51fd49dff).
> - Behavioral Change: the index page no longer renders dev metrics or criterion/rate run KPIs; it now requires `index.runs` entries as objects with `id`/`timestamp` fields and fetches run data from `runs/<id>.json`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4e03ae8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->