### PR TITLE
Add kani-slow feature gate and lower CI parallelism to 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,21 +377,26 @@ jobs:
   # -------------------------------------------------------------------------
   # Kani formal verification — split into four parallel shards by layer so
   # the slowest one finishes within the hosted-runner budget.
+  #
+  # Fast vs slow proofs:
+  #   Proofs gated behind `kani-slow` feature (>30s solver time) run only
+  #   on push-to-main and ci:full PRs. PR CI runs fast proofs only (~5 min
+  #   wall-clock for core shard vs ~45+ min with slow proofs).
+  #
   # Observed proof counts and timing constraints:
-  #   kani-core:           145 proofs (ffwd-core + ffwd-kani)
-  #                        Heavy proofs: cri(unwind 100), structural(unwind 65)
-  #   kani-arrow:           24 proofs (ffwd-arrow)
-  #                        SIMD/accumulator proofs ~15-40s each
-  #   kani-runtime-types:   63 proofs (ffwd-runtime + ffwd-types)
+  #   kani-core:           ~130 fast + ~15 slow proofs (ffwd-core + ffwd-kani)
+  #                        Slow: structural(unwind 65), cri(unwind 52), severity
+  #   kani-arrow:           24 proofs (ffwd-arrow) — all fast
+  #   kani-runtime-types:   63 proofs (ffwd-runtime + ffwd-types) — all fast
   #   kani-io-output:       59 proofs (ffwd-io + ffwd-output +
-  #                        ffwd-diagnostics + ffwd binary)
+  #                        ffwd-diagnostics + ffwd binary) — all fast
   #
   # All shards use --jobs 2 (not 3 or 4). CBMC solver processes consume
   # 3-5 GB each; at --jobs 3+ on 16 GB runners, memory pressure causes
   # OOM kills or runner preemption (manifests as "runner shutdown signal"
   # after only minutes). --jobs 2 keeps peak memory under ~10 GB.
   #
-  # The core shard gets 120 min (145 proofs with high unwind bounds).
+  # The core shard gets 120 min (slow proofs need it on main).
   # Arrow gets 60 min (finishes in ~5 min, but needs compilation time).
   # Runtime and IO shards get 120 min for cold-cache variance.
   # -------------------------------------------------------------------------
@@ -424,6 +429,7 @@ jobs:
             -Z stubbing
             -p ffwd-kani
             -p ffwd-core
+            ${{ (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci:full')) && '--features kani-slow' || '' }}
 
   kani-arrow:
     name: Kani proofs (arrow)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,24 +377,23 @@ jobs:
   # -------------------------------------------------------------------------
   # Kani formal verification — split into four parallel shards by layer so
   # the slowest one finishes within the hosted-runner budget.
-  # Observed wall-clock medians on main (per-job, --jobs 3):
-  #   kani-core:           ~15 min  (ffwd-core,                ~103 proofs)
-  #   kani-arrow:          ~19 min  (ffwd-arrow,                ~27 proofs;
-  #                                  SIMD/columnar accumulator proofs are
-  #                                  individually expensive — ~42s/proof)
-  #   kani-runtime-types:  ~?? min  (ffwd-runtime + ffwd-types,
-  #                                  ~55 orchestration-layer proofs)
-  #   kani-io-output:      ~?? min  (ffwd-io + ffwd-output +
-  #                                  ffwd-diagnostics + ffwd binary,
-  #                                  ~52 I/O-layer proofs)
-  # The previous monolithic kani-periphery shard (six crates, 107 proofs)
-  # was the long pole at ~21 minutes. The split keeps ownership boundaries
-  # clear while the 120-minute timeout on the two broad shards leaves room
-  # for cold-cache variance and hosted-runner throttling. Revisit this after
-  # collecting stable main-branch runtime history and tune the broad shards
-  # back toward the 90-minute core/arrow budget if the split remains stable.
-  # Each shard uses kissat and --jobs 3 — ubuntu-latest has 4 vCPUs; jobs=3
-  # leaves headroom for solver memory spikes while still using the runner.
+  # Observed proof counts and timing constraints:
+  #   kani-core:           145 proofs (ffwd-core + ffwd-kani)
+  #                        Heavy proofs: cri(unwind 100), structural(unwind 65)
+  #   kani-arrow:           24 proofs (ffwd-arrow)
+  #                        SIMD/accumulator proofs ~15-40s each
+  #   kani-runtime-types:   63 proofs (ffwd-runtime + ffwd-types)
+  #   kani-io-output:       59 proofs (ffwd-io + ffwd-output +
+  #                        ffwd-diagnostics + ffwd binary)
+  #
+  # All shards use --jobs 2 (not 3 or 4). CBMC solver processes consume
+  # 3-5 GB each; at --jobs 3+ on 16 GB runners, memory pressure causes
+  # OOM kills or runner preemption (manifests as "runner shutdown signal"
+  # after only minutes). --jobs 2 keeps peak memory under ~10 GB.
+  #
+  # The core shard gets 120 min (145 proofs with high unwind bounds).
+  # Arrow gets 60 min (finishes in ~5 min, but needs compilation time).
+  # Runtime and IO shards get 120 min for cold-cache variance.
   # -------------------------------------------------------------------------
   kani-core:
     name: Kani proofs (core)
@@ -404,7 +403,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.kani_required == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
 
@@ -413,12 +412,12 @@ jobs:
           save-if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
           key: kani-core
 
-      - name: Run Kani verification (ffwd-core)
+      - name: Run Kani verification (ffwd-core + ffwd-kani)
         uses: model-checking/kani-github-action@v1
         with:
           args: >-
             --solver kissat
-            --jobs 3
+            --jobs 2
             --output-format terse
             -Z function-contracts
             -Z mem-predicates
@@ -434,7 +433,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'ci:full') ||
       (github.event.pull_request.draft == false && needs.changes.outputs.kani_required == 'true')
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 
@@ -446,14 +445,11 @@ jobs:
       - name: Run Kani verification (ffwd-arrow --lib)
         # ffwd-arrow has a binary with required-features that cargo-kani
         # cannot skip, so verify only the library target.
-        # --jobs 4: arrow proofs are the heaviest per-proof (up to ~90s each
-        # on the make_string_view/scatter families) so saturating all 4
-        # vCPUs here gives more wall-clock return than on the other shards.
         uses: model-checking/kani-github-action@v1
         with:
           args: >-
             --solver kissat
-            --jobs 4
+            --jobs 2
             --output-format terse
             -Z function-contracts
             -Z mem-predicates
@@ -485,7 +481,7 @@ jobs:
         with:
           args: >-
             --solver kissat
-            --jobs 3
+            --jobs 2
             --output-format terse
             -Z function-contracts
             -Z mem-predicates
@@ -518,7 +514,7 @@ jobs:
         with:
           args: >-
             --solver kissat
-            --jobs 3
+            --jobs 2
             --output-format terse
             -Z function-contracts
             -Z mem-predicates

--- a/crates/ffwd-core/Cargo.toml
+++ b/crates/ffwd-core/Cargo.toml
@@ -5,6 +5,11 @@ edition.workspace = true
 rust-version.workspace = true
 publish = false
 
+[features]
+# Gate expensive Kani proofs (>30s solver time) so PR CI stays fast.
+# Push-to-main and nightly runs use --features kani-slow to verify everything.
+kani-slow = []
+
 [lib]
 doctest = false
 

--- a/crates/ffwd-core/src/cri.rs
+++ b/crates/ffwd-core/src/cri.rs
@@ -893,6 +893,9 @@ mod verification {
     }
 
     /// Prove the configurable plain-text field wrapper path never panics.
+    ///
+    /// Gated behind `kani-slow`: [u8; 48] symbolic + unwind 52 takes >60s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(52)]
     #[kani::solver(kissat)]
@@ -1128,6 +1131,9 @@ mod verification {
     ///   - verify_write_json_line_no_prefix_quote_escape
     ///   - verify_write_json_line_no_prefix_backslash_escape
     ///   - verify_write_json_line_no_prefix_control_escape
+    ///
+    /// Gated behind `kani-slow`: unwind 52 through JSON escaping takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(52)]
     fn verify_write_json_line_parametric() {
@@ -1236,6 +1242,9 @@ mod verification {
     /// shared logic bugs in both implementations.
     /// Bounded to 8 bytes (from 16) to keep solver under 30s. Each byte can
     /// expand to 6 chars (\uXXXX), so worst case = 48 output bytes.
+    ///
+    /// Gated behind `kani-slow`: [u8; 8] + unwind 50 through escape logic ~30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(50)]
     pub(super) fn verify_json_escape_bytes_vs_oracle() {

--- a/crates/ffwd-core/src/cri.rs
+++ b/crates/ffwd-core/src/cri.rs
@@ -1228,19 +1228,21 @@ mod verification {
     }
 
     /// Oracle equivalence: `json_escape_bytes` matches `ffwd_kani::bytes::json_escape_oracle`
-    /// for all byte-slice inputs of length at most 16.
+    /// for all byte-slice inputs of length at most 8.
     ///
     /// # Oracle Design Note
     /// The oracle is a golden copy (see `ffwd_kani::bytes::json_escape_oracle` docs).
     /// This proof provides no-panic and output-bound guarantees, but would not detect
     /// shared logic bugs in both implementations.
+    /// Bounded to 8 bytes (from 16) to keep solver under 30s. Each byte can
+    /// expand to 6 chars (\uXXXX), so worst case = 48 output bytes.
     #[kani::proof]
-    #[kani::unwind(100)]
+    #[kani::unwind(50)]
     pub(super) fn verify_json_escape_bytes_vs_oracle() {
-        let src: [u8; 16] = kani::any();
-        let len: usize = kani::any_where(|&l| l <= 16);
+        let src: [u8; 8] = kani::any();
+        let len: usize = kani::any_where(|&l| l <= 8);
 
-        let mut prod_dst = Vec::with_capacity(16 * 6);
+        let mut prod_dst = Vec::with_capacity(8 * 6);
         let ora_result = json_escape_oracle(&src[..len]);
         json_escape_bytes(&src[..len], &mut prod_dst);
 

--- a/crates/ffwd-core/src/framer.rs
+++ b/crates/ffwd-core/src/framer.rs
@@ -200,6 +200,9 @@ mod verification {
     }
 
     /// Prove NewlineFramer line ranges are valid sub-ranges of input.
+    ///
+    /// Gated behind `kani-slow`: [u8; 32] symbolic + unwind 34 + kissat takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::solver(kissat)]
     #[kani::proof]
     #[kani::unwind(34)]

--- a/crates/ffwd-core/src/json_scanner.rs
+++ b/crates/ffwd-core/src/json_scanner.rs
@@ -2621,6 +2621,9 @@ mod verification {
 
     /// next_quote on a single block: if found, the position has a set bit
     /// in the bitmask. If not found, no bits are set in [from, end).
+    ///
+    /// Gated behind `kani-slow`: symbolic u64 bitmask + 66-unwind takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(66)] // inner None-branch loop: up to 64 iterations (end≤64) + 2 margin
     #[kani::solver(kissat)]

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -1531,6 +1531,10 @@ mod verification {
     /// Prove parse_severity ONLY returns non-Unspecified for the 10
     /// recognized level strings (6 standard + 4 aliases, any case).
     /// No false positives.
+    ///
+    /// Gated behind `kani-slow`: 10 case-insensitive comparisons over
+    /// symbolic [u8; 8] takes ~59s in the solver.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(9)] // eq_ignore_case_match: Zip over ≤8-byte targets + 1 terminator
     pub(super) fn verify_parse_severity_no_false_positives() {
@@ -2242,6 +2246,9 @@ mod verification {
 
     /// Oracle equivalence: `skip_field` matches `ffwd_kani::proto::skip_field_oracle`
     /// for all bounded byte inputs and valid wire types, including the EOF boundary.
+    ///
+    /// Gated behind `kani-slow`: [u8; 32] symbolic + varint decode loops takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(22)]
     pub(super) fn verify_skip_field_vs_oracle() {
@@ -2282,6 +2289,9 @@ mod verification {
 
     /// No-panic proof: `skip_field` never panics for any bounded input and any wire type
     /// (including unsupported values).
+    ///
+    /// Gated behind `kani-slow`: [u8; 32] symbolic + unwind 36 takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(36)]
     pub(super) fn verify_skip_field_no_panic() {

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -2154,9 +2154,11 @@ mod verification {
     /// With the stub, tag and length each append 1-10 bytes, plus data_len
     /// bytes of payload.
     /// Bounded to 4 data bytes (vs 8) to keep solver under 60s.
+    /// unwind(12) covers the stub's up-to-10-iteration loop (11 unwinds)
+    /// plus the data comparison and extend_from_slice loops.
     #[kani::proof]
     #[kani::stub(encode_varint, encode_varint_stub)]
-    #[kani::unwind(6)]
+    #[kani::unwind(12)]
     fn verify_encode_bytes_field_content_compositional() {
         let field_number: u32 = kani::any();
         kani::assume(field_number > 0 && field_number <= 100);

--- a/crates/ffwd-core/src/otlp.rs
+++ b/crates/ffwd-core/src/otlp.rs
@@ -1942,13 +1942,15 @@ mod verification {
     }
 
     /// Prove hex_decode rejects inputs where hex length != 2 * output length.
+    /// Uses a fixed-size stack array to avoid heap allocation (Vec) which
+    /// causes CBMC to spend 800s+ modeling the allocator.
     #[kani::proof]
+    #[kani::unwind(36)]
     fn verify_hex_decode_rejects_wrong_length() {
-        // Any length mismatch should return false
         let hex_len: usize = kani::any_where(|&l: &usize| l <= 34 && l != 32);
-        let hex = vec![b'a'; hex_len];
+        let hex = [b'a'; 34];
         let mut out = [0u8; 16];
-        assert!(!hex_decode(&hex, &mut out));
+        assert!(!hex_decode(&hex[..hex_len], &mut out));
     }
 
     // -----------------------------------------------------------------------
@@ -2151,19 +2153,20 @@ mod verification {
     /// then encode_varint for the length, then extends with the data slice.
     /// With the stub, tag and length each append 1-10 bytes, plus data_len
     /// bytes of payload.
+    /// Bounded to 4 data bytes (vs 8) to keep solver under 60s.
     #[kani::proof]
     #[kani::stub(encode_varint, encode_varint_stub)]
-    #[kani::unwind(12)]
+    #[kani::unwind(6)]
     fn verify_encode_bytes_field_content_compositional() {
         let field_number: u32 = kani::any();
         kani::assume(field_number > 0 && field_number <= 100);
-        let data_len: usize = kani::any_where(|&l: &usize| l <= 8);
-        let data: [u8; 8] = kani::any();
+        let data_len: usize = kani::any_where(|&l: &usize| l <= 4);
+        let data: [u8; 4] = kani::any();
 
         let mut buf = Vec::new();
         encode_bytes_field(&mut buf, field_number, &data[..data_len]);
 
-        // Tag (1-10) + length varint (1-10) + data (0-8) = 2-28 bytes
+        // Tag (1-10) + length varint (1-10) + data (0-4) = 2-24 bytes
         assert!(buf.len() >= 2 + data_len && buf.len() <= 20 + data_len);
 
         // Last data_len bytes must be the exact input data

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -258,6 +258,9 @@ mod verification {
     ///
     /// By restricting to digit-only inputs, the solver state space is
     /// dramatically smaller than fully symbolic 20-byte arrays.
+    ///
+    /// Gated behind `kani-slow`: 20-byte constrained array + overflow math ~30-60s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(22)]
     #[kani::solver(kissat)]

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -231,6 +231,7 @@ mod verification {
     ///
     /// Bounded to 10 bytes to keep solver tractable (~30s vs 534s at 20).
     /// 10 bytes covers all i32 values and most i64 (up to 9,999,999,999).
+    /// See verify_parse_int_fast_overflow_boundary for i64 overflow coverage.
     #[kani::proof]
     #[kani::unwind(12)]
     #[kani::solver(kissat)]
@@ -245,5 +246,56 @@ mod verification {
         let expected = ffwd_kani::numeric::parse_int_oracle(input);
 
         assert!(result == expected, "parse_int_fast disagrees with oracle");
+    }
+
+    /// Targeted proof for i64 overflow boundary in parse_int_fast.
+    ///
+    /// The main oracle proof (verify_parse_int_fast_vs_oracle) is bounded to
+    /// 10 bytes for solver tractability, which doesn't reach i64 overflow
+    /// (19+ digits). This proof specifically covers the overflow region by
+    /// constraining inputs to pure ASCII digits of length 19-20 and an
+    /// optional leading minus sign, then verifying against the oracle.
+    ///
+    /// By restricting to digit-only inputs, the solver state space is
+    /// dramatically smaller than fully symbolic 20-byte arrays.
+    #[kani::proof]
+    #[kani::unwind(22)]
+    #[kani::solver(kissat)]
+    fn verify_parse_int_fast_overflow_boundary() {
+        // 20 bytes: optional minus + up to 20 digits covers the i64 boundary.
+        // i64::MAX = 9223372036854775807 (19 digits)
+        // i64::MIN = -9223372036854775808 (20 chars with minus)
+        let len: usize = kani::any();
+        kani::assume(len >= 18 && len <= 20);
+
+        let has_minus: bool = kani::any();
+        let start = if has_minus { 1 } else { 0 };
+        // Ensure we have at least 1 digit after optional minus
+        kani::assume(len > start);
+
+        let mut bytes = [0u8; 20];
+        if has_minus {
+            bytes[0] = b'-';
+        }
+        // Fill digits as constrained symbolic values (b'0'..=b'9' only)
+        let mut i = start;
+        while i < len {
+            let d: u8 = kani::any();
+            kani::assume(d >= b'0' && d <= b'9');
+            bytes[i] = d;
+            i += 1;
+        }
+
+        let input = &bytes[..len];
+        let result = parse_int_fast(input);
+        let expected = ffwd_kani::numeric::parse_int_oracle(input);
+
+        assert!(
+            result == expected,
+            "overflow boundary: disagrees with oracle"
+        );
+
+        kani::cover!(result.is_none() && len >= 19, "overflow returns None");
+        kani::cover!(result.is_some() && len >= 19, "large valid i64");
     }
 }

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -231,7 +231,8 @@ mod verification {
     ///
     /// Bounded to 10 bytes to keep solver tractable (~30s vs 534s at 20).
     /// 10 bytes covers all i32 values and most i64 (up to 9,999,999,999).
-    /// See verify_parse_int_fast_overflow_boundary for i64 overflow coverage.
+    /// See verify_parse_int_fast_mid_range for 11-17 byte coverage and
+    /// verify_parse_int_fast_overflow_boundary for i64 overflow coverage.
     #[kani::proof]
     #[kani::unwind(12)]
     #[kani::solver(kissat)]
@@ -300,5 +301,48 @@ mod verification {
 
         kani::cover!(result.is_none() && len >= 19, "overflow returns None");
         kani::cover!(result.is_some() && len >= 19, "large valid i64");
+    }
+
+    /// Oracle proof for mid-range inputs (11-17 bytes).
+    ///
+    /// Bridges the gap between the main oracle proof (0-10 bytes) and the
+    /// overflow boundary proof (18-20 bytes). Uses digit-only constraints
+    /// with optional leading minus to keep solver time manageable.
+    ///
+    /// Gated behind `kani-slow`: 17-byte constrained array ~30-60s.
+    #[cfg(feature = "kani-slow")]
+    #[kani::proof]
+    #[kani::unwind(19)]
+    #[kani::solver(kissat)]
+    fn verify_parse_int_fast_mid_range() {
+        let len: usize = kani::any();
+        kani::assume(len >= 11 && len <= 17);
+
+        let has_minus: bool = kani::any();
+        let start = if has_minus { 1 } else { 0 };
+        kani::assume(len > start);
+
+        let mut bytes = [0u8; 17];
+        if has_minus {
+            bytes[0] = b'-';
+        }
+        let mut i = start;
+        while i < len {
+            let d: u8 = kani::any();
+            kani::assume(d >= b'0' && d <= b'9');
+            bytes[i] = d;
+            i += 1;
+        }
+
+        let input = &bytes[..len];
+        let result = parse_int_fast(input);
+        let expected = ffwd_kani::numeric::parse_int_oracle(input);
+
+        assert!(
+            result == expected,
+            "mid-range: parse_int_fast disagrees with oracle"
+        );
+
+        kani::cover!(result.is_some() && len >= 15, "large mid-range i64");
     }
 }

--- a/crates/ffwd-core/src/scan_config.rs
+++ b/crates/ffwd-core/src/scan_config.rs
@@ -203,6 +203,9 @@ mod verification {
     use alloc::string::ToString;
 
     /// Prove parse_int_fast never panics for any 8-byte input.
+    /// NOTE: The roundtrip check (to_string + re-parse) is intentionally
+    /// omitted here — it adds 500s+ of solver time modeling the allocator
+    /// and digit-formatting logic. The oracle proof below covers correctness.
     #[kani::proof]
     #[kani::unwind(10)]
     #[kani::solver(kissat)]
@@ -213,18 +216,12 @@ mod verification {
         let input = &bytes[..len];
         let _ = parse_int_fast(input);
 
-        // If parser accepts input, decimal re-encode/re-parse must roundtrip.
-        if let Some(n) = parse_int_fast(input) {
-            let decimal = n.to_string();
-            assert!(
-                parse_int_fast(decimal.as_bytes()) == Some(n),
-                "roundtrip parse mismatch"
-            );
-        }
+        // Cover both parsing outcomes
+        kani::cover!(parse_int_fast(input).is_some(), "valid integer parsed");
+        kani::cover!(parse_int_fast(input).is_none(), "invalid input rejected");
     }
 
-    /// Prove parse_int_fast matches a reference i128 oracle for all
-    /// inputs up to 20 bytes.
+    /// Prove parse_int_fast matches a reference i128 oracle.
     ///
     /// The oracle independently parses the input as i128, then checks:
     /// - If the input is valid digits (optional minus + ASCII digits)
@@ -232,16 +229,15 @@ mod verification {
     /// - If the input is invalid or overflows i64 → parse_int_fast must
     ///   return None
     ///
-    /// This is a full behavioral equivalence proof, not just overflow
-    /// detection. WARNING: takes ~4 minutes (i128 oracle adds solver
-    /// complexity).
+    /// Bounded to 10 bytes to keep solver tractable (~30s vs 534s at 20).
+    /// 10 bytes covers all i32 values and most i64 (up to 9,999,999,999).
     #[kani::proof]
-    #[kani::unwind(22)]
+    #[kani::unwind(12)]
     #[kani::solver(kissat)]
     fn verify_parse_int_fast_vs_oracle() {
-        let bytes: [u8; 20] = kani::any();
+        let bytes: [u8; 10] = kani::any();
         let len: usize = kani::any();
-        kani::assume(len <= 20);
+        kani::assume(len <= 10);
 
         let input = &bytes[..len];
         let result = parse_int_fast(input);

--- a/crates/ffwd-core/src/structural.rs
+++ b/crates/ffwd-core/src/structural.rs
@@ -711,6 +711,10 @@ mod verification {
 
     /// Oracle proof: prefix_xor matches naive bit-by-bit running XOR
     /// for ALL u64 inputs. Exhaustive — no gap.
+    ///
+    /// Gated behind `kani-slow`: 65-unwind loop over symbolic u64 takes >30s.
+    /// PR CI runs the fast `verify_prefix_xor_vs_oracle` instead.
+    #[cfg(feature = "kani-slow")]
     #[kani::solver(kissat)]
     #[kani::proof]
     #[kani::unwind(65)] // proof loop: while i < 64
@@ -743,6 +747,9 @@ mod verification {
     /// Most critical proof in the codebase — if escape detection is
     /// wrong, the scanner silently misparses every JSON string with
     /// backslashes.
+    ///
+    /// Gated behind `kani-slow`: three symbolic u64 + 65-unwind takes >60s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(65)]
     #[kani::solver(kissat)]
@@ -793,6 +800,9 @@ mod verification {
     /// This formally links the production function to the canonical oracle in ffwd-kani,
     /// enabling downstream consumers of `#[verified(kani = "verify_compute_real_quotes_vs_oracle")]`
     /// to inherit the proof without re-verification.
+    ///
+    /// Gated behind `kani-slow`: three symbolic u64 + 65-unwind takes >60s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(65)]
     #[kani::solver(kissat)]
@@ -818,6 +828,9 @@ mod verification {
     /// for ALL u64 inputs.
     ///
     /// This formally links the production function to the canonical oracle in ffwd-kani.
+    ///
+    /// Gated behind `kani-slow`: symbolic u64 + 65-unwind takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(65)]
     #[kani::solver(kissat)]
@@ -835,6 +848,9 @@ mod verification {
     /// 64-byte block and any needle. Checks one arbitrary position per
     /// run — the function is a simple loop so correctness at one
     /// arbitrary position implies correctness at all.
+    ///
+    /// Gated behind `kani-slow`: [u8; 64] symbolic + 65-unwind takes >60s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(65)]
     #[kani::solver(cadical)]
@@ -852,6 +868,9 @@ mod verification {
     /// Consistency: find_structural_chars_scalar matches find_char_mask
     /// for the quote character. Only checks one of 10 characters — all
     /// use identical match-arm logic.
+    ///
+    /// Gated behind `kani-slow`: [u8; 64] symbolic + 65-unwind takes >60s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(65)]
     #[kani::solver(cadical)]

--- a/crates/ffwd-core/src/structural_iter.rs
+++ b/crates/ffwd-core/src/structural_iter.rs
@@ -586,6 +586,9 @@ mod verification {
     ///
     /// Uses 8-byte input (1 block, padded to 64) to keep the proof
     /// tractable while exercising the full load_block + advance pipeline.
+    ///
+    /// Gated behind `kani-slow`: full StructuralIter pipeline + 66-unwind takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(66)]
     #[kani::solver(kissat)]

--- a/crates/ffwd-kani/Cargo.toml
+++ b/crates/ffwd-kani/Cargo.toml
@@ -6,6 +6,11 @@ rust-version.workspace = true
 publish = false
 description = "Shared oracle and reference implementations for Kani formal verification proofs."
 
+[features]
+# Gate expensive Kani proofs (>30s solver time) so PR CI stays fast.
+# Push-to-main and nightly runs use --features kani-slow to verify everything.
+kani-slow = []
+
 [lib]
 doctest = false
 

--- a/crates/ffwd-kani/src/bytes.rs
+++ b/crates/ffwd-kani/src/bytes.rs
@@ -213,6 +213,8 @@ mod verification {
         kani::cover!(!res, "non-printable reachable");
     }
 
+    /// Gated behind `kani-slow`: symbolic u64 + 65-unwind takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof_for_contract(compute_real_quotes_oracle)]
     #[kani::unwind(65)]
     #[kani::solver(kissat)]
@@ -226,6 +228,8 @@ mod verification {
         kani::cover!(res == quote_bits && quote_bits != 0, "no quotes masked");
     }
 
+    /// Gated behind `kani-slow`: symbolic u64 + 65-unwind takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof_for_contract(prefix_xor_oracle)]
     #[kani::unwind(65)]
     #[kani::solver(kissat)]
@@ -236,6 +240,8 @@ mod verification {
         kani::cover!(res == 0 && bitmask == 0, "zero result");
     }
 
+    /// Gated behind `kani-slow`: symbolic u64 + 65-unwind takes >30s.
+    #[cfg(feature = "kani-slow")]
     #[kani::proof]
     #[kani::unwind(65)]
     #[kani::solver(kissat)]

--- a/crates/ffwd-output/src/sink.rs
+++ b/crates/ffwd-output/src/sink.rs
@@ -392,14 +392,17 @@ mod verification {
         // Use a symbolic initial max_retry so the proof covers both the
         // `max_retry.is_none()` path and the `d > prev` / `d <= prev` branches
         // inside the RetryAfter arm of merge_child_send_result.
-        let initial_ms: Option<u64> = kani::any();
+        // Bounded to <= 30_000 ms to keep solver tractable (Duration arithmetic
+        // on full u64 causes 500s+ solve times with no extra coverage).
+        let initial_ms: Option<u64> =
+            if kani::any() { Some(kani::any_where(|&v: &u64| v <= 30_000)) } else { None };
         let mut max_retry = initial_ms.map(Duration::from_millis);
 
         let result = match tag {
             0 => SendResult::Ok,
             1 => SendResult::Rejected("no".to_string()),
             2 => {
-                let retry_ms: u64 = kani::any();
+                let retry_ms: u64 = kani::any_where(|&v| v <= 30_000);
                 SendResult::RetryAfter(Duration::from_millis(retry_ms))
             }
             _ => SendResult::IoError(io::Error::other("boom")),

--- a/crates/ffwd-output/src/sink.rs
+++ b/crates/ffwd-output/src/sink.rs
@@ -394,8 +394,11 @@ mod verification {
         // inside the RetryAfter arm of merge_child_send_result.
         // Bounded to <= 30_000 ms to keep solver tractable (Duration arithmetic
         // on full u64 causes 500s+ solve times with no extra coverage).
-        let initial_ms: Option<u64> =
-            if kani::any() { Some(kani::any_where(|&v: &u64| v <= 30_000)) } else { None };
+        let initial_ms: Option<u64> = if kani::any() {
+            Some(kani::any_where(|&v: &u64| v <= 30_000))
+        } else {
+            None
+        };
         let mut max_retry = initial_ms.map(Duration::from_millis);
 
         let result = match tag {

--- a/dev-docs/references/kani-verification.md
+++ b/dev-docs/references/kani-verification.md
@@ -164,6 +164,102 @@ already-verified contracts.
   too low yields inconclusive behavior.
 - Prefer proving smaller pure components compositionally over one monolith.
 
+## Performance Best Practices (Avoiding Slow Proofs)
+
+These patterns emerged from profiling our CI (where 5 proofs consumed 88% of
+solver time) and from Firecracker's production Kani usage:
+
+### Avoid heap allocation in proofs
+
+`Vec`, `String`, `to_string()` force CBMC to model the heap allocator, which
+dramatically increases SAT formula size. Prefer stack-allocated arrays:
+
+```rust
+// BAD: 500s+ to solve (models allocator)
+let v: Vec<u8> = vec![kani::any(); 16];
+
+// GOOD: ~30s (pure stack)
+let a: [u8; 16] = kani::any();
+```
+
+### Bound Duration / large integer arithmetic
+
+Full `u64` symbolic arithmetic (especially `checked_mul`, `checked_add` chains)
+creates massive SAT formulas. Bound to realistic ranges:
+
+```rust
+// BAD: 556s (full u64 Duration)
+let ms: u64 = kani::any();
+let d = Duration::from_millis(ms);
+
+// GOOD: ~5s (bounded to 30s)
+let ms: u64 = kani::any_where(|&v| v <= 30_000);
+let d = Duration::from_millis(ms);
+```
+
+### Constrain inputs when testing specific properties
+
+For overflow boundary proofs, don't use fully symbolic arrays. Constrain to
+the relevant input class:
+
+```rust
+// Tests overflow with 20-byte fully symbolic: ~534s
+let bytes: [u8; 20] = kani::any();
+
+// Tests overflow with digit-only constraint: ~30s
+let mut bytes = [0u8; 20];
+for i in 0..len {
+    let d: u8 = kani::any();
+    kani::assume(d >= b'0' && d <= b'9');
+    bytes[i] = d;
+}
+```
+
+### Input partitioning for expensive proofs
+
+If one proof covers a wide domain and takes >60s, split it into focused proofs
+that partition the input space:
+
+- `verify_fn_small_inputs` (len 0-10, fully symbolic)
+- `verify_fn_overflow_boundary` (len 18-20, constrained digits)
+
+### Function contracts for repeated callees
+
+When multiple proofs call the same expensive function, verify it once with a
+contract and stub it in callers. This is Firecracker's key scaling technique:
+
+```rust
+#[cfg_attr(kani, kani::requires(x > 0))]
+#[cfg_attr(kani, kani::ensures(|&result| result != 0 && x % result == 0))]
+fn expensive_fn(x: u64) -> u64 { ... }
+
+#[kani::proof_for_contract(expensive_fn)]
+fn check_expensive_fn() {
+    let x: u64 = kani::any();
+    expensive_fn(x);
+}
+
+// Callers get free speedup:
+#[kani::proof]
+#[kani::stub_verified(expensive_fn)]
+fn check_caller() {
+    let v: u64 = kani::any();
+    caller_of_expensive(v);
+}
+```
+
+Our `encode_varint_stub` in `otlp.rs` is a manual version of this pattern.
+When Kani stabilizes `modifies` clause support for `&mut Vec<u8>`, we should
+migrate to proper `proof_for_contract` + `stub_verified`.
+
+### CI resource constraints
+
+- CBMC solver processes use 3-5 GB each
+- GitHub Actions runners have ~7 GB free (16 GB total minus OS)
+- `--jobs 2` is the safe maximum (peak ~10 GB)
+- `--jobs 3` causes sporadic OOM; `--jobs 4` guarantees OOM
+- OOM manifests as "runner has received a shutdown signal" with lost logs
+
 ## Failure Triage
 
 - `cover!` unsat:

--- a/dev-docs/references/kani-verification.md
+++ b/dev-docs/references/kani-verification.md
@@ -176,7 +176,8 @@ dramatically increases SAT formula size. Prefer stack-allocated arrays:
 
 ```rust
 // BAD: 500s+ to solve (models allocator)
-let v: Vec<u8> = vec![kani::any(); 16];
+let mut v = Vec::with_capacity(16);
+for _ in 0..16 { v.push(kani::any::<u8>()); }
 
 // GOOD: ~30s (pure stack)
 let a: [u8; 16] = kani::any();
@@ -208,7 +209,7 @@ let bytes: [u8; 20] = kani::any();
 
 // Tests overflow with digit-only constraint: ~30s
 let mut bytes = [0u8; 20];
-for i in 0..len {
+for i in 0..20 {
     let d: u8 = kani::any();
     kani::assume(d >= b'0' && d <= b'9');
     bytes[i] = d;
@@ -221,6 +222,7 @@ If one proof covers a wide domain and takes >60s, split it into focused proofs
 that partition the input space:
 
 - `verify_fn_small_inputs` (len 0-10, fully symbolic)
+- `verify_fn_mid_range` (len 11-17, constrained digits)
 - `verify_fn_overflow_boundary` (len 18-20, constrained digits)
 
 ### Function contracts for repeated callees


### PR DESCRIPTION
Reduce Kani CI resource usage to prevent OOM on 16 GB runners by reducing parallel jobs, tightening proof bounds, and gating expensive proofs behind a `kani-slow` feature. The `kani-slow` proofs (~15 proofs, >30s each) run only on push-to-main and `ci:full` PRs, keeping PR CI fast at ~5 min wall-clock for the core shard.

- CI: All shards now use `--jobs 2` (down from 3–4) since CBMC solver processes consume 3–5 GB each and `--jobs 3+` causes OOM/preemption on 16 GB runners
- Added `kani-slow` feature flag to `ffwd-core` and `ffwd-kani` crates, gating ~15 expensive proofs behind `--features kani-slow`; conditional in CI for push-to-main and `ci:full` label
- `verify_json_escape_bytes_vs_oracle`: Array bounded 16 → 8 bytes, unwind 100 → 50
- `verify_hex_decode_rejects_wrong_length`: Vec replaced with `[b'a'; 34]` stack array, unwind 36 (Vec caused 800s+ of CBMC allocator modeling)
- `verify_encode_bytes_field_content_compositional`: Data bounded 8 → 4 bytes, unwind 12
- `verify_parse_int_fast_vs_oracle`: Bounded 20 → 10 bytes, unwind 22 → 12; removed 500s+ roundtrip check that modeled allocator; split into two `kani-slow` proofs for mid-range (11-17 bytes) and overflow boundary (18-20 bytes, constrained to digits)
- `merge_child_send_result` in sink.rs: Duration values bounded to ≤30,000 ms to avoid 500s+ of symbolic u64/Duration arithmetic
- Added `dev-docs/references/kani-verification.md` section on performance best practices (avoid Vec/String in proofs, bound arithmetic, constrain inputs for targeted proofs)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `kani-slow` feature gate and reduce CI parallelism to 2 jobs for Kani proofs
> - Introduces a `kani-slow` feature flag in `ffwd-core` and `ffwd-kani` to gate expensive Kani proofs, which are now only run on push to main or PRs labeled `ci:full`; default PRs run fast proofs only.
> - Gates ~15 heavy proofs across `cri.rs`, `framer.rs`, `json_scanner.rs`, `otlp.rs`, `scan_config.rs`, `structural.rs`, `structural_iter.rs`, and `bytes.rs` behind `#[cfg(feature = "kani-slow")]`.
> - Reduces `--jobs` from 3–4 to 2 across all Kani CI shards to reduce memory pressure, raises `kani-core` timeout from 90 to 120 minutes, and lowers `kani-arrow` timeout from 90 to 60 minutes.
> - Tightens several proof bounds (e.g. json escape oracle input reduced from 16→8 bytes, `verify_encode_bytes_field_content_compositional` data length bounded to ≤4) to keep fast proofs tractable.
> - Adds a new Kani performance best-practices section to [kani-verification.md](https://github.com/strawgate/fastforward/pull/2751/files#diff-6c3f1587dd3b7be03d546bed29d98c4a228016e3c15289bab2cb66f3b3382d4d).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c92fc41.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->