### PR TITLE
Fix DrainIngress regression blocking queued input draining on shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.kani_required == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
 
@@ -501,7 +501,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.kani_required == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust
 
-      - name: Enable coverage instrumentation
-        run: echo 'RUSTFLAGS=-C instrument-coverage' >> "$GITHUB_ENV"
-
       - name: Install cargo-fuzz
         run: cargo +nightly install cargo-fuzz
+
+      - name: Enable coverage instrumentation
+        run: echo 'RUSTFLAGS=-C instrument-coverage' >> "$GITHUB_ENV"
 
       - name: Download previous corpus
         uses: actions/download-artifact@v4
@@ -86,11 +86,11 @@ jobs:
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust
 
-      - name: Enable coverage instrumentation
-        run: echo 'RUSTFLAGS=-C instrument-coverage' >> "$GITHUB_ENV"
-
       - name: Install cargo-fuzz
         run: cargo +nightly install cargo-fuzz
+
+      - name: Enable coverage instrumentation
+        run: echo 'RUSTFLAGS=-C instrument-coverage' >> "$GITHUB_ENV"
 
       - name: Download previous corpus
         uses: actions/download-artifact@v4

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -23,8 +23,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust
-        with:
-          rustflags: -C instrument-coverage
+
+      - name: Enable coverage instrumentation
+        run: echo 'RUSTFLAGS=-C instrument-coverage' >> "$GITHUB_ENV"
 
       - name: Install cargo-fuzz
         run: cargo +nightly install cargo-fuzz
@@ -49,7 +50,7 @@ jobs:
         env:
           DURATION_HOURS: ${{ inputs.duration-hours || '2' }}
         run: |
-          DURATION_SECS=$(( ${DURATION_HOURS} * 3600 ))
+          DURATION_SECS=$(( DURATION_HOURS * 3600 ))
           cd crates/ffwd-core/fuzz
           for TARGET in fuzz_scanner fuzz_zero_copy_scanner fuzz_scanner_consistency \
                        fuzz_structural_streaming fuzz_cri fuzz_pipe_event \
@@ -84,8 +85,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: ./.github/actions/setup-rust
-        with:
-          rustflags: -C instrument-coverage
+
+      - name: Enable coverage instrumentation
+        run: echo 'RUSTFLAGS=-C instrument-coverage' >> "$GITHUB_ENV"
 
       - name: Install cargo-fuzz
         run: cargo +nightly install cargo-fuzz
@@ -109,7 +111,7 @@ jobs:
         env:
           DURATION_HOURS: ${{ inputs.duration-hours || '2' }}
         run: |
-          DURATION_SECS=$(( ${DURATION_HOURS} * 3600 ))
+          DURATION_SECS=$(( DURATION_HOURS * 3600 ))
           cd crates/ffwd-io/fuzz
           for TARGET in fuzz_otlp_protobuf_decode fuzz_otlp_json_decode fuzz_decompress \
                        fuzz_arrow_ipc_decode fuzz_otap_decode fuzz_protojson_numbers; do

--- a/.github/workflows/fuzz-pr.yml
+++ b/.github/workflows/fuzz-pr.yml
@@ -12,7 +12,7 @@ jobs:
   fuzz-pr:
     name: Fuzz smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -21,6 +21,11 @@ jobs:
 
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install just
+        uses: taiki-e/install-action@9ed832ec9b05207a87c28eab74dbfb661ff969d3
+        with:
+          tool: just
 
       - name: Install cargo-fuzz
         run: cargo +nightly install cargo-fuzz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,15 +670,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,12 +854,6 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "cmov"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "colorchoice"
@@ -1097,15 +1082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,15 +1100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
 ]
 
 [[package]]
@@ -1826,19 +1793,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "crypto-common 0.2.1",
- "ctutils",
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2704,11 +2661,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.13.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.11.2",
+ "digest",
 ]
 
 [[package]]
@@ -2761,15 +2718,6 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "hyper"
@@ -4926,7 +4874,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4937,7 +4885,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]

--- a/crates/ffwd-bench/benches/backpressure.rs
+++ b/crates/ffwd-bench/benches/backpressure.rs
@@ -211,17 +211,27 @@ fn bench_backpressure_mixed(c: &mut Criterion) {
                     format!("d{delay_ms}_c{capacity}_p{producers}"),
                     format!("{delay_ms}_{capacity}_{producers}"),
                 );
-                group.bench_with_input(id, &(delay_ms, capacity, producers), |b, &(delay, capacity, producers)| {
-                    let bytes = data_bytes.clone();
-                    b.iter_custom(|iters| {
-                        let start = Instant::now();
-                        for _ in 0..iters {
-                            let result = run_backpressure_benchmark(delay, &bytes, capacity, producers, RUNTIME_SECS);
-                            std::hint::black_box(result);
-                        }
-                        start.elapsed()
-                    });
-                });
+                group.bench_with_input(
+                    id,
+                    &(delay_ms, capacity, producers),
+                    |b, &(delay, capacity, producers)| {
+                        let bytes = data_bytes.clone();
+                        b.iter_custom(|iters| {
+                            let start = Instant::now();
+                            for _ in 0..iters {
+                                let result = run_backpressure_benchmark(
+                                    delay,
+                                    &bytes,
+                                    capacity,
+                                    producers,
+                                    RUNTIME_SECS,
+                                );
+                                std::hint::black_box(result);
+                            }
+                            start.elapsed()
+                        });
+                    },
+                );
             }
         }
     }
@@ -230,14 +240,31 @@ fn bench_backpressure_mixed(c: &mut Criterion) {
         #[allow(clippy::print_stderr)]
         {
             eprintln!("\n=== Backpressure Summary (mixed, runtime: {RUNTIME_SECS}s) ===");
-            eprintln!("{:>8} {:>8} {:>8} {:>15} {:>12} {:>12} {:>12}", "Delay", "Cap", "Prods", "Lines/sec", "Stalls", "Batches", "Stall Rate");
+            eprintln!(
+                "{:>8} {:>8} {:>8} {:>15} {:>12} {:>12} {:>12}",
+                "Delay", "Cap", "Prods", "Lines/sec", "Stalls", "Batches", "Stall Rate"
+            );
             for &delay_ms in DELAYS_MS {
                 for &capacity in CHANNEL_CAPACITIES {
                     for &producers in PRODUCER_COUNTS {
                         let (lines_per_sec, stalls, batches_sent, stall_rate) =
-                            run_backpressure_benchmark(delay_ms, &data_bytes, capacity, producers, RUNTIME_SECS);
-                        eprintln!("{:>8} {:>8} {:>8} {:>15.0} {:>12} {:>12} {:>12.3}",
-                            format!("{delay_ms}ms"), capacity, producers, lines_per_sec, stalls, batches_sent, stall_rate);
+                            run_backpressure_benchmark(
+                                delay_ms,
+                                &data_bytes,
+                                capacity,
+                                producers,
+                                RUNTIME_SECS,
+                            );
+                        eprintln!(
+                            "{:>8} {:>8} {:>8} {:>15.0} {:>12} {:>12} {:>12.3}",
+                            format!("{delay_ms}ms"),
+                            capacity,
+                            producers,
+                            lines_per_sec,
+                            stalls,
+                            batches_sent,
+                            stall_rate
+                        );
                     }
                 }
             }
@@ -340,7 +367,8 @@ fn bench_backpressure_producers(c: &mut Criterion) {
             b.iter_custom(|iters| {
                 let start = Instant::now();
                 for _ in 0..iters {
-                    let result = run_backpressure_benchmark(50, &bytes, 16, producers, RUNTIME_SECS);
+                    let result =
+                        run_backpressure_benchmark(50, &bytes, 16, producers, RUNTIME_SECS);
                     std::hint::black_box(result);
                 }
                 start.elapsed()

--- a/crates/ffwd-bench/src/lib.rs
+++ b/crates/ffwd-bench/src/lib.rs
@@ -2,8 +2,14 @@
 //!
 //! All generators accept a `seed` parameter for reproducible output. Given the
 //! same `(count, seed)` pair, every call returns byte-identical results.
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::print_stderr,
+    clippy::print_stdout
+)]
 // Bench harnesses print reports to stdout/stderr.
+// Synthetic data generators use fixed non-empty lookup tables and modulo indexes.
 
 use std::sync::Arc;
 

--- a/crates/ffwd-config-wasm/src/lib.rs
+++ b/crates/ffwd-config-wasm/src/lib.rs
@@ -91,7 +91,15 @@ pub fn get_output_snippet(id: &str) -> Option<String> {
 fn serde_wasm_bindgen_or_json<T: serde::Serialize + ?Sized>(value: &T) -> JsValue {
     // Serialize to JSON string then parse — avoids needing serde-wasm-bindgen.
     // All callers pass compile-time static data; serialization cannot fail.
+    #[expect(
+        clippy::expect_used,
+        reason = "static template data should always serialize to JSON"
+    )]
     let json = serde_json::to_string(value).expect("static template data serialization failed");
+    #[expect(
+        clippy::expect_used,
+        reason = "serde_json output should always parse as JavaScript JSON"
+    )]
     js_sys::JSON::parse(&json).expect("static template data produced invalid JSON")
 }
 

--- a/crates/ffwd-ebpf-proto/sensor-ebpf/src/linux.rs
+++ b/crates/ffwd-ebpf-proto/sensor-ebpf/src/linux.rs
@@ -547,7 +547,7 @@ pub(crate) fn run() -> Result<(), Box<dyn std::error::Error>> {
                     let ev = unsafe { &*(ptr.cast::<DnsQueryEvent>()) };
                     counts.dns_query += 1;
                     let wire_len = (ev.qname_len as usize).min(MAX_DNS_NAME);
-                    let wire = &ev.qname[..wire_len];
+                    let wire = ev.qname.get(..wire_len).unwrap_or_default();
                     let (qname_opt, qtype_opt) = dns_wire_to_dotted(wire);
                     let qname = qname_opt.as_deref().unwrap_or("<undecoded>");
                     let qtype_str = match qtype_opt {
@@ -655,14 +655,14 @@ fn format_addr(addr: u32) -> Ipv4Addr {
 
 fn comm_str(comm: &[u8; COMM_SIZE]) -> &str {
     let end = comm.iter().position(|&b| b == 0).unwrap_or(COMM_SIZE);
-    std::str::from_utf8(&comm[..end]).unwrap_or("<invalid>")
+    std::str::from_utf8(comm.get(..end).unwrap_or_default()).unwrap_or("<invalid>")
 }
 
 fn safe_str(buf: &[u8], len: usize) -> &str {
     let end = len.min(buf.len());
-    let slice = &buf[..end];
+    let slice = buf.get(..end).unwrap_or_default();
     let nul = slice.iter().position(|&b| b == 0).unwrap_or(end);
-    std::str::from_utf8(&slice[..nul]).unwrap_or("<invalid>")
+    std::str::from_utf8(slice.get(..nul).unwrap_or_default()).unwrap_or("<invalid>")
 }
 
 // dns_wire_to_dotted is provided by sensor_ebpf_common::dns::dns_wire_to_dotted

--- a/crates/ffwd-io/Cargo.toml
+++ b/crates/ffwd-io/Cargo.toml
@@ -50,7 +50,7 @@ flate2 = "1"
 futures-util = { version = "0.3", optional = true }
 globset = { workspace = true }
 hex = { version = "0.4", optional = true }
-hmac = { version = "0.13", optional = true }
+hmac = { version = "0.12", optional = true }
 http-body-util = "0.1"
 itoa = "1"
 libc = "0.2"

--- a/crates/ffwd-io/Cargo.toml
+++ b/crates/ffwd-io/Cargo.toml
@@ -50,6 +50,7 @@ flate2 = "1"
 futures-util = { version = "0.3", optional = true }
 globset = { workspace = true }
 hex = { version = "0.4", optional = true }
+# hmac 0.12 stays aligned with the digest 0.10 API used by the AWS SigV4 stack; do not re-upgrade to 0.13 without checking #2699.
 hmac = { version = "0.12", optional = true }
 http-body-util = "0.1"
 itoa = "1"

--- a/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
@@ -847,10 +847,7 @@ pub(super) fn decode_any_value_wire(value: &[u8]) -> Result<Option<WireAny<'_>>,
 ///   validated key, so re-validation is redundant.
 /// * `decode::collect_resource_attrs` — validates eagerly because there
 ///   is no per-position cache for resource attrs.
-#[expect(
-    dead_code,
-    reason = "generated projection API retained for wire decoders"
-)]
+#[cfg(test)]
 pub(super) fn decode_key_value_wire(
     kv: &[u8],
 ) -> Result<Option<(&[u8], WireAny<'_>)>, ProjectionError> {

--- a/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
+++ b/crates/ffwd-io/src/otlp_receiver/projection/generated.rs
@@ -847,6 +847,10 @@ pub(super) fn decode_any_value_wire(value: &[u8]) -> Result<Option<WireAny<'_>>,
 ///   validated key, so re-validation is redundant.
 /// * `decode::collect_resource_attrs` — validates eagerly because there
 ///   is no per-position cache for resource attrs.
+#[expect(
+    dead_code,
+    reason = "generated projection API retained for wire decoders"
+)]
 pub(super) fn decode_key_value_wire(
     kv: &[u8],
 ) -> Result<Option<(&[u8], WireAny<'_>)>, ProjectionError> {

--- a/crates/ffwd-io/src/platform_sensor.rs
+++ b/crates/ffwd-io/src/platform_sensor.rs
@@ -467,56 +467,63 @@ impl PlatformSensorInput {
         })
     }
 
-    /// Discover `task_struct.exit_code` offset from `/sys/kernel/btf/vmlinux`.
-    ///
-    /// Uses `pahole` (from the `dwarves` package) to introspect kernel BTF.
-    /// Returns the byte offset on success.
-    fn check_drops(ebpf: &mut Ebpf) -> u64 {
+    /// Read and reset the eBPF drop counter map.
+    fn check_drops(ebpf: &mut Ebpf) -> io::Result<u64> {
         let drops_map = match ebpf.map_mut("DROPS") {
             Some(map) => map,
-            None => return 0,
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "DROPS map not found in eBPF binary",
+                ));
+            }
         };
 
         let mut drops_array = match aya::maps::PerCpuArray::<_, u64>::try_from(drops_map) {
             Ok(array) => array,
-            Err(_) => return 0,
+            Err(error) => {
+                return Err(io::Error::other(format!(
+                    "failed to interpret DROPS map as PerCpuArray<u64>: {error}"
+                )));
+            }
         };
 
         let mut total_drops = 0;
 
         // Sum drops across all CPUs, then zero them out so we only report deltas.
-        if let Ok(per_cpu_values) = drops_array.get(&0, 0) {
-            for val in per_cpu_values.iter() {
-                if *val > 0 {
-                    total_drops += val;
-                }
+        let per_cpu_values = drops_array
+            .get(&0, 0)
+            .map_err(|error| io::Error::other(format!("failed to read eBPF DROPS map: {error}")))?;
+        for val in per_cpu_values.iter() {
+            if *val > 0 {
+                total_drops += val;
             }
-            if total_drops > 0 {
-                // Zero out the map to prevent overcounting on the next poll
-                use aya::maps::PerCpuValues;
-                let zero_vals: Vec<u64> = per_cpu_values.iter().map(|_| 0).collect();
-                match PerCpuValues::try_from(zero_vals) {
-                    Ok(zero_per_cpu_values) => {
-                        if let Err(error) = drops_array.set(0, zero_per_cpu_values, 0) {
-                            tracing::warn!(
-                                total_drops,
-                                ?error,
-                                "failed to reset eBPF DROPS map after reporting drops"
-                            );
-                        }
-                    }
-                    Err(error) => {
+        }
+        if total_drops > 0 {
+            // Zero out the map to prevent overcounting on the next poll.
+            use aya::maps::PerCpuValues;
+            let zero_vals: Vec<u64> = per_cpu_values.iter().map(|_| 0).collect();
+            match PerCpuValues::try_from(zero_vals) {
+                Ok(zero_per_cpu_values) => {
+                    if let Err(error) = drops_array.set(0, zero_per_cpu_values, 0) {
                         tracing::warn!(
                             total_drops,
                             ?error,
-                            "failed to build eBPF DROPS reset values after reporting drops"
+                            "failed to reset eBPF DROPS map after reporting drops"
                         );
                     }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        total_drops,
+                        ?error,
+                        "failed to build eBPF DROPS reset values after reporting drops"
+                    );
                 }
             }
         }
 
-        total_drops
+        Ok(total_drops)
     }
 
     fn drain_events(
@@ -883,9 +890,13 @@ impl InputSource for PlatformSensorInput {
                 skipped_probes,
                 degraded_capabilities,
             } => {
-                let drops = Self::check_drops(&mut ebpf);
-                if drops > 0 {
-                    self.stats.inc_ebpf_drops(drops);
+                match Self::check_drops(&mut ebpf) {
+                    Ok(drops) if drops > 0 => self.stats.inc_ebpf_drops(drops),
+                    Ok(_) => {}
+                    Err(error) => tracing::warn!(
+                        ?error,
+                        "failed to read eBPF DROPS map; drop telemetry is unavailable"
+                    ),
                 }
                 let result = Self::drain_events(
                     &mut ebpf,

--- a/crates/ffwd-io/src/platform_sensor.rs
+++ b/crates/ffwd-io/src/platform_sensor.rs
@@ -471,15 +471,15 @@ impl PlatformSensorInput {
     ///
     /// Uses `pahole` (from the `dwarves` package) to introspect kernel BTF.
     /// Returns the byte offset on success.
-    fn check_drops(ebpf: &mut Ebpf) -> io::Result<u64> {
+    fn check_drops(ebpf: &mut Ebpf) -> u64 {
         let drops_map = match ebpf.map_mut("DROPS") {
             Some(map) => map,
-            None => return Ok(0),
+            None => return 0,
         };
 
         let mut drops_array = match aya::maps::PerCpuArray::<_, u64>::try_from(drops_map) {
             Ok(array) => array,
-            Err(_) => return Ok(0),
+            Err(_) => return 0,
         };
 
         let mut total_drops = 0;
@@ -516,7 +516,7 @@ impl PlatformSensorInput {
             }
         }
 
-        Ok(total_drops)
+        total_drops
     }
 
     fn drain_events(
@@ -883,9 +883,8 @@ impl InputSource for PlatformSensorInput {
                 skipped_probes,
                 degraded_capabilities,
             } => {
-                if let Ok(drops) = Self::check_drops(&mut ebpf)
-                    && drops > 0
-                {
+                let drops = Self::check_drops(&mut ebpf);
+                if drops > 0 {
                     self.stats.inc_ebpf_drops(drops);
                 }
                 let result = Self::drain_events(

--- a/crates/ffwd-io/src/platform_sensor.rs
+++ b/crates/ffwd-io/src/platform_sensor.rs
@@ -497,7 +497,11 @@ impl PlatformSensorInput {
                 // Zero out the map to prevent overcounting on the next poll
                 use aya::maps::PerCpuValues;
                 let zero_vals: Vec<u64> = cpus.iter().map(|_| 0).collect();
-                let _ = drops_array.set(0, PerCpuValues::try_from(zero_vals).unwrap(), 0);
+                let zero_per_cpu_values = PerCpuValues::try_from(zero_vals)
+                    .map_err(|e| io::Error::other(format!("failed to build DROPS reset: {e:?}")))?;
+                drops_array
+                    .set(0, zero_per_cpu_values, 0)
+                    .map_err(|e| io::Error::other(format!("failed to reset DROPS map: {e:?}")))?;
             }
         }
 

--- a/crates/ffwd-io/src/platform_sensor.rs
+++ b/crates/ffwd-io/src/platform_sensor.rs
@@ -483,8 +483,6 @@ impl PlatformSensorInput {
         };
 
         let mut total_drops = 0;
-        let cpus = aya::util::online_cpus()
-            .map_err(|e| io::Error::other(format!("failed to get online cpus: {e:?}")))?;
 
         // Sum drops across all CPUs, then zero them out so we only report deltas.
         if let Ok(per_cpu_values) = drops_array.get(&0, 0) {
@@ -496,12 +494,25 @@ impl PlatformSensorInput {
             if total_drops > 0 {
                 // Zero out the map to prevent overcounting on the next poll
                 use aya::maps::PerCpuValues;
-                let zero_vals: Vec<u64> = cpus.iter().map(|_| 0).collect();
-                let zero_per_cpu_values = PerCpuValues::try_from(zero_vals)
-                    .map_err(|e| io::Error::other(format!("failed to build DROPS reset: {e:?}")))?;
-                drops_array
-                    .set(0, zero_per_cpu_values, 0)
-                    .map_err(|e| io::Error::other(format!("failed to reset DROPS map: {e:?}")))?;
+                let zero_vals: Vec<u64> = per_cpu_values.iter().map(|_| 0).collect();
+                match PerCpuValues::try_from(zero_vals) {
+                    Ok(zero_per_cpu_values) => {
+                        if let Err(error) = drops_array.set(0, zero_per_cpu_values, 0) {
+                            tracing::warn!(
+                                total_drops,
+                                ?error,
+                                "failed to reset eBPF DROPS map after reporting drops"
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            total_drops,
+                            ?error,
+                            "failed to build eBPF DROPS reset values after reporting drops"
+                        );
+                    }
+                }
             }
         }
 

--- a/crates/ffwd-io/src/s3_input/client.rs
+++ b/crates/ffwd-io/src/s3_input/client.rs
@@ -706,29 +706,13 @@ impl S3Client {
 
 fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option<String>)> {
     use quick_xml::Reader;
-    use quick_xml::escape::resolve_predefined_entity;
-    use quick_xml::events::BytesRef;
     use quick_xml::events::Event;
 
-    fn push_xml_reference(out: &mut String, reference: BytesRef<'_>) -> io::Result<()> {
-        if let Some(ch) = reference
-            .resolve_char_ref()
-            .map_err(|e| io::Error::other(format!("XML character reference: {e}")))?
-        {
-            out.push(ch);
-            return Ok(());
-        }
-
-        let decoded = reference
-            .decode()
-            .map_err(|e| io::Error::other(format!("XML reference decode: {e}")))?;
-        let Some(entity) = resolve_predefined_entity(decoded.as_ref()) else {
-            return Err(io::Error::other(format!(
-                "XML unrecognized entity: &{decoded};"
-            )));
-        };
-        out.push_str(entity);
-        Ok(())
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum CaptureField {
+        Key,
+        Size,
+        NextToken,
     }
 
     let mut reader = Reader::from_reader(data);
@@ -740,7 +724,7 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
     let mut in_contents = false;
     let mut current_key = String::new();
     let mut current_size: u64 = 0;
-    let mut capture: Option<&'static str> = None; // which field we're reading
+    let mut capture: Option<CaptureField> = None;
     let mut current_text = String::new();
 
     let mut buf = Vec::new();
@@ -753,15 +737,15 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
                     current_size = 0;
                 }
                 b"Key" if in_contents => {
-                    capture = Some("key");
+                    capture = Some(CaptureField::Key);
                     current_text.clear();
                 }
                 b"Size" if in_contents => {
-                    capture = Some("size");
+                    capture = Some(CaptureField::Size);
                     current_text.clear();
                 }
                 b"NextContinuationToken" => {
-                    capture = Some("next_token");
+                    capture = Some(CaptureField::NextToken);
                     current_text.clear();
                 }
                 _ => {}
@@ -773,14 +757,14 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
                 current_text.push_str(decoded.as_ref());
             }
             Ok(Event::GeneralRef(e)) if capture.is_some() => {
-                push_xml_reference(&mut current_text, e)?;
+                super::push_xml_reference(&mut current_text, e, "S3")?;
             }
             Ok(Event::End(e)) => match e.local_name().as_ref() {
-                b"Key" if capture == Some("key") => {
+                b"Key" if capture == Some(CaptureField::Key) => {
                     current_key = std::mem::take(&mut current_text);
                     capture = None;
                 }
-                b"Size" if capture == Some("size") => {
+                b"Size" if capture == Some(CaptureField::Size) => {
                     current_size = current_text.parse::<u64>().map_err(|e| {
                         io::Error::other(format!(
                             "S3 list XML parse: invalid object size {current_text:?}: {e}"
@@ -789,7 +773,7 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
                     capture = None;
                     current_text.clear();
                 }
-                b"NextContinuationToken" if capture == Some("next_token") => {
+                b"NextContinuationToken" if capture == Some(CaptureField::NextToken) => {
                     next_token = Some(std::mem::take(&mut current_text));
                     capture = None;
                 }

--- a/crates/ffwd-io/src/s3_input/client.rs
+++ b/crates/ffwd-io/src/s3_input/client.rs
@@ -706,7 +706,30 @@ impl S3Client {
 
 fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option<String>)> {
     use quick_xml::Reader;
+    use quick_xml::escape::resolve_predefined_entity;
+    use quick_xml::events::BytesRef;
     use quick_xml::events::Event;
+
+    fn push_xml_reference(out: &mut String, reference: BytesRef<'_>) -> io::Result<()> {
+        if let Some(ch) = reference
+            .resolve_char_ref()
+            .map_err(|e| io::Error::other(format!("XML character reference: {e}")))?
+        {
+            out.push(ch);
+            return Ok(());
+        }
+
+        let decoded = reference
+            .decode()
+            .map_err(|e| io::Error::other(format!("XML reference decode: {e}")))?;
+        let Some(entity) = resolve_predefined_entity(decoded.as_ref()) else {
+            return Err(io::Error::other(format!(
+                "XML unrecognized entity: &{decoded};"
+            )));
+        };
+        out.push_str(entity);
+        Ok(())
+    }
 
     let mut reader = Reader::from_reader(data);
     reader.config_mut().trim_text(true);
@@ -718,6 +741,7 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
     let mut current_key = String::new();
     let mut current_size: u64 = 0;
     let mut capture: Option<&'static str> = None; // which field we're reading
+    let mut current_text = String::new();
 
     let mut buf = Vec::new();
     loop {
@@ -728,35 +752,60 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
                     current_key.clear();
                     current_size = 0;
                 }
-                b"Key" if in_contents => capture = Some("key"),
-                b"Size" if in_contents => capture = Some("size"),
-                b"NextContinuationToken" => capture = Some("next_token"),
+                b"Key" if in_contents => {
+                    capture = Some("key");
+                    current_text.clear();
+                }
+                b"Size" if in_contents => {
+                    capture = Some("size");
+                    current_text.clear();
+                }
+                b"NextContinuationToken" => {
+                    capture = Some("next_token");
+                    current_text.clear();
+                }
                 _ => {}
             },
-            Ok(Event::Text(e)) => {
-                if let Some(field) = capture {
-                    let text = e
-                        .unescape()
-                        .map_err(|e| io::Error::other(format!("XML unescape: {e}")))?;
-                    match field {
-                        "key" => current_key = text.into_owned(),
-                        "size" => {
-                            current_size = text.parse::<u64>().unwrap_or(0);
-                        }
-                        "next_token" => next_token = Some(text.into_owned()),
-                        _ => {}
-                    }
+            Ok(Event::Text(e)) if capture.is_some() => {
+                let decoded = e
+                    .decode()
+                    .map_err(|e| io::Error::other(format!("XML decode: {e}")))?;
+                current_text.push_str(decoded.as_ref());
+            }
+            Ok(Event::GeneralRef(e)) if capture.is_some() => {
+                push_xml_reference(&mut current_text, e)?;
+            }
+            Ok(Event::End(e)) => match e.local_name().as_ref() {
+                b"Key" if capture == Some("key") => {
+                    current_key.clone_from(&current_text);
                     capture = None;
+                    current_text.clear();
                 }
-            }
-            Ok(Event::End(e)) if e.local_name().as_ref() == b"Contents" && in_contents => {
-                objects.push(S3Object {
-                    key: current_key.clone(),
-                    size: current_size,
-                });
-                in_contents = false;
-                capture = None;
-            }
+                b"Size" if capture == Some("size") => {
+                    current_size = current_text.parse::<u64>().map_err(|e| {
+                        io::Error::other(format!(
+                            "S3 list XML parse: invalid object size {current_text:?}: {e}"
+                        ))
+                    })?;
+                    capture = None;
+                    current_text.clear();
+                }
+                b"NextContinuationToken" if capture == Some("next_token") => {
+                    next_token = Some(current_text.clone());
+                    capture = None;
+                    current_text.clear();
+                }
+                b"Contents" if in_contents => {
+                    objects.push(S3Object {
+                        key: current_key.clone(),
+                        size: current_size,
+                    });
+                    in_contents = false;
+                    capture = None;
+                    current_text.clear();
+                }
+                _ => {}
+            },
             Ok(Event::Eof) => break,
             Err(e) => {
                 return Err(io::Error::other(format!("S3 list XML parse: {e}")));
@@ -924,5 +973,38 @@ mod tests {
         let (objects, token) = parse_list_objects_response(xml).expect("parse ok");
         assert_eq!(objects.len(), 1);
         assert_eq!(token.as_deref(), Some("abc123"));
+    }
+
+    #[test]
+    fn parse_list_objects_response_preserves_entity_fragments() {
+        let xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <NextContinuationToken>page&amp;&#50;</NextContinuationToken>
+  <Contents>
+    <Key>logs/a&amp;b&#x2F;c.log</Key>
+    <Size>10</Size>
+  </Contents>
+</ListBucketResult>"#;
+        let (objects, token) = parse_list_objects_response(xml).expect("parse ok");
+        assert_eq!(objects.len(), 1);
+        assert_eq!(objects[0].key, "logs/a&b/c.log");
+        assert_eq!(objects[0].size, 10);
+        assert_eq!(token.as_deref(), Some("page&2"));
+    }
+
+    #[test]
+    fn parse_list_objects_response_rejects_invalid_size() {
+        let xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Contents>
+    <Key>logs/bad.log</Key>
+    <Size>not-a-number</Size>
+  </Contents>
+</ListBucketResult>"#;
+        let err = parse_list_objects_response(xml).expect_err("invalid size should fail");
+        assert!(
+            err.to_string().contains("invalid object size"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/ffwd-io/src/s3_input/client.rs
+++ b/crates/ffwd-io/src/s3_input/client.rs
@@ -777,9 +777,8 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
             }
             Ok(Event::End(e)) => match e.local_name().as_ref() {
                 b"Key" if capture == Some("key") => {
-                    current_key.clone_from(&current_text);
+                    current_key = std::mem::take(&mut current_text);
                     capture = None;
-                    current_text.clear();
                 }
                 b"Size" if capture == Some("size") => {
                     current_size = current_text.parse::<u64>().map_err(|e| {
@@ -791,13 +790,12 @@ fn parse_list_objects_response(data: &[u8]) -> io::Result<(Vec<S3Object>, Option
                     current_text.clear();
                 }
                 b"NextContinuationToken" if capture == Some("next_token") => {
-                    next_token = Some(current_text.clone());
+                    next_token = Some(std::mem::take(&mut current_text));
                     capture = None;
-                    current_text.clear();
                 }
                 b"Contents" if in_contents => {
                     objects.push(S3Object {
-                        key: current_key.clone(),
+                        key: std::mem::take(&mut current_key),
                         size: current_size,
                     });
                     in_contents = false;

--- a/crates/ffwd-io/src/s3_input/mod.rs
+++ b/crates/ffwd-io/src/s3_input/mod.rs
@@ -53,6 +53,31 @@ use client::S3Client;
 use decompress::{Compression, detect_compression};
 use sqs::SqsClient;
 
+fn push_xml_reference(
+    out: &mut String,
+    reference: quick_xml::events::BytesRef<'_>,
+    context: &str,
+) -> io::Result<()> {
+    if let Some(ch) = reference
+        .resolve_char_ref()
+        .map_err(|e| io::Error::other(format!("{context} XML character reference: {e}")))?
+    {
+        out.push(ch);
+        return Ok(());
+    }
+
+    let decoded = reference
+        .decode()
+        .map_err(|e| io::Error::other(format!("{context} XML reference decode: {e}")))?;
+    let Some(entity) = quick_xml::escape::resolve_predefined_entity(decoded.as_ref()) else {
+        return Err(io::Error::other(format!(
+            "{context} XML unrecognized entity: &{decoded};"
+        )));
+    };
+    out.push_str(entity);
+    Ok(())
+}
+
 // ── Constants ──────────────────────────────────────────────────────────────
 
 /// Bounded output channel capacity.  Each slot holds a ~256 KiB chunk.

--- a/crates/ffwd-io/src/s3_input/sqs.rs
+++ b/crates/ffwd-io/src/s3_input/sqs.rs
@@ -433,14 +433,12 @@ fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> 
             }
             Ok(Event::End(e)) => match e.local_name().as_ref() {
                 b"ReceiptHandle" if capture == Some("receipt") => {
-                    receipt_handle.clone_from(&current_text);
+                    receipt_handle = std::mem::take(&mut current_text);
                     capture = None;
-                    current_text.clear();
                 }
                 b"Body" if capture == Some("body") => {
-                    body.clone_from(&current_text);
+                    body = std::mem::take(&mut current_text);
                     capture = None;
-                    current_text.clear();
                 }
                 b"Message" if in_message => {
                     in_message = false;
@@ -450,10 +448,9 @@ fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> 
                     // (test notifications, non-ObjectCreated events) by
                     // checking `records.is_empty()`.
                     messages.push(SqsMessage {
-                        receipt_handle: receipt_handle.clone(),
+                        receipt_handle: std::mem::take(&mut receipt_handle),
                         records,
                     });
-                    receipt_handle.clear();
                     body.clear();
                     capture = None;
                     current_text.clear();
@@ -637,5 +634,26 @@ mod tests {
         assert_eq!(messages[0].records.len(), 1);
         assert_eq!(messages[0].records[0].key, "logs/app&x.log");
         assert_eq!(messages[0].records[0].size, 42);
+    }
+
+    #[test]
+    fn parse_receive_messages_response_preserves_cdata_fragments() {
+        let xml = Bytes::from_static(
+            br#"<ReceiveMessageResponse>
+  <ReceiveMessageResult>
+    <Message>
+      <ReceiptHandle><![CDATA[rh-cdata]]></ReceiptHandle>
+      <Body><![CDATA[{"Records":[{"eventName":"ObjectCreated:Put","s3":{"object":{"key":"logs%2Fcdata.log","size":7}}}]}]]></Body>
+    </Message>
+  </ReceiveMessageResult>
+</ReceiveMessageResponse>"#,
+        );
+
+        let messages = parse_receive_messages_response(&xml).expect("parse ok");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].receipt_handle, "rh-cdata");
+        assert_eq!(messages[0].records.len(), 1);
+        assert_eq!(messages[0].records[0].key, "logs/cdata.log");
+        assert_eq!(messages[0].records[0].size, 7);
     }
 }

--- a/crates/ffwd-io/src/s3_input/sqs.rs
+++ b/crates/ffwd-io/src/s3_input/sqs.rs
@@ -365,7 +365,30 @@ pub(super) fn extract_region_from_sqs_url(url: &str) -> Option<String> {
 
 fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> {
     use quick_xml::Reader;
+    use quick_xml::escape::resolve_predefined_entity;
+    use quick_xml::events::BytesRef;
     use quick_xml::events::Event;
+
+    fn push_xml_reference(out: &mut String, reference: BytesRef<'_>) -> io::Result<()> {
+        if let Some(ch) = reference
+            .resolve_char_ref()
+            .map_err(|e| io::Error::other(format!("SQS XML character reference: {e}")))?
+        {
+            out.push(ch);
+            return Ok(());
+        }
+
+        let decoded = reference
+            .decode()
+            .map_err(|e| io::Error::other(format!("SQS XML reference decode: {e}")))?;
+        let Some(entity) = resolve_predefined_entity(decoded.as_ref()) else {
+            return Err(io::Error::other(format!(
+                "SQS XML unrecognized entity: &{decoded};"
+            )));
+        };
+        out.push_str(entity);
+        Ok(())
+    }
 
     let mut reader = Reader::from_reader(data.as_ref());
     reader.config_mut().trim_text(true);
@@ -375,6 +398,7 @@ fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> 
     let mut receipt_handle = String::new();
     let mut body = String::new();
     let mut capture: Option<&'static str> = None;
+    let mut current_text = String::new();
 
     let mut buf = Vec::new();
     loop {
@@ -385,40 +409,57 @@ fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> 
                     receipt_handle.clear();
                     body.clear();
                 }
-                b"ReceiptHandle" if in_message => capture = Some("receipt"),
-                b"Body" if in_message => capture = Some("body"),
+                b"ReceiptHandle" if in_message => {
+                    capture = Some("receipt");
+                    current_text.clear();
+                }
+                b"Body" if in_message => {
+                    capture = Some("body");
+                    current_text.clear();
+                }
                 _ => {}
             },
-            Ok(Event::Text(e)) => {
-                if let Some(field) = capture {
-                    let text = e
-                        .unescape()
-                        .map_err(|e| io::Error::other(format!("SQS XML unescape: {e}")))?;
-                    match field {
-                        "receipt" => receipt_handle = text.into_owned(),
-                        "body" => body = text.into_owned(),
-                        _ => {}
-                    }
+            Ok(Event::Text(e)) if capture.is_some() => {
+                let decoded = e
+                    .decode()
+                    .map_err(|e| io::Error::other(format!("SQS XML decode: {e}")))?;
+                current_text.push_str(decoded.as_ref());
+            }
+            Ok(Event::GeneralRef(e)) if capture.is_some() => {
+                push_xml_reference(&mut current_text, e)?;
+            }
+            Ok(Event::CData(e)) if capture.is_some() => {
+                current_text.push_str(&String::from_utf8_lossy(e.into_inner().as_ref()));
+            }
+            Ok(Event::End(e)) => match e.local_name().as_ref() {
+                b"ReceiptHandle" if capture == Some("receipt") => {
+                    receipt_handle.clone_from(&current_text);
                     capture = None;
+                    current_text.clear();
                 }
-            }
-            Ok(Event::CData(e)) if capture == Some("body") => {
-                body = String::from_utf8_lossy(e.into_inner().as_ref()).into_owned();
-                capture = None;
-            }
-            Ok(Event::End(e)) if e.local_name().as_ref() == b"Message" && in_message => {
-                in_message = false;
-                let records = parse_s3_event_body(&body);
-                // Always push the message even when records is empty.
-                // The discovery loop deletes non-actionable messages
-                // (test notifications, non-ObjectCreated events) by
-                // checking `records.is_empty()`.
-                messages.push(SqsMessage {
-                    receipt_handle: receipt_handle.clone(),
-                    records,
-                });
-                capture = None;
-            }
+                b"Body" if capture == Some("body") => {
+                    body.clone_from(&current_text);
+                    capture = None;
+                    current_text.clear();
+                }
+                b"Message" if in_message => {
+                    in_message = false;
+                    let records = parse_s3_event_body(&body);
+                    // Always push the message even when records is empty.
+                    // The discovery loop deletes non-actionable messages
+                    // (test notifications, non-ObjectCreated events) by
+                    // checking `records.is_empty()`.
+                    messages.push(SqsMessage {
+                        receipt_handle: receipt_handle.clone(),
+                        records,
+                    });
+                    receipt_handle.clear();
+                    body.clear();
+                    capture = None;
+                    current_text.clear();
+                }
+                _ => {}
+            },
             Ok(Event::Eof) => break,
             Err(e) => {
                 return Err(io::Error::other(format!("SQS XML parse: {e}")));
@@ -575,5 +616,26 @@ mod tests {
         let body = r#"{"Records":[{"eventName":"ObjectRemoved:Delete","s3":{"object":{"key":"k","size":0}}}]}"#;
         let records = parse_s3_event_body(body);
         assert!(records.is_empty());
+    }
+
+    #[test]
+    fn parse_receive_messages_response_preserves_entity_fragments() {
+        let xml = Bytes::from_static(
+            br#"<ReceiveMessageResponse>
+  <ReceiveMessageResult>
+    <Message>
+      <ReceiptHandle>rh&amp;&#49;</ReceiptHandle>
+      <Body>{&quot;Records&quot;:[{&quot;eventName&quot;:&quot;ObjectCreated:Put&quot;,&quot;s3&quot;:{&quot;object&quot;:{&quot;key&quot;:&quot;logs%2Fapp%26x.log&quot;,&quot;size&quot;:42}}}]}</Body>
+    </Message>
+  </ReceiveMessageResult>
+</ReceiveMessageResponse>"#,
+        );
+
+        let messages = parse_receive_messages_response(&xml).expect("parse ok");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].receipt_handle, "rh&1");
+        assert_eq!(messages[0].records.len(), 1);
+        assert_eq!(messages[0].records[0].key, "logs/app&x.log");
+        assert_eq!(messages[0].records[0].size, 42);
     }
 }

--- a/crates/ffwd-io/src/s3_input/sqs.rs
+++ b/crates/ffwd-io/src/s3_input/sqs.rs
@@ -365,29 +365,12 @@ pub(super) fn extract_region_from_sqs_url(url: &str) -> Option<String> {
 
 fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> {
     use quick_xml::Reader;
-    use quick_xml::escape::resolve_predefined_entity;
-    use quick_xml::events::BytesRef;
     use quick_xml::events::Event;
 
-    fn push_xml_reference(out: &mut String, reference: BytesRef<'_>) -> io::Result<()> {
-        if let Some(ch) = reference
-            .resolve_char_ref()
-            .map_err(|e| io::Error::other(format!("SQS XML character reference: {e}")))?
-        {
-            out.push(ch);
-            return Ok(());
-        }
-
-        let decoded = reference
-            .decode()
-            .map_err(|e| io::Error::other(format!("SQS XML reference decode: {e}")))?;
-        let Some(entity) = resolve_predefined_entity(decoded.as_ref()) else {
-            return Err(io::Error::other(format!(
-                "SQS XML unrecognized entity: &{decoded};"
-            )));
-        };
-        out.push_str(entity);
-        Ok(())
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum CaptureField {
+        Receipt,
+        Body,
     }
 
     let mut reader = Reader::from_reader(data.as_ref());
@@ -397,7 +380,7 @@ fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> 
     let mut in_message = false;
     let mut receipt_handle = String::new();
     let mut body = String::new();
-    let mut capture: Option<&'static str> = None;
+    let mut capture: Option<CaptureField> = None;
     let mut current_text = String::new();
 
     let mut buf = Vec::new();
@@ -410,11 +393,11 @@ fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> 
                     body.clear();
                 }
                 b"ReceiptHandle" if in_message => {
-                    capture = Some("receipt");
+                    capture = Some(CaptureField::Receipt);
                     current_text.clear();
                 }
                 b"Body" if in_message => {
-                    capture = Some("body");
+                    capture = Some(CaptureField::Body);
                     current_text.clear();
                 }
                 _ => {}
@@ -426,17 +409,17 @@ fn parse_receive_messages_response(data: &Bytes) -> io::Result<Vec<SqsMessage>> 
                 current_text.push_str(decoded.as_ref());
             }
             Ok(Event::GeneralRef(e)) if capture.is_some() => {
-                push_xml_reference(&mut current_text, e)?;
+                super::push_xml_reference(&mut current_text, e, "SQS")?;
             }
             Ok(Event::CData(e)) if capture.is_some() => {
                 current_text.push_str(&String::from_utf8_lossy(e.into_inner().as_ref()));
             }
             Ok(Event::End(e)) => match e.local_name().as_ref() {
-                b"ReceiptHandle" if capture == Some("receipt") => {
+                b"ReceiptHandle" if capture == Some(CaptureField::Receipt) => {
                     receipt_handle = std::mem::take(&mut current_text);
                     capture = None;
                 }
-                b"Body" if capture == Some("body") => {
+                b"Body" if capture == Some(CaptureField::Body) => {
                     body = std::mem::take(&mut current_text);
                     capture = None;
                 }

--- a/crates/ffwd-runtime/src/pipeline/build.rs
+++ b/crates/ffwd-runtime/src/pipeline/build.rs
@@ -584,7 +584,10 @@ impl Pipeline {
 
         // Build output sink factory → pool.
         let factory: Arc<dyn SinkFactory> = if config.outputs.len() == 1 {
-            let output_cfg = &config.outputs[0];
+            let output_cfg = config
+                .outputs
+                .first()
+                .ok_or_else(|| "pipeline must have at least one output".to_string())?;
             build_output_factory_from_config(0, output_cfg, base_path, &mut metrics)?
         } else {
             let mut factories: Vec<Arc<dyn SinkFactory>> = Vec::new();

--- a/crates/ffwd-runtime/src/pipeline/io_worker.rs
+++ b/crates/ffwd-runtime/src/pipeline/io_worker.rs
@@ -317,7 +317,8 @@ pub(super) fn append_data_row_origins(
 
     let mut line_start = 0usize;
     for newline in memchr::memchr_iter(b'\n', bytes) {
-        let segment_has_content = scanner_line_has_content(&bytes[line_start..newline]);
+        let segment = bytes.get(line_start..newline).unwrap_or_default();
+        let segment_has_content = scanner_line_has_content(segment);
         if let Some(pending) = pending_row_origin
             && pending.source_id != source_id
         {
@@ -340,7 +341,7 @@ pub(super) fn append_data_row_origins(
         line_start = newline + 1;
     }
 
-    let tail = &bytes[line_start..];
+    let tail = bytes.get(line_start..).unwrap_or_default();
     if !tail.is_empty() {
         let tail_has_content = scanner_line_has_content(tail);
         match pending_row_origin {
@@ -723,6 +724,11 @@ pub(super) fn process_buffered_events(
                 source_id,
                 cri_metadata,
             } => {
+                let Some(data_bytes) = input.buf.get(range.clone()) else {
+                    input.stats.inc_errors();
+                    tracing::warn!(?range, "framed input returned out-of-bounds data range");
+                    return false;
+                };
                 if source_metadata_plan.has_any() {
                     if source_metadata_plan.has_source_path() {
                         capture_source_path(
@@ -736,14 +742,19 @@ pub(super) fn process_buffered_events(
                         pending_row_origin,
                         source_id,
                         input_name,
-                        &input.buf[range.clone()],
+                        data_bytes,
                     );
                 }
+                let Some(prefix_bytes) = input.buf.get(..range.start) else {
+                    input.stats.inc_errors();
+                    tracing::warn!(?range, "framed input returned out-of-bounds prefix range");
+                    return false;
+                };
                 append_cri_metadata_for_data(
                     &mut input.cri_metadata,
                     cri_metadata,
-                    &input.buf[..range.start],
-                    &input.buf[range],
+                    prefix_bytes,
+                    data_bytes,
                 );
             }
             FramedReadEvent::Rotated { .. } => {

--- a/crates/ffwd-runtime/src/pipeline/io_worker.rs
+++ b/crates/ffwd-runtime/src/pipeline/io_worker.rs
@@ -726,8 +726,12 @@ pub(super) fn process_buffered_events(
             } => {
                 let Some(data_bytes) = input.buf.get(range.clone()) else {
                     input.stats.inc_errors();
-                    tracing::warn!(?range, "framed input returned out-of-bounds data range");
-                    return false;
+                    tracing::warn!(
+                        ?range,
+                        buf_len = input.buf.len(),
+                        "framed input returned out-of-bounds data range"
+                    );
+                    continue;
                 };
                 if source_metadata_plan.has_any() {
                     if source_metadata_plan.has_source_path() {
@@ -747,8 +751,12 @@ pub(super) fn process_buffered_events(
                 }
                 let Some(prefix_bytes) = input.buf.get(..range.start) else {
                     input.stats.inc_errors();
-                    tracing::warn!(?range, "framed input returned out-of-bounds prefix range");
-                    return false;
+                    tracing::warn!(
+                        ?range,
+                        buf_len = input.buf.len(),
+                        "framed input returned out-of-bounds prefix range"
+                    );
+                    continue;
                 };
                 append_cri_metadata_for_data(
                     &mut input.cri_metadata,

--- a/crates/ffwd-runtime/src/pipeline/mod.rs
+++ b/crates/ffwd-runtime/src/pipeline/mod.rs
@@ -174,14 +174,16 @@ struct IngestState {
 pub enum ControlMessage {
     /// Graceful shutdown: stop accepting new data, cancel workers, drain processors.
     Shutdown,
-    /// Intended to stop new ingress while allowing in-flight data to finish.
-    /// Current status: staged placeholder (logs only).
+    /// Forwarded to workers as a drain-ingress coordination signal.
+    ///
+    /// Current status: workers log this message and continue normal operation;
+    /// the pipeline keeps queued-input draining behavior unchanged.
     DrainIngress,
     /// Trigger checkpoint persistence via the pipeline's [`flush_checkpoints()`][Pipeline::flush_checkpoints] method.
     /// Current status: flushes checkpoint store only; does not evacuate I/O or worker buffers.
     Flush,
     /// Intended hot-reload hook.
-    /// Current status: staged placeholder (logs only).
+    /// Current status: forwarded to workers for observability/logging only.
     Reconfigure,
 }
 
@@ -267,6 +269,10 @@ impl Pipeline {
         });
         // Keep input_transforms in sync: one transform per input.
         while self.input_transforms.len() < self.inputs.len() {
+            #[expect(
+                clippy::expect_used,
+                reason = "hardcoded passthrough SQL is validated by transform tests"
+            )]
             let transform = create_transform("SELECT * FROM logs")
                 .expect("hardcoded passthrough 'SELECT * FROM logs' is always valid");
             let scanner = Scanner::new(transform.scan_config());
@@ -451,7 +457,8 @@ impl Pipeline {
     /// Note: [`ControlMessage::Shutdown`] is functional.
     /// [`ControlMessage::Flush`] triggers checkpoint-store flush only.
     /// [`ControlMessage::DrainIngress`] and [`ControlMessage::Reconfigure`]
-    /// are currently staged placeholders.
+    /// are forwarded to workers for observability/logging, but they do not
+    /// currently mutate worker behavior.
     pub fn clone_control_sender(&self) -> tokio::sync::mpsc::UnboundedSender<ControlMessage> {
         self.control_tx.clone()
     }

--- a/crates/ffwd-runtime/src/pipeline/mod.rs
+++ b/crates/ffwd-runtime/src/pipeline/mod.rs
@@ -269,12 +269,14 @@ impl Pipeline {
         });
         // Keep input_transforms in sync: one transform per input.
         while self.input_transforms.len() < self.inputs.len() {
-            #[expect(
-                clippy::expect_used,
-                reason = "hardcoded passthrough SQL is validated by transform tests"
-            )]
-            let transform = create_transform("SELECT * FROM logs")
-                .expect("hardcoded passthrough 'SELECT * FROM logs' is always valid");
+            let Ok(transform) = create_transform("SELECT * FROM logs") else {
+                tracing::error!(
+                    input_name = name,
+                    "failed to build hardcoded passthrough transform for test input"
+                );
+                let _ = self.inputs.pop();
+                break;
+            };
             let scanner = Scanner::new(transform.scan_config());
             self.input_transforms.push(SourcePipeline {
                 scanner,

--- a/crates/ffwd-runtime/src/pipeline/pipeline_tests/shutdown.rs
+++ b/crates/ffwd-runtime/src/pipeline/pipeline_tests/shutdown.rs
@@ -92,6 +92,71 @@ async fn test_async_shutdown_drains_with_slow_output() {
     );
 }
 
+/// DrainIngress must not disable queued-input draining during a later shutdown.
+///
+/// Regression for #2716: the control-plane branch previously set
+/// `should_drain_input_channel = false` on DrainIngress, which caused a later
+/// shutdown to skip draining already queued batches.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_drain_ingress_keeps_later_shutdown_channel_drain_enabled() {
+    use std::sync::atomic::Ordering;
+
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("drain_ingress_then_shutdown.log");
+
+    let mut data = String::new();
+    for i in 0..120 {
+        data.push_str(&format!(r#"{{"msg":"drain-ingress {}"}}"#, i));
+        data.push('\n');
+    }
+    std::fs::write(&log_path, data.as_bytes()).unwrap();
+
+    let yaml = single_pipeline_yaml(
+        &format!("type: file\npath: \"{}\"\nformat: json", log_path.display()),
+        "type: stdout\nformat: json",
+    );
+
+    let config = ffwd_config::Config::load_str(&yaml).unwrap();
+    let pipe_cfg = &config.pipelines["default"];
+    let mut pipeline = Pipeline::from_config("default", pipe_cfg, &test_meter(), None).unwrap();
+    pipeline = pipeline.with_sink(Box::new(SlowSink {
+        delay: Duration::from_millis(30),
+    }));
+    // Encourage queue buildup so shutdown has buffered work to drain.
+    pipeline.batch_target_bytes = 64;
+    pipeline.batch_timeout = Duration::from_millis(10);
+
+    let control_tx = pipeline.clone_control_sender();
+    let metrics = Arc::clone(&pipeline.metrics);
+    let shutdown = CancellationToken::new();
+    let sd = shutdown.clone();
+
+    tokio::spawn(async move {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        while metrics.transform_in.lines_total.load(Ordering::Relaxed) < 64 {
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        let _ = control_tx.send(ControlMessage::DrainIngress);
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        sd.cancel();
+    });
+
+    pipeline.run_async(&shutdown).await.unwrap();
+
+    let lines_out = pipeline
+        .metrics
+        .transform_out
+        .lines_total
+        .load(Ordering::Relaxed);
+    assert!(
+        lines_out >= 120,
+        "shutdown after drain-ingress should still process queued input, got {lines_out} output lines"
+    );
+}
+
 /// After all file data is read, shutdown must still drain everything.
 /// The file tailer keeps polling after EOF (it's a tailer, not a
 /// reader), so the pipeline only exits via shutdown signal.

--- a/crates/ffwd-runtime/src/pipeline/processor_stage.rs
+++ b/crates/ffwd-runtime/src/pipeline/processor_stage.rs
@@ -56,9 +56,22 @@ pub(super) fn run_processor_stage(
     }
 
     let batch = if results.len() == 1 {
-        results.into_iter().next().expect("checked len == 1")
+        let mut results = results.into_iter();
+        match results.next() {
+            Some(batch) => batch,
+            None => {
+                return ProcessorStageResult::Reject {
+                    reason: "processor chain produced no result batches".to_string(),
+                };
+            }
+        }
     } else {
-        match arrow::compute::concat_batches(&results[0].schema(), results.iter()) {
+        let Some(first) = results.first() else {
+            return ProcessorStageResult::Reject {
+                reason: "processor chain produced no result batches".to_string(),
+            };
+        };
+        match arrow::compute::concat_batches(&first.schema(), results.iter()) {
             Ok(batch) => batch,
             Err(e) => {
                 return ProcessorStageResult::Reject {

--- a/crates/ffwd-runtime/src/pipeline/run.rs
+++ b/crates/ffwd-runtime/src/pipeline/run.rs
@@ -38,7 +38,7 @@ impl Pipeline {
         }
         builder
             .build()
-            .expect("failed to create tokio runtime")
+            .map_err(|e| io::Error::other(format!("failed to create tokio runtime: {e}")))?
             .block_on(self.run_async(shutdown))
     }
 
@@ -168,7 +168,8 @@ impl Pipeline {
                             tracing::debug!("received drain ingress control message");
                             let _ = self.worker_control_tx.send(ControlMessage::DrainIngress);
                             // TODO(#233): stop accepting new input but finish in-flight batches.
-                            should_drain_input_channel = false;
+                            // Keep input-channel drain enabled so a later shutdown still
+                            // drains already-queued messages instead of dropping them.
                         }
                         Some(ControlMessage::Flush) => {
                             tracing::debug!("received flush control message");

--- a/crates/ffwd-runtime/src/processor/http_enrich.rs
+++ b/crates/ffwd-runtime/src/processor/http_enrich.rs
@@ -317,12 +317,19 @@ impl HttpEnrichProcessor {
                 }
 
                 // Check this chunk's results only for missing keys (panicked threads).
-                let chunk_result_keys: HashSet<&str> = all_results
-                    .get(results_before..)
-                    .unwrap_or_default()
-                    .iter()
-                    .map(|(k, _)| k.as_str())
-                    .collect();
+                let chunk_results = match all_results.get(results_before..) {
+                    Some(results) => results,
+                    None => {
+                        tracing::error!(
+                            results_before,
+                            results_len = all_results.len(),
+                            "invalid enrichment result window"
+                        );
+                        &[]
+                    }
+                };
+                let chunk_result_keys: HashSet<&str> =
+                    chunk_results.iter().map(|(k, _)| k.as_str()).collect();
                 let missing: Vec<String> = chunk_keys
                     .iter()
                     .filter(|k| !chunk_result_keys.contains(**k))

--- a/crates/ffwd-runtime/src/processor/http_enrich.rs
+++ b/crates/ffwd-runtime/src/processor/http_enrich.rs
@@ -180,9 +180,11 @@ impl HttpEnrichProcessor {
 
         // If more cacheable results than capacity, only keep the newest ones.
         let cacheable = if cacheable.len() > self.config.max_entries {
-            &cacheable[cacheable.len() - self.config.max_entries..]
+            cacheable
+                .get(cacheable.len() - self.config.max_entries..)
+                .unwrap_or_default()
         } else {
-            &cacheable[..]
+            cacheable.as_slice()
         };
 
         // Count only net-new keys (not already in cache) for eviction sizing.
@@ -315,7 +317,9 @@ impl HttpEnrichProcessor {
                 }
 
                 // Check this chunk's results only for missing keys (panicked threads).
-                let chunk_result_keys: HashSet<&str> = all_results[results_before..]
+                let chunk_result_keys: HashSet<&str> = all_results
+                    .get(results_before..)
+                    .unwrap_or_default()
                     .iter()
                     .map(|(k, _)| k.as_str())
                     .collect();

--- a/crates/ffwd-runtime/src/processor/mod.rs
+++ b/crates/ffwd-runtime/src/processor/mod.rs
@@ -105,10 +105,14 @@ pub fn cascading_flush(
     let mut all_output = SmallVec::new();
 
     for i in 0..processors.len() {
-        let mut emitted = processors[i].flush();
+        let (_, tail) = processors.split_at_mut(i);
+        let Some((processor, remaining)) = tail.split_first_mut() else {
+            continue;
+        };
+        let mut emitted = processor.flush();
 
         // Cascade through remaining processors
-        for processor in &mut processors[(i + 1)..] {
+        for processor in remaining {
             let mut next = SmallVec::new();
             for b in emitted {
                 match processor.process(b, meta) {

--- a/crates/ffwd-runtime/src/transform.rs
+++ b/crates/ffwd-runtime/src/transform.rs
@@ -271,6 +271,15 @@ pub use passthrough::PassthroughTransform;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::Int32Array;
+    use arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn make_test_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from(vec![1, 2, 3]))])
+            .expect("valid test batch")
+    }
 
     #[test]
     fn transform_error_new_creates_message_variant() {
@@ -282,6 +291,16 @@ mod tests {
     fn transform_error_display_formats_correctly() {
         let err = TransformError::Message("test error".to_string());
         assert!(err.to_string().contains("test error"));
+    }
+
+    #[tokio::test]
+    async fn create_transform_trait_object_executes_async() {
+        let mut transform = create_transform("SELECT * FROM logs").expect("create transform");
+        let result = transform
+            .execute_async(make_test_batch())
+            .await
+            .expect("execute transform");
+        assert_eq!(result.num_rows(), 3);
     }
 
     /// Tests for the `PassthroughTransform` — only compiled when DataFusion is absent.
@@ -312,20 +331,11 @@ mod tests {
 
         #[test]
         fn passthrough_execute_blocking_passes_batch_through() {
-            use arrow::array::Int32Array;
-            use arrow::datatypes::{DataType, Field, Schema};
-            use std::sync::Arc;
-
-            let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-            let batch = arrow::record_batch::RecordBatch::try_new(
-                schema,
-                vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
-            )
-            .expect("valid test batch");
-
             let mut transform =
                 PassthroughTransform::new("SELECT * FROM logs").expect("passthrough sql");
-            let result = transform.execute_blocking(batch).expect("execute");
+            let result = transform
+                .execute_blocking(make_test_batch())
+                .expect("execute");
             assert_eq!(result.num_rows(), 3);
         }
 

--- a/crates/ffwd-runtime/src/worker_pool/pool/health.rs
+++ b/crates/ffwd-runtime/src/worker_pool/pool/health.rs
@@ -19,11 +19,14 @@ impl OutputHealthTracker {
         aggregate_output_health(state.idle_health, state.worker_slots.values().copied())
     }
 
-    fn insert_worker(&self, worker_id: usize, initial: ComponentHealth) -> ComponentHealth {
-        let mut state = self
-            .state
+    fn state_guard(&self) -> std::sync::MutexGuard<'_, OutputHealthState> {
+        self.state
             .lock()
-            .expect("output health tracker mutex poisoned during worker insertion");
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn insert_worker(&self, worker_id: usize, initial: ComponentHealth) -> ComponentHealth {
+        let mut state = self.state_guard();
         state.idle_health = idle_health_after_worker_insert(state.idle_health);
         state.worker_slots.insert(worker_id, initial);
         let aggregate = Self::aggregate(&state);
@@ -36,10 +39,7 @@ impl OutputHealthTracker {
         worker_id: usize,
         event: OutputHealthEvent,
     ) -> ComponentHealth {
-        let mut state = self
-            .state
-            .lock()
-            .expect("output health tracker mutex poisoned during worker event");
+        let mut state = self.state_guard();
         let Some(current) = state.worker_slots.get(&worker_id).copied() else {
             let aggregate = Self::aggregate(&state);
             tracing::warn!(
@@ -57,10 +57,7 @@ impl OutputHealthTracker {
     }
 
     pub(super) fn remove_worker(&self, worker_id: usize) -> ComponentHealth {
-        let mut state = self
-            .state
-            .lock()
-            .expect("output health tracker mutex poisoned during worker removal");
+        let mut state = self.state_guard();
         state.worker_slots.remove(&worker_id);
         let aggregate = Self::aggregate(&state);
         self.publish(aggregate);
@@ -68,29 +65,18 @@ impl OutputHealthTracker {
     }
 
     fn has_active_workers(&self) -> bool {
-        !self
-            .state
-            .lock()
-            .expect("output health tracker mutex poisoned during worker liveness check")
-            .worker_slots
-            .is_empty()
+        !self.state_guard().worker_slots.is_empty()
     }
 
     fn set_pool_health(&self, health: ComponentHealth) {
-        let mut state = self
-            .state
-            .lock()
-            .expect("output health tracker mutex poisoned during pool health update");
+        let mut state = self.state_guard();
         state.idle_health = health;
         let aggregate = Self::aggregate(&state);
         self.publish(aggregate);
     }
 
     fn clear_workers_and_set_pool_health(&self, health: ComponentHealth) -> ComponentHealth {
-        let mut state = self
-            .state
-            .lock()
-            .expect("output health tracker mutex poisoned during forced worker clear");
+        let mut state = self.state_guard();
         state.worker_slots.clear();
         state.idle_health = health;
         let aggregate = Self::aggregate(&state);

--- a/crates/ffwd-runtime/src/worker_pool/pool/health.rs
+++ b/crates/ffwd-runtime/src/worker_pool/pool/health.rs
@@ -19,14 +19,15 @@ impl OutputHealthTracker {
         aggregate_output_health(state.idle_health, state.worker_slots.values().copied())
     }
 
-    fn state_guard(&self) -> std::sync::MutexGuard<'_, OutputHealthState> {
-        self.state
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, OutputHealthState> {
+        self.state.lock().unwrap_or_else(|poisoned| {
+            tracing::error!("worker_pool: recovering output health tracker after mutex poison");
+            poisoned.into_inner()
+        })
     }
 
     fn insert_worker(&self, worker_id: usize, initial: ComponentHealth) -> ComponentHealth {
-        let mut state = self.state_guard();
+        let mut state = self.lock_state();
         state.idle_health = idle_health_after_worker_insert(state.idle_health);
         state.worker_slots.insert(worker_id, initial);
         let aggregate = Self::aggregate(&state);
@@ -39,7 +40,7 @@ impl OutputHealthTracker {
         worker_id: usize,
         event: OutputHealthEvent,
     ) -> ComponentHealth {
-        let mut state = self.state_guard();
+        let mut state = self.lock_state();
         let Some(current) = state.worker_slots.get(&worker_id).copied() else {
             let aggregate = Self::aggregate(&state);
             tracing::warn!(
@@ -57,7 +58,7 @@ impl OutputHealthTracker {
     }
 
     pub(super) fn remove_worker(&self, worker_id: usize) -> ComponentHealth {
-        let mut state = self.state_guard();
+        let mut state = self.lock_state();
         state.worker_slots.remove(&worker_id);
         let aggregate = Self::aggregate(&state);
         self.publish(aggregate);
@@ -65,18 +66,18 @@ impl OutputHealthTracker {
     }
 
     fn has_active_workers(&self) -> bool {
-        !self.state_guard().worker_slots.is_empty()
+        !self.lock_state().worker_slots.is_empty()
     }
 
     fn set_pool_health(&self, health: ComponentHealth) {
-        let mut state = self.state_guard();
+        let mut state = self.lock_state();
         state.idle_health = health;
         let aggregate = Self::aggregate(&state);
         self.publish(aggregate);
     }
 
     fn clear_workers_and_set_pool_health(&self, health: ComponentHealth) -> ComponentHealth {
-        let mut state = self.state_guard();
+        let mut state = self.lock_state();
         state.worker_slots.clear();
         state.idle_health = health;
         let aggregate = Self::aggregate(&state);

--- a/crates/ffwd-runtime/src/worker_pool/pool/runtime.rs
+++ b/crates/ffwd-runtime/src/worker_pool/pool/runtime.rs
@@ -87,7 +87,10 @@ impl OutputWorkerPool {
         let mut i = 0;
         while i < self.workers.len() {
             // Try to send without blocking.
-            match self.workers[i].tx.try_send(msg) {
+            let Some(tx) = self.workers.get(i).map(|worker| worker.tx.clone()) else {
+                break;
+            };
+            match tx.try_send(msg) {
                 Ok(()) => {
                     // Promote this worker to front (MRU).
                     self.workers.swap(0, i);

--- a/crates/ffwd-runtime/src/worker_pool/pool/runtime.rs
+++ b/crates/ffwd-runtime/src/worker_pool/pool/runtime.rs
@@ -87,10 +87,10 @@ impl OutputWorkerPool {
         let mut i = 0;
         while i < self.workers.len() {
             // Try to send without blocking.
-            let Some(tx) = self.workers.get(i).map(|worker| worker.tx.clone()) else {
+            let Some(worker) = self.workers.get(i) else {
                 break;
             };
-            match tx.try_send(msg) {
+            match worker.tx.try_send(msg) {
                 Ok(()) => {
                     // Promote this worker to front (MRU).
                     self.workers.swap(0, i);

--- a/crates/ffwd-transform/src/cast_udf.rs
+++ b/crates/ffwd-transform/src/cast_udf.rs
@@ -76,7 +76,11 @@ impl ScalarUDFImpl for IntCastUdf {
         &self,
         args: ScalarFunctionArgs,
     ) -> datafusion::common::Result<ColumnarValue> {
-        let arg = &args.args[0];
+        let [arg] = args.args.as_slice() else {
+            return Err(datafusion::error::DataFusionError::Execution(
+                "int() expects exactly one argument".to_string(),
+            ));
+        };
         match arg {
             ColumnarValue::Array(array) => cast_or_passthrough_array(array, &DataType::Int64),
             ColumnarValue::Scalar(scalar @ datafusion::common::ScalarValue::Int64(_)) => {
@@ -134,7 +138,11 @@ impl ScalarUDFImpl for FloatCastUdf {
         &self,
         args: ScalarFunctionArgs,
     ) -> datafusion::common::Result<ColumnarValue> {
-        let arg = &args.args[0];
+        let [arg] = args.args.as_slice() else {
+            return Err(datafusion::error::DataFusionError::Execution(
+                "float() expects exactly one argument".to_string(),
+            ));
+        };
         match arg {
             ColumnarValue::Array(array) => cast_or_passthrough_array(array, &DataType::Float64),
             ColumnarValue::Scalar(scalar @ datafusion::common::ScalarValue::Float64(_)) => {

--- a/crates/ffwd-transform/src/enrichment.rs
+++ b/crates/ffwd-transform/src/enrichment.rs
@@ -236,6 +236,10 @@ impl HostInfoTable {
             Field::new(cols.host_id, DataType::Utf8, false),
             Field::new(cols.boot_id, DataType::Utf8, false),
         ]));
+        #[expect(
+            clippy::expect_used,
+            reason = "host_info schema is constructed in lockstep"
+        )]
         let batch = RecordBatch::try_new(
             schema,
             vec![
@@ -461,6 +465,10 @@ fn build_k8s_batch(entries: &[K8sPodEntry]) -> RecordBatch {
     let uids: Vec<&str> = entries.iter().map(|e| e.pod_uid.as_str()).collect();
     let containers: Vec<&str> = entries.iter().map(|e| e.container_name.as_str()).collect();
 
+    #[expect(
+        clippy::expect_used,
+        reason = "k8s table schema is constructed in lockstep"
+    )]
     RecordBatch::try_new(
         schema,
         vec![
@@ -616,8 +624,18 @@ fn restore_csv_header_columns(
     for header in headers {
         match index_by_name.get(header.as_str()).copied() {
             Some(idx) => {
-                fields.push(Arc::clone(&schema.fields()[idx]));
-                arrays.push(Arc::clone(batch.column(idx)));
+                let field = schema.fields().get(idx).ok_or_else(|| {
+                    TransformError::Enrichment(format!(
+                        "CSV header '{header}' resolved to invalid column index {idx}"
+                    ))
+                })?;
+                let array = batch.columns().get(idx).ok_or_else(|| {
+                    TransformError::Enrichment(format!(
+                        "CSV header '{header}' resolved to missing batch column {idx}"
+                    ))
+                })?;
+                fields.push(Arc::clone(field));
+                arrays.push(Arc::clone(array));
             }
             None => {
                 fields.push(Arc::new(Field::new(header, DataType::Utf8View, true)));
@@ -1013,11 +1031,13 @@ impl EnvTable {
 
         // Reject duplicate column names after lowercase normalization (e.g.
         // FFWD_META_REGION and FFWD_META_region both present would collide).
-        for w in pairs.windows(2) {
-            if w[0].0 == w[1].0 {
+        for window in pairs.windows(2) {
+            if let [first, second] = window
+                && first.0 == second.0
+            {
                 return Err(TransformError::Enrichment(format!(
                     "EnvTable: duplicate column name '{}' after lowercasing (prefix '{prefix}')",
-                    w[0].0
+                    first.0
                 )));
             }
         }
@@ -1105,6 +1125,10 @@ impl ProcessInfoTable {
             Field::new("pid", DataType::Utf8, false),
             Field::new("start_time", DataType::Utf8, false),
         ]));
+        #[expect(
+            clippy::expect_used,
+            reason = "process_info schema is constructed in lockstep"
+        )]
         let batch = RecordBatch::try_new(
             schema,
             vec![
@@ -1246,10 +1270,12 @@ fn parse_kv_file(path: &Path) -> Result<Vec<(String, String)>, TransformError> {
     }
     pairs.sort_by(|a, b| a.0.cmp(&b.0));
     for window in pairs.windows(2) {
-        if window[0].0 == window[1].0 {
+        if let [first, second] = window
+            && first.0 == second.0
+        {
             return Err(TransformError::Enrichment(format!(
                 "duplicate key '{}' in '{}'",
-                window[0].0,
+                first.0,
                 path.display()
             )));
         }
@@ -1320,6 +1346,10 @@ impl NetworkInfoTable {
             Field::new("all_ipv4", DataType::Utf8, false),
             Field::new("all_ipv6", DataType::Utf8, false),
         ]));
+        #[expect(
+            clippy::expect_used,
+            reason = "network_info schema is constructed in lockstep"
+        )]
         let batch = RecordBatch::try_new(
             schema,
             vec![
@@ -1396,10 +1426,14 @@ fn discover_ipv6_from_proc() -> Vec<String> {
         if parts.len() < 4 {
             continue;
         }
-        let hex = parts[0];
-        let scope = parts[3];
+        let Some(hex) = parts.first() else {
+            continue;
+        };
+        let Some(scope) = parts.get(3) else {
+            continue;
+        };
         // Skip link-local (scope 20) and loopback (scope 10)
-        if scope == "20" || scope == "10" {
+        if *scope == "20" || *scope == "10" {
             continue;
         }
         if hex.len() == 32
@@ -1471,6 +1505,10 @@ impl ContainerInfoTable {
             Field::new("container_id", DataType::Utf8, false),
             Field::new("container_runtime", DataType::Utf8, false),
         ]));
+        #[expect(
+            clippy::expect_used,
+            reason = "container_info schema is constructed in lockstep"
+        )]
         let batch = RecordBatch::try_new(
             schema,
             vec![
@@ -1702,6 +1740,10 @@ impl K8sClusterInfoTable {
             Field::new("service_account", DataType::Utf8, false),
             Field::new("cluster_name", DataType::Utf8, false),
         ]));
+        #[expect(
+            clippy::expect_used,
+            reason = "k8s_cluster_info schema is constructed in lockstep"
+        )]
         let batch = RecordBatch::try_new(
             schema,
             vec![

--- a/crates/ffwd-transform/src/query_analyzer.rs
+++ b/crates/ffwd-transform/src/query_analyzer.rs
@@ -80,7 +80,9 @@ impl QueryAnalyzer {
             ));
         }
 
-        let stmt = &statements[0];
+        let stmt = statements
+            .first()
+            .ok_or_else(|| TransformError::Sql("Expected exactly one SQL statement".to_string()))?;
         let mut referenced_columns = HashSet::new();
         let mut uses_select_star = false;
         let mut except_fields = Vec::new();

--- a/crates/ffwd-transform/src/sql_transform.rs
+++ b/crates/ffwd-transform/src/sql_transform.rs
@@ -181,11 +181,18 @@ impl SqlTransform {
             .map_err(|e| TransformError::Sql(format!("Failed to collect results: {e}")))?;
 
         // Concat all result batches into one.
-        let result = match batches.len() {
-            0 => Ok(RecordBatch::new_empty(output_schema)),
-            1 => Ok(batches.into_iter().next().expect("verified len==1")),
-            _ => {
-                let schema = batches[0].schema();
+        let result = match batches.as_slice() {
+            [] => Ok(RecordBatch::new_empty(output_schema)),
+            [_] => {
+                let mut batches = batches.into_iter();
+                batches.next().ok_or_else(|| {
+                    TransformError::Sql(
+                        "DataFusion returned no batches after len check".to_string(),
+                    )
+                })
+            }
+            [first, ..] => {
+                let schema = first.schema();
                 concat_batches(&schema, &batches).map_err(TransformError::Arrow)
             }
         }?;

--- a/crates/ffwd-transform/src/udf/bounded_lru.rs
+++ b/crates/ffwd-transform/src/udf/bounded_lru.rs
@@ -66,8 +66,9 @@ where
         K: Borrow<Q>,
         Q: Eq + ?Sized,
     {
-        if let Some(idx) = self.lru.iter().position(|entry| entry.borrow() == key) {
-            let key = self.lru.remove(idx).expect("lru index must be valid");
+        if let Some(idx) = self.lru.iter().position(|entry| entry.borrow() == key)
+            && let Some(key) = self.lru.remove(idx)
+        {
             self.lru.push_back(key);
         }
     }

--- a/crates/ffwd-transform/src/udf/csv_range_geo.rs
+++ b/crates/ffwd-transform/src/udf/csv_range_geo.rs
@@ -174,11 +174,13 @@ impl CsvRangeDatabase {
 
         // Reject overlapping ranges — they cause ambiguous lookups with binary search.
         for pair in ranges.windows(2) {
-            if pair[0].end >= pair[1].start {
+            if let [first, second] = pair
+                && first.end >= second.start
+            {
                 return Err(TransformError::Enrichment(format!(
                     "CSV geo database contains overlapping IP ranges: range ending at {} overlaps range starting at {}",
-                    u128_to_ip_string(pair[0].end),
-                    u128_to_ip_string(pair[1].start),
+                    u128_to_ip_string(first.end),
+                    u128_to_ip_string(second.start),
                 )));
             }
         }
@@ -219,7 +221,7 @@ impl GeoDatabase for CsvRangeDatabase {
             .partition_point(|e| e.start <= key)
             .checked_sub(1)?;
 
-        let entry = &self.ranges[idx];
+        let entry = self.ranges.get(idx)?;
         (entry.end >= key).then(|| entry.result.clone())
     }
 }

--- a/crates/ffwd-transform/src/udf/geo_lookup.rs
+++ b/crates/ffwd-transform/src/udf/geo_lookup.rs
@@ -127,7 +127,11 @@ impl ScalarUDFImpl for GeoLookupUdf {
             ));
         }
 
-        let input = &args.args[0];
+        let input = args.args.first().ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "geo_lookup() expects exactly one argument".to_string(),
+            )
+        })?;
 
         match input {
             ColumnarValue::Array(array) => {

--- a/crates/ffwd-transform/src/udf/grok.rs
+++ b/crates/ffwd-transform/src/udf/grok.rs
@@ -250,7 +250,7 @@ impl ScalarUDFImpl for GrokUdf {
                 datafusion::common::ScalarValue::Utf8(Some(pattern_str))
                 | datafusion::common::ScalarValue::Utf8View(Some(pattern_str))
                 | datafusion::common::ScalarValue::LargeUtf8(Some(pattern_str)),
-            ) = args.scalar_arguments[1]
+            ) = args.scalar_arguments.get(1).and_then(Option::as_ref)
             && let Ok(compiled) = compile_grok(pattern_str)
         {
             let fields: Vec<Field> = compiled
@@ -277,8 +277,16 @@ impl ScalarUDFImpl for GrokUdf {
             ));
         }
 
-        let input = &args.args[0];
-        let pattern = &args.args[1];
+        let input = args.args.first().ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "grok() expects an input argument".to_string(),
+            )
+        })?;
+        let pattern = args.args.get(1).ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "grok() expects a pattern argument".to_string(),
+            )
+        })?;
 
         // Extract pattern string.
         let pattern_str = match pattern {
@@ -339,10 +347,12 @@ impl ScalarUDFImpl for GrokUdf {
                             // pathological matches by logging when a match is slow.
                             match self.timed_match_against(&compiled, strings.value(row)) {
                                 Some(matches) => {
-                                    for (i, name) in compiled.field_names.iter().enumerate() {
+                                    for (builder, name) in
+                                        builders.iter_mut().zip(compiled.field_names.iter())
+                                    {
                                         match matches.get(name) {
-                                            Some(v) => builders[i].append_value(v),
-                                            None => builders[i].append_null(),
+                                            Some(v) => builder.append_value(v),
+                                            None => builder.append_null(),
                                         }
                                     }
                                 }
@@ -365,10 +375,12 @@ impl ScalarUDFImpl for GrokUdf {
                             }
                             match self.timed_match_against(&compiled, strings.value(row)) {
                                 Some(matches) => {
-                                    for (i, name) in compiled.field_names.iter().enumerate() {
+                                    for (builder, name) in
+                                        builders.iter_mut().zip(compiled.field_names.iter())
+                                    {
                                         match matches.get(name) {
-                                            Some(v) => builders[i].append_value(v),
-                                            None => builders[i].append_null(),
+                                            Some(v) => builder.append_value(v),
+                                            None => builder.append_null(),
                                         }
                                     }
                                 }
@@ -391,10 +403,12 @@ impl ScalarUDFImpl for GrokUdf {
                             }
                             match self.timed_match_against(&compiled, strings.value(row)) {
                                 Some(matches) => {
-                                    for (i, name) in compiled.field_names.iter().enumerate() {
+                                    for (builder, name) in
+                                        builders.iter_mut().zip(compiled.field_names.iter())
+                                    {
                                         match matches.get(name) {
-                                            Some(v) => builders[i].append_value(v),
-                                            None => builders[i].append_null(),
+                                            Some(v) => builder.append_value(v),
+                                            None => builder.append_null(),
                                         }
                                     }
                                 }

--- a/crates/ffwd-transform/src/udf/hash.rs
+++ b/crates/ffwd-transform/src/udf/hash.rs
@@ -111,7 +111,11 @@ impl ScalarUDFImpl for HashUdf {
             ));
         }
 
-        let arg = &args.args[0];
+        let arg = args.args.first().ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "hash() expects exactly one argument".to_string(),
+            )
+        })?;
         match arg {
             ColumnarValue::Array(array) => {
                 let dt = array.data_type();

--- a/crates/ffwd-transform/src/udf/json_extract.rs
+++ b/crates/ffwd-transform/src/udf/json_extract.rs
@@ -144,7 +144,11 @@ fn coerce_to_string_array(arr: &dyn Array) -> Result<StringArray, DataFusionErro
         Arc::new(
             arr.as_any()
                 .downcast_ref::<StringArray>()
-                .expect("already checked Utf8")
+                .ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "array declared as Utf8 did not downcast to StringArray".to_string(),
+                    )
+                })?
                 .clone(),
         ) as _
     } else {
@@ -154,7 +158,9 @@ fn coerce_to_string_array(arr: &dyn Array) -> Result<StringArray, DataFusionErro
     Ok(coerced
         .as_any()
         .downcast_ref::<StringArray>()
-        .expect("cast to Utf8 must yield StringArray")
+        .ok_or_else(|| {
+            DataFusionError::Execution("cast to Utf8 did not yield StringArray".to_string())
+        })?
         .clone())
 }
 
@@ -217,7 +223,10 @@ impl ScalarUDFImpl for JsonExtractUdf {
         }
 
         // --- arg 0: the raw column (coerce to StringArray) ---
-        let raw_array = match &args.args[0] {
+        let raw_arg = args.args.first().ok_or_else(|| {
+            DataFusionError::Execution(format!("{udf_name}() expects a raw column argument"))
+        })?;
+        let raw_array = match raw_arg {
             ColumnarValue::Array(a) => coerce_to_string_array(a.as_ref())?,
             ColumnarValue::Scalar(_) => {
                 return Err(DataFusionError::Internal(format!(
@@ -227,7 +236,10 @@ impl ScalarUDFImpl for JsonExtractUdf {
         };
 
         // --- arg 1: field name (constant string) ---
-        let key = match &args.args[1] {
+        let key_arg = args.args.get(1).ok_or_else(|| {
+            DataFusionError::Execution(format!("{udf_name}() expects a field name argument"))
+        })?;
+        let key = match key_arg {
             ColumnarValue::Scalar(ScalarValue::Utf8(Some(k)))
             | ColumnarValue::Scalar(ScalarValue::Utf8View(Some(k))) => k.as_str(),
             _ => {
@@ -318,7 +330,11 @@ impl ScalarUDFImpl for JsonExtractUdf {
                 .column(idx)
                 .as_any()
                 .downcast_ref::<StructArray>()
-                .expect("column declared as Struct must downcast to StructArray");
+                .ok_or_else(|| {
+                    DataFusionError::Execution(
+                        "column declared as Struct did not downcast to StructArray".to_string(),
+                    )
+                })?;
             let field_dt = batch.schema().field(idx).data_type().clone();
             let child_fields = match &field_dt {
                 DataType::Struct(f) => f.clone(),

--- a/crates/ffwd-transform/src/udf/regexp_extract.rs
+++ b/crates/ffwd-transform/src/udf/regexp_extract.rs
@@ -170,9 +170,21 @@ impl ScalarUDFImpl for RegexpExtractUdf {
             ));
         }
 
-        let input = &args.args[0];
-        let pattern = &args.args[1];
-        let group_idx = &args.args[2];
+        let input = args.args.first().ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "regexp_extract() expects an input argument".to_string(),
+            )
+        })?;
+        let pattern = args.args.get(1).ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "regexp_extract() expects a pattern argument".to_string(),
+            )
+        })?;
+        let group_idx = args.args.get(2).ok_or_else(|| {
+            datafusion::error::DataFusionError::Execution(
+                "regexp_extract() expects a group index argument".to_string(),
+            )
+        })?;
 
         // Extract the pattern string (must be a constant/scalar).
         let pattern_str = match pattern {

--- a/crates/ffwd/src/commands.rs
+++ b/crates/ffwd/src/commands.rs
@@ -435,7 +435,9 @@ fn cmd_wizard() -> Result<(), CliError> {
         let labels: Vec<&str> = USE_CASE_TEMPLATES.iter().map(|t| t.title).collect();
         let descs: Vec<&str> = USE_CASE_TEMPLATES.iter().map(|t| t.description).collect();
         let uc_idx = prompt_select_described("Pick a scenario:", &labels, &descs)?;
-        let uc = &USE_CASE_TEMPLATES[uc_idx];
+        let uc = USE_CASE_TEMPLATES.get(uc_idx).ok_or_else(|| {
+            CliError::Config(format!("selected use-case index {uc_idx} is invalid"))
+        })?;
         println!("{}selected{}: {}", green(), reset(), uc.title);
         println!();
         let sql = prompt_text(
@@ -472,8 +474,12 @@ fn cmd_wizard() -> Result<(), CliError> {
             sql.trim()
         };
 
-        let input = &INPUT_TEMPLATES[input_idx];
-        let output = &OUTPUT_TEMPLATES[output_idx];
+        let input = INPUT_TEMPLATES.get(input_idx).ok_or_else(|| {
+            CliError::Config(format!("selected input index {input_idx} is invalid"))
+        })?;
+        let output = OUTPUT_TEMPLATES.get(output_idx).ok_or_else(|| {
+            CliError::Config(format!("selected output index {output_idx} is invalid"))
+        })?;
         render_config(input, output, sql)
     };
 
@@ -1025,8 +1031,8 @@ mod tests {
             .find(|template| template.id == "nginx_access_to_loki")
             .expect("loki use-case template");
         let cfg = config_templates::render_use_case(use_case, use_case.transform);
-        assert!(cfg.contains("        static_labels:\n          app: nginx"));
-        assert!(cfg.contains("        label_columns:\n          - status"));
+        assert!(cfg.contains("        static_labels:\n          service: myapp"));
+        assert!(cfg.contains("        label_columns:\n          - level"));
         ffwd_config::Config::load_str(&cfg).expect("rendered loki use case should parse");
     }
 

--- a/crates/ffwd/src/generate.rs
+++ b/crates/ffwd/src/generate.rs
@@ -93,12 +93,13 @@ pub(crate) fn generate_json_log_file(num_lines: usize, output: &str) -> io::Resu
 
     for i in 0..num_lines {
         let seq = i as u64;
-        let level = levels[i % 4];
-        let path = paths[i % 5];
+        let level = levels.get(i % levels.len()).copied().unwrap_or("INFO");
+        let path = paths.get(i % paths.len()).copied().unwrap_or("/health");
         let id = 10000 + (i * 7) % 90000;
         let dur = 1 + (i * 13) % 500;
         let rid = format!("{:016x}", seq.wrapping_mul(0x517cc1b727220a95));
-        let status = [200, 201, 400, 404, 500, 503][i % 6];
+        let statuses = [200, 201, 400, 404, 500, 503];
+        let status = statuses.get(i % statuses.len()).copied().unwrap_or(200);
         let ts = timestamp_parts_for_generated_log(seq);
 
         write!(

--- a/crates/ffwd/src/generate.rs
+++ b/crates/ffwd/src/generate.rs
@@ -90,6 +90,7 @@ pub(crate) fn generate_json_log_file(num_lines: usize, output: &str) -> io::Resu
         "/health",
         "/api/v1/auth",
     ];
+    let statuses = [200, 201, 400, 404, 500, 503];
 
     for i in 0..num_lines {
         let seq = i as u64;
@@ -98,7 +99,6 @@ pub(crate) fn generate_json_log_file(num_lines: usize, output: &str) -> io::Resu
         let id = 10000 + (i * 7) % 90000;
         let dur = 1 + (i * 13) % 500;
         let rid = format!("{:016x}", seq.wrapping_mul(0x517cc1b727220a95));
-        let statuses = [200, 201, 400, 404, 500, 503];
         let status = statuses.get(i % statuses.len()).copied().unwrap_or(200);
         let ts = timestamp_parts_for_generated_log(seq);
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -404,7 +404,7 @@ fn check_unsafe_needs_safety_comment(
             }
             let start = idx.saturating_sub(6);
             let mut ok = false;
-            for ctx in &lines[start..=idx] {
+            for ctx in lines.get(start..=idx).unwrap_or_default() {
                 if ctx.contains("SAFETY:") {
                     ok = true;
                     break;


### PR DESCRIPTION
Fixes a regression where `DrainIngress` incorrectly disabled input-channel draining, causing shutdown to drop queued batches instead of draining them. Adds a regression test and replaces panicking index/slice operations with safe lookups across runtime, transforms, and IO crates.

- Fixed `DrainIngress` from blocking later shutdowns from draining queued input
- Added regression test verifying `DrainIngress` followed by shutdown drains all queued messages
- Replaced panicking index accesses with safe lookups across runtime, transform, and IO crates
- Downgraded `hmac` to 0.12 and updated S3/SQS XML parsers for current quick-xml API

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix DrainIngress regression that blocked queued input draining on shutdown
> - Removes a line in [`run.rs`](https://github.com/strawgate/fastforward/pull/2741/files#diff-0ca8afafe7514fb7d1a1efed81c5082ddcd5f721e415101399a50805d3419dd8) that set `should_drain_input_channel = false` when a `DrainIngress` control message was received, restoring the intended behavior where a subsequent `Shutdown` still drains already-queued messages.
> - Adds a regression test [`test_drain_ingress_keeps_later_shutdown_channel_drain_enabled`](https://github.com/strawgate/fastforward/pull/2741/files#diff-b84cb858df62714b58a4a3f34a97e0854b9a7e6d2c356409328b7e6b5607546e) that writes 120 JSON lines, sends `DrainIngress` then `Shutdown`, and asserts all lines are processed.
> - Also includes a broad panic-hardening pass across the runtime and transform crates, replacing direct index/slice access with safe alternatives and converting panics into logged errors or returned `Result`s.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea8ca79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->